### PR TITLE
ci: Remove dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,6 @@ updates:
     commit-message:
       prefix: "deps"
       prefix-development: "deps(dev)"
-    groups:
-      dependencies:
-        dependency-type: "production"
-      dev-dependencies:
-        dependency-type: "development"
     ignore:
       # Ignore updates to the @types/node package due to conflict between
       # Headers in DOM.


### PR DESCRIPTION
This removes the dependabot groups.

I am finding it annoying to group dependency updates together because we run Socket on the PRs and sometimes I want to merge one dependency update but another requires research/investigation due to changes.