### PR TITLE
chore(rollup): Fail compilation on type check failure

### DIFF
--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -87,12 +87,14 @@ export function createConfig(root, { plugins = [] } = {}) {
         exclude: ["node_modules", "test/*.ts"],
         declaration: true,
         declarationDir: ".",
+        noEmitOnError: true,
       }),
       typescript({
         tsconfig: "./tsconfig.json",
         // Override the `includes` specified in the tsconfig so we don't
         // generate definition files for our tests
         include: "test/*.ts",
+        noEmitOnError: true,
       }),
       ...plugins,
     ],


### PR DESCRIPTION
It seems that, by default, rollup does not exit with an error if the TypeScript code fails to type check. Setting the `noEmitOnError` option to `true` will cause it to exit if the TS fails to build.