### PR TITLE
chore: Add codeowners to project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @arcjet/js-sdk-team will be required to approve
+# a pull request before it can be merged.
+*   @arcjet/js-sdk-team


### PR DESCRIPTION
This adds the @arcjet/js-sdk-team as the codeowner on all files in this repository. Once merged, we'll enable protections as outlined in the file comment.

This will also auto-request the team on every PR submitted 🎉 