### PR TITLE
fix: Add ttl to some new code paths

### DIFF
--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -449,6 +449,7 @@ export function ArcjetDecisionFromProtocol(
     default:
       const _exhaustive: never = decision.conclusion;
       return new ArcjetErrorDecision({
+        ttl: 0,
         reason: new ArcjetErrorReason("Missing Conclusion"),
         results: [],
       });

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -477,6 +477,7 @@ describe("convert", () => {
     expect(
       ArcjetRuleResultToProtocol(
         new ArcjetRuleResult({
+          ttl: 0,
           state: "RUN",
           conclusion: "ALLOW",
           reason: new ArcjetReason(),
@@ -504,6 +505,7 @@ describe("convert", () => {
       ),
     ).toEqual(
       new ArcjetRuleResult({
+        ttl: 0,
         state: "RUN",
         conclusion: "ALLOW",
         reason: new ArcjetReason(),
@@ -516,6 +518,7 @@ describe("convert", () => {
       ArcjetDecisionToProtocol(
         new ArcjetAllowDecision({
           id: "abc123",
+          ttl: 0,
           results: [],
           reason: new ArcjetReason(),
         }),


### PR DESCRIPTION
This fixes an issue with TypeScript compilation. In #41, I added new code paths that didn't get the TTL property from #7 but we don't require the branch to be up-to-date so this got merged and then failed in CI on main.

We should look into merge queues or "require branch is up to date". I dislike the limitations/problems with both of them, but I want to catch issues like this. Perhaps we integrate Bors or something 🤔 