### PR TITLE
feat!: Pass ArcjetContext to rules

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1,4 +1,5 @@
 import {
+  ArcjetContext,
   ArcjetBotReason,
   ArcjetBotType,
   ArcjetEmailReason,
@@ -150,22 +151,16 @@ export type UnionToIntersection<Union> =
       Intersection & Union
     : never;
 
-export type RemoteClientContext = {
-  key: string;
-  fingerprint: string;
-  log: Logger;
-};
-
 export interface RemoteClient {
   decide(
-    context: RemoteClientContext,
+    context: ArcjetContext,
     details: Partial<ArcjetRequestDetails>,
     rules: ArcjetRule[],
   ): Promise<ArcjetDecision>;
   // Call the Arcjet Log Decision API with details of the request and decision
   // made so we can log it.
   report(
-    context: RemoteClientContext,
+    context: ArcjetContext,
     request: Partial<ArcjetRequestDetails>,
     decision: ArcjetDecision,
     rules: ArcjetRule[],
@@ -211,7 +206,7 @@ export function createRemoteClient(
 
   return Object.freeze({
     async decide(
-      context: RemoteClientContext,
+      context: ArcjetContext,
       details: ArcjetRequestDetails,
       rules: ArcjetRule[],
     ): Promise<ArcjetDecision> {
@@ -244,7 +239,7 @@ export function createRemoteClient(
     },
 
     report(
-      context: RemoteClientContext,
+      context: ArcjetContext,
       details: ArcjetRequestDetails,
       decision: ArcjetDecision,
       rules: ArcjetRule[],
@@ -539,7 +534,7 @@ export function validateEmail(
       allowDomainLiteral,
 
       validate(
-        fingerprint: string,
+        context: ArcjetContext,
         details: Partial<ArcjetRequestDetails & { email: string }>,
       ): asserts details is ArcjetRequestDetails & { email: string } {
         assert(
@@ -549,7 +544,7 @@ export function validateEmail(
       },
 
       async protect(
-        fingerprint: string,
+        context: ArcjetContext,
         { email }: ArcjetRequestDetails & { email: string },
       ): Promise<ArcjetRuleResult> {
         if (await analyze.isValidEmail(email, analyzeOpts)) {
@@ -607,7 +602,7 @@ export function detectBot(
       remove,
 
       validate(
-        fingerprint: string,
+        context: ArcjetContext,
         details: Partial<ArcjetRequestDetails>,
       ): asserts details is ArcjetRequestDetails {
         assert(
@@ -620,7 +615,7 @@ export function detectBot(
        * Attempts to call the bot detection on the headers.
        */
       async protect(
-        fingerprint: string,
+        context: ArcjetContext,
         { headers }: ArcjetRequestDetails,
       ): Promise<ArcjetRuleResult> {
         const headersKV: Record<string, string> = {};
@@ -805,6 +800,8 @@ export default function arcjet<
       log.debug("fingerprint (%s): %s", runtime(), fingerprint);
       log.timeEnd("fingerprint");
 
+      const context: ArcjetContext = { key, fingerprint, log };
+
       if (flatSortedRules.length > 10) {
         log.error("Failure running rules. Only 10 rules may be specified.");
 
@@ -817,7 +814,7 @@ export default function arcjet<
         });
 
         client.report(
-          { key, fingerprint, log },
+          context,
           details,
           decision,
           // No rules because we've determined they were too long and we don't
@@ -862,12 +859,7 @@ export default function arcjet<
           results,
         });
 
-        client.report(
-          { key, fingerprint, log },
-          details,
-          decision,
-          flatSortedRules,
-        );
+        client.report(context, details, decision, flatSortedRules);
 
         log.debug("decide: already blocked", {
           id: decision.id,
@@ -893,8 +885,8 @@ export default function arcjet<
         log.time(rule.type);
 
         try {
-          localRule.validate(fingerprint, details);
-          results[idx] = await localRule.protect(fingerprint, details);
+          localRule.validate(context, details);
+          results[idx] = await localRule.protect(context, details);
 
           log.debug("Local rule result:", {
             id: results[idx].ruleId,
@@ -934,12 +926,7 @@ export default function arcjet<
           // Only a DENY decision is reported to avoid creating 2 entries for a
           // request. Upon ALLOW, the `decide` call will create an entry for the
           // request.
-          client.report(
-            { key, fingerprint, log },
-            details,
-            decision,
-            flatSortedRules,
-          );
+          client.report(context, details, decision, flatSortedRules);
 
           // If we're not in DRY_RUN mode, we want to cache non-zero TTL results
           // and return this DENY decision.
@@ -951,11 +938,7 @@ export default function arcjet<
                 reason: decision.reason,
               });
 
-              blockCache.set(
-                fingerprint,
-                decision.reason,
-                decision.ttl,
-              );
+              blockCache.set(fingerprint, decision.reason, decision.ttl);
             }
 
             return decision;
@@ -976,11 +959,7 @@ export default function arcjet<
       // fail open.
       try {
         log.time("decideApi");
-        const decision = await client.decide(
-          { key, fingerprint, log },
-          details,
-          flatSortedRules,
-        );
+        const decision = await client.decide(context, details, flatSortedRules);
         log.timeEnd("decideApi");
 
         log.debug("remote rule result:", {
@@ -997,13 +976,12 @@ export default function arcjet<
         // If the decision is to block and we have a non-zero TTL, we cache the
         // block locally
         if (decision.isDenied() && decision.ttl > 0) {
-          log.debug("decide: Caching block locally for %d milliseconds", decision.ttl);
-
-          blockCache.set(
-            fingerprint,
-            decision.reason,
+          log.debug(
+            "decide: Caching block locally for %d milliseconds",
             decision.ttl,
           );
+
+          blockCache.set(fingerprint, decision.reason, decision.ttl);
         }
 
         return decision;

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -1459,6 +1459,11 @@ describe("Primitives > detectBot", () => {
   });
 
   test("validates that headers is defined", () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       headers: new Headers(),
     };
@@ -1467,11 +1472,16 @@ describe("Primitives > detectBot", () => {
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
     expect(() => {
-      const _ = rule.validate("test-fingerprint", details);
+      const _ = rule.validate(context, details);
     }).not.toThrow();
   });
 
   test("throws via `validate()` if headers is undefined", () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       headers: undefined,
     };
@@ -1480,11 +1490,16 @@ describe("Primitives > detectBot", () => {
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
     expect(() => {
-      const _ = rule.validate("test-fingerprint", details);
+      const _ = rule.validate(context, details);
     }).toThrow();
   });
 
   test("does not analyze if no headers are specified", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1498,7 +1513,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot();
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "ALLOW",
@@ -1522,7 +1537,11 @@ describe("Primitives > detectBot", () => {
         },
       },
     };
-
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1543,7 +1562,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot(options);
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -1570,7 +1589,11 @@ describe("Primitives > detectBot", () => {
         },
       },
     };
-
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1591,7 +1614,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot(options);
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -1618,7 +1641,11 @@ describe("Primitives > detectBot", () => {
         },
       },
     };
-
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1639,7 +1666,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot(options);
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -1653,6 +1680,11 @@ describe("Primitives > detectBot", () => {
   });
 
   test("can be configured for invalid bots", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1687,7 +1719,7 @@ describe("Primitives > detectBot", () => {
     });
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -1709,7 +1741,11 @@ describe("Primitives > detectBot", () => {
         ArcjetBotType.LIKELY_NOT_A_BOT,
       ],
     };
-
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1725,7 +1761,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot(options);
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -1751,7 +1787,11 @@ describe("Primitives > detectBot", () => {
         },
       },
     };
-
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1772,7 +1812,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot(options);
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -1792,7 +1832,11 @@ describe("Primitives > detectBot", () => {
         remove: ["^curl"],
       },
     };
-
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1808,7 +1852,7 @@ describe("Primitives > detectBot", () => {
     const [rule] = detectBot(options);
     expect(rule.type).toEqual("BOT");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "ALLOW",
@@ -1996,6 +2040,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("validates that email is defined", () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       email: "abc@example.com",
     };
@@ -2004,11 +2053,16 @@ describe("Primitives > validateEmail", () => {
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
     expect(() => {
-      const _ = rule.validate("test-fingerprint", details);
+      const _ = rule.validate(context, details);
     }).not.toThrow();
   });
 
   test("throws via `validate()` if email is undefined", () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       email: undefined,
     };
@@ -2017,11 +2071,16 @@ describe("Primitives > validateEmail", () => {
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
     expect(() => {
-      const _ = rule.validate("test-fingerprint", details);
+      const _ = rule.validate(context, details);
     }).toThrow();
   });
 
   test("allows a valid email", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2036,7 +2095,7 @@ describe("Primitives > validateEmail", () => {
     const [rule] = validateEmail();
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "ALLOW",
@@ -2047,6 +2106,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("denies email with no domain segment", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2061,7 +2125,7 @@ describe("Primitives > validateEmail", () => {
     const [rule] = validateEmail();
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -2072,6 +2136,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("denies email with no TLD", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2086,7 +2155,7 @@ describe("Primitives > validateEmail", () => {
     const [rule] = validateEmail();
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -2097,6 +2166,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("denies email with no TLD even if some options are specified", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2113,7 +2187,7 @@ describe("Primitives > validateEmail", () => {
     });
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -2124,6 +2198,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("denies email with empty name segment", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2138,7 +2217,7 @@ describe("Primitives > validateEmail", () => {
     const [rule] = validateEmail();
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -2149,6 +2228,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("denies email with domain literal", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2163,7 +2247,7 @@ describe("Primitives > validateEmail", () => {
     const [rule] = validateEmail();
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "DENY",
@@ -2174,6 +2258,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("can be configured to allow no TLD", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2190,7 +2279,7 @@ describe("Primitives > validateEmail", () => {
     });
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "ALLOW",
@@ -2201,6 +2290,11 @@ describe("Primitives > validateEmail", () => {
   });
 
   test("can be configured to allow domain literals", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      log: new Logger(),
+    };
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -2217,7 +2311,7 @@ describe("Primitives > validateEmail", () => {
     });
     expect(rule.type).toEqual("EMAIL");
     assertIsLocalRule(rule);
-    const result = await rule.protect("test-fingerprint", details);
+    const result = await rule.protect(context, details);
     expect(result).toMatchObject({
       state: "RUN",
       conclusion: "ALLOW",
@@ -3039,15 +3133,18 @@ describe("SDK", () => {
       },
     };
 
+    let errorLogSpy;
+
     function testRuleLocalThrowString(): ArcjetLocalRule {
       return {
         mode: ArcjetMode.LIVE,
         type: "TEST_RULE_LOCAL_THROW_STRING",
         priority: 1,
         validate: jest.fn(),
-        protect: jest.fn(async () => {
+        async protect(context, req) {
+          errorLogSpy = jest.spyOn(context.log, "error");
           throw "Local rule protect failed";
-        }),
+        },
       };
     }
 
@@ -3057,13 +3154,14 @@ describe("SDK", () => {
       client,
     });
 
-    // TODO: Assert on the error log arguments when we can access the logger in a rule
-    // const errorLogSpy = jest.spyOn(logger, "error");
-
     const _ = await aj.protect(details);
 
-    // expect(errorLogSpy).toHaveBeenCalledTimes(1);
-    // expect(errorLogSpy).toHaveBeenCalledWith("");
+    expect(errorLogSpy).toHaveBeenCalledTimes(1);
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      "Failure running rule: %s due to %s",
+      "TEST_RULE_LOCAL_THROW_STRING",
+      "Local rule protect failed",
+    );
   });
 
   test("correctly logs an error message if a local rule throws a non-error", async () => {
@@ -3091,15 +3189,18 @@ describe("SDK", () => {
       },
     };
 
+    let errorLogSpy;
+
     function testRuleLocalThrowNull(): ArcjetLocalRule {
       return {
         mode: ArcjetMode.LIVE,
         type: "TEST_RULE_LOCAL_THROW_NULL",
         priority: 1,
         validate: jest.fn(),
-        protect: jest.fn(async () => {
+        async protect(context, req) {
+          errorLogSpy = jest.spyOn(context.log, "error");
           throw null;
-        }),
+        },
       };
     }
 
@@ -3109,13 +3210,14 @@ describe("SDK", () => {
       client,
     });
 
-    // TODO: Assert on the error log arguments when we can access the logger in a rule
-    // const errorLogSpy = jest.spyOn(logger, "error");
-
     const _ = await aj.protect(details);
 
-    // expect(errorLogSpy).toHaveBeenCalledTimes(1);
-    // expect(errorLogSpy).toHaveBeenCalledWith("");
+    expect(errorLogSpy).toHaveBeenCalledTimes(1);
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      "Failure running rule: %s due to %s",
+      "TEST_RULE_LOCAL_THROW_NULL",
+      "Unknown problem",
+    );
   });
 
   test("does not return nor cache a deny decision if DENY decision in a dry run local rule", async () => {

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -1,5 +1,6 @@
 import { typeid } from "typeid-js";
 import { Reason } from "./gen/es/decide/v1alpha1/decide_pb.js";
+import type { Logger } from "@arcjet/logger";
 
 type ArcjetEnum<T extends string> = { readonly [Key in T]: T };
 
@@ -227,7 +228,7 @@ export class ArcjetRuleResult {
   reason: ArcjetReason;
 
   constructor(init: {
-    ttl: number,
+    ttl: number;
     state: ArcjetRuleState;
     conclusion: ArcjetConclusion;
     reason: ArcjetReason;
@@ -356,7 +357,7 @@ export class ArcjetErrorDecision extends ArcjetDecision {
   constructor(init: {
     id?: string;
     results: ArcjetRuleResult[];
-    ttl: number,
+    ttl: number;
     reason: ArcjetErrorReason;
   }) {
     super(init);
@@ -386,11 +387,11 @@ export type ArcjetRule<Props extends {} = {}> = {
 export interface ArcjetLocalRule<Props extends { [key: string]: unknown } = {}>
   extends ArcjetRule<Props> {
   validate(
-    fingerprint: string,
+    context: ArcjetContext,
     details: Partial<ArcjetRequestDetails & Props>,
   ): asserts details is ArcjetRequestDetails & Props;
   protect(
-    fingerprint: string,
+    context: ArcjetContext,
     details: ArcjetRequestDetails & Props,
   ): Promise<ArcjetRuleResult>;
 }
@@ -423,3 +424,9 @@ export interface ArcjetBotRule<Props extends {}>
   add: [string, ArcjetBotType][];
   remove: string[];
 }
+
+export type ArcjetContext = {
+  key: string;
+  fingerprint: string;
+  log: Logger;
+};

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -32,6 +32,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
+    "@arcjet/logger": "1.0.0-alpha.5",
     "@bufbuild/protobuf": "1.6.0",
     "@connectrpc/connect": "1.1.4",
     "typeid-js": "0.3.0"


### PR DESCRIPTION
Closes #64 

Even though we don't currently use the key, fingerprint, or logger in the local rules, we should still have access to the context. This also allows me to spy on the logger and assert the messages are correct in tests.

Technically breaking since I renamed the exported `RemoteClientContext` to `ArcjetContext`.