### PR TITLE
chore: Remove npm engine version

### DIFF
--- a/analyze/package.json
+++ b/analyze/package.json
@@ -10,8 +10,7 @@
     "directory": "analyze"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/arcjet-next/package.json
+++ b/arcjet-next/package.json
@@ -10,8 +10,7 @@
     "directory": "arcjet-next"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -10,8 +10,7 @@
     "directory": "arcjet"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -10,8 +10,7 @@
     "directory": "eslint-config"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "commonjs",
   "main": "./index.js",

--- a/ip/package.json
+++ b/ip/package.json
@@ -10,8 +10,7 @@
     "directory": "ip"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/logger/package.json
+++ b/logger/package.json
@@ -10,8 +10,7 @@
     "directory": "logger"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
         "examples/*"
       ],
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "analyze": {
@@ -32,8 +31,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "arcjet": {
@@ -56,8 +54,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "arcjet-next": {
@@ -81,8 +78,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "eslint-config": {
@@ -100,8 +96,7 @@
         "eslint": "8.55.0"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^8"
@@ -372,8 +367,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "logger": {
@@ -391,8 +385,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -8163,8 +8156,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       }
     },
     "rollup-config": {
@@ -8185,8 +8177,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@rollup/wasm-node": "^4"
@@ -8198,8 +8189,7 @@
       "license": "Apache-2.0",
       "devDependencies": {},
       "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "arcjet-js",
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "workspaces": [
     "*",

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -10,8 +10,7 @@
     "directory": "protocol"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/rollup-config/package.json
+++ b/rollup-config/package.json
@@ -10,8 +10,7 @@
     "directory": "rollup-config"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "type": "module",
   "main": "./index.js",

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -10,8 +10,7 @@
     "directory": "tsconfig"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=10"
+    "node": ">=18"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
I added the npm engine to see if it would fix the optional dependency stuff with dependabot. It didn't change anything but it causes warnings in the logs for some users, so let's just remove it.