### PR TITLE
chore(protocol): Add convert tests and add exhaustiveness checks

### DIFF
--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -43,14 +43,14 @@ import {
   SuspiciousReason,
 } from "./gen/es/decide/v1alpha1/decide_pb.js";
 
-export function ArcjetModeToProtocol(value: ArcjetMode) {
-  switch (value) {
+export function ArcjetModeToProtocol(mode: ArcjetMode) {
+  switch (mode) {
     case "LIVE":
       return Mode.LIVE;
     case "DRY_RUN":
       return Mode.DRY_RUN;
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = mode;
       return Mode.UNSPECIFIED;
   }
 }
@@ -68,7 +68,7 @@ export function ArcjetBotTypeToProtocol(botType: ArcjetBotType): BotType {
     case "VERIFIED_BOT":
       return BotType.VERIFIED_BOT;
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = botType;
       return BotType.UNSPECIFIED;
   }
 }
@@ -88,7 +88,7 @@ export function ArcjetBotTypeFromProtocol(botType: BotType): ArcjetBotType {
     case BotType.VERIFIED_BOT:
       return "VERIFIED_BOT";
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = botType;
       throw new Error("Invalid BotType");
   }
 }
@@ -108,13 +108,15 @@ export function ArcjetEmailTypeToProtocol(
     case "INVALID":
       return EmailType.INVALID;
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = emailType;
       return EmailType.UNSPECIFIED;
   }
 }
 
-export function ArcjetEmailTypeFromProtocol(proto: EmailType): ArcjetEmailType {
-  switch (proto) {
+export function ArcjetEmailTypeFromProtocol(
+  emailType: EmailType,
+): ArcjetEmailType {
+  switch (emailType) {
     case EmailType.UNSPECIFIED:
       throw new Error("Invalid EmailType");
     case EmailType.DISPOSABLE:
@@ -128,7 +130,7 @@ export function ArcjetEmailTypeFromProtocol(proto: EmailType): ArcjetEmailType {
     case EmailType.INVALID:
       return "INVALID";
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = emailType;
       throw new Error("Invalid EmailType");
   }
 }
@@ -140,15 +142,13 @@ export function ArcjetStackToProtocol(stack: ArcjetStack): SDKStack {
     case "NEXTJS":
       return SDKStack.SDK_STACK_NEXTJS;
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = stack;
       return SDKStack.SDK_STACK_UNSPECIFIED;
   }
 }
 
-export function ArcjetRuleStateToProtocol(
-  ruleState: ArcjetRuleState,
-): RuleState {
-  switch (ruleState) {
+export function ArcjetRuleStateToProtocol(stack: ArcjetRuleState): RuleState {
+  switch (stack) {
     case "RUN":
       return RuleState.RUN;
     case "NOT_RUN":
@@ -158,13 +158,15 @@ export function ArcjetRuleStateToProtocol(
     case "DRY_RUN":
       return RuleState.DRY_RUN;
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = stack;
       return RuleState.UNSPECIFIED;
   }
 }
 
-export function ArcjetRuleStateFromProtocol(proto: RuleState): ArcjetRuleState {
-  switch (proto) {
+export function ArcjetRuleStateFromProtocol(
+  ruleState: RuleState,
+): ArcjetRuleState {
+  switch (ruleState) {
     case RuleState.UNSPECIFIED:
       throw new Error("Invalid RuleState");
     case RuleState.RUN:
@@ -176,7 +178,7 @@ export function ArcjetRuleStateFromProtocol(proto: RuleState): ArcjetRuleState {
     case RuleState.CACHED:
       return "CACHED";
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = ruleState;
       throw new Error("Invalid RuleState");
   }
 }
@@ -194,15 +196,15 @@ export function ArcjetConclusionToProtocol(
     case "ERROR":
       return Conclusion.ERROR;
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = conclusion;
       return Conclusion.UNSPECIFIED;
   }
 }
 
 export function ArcjetConclusionFromProtocol(
-  proto: Conclusion,
+  conclusion: Conclusion,
 ): ArcjetConclusion {
-  switch (proto) {
+  switch (conclusion) {
     case Conclusion.UNSPECIFIED:
       throw new Error("Invalid Conclusion");
     case Conclusion.ALLOW:
@@ -214,7 +216,7 @@ export function ArcjetConclusionFromProtocol(
     case Conclusion.ERROR:
       return "ERROR";
     default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+      const _exhaustive: never = conclusion;
       throw new Error("Invalid Conclusion");
   }
 }
@@ -222,6 +224,10 @@ export function ArcjetConclusionFromProtocol(
 export function ArcjetReasonFromProtocol(proto?: Reason) {
   if (typeof proto === "undefined") {
     return new ArcjetReason();
+  }
+
+  if (typeof proto !== "object" || typeof proto.reason !== "object") {
+    throw new Error("Invalid Reason");
   }
 
   switch (proto.reason.case) {
@@ -266,9 +272,13 @@ export function ArcjetReasonFromProtocol(proto?: Reason) {
       const reason = proto.reason.value;
       return new ArcjetErrorReason(reason.message);
     }
-    default:
-      // TODO(#210): TypeScript exhaustiveness check that doesn't mess up coverage stats
+    case undefined: {
       return new ArcjetReason();
+    }
+    default: {
+      const _exhaustive: never = proto.reason;
+      return new ArcjetReason();
+    }
   }
 }
 
@@ -320,7 +330,9 @@ export function ArcjetReasonToProtocol(reason: ArcjetReason): Reason {
     return new Reason({
       reason: {
         case: "suspicious",
-        value: new SuspiciousReason({}),
+        value: new SuspiciousReason({
+          wafTriggered: reason.wafTriggered,
+        }),
       },
     });
   }
@@ -390,7 +402,9 @@ export function ArcjetDecisionFromProtocol(
     });
   }
 
-  const results = decision.ruleResults.map(ArcjetRuleResultFromProtocol);
+  const results = Array.isArray(decision.ruleResults)
+    ? decision.ruleResults.map(ArcjetRuleResultFromProtocol)
+    : [];
 
   switch (decision.conclusion) {
     case Conclusion.ALLOW:
@@ -422,6 +436,12 @@ export function ArcjetDecisionFromProtocol(
         id: decision.id,
         reason: new ArcjetErrorReason("Invalid Conclusion"),
         results,
+      });
+    default:
+      const _exhaustive: never = decision.conclusion;
+      return new ArcjetErrorDecision({
+        reason: new ArcjetErrorReason("Missing Conclusion"),
+        results: [],
       });
   }
 }
@@ -464,12 +484,15 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
   }
 
   if (isEmailRule(rule)) {
+    const block = Array.isArray(rule.block)
+      ? rule.block.map(ArcjetEmailTypeToProtocol)
+      : [];
     return new Rule({
       rule: {
         case: "email",
         value: {
           mode: ArcjetModeToProtocol(rule.mode),
-          block: rule.block.map(ArcjetEmailTypeToProtocol),
+          block,
           requireTopLevelDomain: rule.requireTopLevelDomain,
           allowDomainLiteral: rule.allowDomainLiteral,
         },
@@ -478,16 +501,21 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
   }
 
   if (isBotRule(rule)) {
-    const add = rule.add.map(([key, botType]) => [
-      key,
-      ArcjetBotTypeToProtocol(botType),
-    ]);
+    const block = Array.isArray(rule.block)
+      ? rule.block.map(ArcjetBotTypeToProtocol)
+      : [];
+    const add = Array.isArray(rule.add)
+      ? rule.add.map(([key, botType]) => [
+          key,
+          ArcjetBotTypeToProtocol(botType),
+        ])
+      : [];
     return new Rule({
       rule: {
         case: "bots",
         value: {
           mode: ArcjetModeToProtocol(rule.mode),
-          block: rule.block.map(ArcjetBotTypeToProtocol),
+          block,
           patterns: {
             add: Object.fromEntries(add),
             remove: rule.remove,

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -30,7 +30,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "pretest": "npm run build",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@bufbuild/protobuf": "1.6.0",

--- a/protocol/rollup.config.js
+++ b/protocol/rollup.config.js
@@ -8,16 +8,16 @@ export default createConfig(import.meta.url, {
       // processed by rollup
       resolveId(source) {
         if (source === "./gen/es/decide/v1alpha1/decide_pb.js") {
-          return {
-            id: "./gen/es/decide/v1alpha1/decide_pb.js",
-            external: true,
-          };
+          return { id: source, external: true };
+        }
+        if (source === "../gen/es/decide/v1alpha1/decide_pb.js") {
+          return { id: source, external: true };
         }
         if (source === "./gen/es/decide/v1alpha1/decide_connect.js") {
-          return {
-            id: "./gen/es/decide/v1alpha1/decide_connect.js",
-            external: true,
-          };
+          return { id: source, external: true };
+        }
+        if (source === "../gen/es/decide/v1alpha1/decide_connect.js") {
+          return { id: source, external: true };
         }
         return null;
       },

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -1,0 +1,684 @@
+/**
+ * @jest-environment node
+ */
+import { describe, expect, test } from "@jest/globals";
+import {
+  ArcjetModeToProtocol,
+  ArcjetBotTypeToProtocol,
+  ArcjetBotTypeFromProtocol,
+  ArcjetEmailTypeToProtocol,
+  ArcjetEmailTypeFromProtocol,
+  ArcjetStackToProtocol,
+  ArcjetRuleStateToProtocol,
+  ArcjetRuleStateFromProtocol,
+  ArcjetConclusionToProtocol,
+  ArcjetConclusionFromProtocol,
+  ArcjetReasonFromProtocol,
+  ArcjetReasonToProtocol,
+  ArcjetRuleResultToProtocol,
+  ArcjetRuleResultFromProtocol,
+  ArcjetDecisionToProtocol,
+  ArcjetDecisionFromProtocol,
+  ArcjetRuleToProtocol,
+} from "../convert.js";
+import {
+  BotType,
+  Conclusion,
+  Decision,
+  EmailType,
+  Mode,
+  Reason,
+  Rule,
+  RuleResult,
+  RuleState,
+  SDKStack,
+} from "../gen/es/decide/v1alpha1/decide_pb.js";
+import {
+  ArcjetAllowDecision,
+  ArcjetBotReason,
+  ArcjetBotRule,
+  ArcjetChallengeDecision,
+  ArcjetDenyDecision,
+  ArcjetEdgeRuleReason,
+  ArcjetEmailReason,
+  ArcjetEmailRule,
+  ArcjetErrorDecision,
+  ArcjetErrorReason,
+  ArcjetRateLimitReason,
+  ArcjetReason,
+  ArcjetRuleResult,
+  ArcjetSuspiciousReason,
+} from "../index.js";
+import { Timestamp } from "@bufbuild/protobuf";
+
+describe("convert", () => {
+  test("ArcjetModeToProtocol", () => {
+    expect(ArcjetModeToProtocol("LIVE")).toEqual(Mode.LIVE);
+    expect(ArcjetModeToProtocol("DRY_RUN")).toEqual(Mode.DRY_RUN);
+    expect(
+      ArcjetModeToProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toEqual(Mode.UNSPECIFIED);
+  });
+
+  test("ArcjetBotTypeToProtocol", () => {
+    expect(ArcjetBotTypeToProtocol("AUTOMATED")).toEqual(BotType.AUTOMATED);
+    expect(ArcjetBotTypeToProtocol("LIKELY_AUTOMATED")).toEqual(
+      BotType.LIKELY_AUTOMATED,
+    );
+    expect(ArcjetBotTypeToProtocol("LIKELY_NOT_A_BOT")).toEqual(
+      BotType.LIKELY_NOT_A_BOT,
+    );
+    expect(ArcjetBotTypeToProtocol("NOT_ANALYZED")).toEqual(
+      BotType.NOT_ANALYZED,
+    );
+    expect(ArcjetBotTypeToProtocol("VERIFIED_BOT")).toEqual(
+      BotType.VERIFIED_BOT,
+    );
+    expect(
+      ArcjetBotTypeToProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toEqual(BotType.UNSPECIFIED);
+  });
+
+  test("ArcjetBotTypeFromProtocol", () => {
+    expect(ArcjetBotTypeFromProtocol(BotType.AUTOMATED)).toEqual("AUTOMATED");
+    expect(ArcjetBotTypeFromProtocol(BotType.LIKELY_AUTOMATED)).toEqual(
+      "LIKELY_AUTOMATED",
+    );
+    expect(ArcjetBotTypeFromProtocol(BotType.LIKELY_NOT_A_BOT)).toEqual(
+      "LIKELY_NOT_A_BOT",
+    );
+    expect(ArcjetBotTypeFromProtocol(BotType.NOT_ANALYZED)).toEqual(
+      "NOT_ANALYZED",
+    );
+    expect(ArcjetBotTypeFromProtocol(BotType.VERIFIED_BOT)).toEqual(
+      "VERIFIED_BOT",
+    );
+    expect(() => {
+      ArcjetBotTypeFromProtocol(BotType.UNSPECIFIED);
+    }).toThrow("Invalid BotType");
+    expect(() => {
+      ArcjetBotTypeFromProtocol(
+        // @ts-expect-error
+        99,
+      );
+    }).toThrow("Invalid BotType");
+  });
+
+  test("ArcjetEmailTypeToProtocol", () => {
+    expect(ArcjetEmailTypeToProtocol("DISPOSABLE")).toEqual(
+      EmailType.DISPOSABLE,
+    );
+    expect(ArcjetEmailTypeToProtocol("FREE")).toEqual(EmailType.FREE);
+    expect(ArcjetEmailTypeToProtocol("INVALID")).toEqual(EmailType.INVALID);
+    expect(ArcjetEmailTypeToProtocol("NO_GRAVATAR")).toEqual(
+      EmailType.NO_GRAVATAR,
+    );
+    expect(ArcjetEmailTypeToProtocol("NO_MX_RECORDS")).toEqual(
+      EmailType.NO_MX_RECORDS,
+    );
+    expect(
+      ArcjetEmailTypeToProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toEqual(EmailType.UNSPECIFIED);
+  });
+
+  test("ArcjetEmailTypeFromProtocol", () => {
+    expect(ArcjetEmailTypeFromProtocol(EmailType.DISPOSABLE)).toEqual(
+      "DISPOSABLE",
+    );
+    expect(ArcjetEmailTypeFromProtocol(EmailType.FREE)).toEqual("FREE");
+    expect(ArcjetEmailTypeFromProtocol(EmailType.INVALID)).toEqual("INVALID");
+    expect(ArcjetEmailTypeFromProtocol(EmailType.NO_GRAVATAR)).toEqual(
+      "NO_GRAVATAR",
+    );
+    expect(ArcjetEmailTypeFromProtocol(EmailType.NO_MX_RECORDS)).toEqual(
+      "NO_MX_RECORDS",
+    );
+    expect(() => {
+      ArcjetEmailTypeFromProtocol(EmailType.UNSPECIFIED);
+    }).toThrow("Invalid EmailType");
+    expect(() => {
+      ArcjetEmailTypeFromProtocol(
+        // @ts-expect-error
+        99,
+      );
+    }).toThrow("Invalid EmailType");
+  });
+
+  test("ArcjetStackToProtocol", () => {
+    expect(ArcjetStackToProtocol("NODEJS")).toEqual(SDKStack.SDK_STACK_NODEJS);
+    expect(ArcjetStackToProtocol("NEXTJS")).toEqual(SDKStack.SDK_STACK_NEXTJS);
+    expect(
+      ArcjetStackToProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toEqual(SDKStack.SDK_STACK_UNSPECIFIED);
+  });
+
+  test("ArcjetRuleStateToProtocol", () => {
+    expect(ArcjetRuleStateToProtocol("CACHED")).toEqual(RuleState.CACHED);
+    expect(ArcjetRuleStateToProtocol("DRY_RUN")).toEqual(RuleState.DRY_RUN);
+    expect(ArcjetRuleStateToProtocol("NOT_RUN")).toEqual(RuleState.NOT_RUN);
+    expect(ArcjetRuleStateToProtocol("RUN")).toEqual(RuleState.RUN);
+    expect(
+      ArcjetRuleStateToProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toEqual(RuleState.UNSPECIFIED);
+  });
+
+  test("ArcjetRuleStateFromProtocol", () => {
+    expect(ArcjetRuleStateFromProtocol(RuleState.CACHED)).toEqual("CACHED");
+    expect(ArcjetRuleStateFromProtocol(RuleState.DRY_RUN)).toEqual("DRY_RUN");
+    expect(ArcjetRuleStateFromProtocol(RuleState.NOT_RUN)).toEqual("NOT_RUN");
+    expect(ArcjetRuleStateFromProtocol(RuleState.RUN)).toEqual("RUN");
+    expect(() => {
+      ArcjetRuleStateFromProtocol(RuleState.UNSPECIFIED);
+    }).toThrow("Invalid RuleState");
+    expect(() => {
+      ArcjetRuleStateFromProtocol(
+        // @ts-expect-error
+        99,
+      );
+    }).toThrow("Invalid RuleState");
+  });
+
+  test("ArcjetConclusionToProtocol", () => {
+    expect(ArcjetConclusionToProtocol("ALLOW")).toEqual(Conclusion.ALLOW);
+    expect(ArcjetConclusionToProtocol("CHALLENGE")).toEqual(
+      Conclusion.CHALLENGE,
+    );
+    expect(ArcjetConclusionToProtocol("DENY")).toEqual(Conclusion.DENY);
+    expect(ArcjetConclusionToProtocol("ERROR")).toEqual(Conclusion.ERROR);
+    expect(
+      ArcjetConclusionToProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toEqual(Conclusion.UNSPECIFIED);
+  });
+
+  test("ArcjetConclusionFromProtocol", () => {
+    expect(ArcjetConclusionFromProtocol(Conclusion.ALLOW)).toEqual("ALLOW");
+    expect(ArcjetConclusionFromProtocol(Conclusion.CHALLENGE)).toEqual(
+      "CHALLENGE",
+    );
+    expect(ArcjetConclusionFromProtocol(Conclusion.DENY)).toEqual("DENY");
+    expect(ArcjetConclusionFromProtocol(Conclusion.ERROR)).toEqual("ERROR");
+    expect(() => {
+      ArcjetConclusionFromProtocol(Conclusion.UNSPECIFIED);
+    }).toThrow("Invalid Conclusion");
+    expect(() => {
+      ArcjetConclusionFromProtocol(
+        // @ts-expect-error
+        99,
+      );
+    }).toThrow("Invalid Conclusion");
+  });
+
+  test("ArcjetReasonFromProtocol", () => {
+    expect(ArcjetReasonFromProtocol()).toBeInstanceOf(ArcjetReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "bot",
+            value: {
+              botType: BotType.AUTOMATED,
+              botScore: 1,
+              userAgentMatch: true,
+              ipHosting: false,
+              ipVpn: false,
+              ipProxy: false,
+              ipTor: false,
+              ipRelay: false,
+            },
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetBotReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "edgeRule",
+            value: {},
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetEdgeRuleReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "email",
+            value: {
+              emailTypes: [EmailType.DISPOSABLE],
+            },
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetEmailReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "error",
+            value: {
+              message: "Test error",
+            },
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetErrorReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "rateLimit",
+            value: {
+              max: 1,
+              count: 2,
+              remaining: -1,
+              resetTime: undefined,
+            },
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetRateLimitReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "rateLimit",
+            value: {
+              max: 1,
+              count: 2,
+              remaining: -1,
+              resetTime: Timestamp.now(),
+            },
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetRateLimitReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            case: "suspicious",
+            value: {
+              wafTriggered: true,
+            },
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetSuspiciousReason);
+    expect(ArcjetReasonFromProtocol(new Reason())).toBeInstanceOf(ArcjetReason);
+    expect(
+      ArcjetReasonFromProtocol(
+        new Reason({
+          reason: {
+            // @ts-expect-error
+            case: "NOT_VALID",
+          },
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetReason);
+    expect(() => {
+      ArcjetReasonFromProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      );
+    }).toThrow("Invalid Reason");
+    expect(() => {
+      ArcjetReasonFromProtocol({
+        // @ts-expect-error
+        reason: "NOT_VALID",
+      });
+    }).toThrow("Invalid Reason");
+  });
+
+  test("ArcjetReasonToProtocol", () => {
+    expect(ArcjetReasonToProtocol(new ArcjetReason())).toBeInstanceOf(Reason);
+    expect(
+      ArcjetReasonToProtocol(
+        new ArcjetRateLimitReason({
+          max: 1,
+          count: 2,
+          remaining: -1,
+        }),
+      ),
+    ).toEqual(
+      new Reason({
+        reason: {
+          case: "rateLimit",
+          value: {
+            max: 1,
+            count: 2,
+            remaining: -1,
+          },
+        },
+      }),
+    );
+    const resetTime = new Date();
+    expect(
+      ArcjetReasonToProtocol(
+        new ArcjetRateLimitReason({
+          max: 1,
+          count: 2,
+          remaining: -1,
+          resetTime,
+        }),
+      ),
+    ).toEqual(
+      new Reason({
+        reason: {
+          case: "rateLimit",
+          value: {
+            max: 1,
+            count: 2,
+            remaining: -1,
+            resetTime: Timestamp.fromDate(resetTime),
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetReasonToProtocol(
+        new ArcjetBotReason({
+          botType: "AUTOMATED",
+          botScore: 1,
+          userAgentMatch: true,
+          ipHosting: false,
+          ipVpn: false,
+          ipProxy: false,
+          ipTor: false,
+          ipRelay: false,
+        }),
+      ),
+    ).toEqual(
+      new Reason({
+        reason: {
+          case: "bot",
+          value: {
+            botType: BotType.AUTOMATED,
+            botScore: 1,
+            userAgentMatch: true,
+            ipHosting: false,
+            ipVpn: false,
+            ipProxy: false,
+            ipTor: false,
+            ipRelay: false,
+          },
+        },
+      }),
+    );
+    expect(ArcjetReasonToProtocol(new ArcjetEdgeRuleReason())).toEqual(
+      new Reason({
+        reason: {
+          case: "edgeRule",
+          value: {},
+        },
+      }),
+    );
+    expect(
+      ArcjetReasonToProtocol(
+        new ArcjetSuspiciousReason({ wafTriggered: true }),
+      ),
+    ).toEqual(
+      new Reason({
+        reason: {
+          case: "suspicious",
+          value: {
+            wafTriggered: true,
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetReasonToProtocol(
+        new ArcjetEmailReason({
+          emailTypes: ["DISPOSABLE"],
+        }),
+      ),
+    ).toEqual(
+      new Reason({
+        reason: {
+          case: "email",
+          value: {
+            emailTypes: [EmailType.DISPOSABLE],
+          },
+        },
+      }),
+    );
+    expect(ArcjetReasonToProtocol(new ArcjetErrorReason("Test error"))).toEqual(
+      new Reason({
+        reason: {
+          case: "error",
+          value: {
+            message: "Test error",
+          },
+        },
+      }),
+    );
+  });
+
+  test("ArcjetRuleResultToProtocol", () => {
+    expect(
+      ArcjetRuleResultToProtocol(
+        new ArcjetRuleResult({
+          state: "RUN",
+          conclusion: "ALLOW",
+          reason: new ArcjetReason(),
+        }),
+      ),
+    ).toEqual(
+      new RuleResult({
+        ruleId: "",
+        state: RuleState.RUN,
+        conclusion: Conclusion.ALLOW,
+        reason: new Reason(),
+      }),
+    );
+  });
+
+  test("ArcjetRuleResultFromProtocol", () => {
+    expect(
+      ArcjetRuleResultFromProtocol(
+        new RuleResult({
+          ruleId: "",
+          state: RuleState.RUN,
+          conclusion: Conclusion.ALLOW,
+          reason: new Reason(),
+        }),
+      ),
+    ).toEqual(
+      new ArcjetRuleResult({
+        state: "RUN",
+        conclusion: "ALLOW",
+        reason: new ArcjetReason(),
+      }),
+    );
+  });
+
+  test("ArcjetDecisionToProtocol", () => {
+    expect(
+      ArcjetDecisionToProtocol(
+        new ArcjetAllowDecision({
+          id: "abc123",
+          results: [],
+          reason: new ArcjetReason(),
+        }),
+      ),
+    ).toEqual(
+      new Decision({
+        id: "abc123",
+        conclusion: Conclusion.ALLOW,
+        ruleResults: [],
+        reason: new Reason(),
+      }),
+    );
+  });
+
+  test("ArcjetDecisionFromProtocol", () => {
+    expect(ArcjetDecisionFromProtocol()).toBeInstanceOf(ArcjetErrorDecision);
+    expect(ArcjetDecisionFromProtocol(new Decision())).toBeInstanceOf(
+      ArcjetErrorDecision,
+    );
+    expect(
+      ArcjetDecisionFromProtocol(
+        new Decision({
+          conclusion: Conclusion.ALLOW,
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetAllowDecision);
+    expect(
+      ArcjetDecisionFromProtocol(
+        new Decision({
+          conclusion: Conclusion.DENY,
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetDenyDecision);
+    expect(
+      ArcjetDecisionFromProtocol(
+        new Decision({
+          conclusion: Conclusion.CHALLENGE,
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetChallengeDecision);
+    expect(
+      ArcjetDecisionFromProtocol(
+        new Decision({
+          conclusion: Conclusion.ERROR,
+        }),
+      ),
+    ).toBeInstanceOf(ArcjetErrorDecision);
+    expect(
+      ArcjetDecisionFromProtocol({
+        // @ts-expect-error
+        conclusion: "NOT_VALID",
+      }),
+    ).toBeInstanceOf(ArcjetErrorDecision);
+    expect(
+      ArcjetDecisionFromProtocol(
+        // @ts-expect-error
+        "NOT_VALID",
+      ),
+    ).toBeInstanceOf(ArcjetErrorDecision);
+  });
+
+  test("ArcjetRuleToProtocol", () => {
+    expect(
+      ArcjetRuleToProtocol({
+        type: "UNKNOWN",
+        mode: "DRY_RUN",
+        priority: 1,
+      }),
+    ).toEqual(new Rule({}));
+    expect(
+      ArcjetRuleToProtocol({
+        type: "RATE_LIMIT",
+        mode: "DRY_RUN",
+        priority: 1,
+      }),
+    ).toEqual(
+      new Rule({
+        rule: {
+          case: "rateLimit",
+          value: {
+            mode: Mode.DRY_RUN,
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetRuleToProtocol({
+        type: "EMAIL",
+        mode: "DRY_RUN",
+        priority: 1,
+      }),
+    ).toEqual(
+      new Rule({
+        rule: {
+          case: "email",
+          value: {
+            mode: Mode.DRY_RUN,
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetRuleToProtocol(<ArcjetEmailRule<{ email: string }>>{
+        type: "EMAIL",
+        mode: "DRY_RUN",
+        priority: 1,
+        block: ["INVALID"],
+      }),
+    ).toEqual(
+      new Rule({
+        rule: {
+          case: "email",
+          value: {
+            mode: Mode.DRY_RUN,
+            block: [EmailType.INVALID],
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetRuleToProtocol({
+        type: "BOT",
+        mode: "DRY_RUN",
+        priority: 1,
+      }),
+    ).toEqual(
+      new Rule({
+        rule: {
+          case: "bots",
+          value: {
+            mode: Mode.DRY_RUN,
+            patterns: {
+              add: {},
+              remove: [],
+            },
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetRuleToProtocol(<ArcjetBotRule<{}>>{
+        type: "BOT",
+        mode: "DRY_RUN",
+        priority: 1,
+        block: ["AUTOMATED"],
+        add: [["chrome", "LIKELY_NOT_A_BOT"]],
+      }),
+    ).toEqual(
+      new Rule({
+        rule: {
+          case: "bots",
+          value: {
+            mode: Mode.DRY_RUN,
+            block: [BotType.AUTOMATED],
+            patterns: {
+              add: {
+                chrome: BotType.LIKELY_NOT_A_BOT,
+              },
+              remove: [],
+            },
+          },
+        },
+      }),
+    );
+  });
+});

--- a/protocol/tsconfig.json
+++ b/protocol/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "@arcjet/tsconfig/base",
-  "include": ["*.ts"]
+  "include": ["*.ts", "test/*.ts"]
 }


### PR DESCRIPTION
Closes #34

This adds tests in our protocol package for the `convert.ts` file, which converts between SDK types and protobuf types.

This file is now the only place where we had comments about exhaustiveness checking, so I added those. It seems that rollup strips the unused variable so we no longer have miscalculated coverage.

While writing the tests, I also found a bunch of edge cases that weren't handled in the implementation and this fixes everything I found with the tests.