### PR TITLE
chore(ci): Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Our devDependencies can be checked weekly
+      interval: "weekly"
+    assignees:
+      - blaine-arcjet
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+    ignore:
+      # Ignore updates to the @types/node package due to conflict between
+      # Headers in DOM.
+      - dependency-name: "@types/node"
+        versions: [">18.18"]
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Our dependencies should be checked daily
+      interval: "daily"
+    assignees:
+      - blaine-arcjet
+    groups:
+      dependencies:
+        dependency-type: "production"


### PR DESCRIPTION
This adds dependabot to the repository. I chose to keep the groups simple so hopefully it updates the root package-lock

I figure we only need to check our devDeps once a week, but we should check our direct dependencies every day. The direct dependency check will go away once we reach zero dependencies. 