### PR TITLE
chore: Specify npm 10 in engines

### DIFF
--- a/analyze/package.json
+++ b/analyze/package.json
@@ -10,7 +10,8 @@
     "directory": "analyze"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/arcjet-next/package.json
+++ b/arcjet-next/package.json
@@ -10,7 +10,8 @@
     "directory": "arcjet-next"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -10,7 +10,8 @@
     "directory": "arcjet"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -10,7 +10,8 @@
     "directory": "eslint-config"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "commonjs",
   "main": "./index.js",

--- a/ip/package.json
+++ b/ip/package.json
@@ -10,7 +10,8 @@
     "directory": "ip"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/logger/package.json
+++ b/logger/package.json
@@ -10,7 +10,8 @@
     "directory": "logger"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "*"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "analyze": {
@@ -30,7 +31,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "arcjet": {
@@ -53,7 +55,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "arcjet-next": {
@@ -77,7 +80,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "arcjet-next/node_modules/@connectrpc/connect": {
@@ -113,7 +117,8 @@
         "eslint": "8.55.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       },
       "peerDependencies": {
         "eslint": "^8"
@@ -134,7 +139,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "logger": {
@@ -152,7 +158,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7234,7 +7241,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "protocol/node_modules/@bufbuild/protobuf": {
@@ -7268,7 +7276,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       },
       "peerDependencies": {
         "@rollup/wasm-node": "^4"
@@ -7280,7 +7289,8 @@
       "license": "Apache-2.0",
       "devDependencies": {},
       "engines": {
-        "node": ">=18"
+        "node": ">=18",
+        "npm": ">=10"
       },
       "peerDependencies": {
         "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "arcjet-js",
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "workspaces": [
     "*"

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -10,7 +10,8 @@
     "directory": "protocol"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/rollup-config/package.json
+++ b/rollup-config/package.json
@@ -10,7 +10,8 @@
     "directory": "rollup-config"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "type": "module",
   "main": "./index.js",

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -10,7 +10,8 @@
     "directory": "tsconfig"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=10"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
When trying to figure out why dependabot was not respecting our `.npmrc`, I found this issue https://github.com/dependabot/dependabot-core/issues/4072 which said that dependabot uses an old version of node, but it should use the `engines` field to detect what npm we want to use.

Since `omit` replaced `optional=false` in npm 7 or 8, perhaps dependabot was updating our lockfile with a very old version.

Node 18 and 20 both ship with npm 10 now.