### PR TITLE
chore: Disallow configuring timeout for report

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -277,7 +277,7 @@ export function createRemoteClient(
       client
         .report(reportRequest, {
           headers: { Authorization: `Bearer ${context.key}` },
-          timeoutMs: 60_000, // 60 seconds
+          timeoutMs: 2_000, // 2 seconds
         })
         .catch((err: unknown) => {
           context.log.log(


### PR DESCRIPTION
Closes #63 

This stops using the `decide` timeout for `report`. Since we don't block on report, we just set it to timeout in 1 minute and no longer allow it to be configured.