### PR TITLE
fix: Allow `withArcjet` to pass next.js compiler checks

### DIFF
--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -251,12 +251,13 @@ export function createMiddleware<const Rules extends (Primitive | Product)[]>(
  * the request is blocked, a `NextApiResponse` instance will be returned based
  * on the configured decision response.
  */
-export function withArcjet(
+export function withArcjet<Args extends [ArcjetNextRequest, ...unknown[]], Res>(
   // TODO(#221): This type needs to be tightened to only allow Primitives or Products that don't have extra props
   arcjet: ArcjetNext<(Primitive<EmptyObject> | Product<EmptyObject>)[]>,
-  handler: (...args: any[]) => any,
+  handler: (...args: Args) => Promise<Res>,
 ) {
-  return async (request: ArcjetNextRequest, ...rest: unknown[]) => {
+  return async (...args: Args) => {
+    const request = args[0];
     const decision = await arcjet.protect(request);
     if (decision.isDenied()) {
       // TODO(#222): Content type negotiation using `Accept` header
@@ -272,7 +273,7 @@ export function withArcjet(
         );
       }
     } else {
-      return handler(request, ...rest);
+      return handler(...args);
     }
   };
 }


### PR DESCRIPTION
This attempts to rework the function types of `withArcjet` to avoid an issue where the Next.js compiler demanded a `Request | NextRequest` while staying dynamic enough to work with the various handlers users might wrap.