### PR TITLE
chore(ci): Update the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(#496): Figure out why Node 18 is segfaulting
-        node: [20]
-        os: [ubuntu-latest, macos-latest]
+        node: [18, 20]
+        os: [ubuntu-latest]
     steps:
       # Environment security
       - name: Step Security


### PR DESCRIPTION
This re-adds node 18 and removes macos since harden-runner doesn't work there.