### PR TITLE
ci: Add dependabot groups for our example apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,8 @@ updates:
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: "deps(example)"
+      prefix-development: "deps(example)"
     groups:
       dependencies:
         patterns:
@@ -54,8 +54,8 @@ updates:
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: "deps(example)"
+      prefix-development: "deps(example)"
     groups:
       dependencies:
         patterns:
@@ -76,8 +76,8 @@ updates:
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: "deps(example)"
+      prefix-development: "deps(example)"
     groups:
       dependencies:
         patterns:
@@ -98,8 +98,8 @@ updates:
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: "deps(example)"
+      prefix-development: "deps(example)"
     groups:
       dependencies:
         patterns:
@@ -120,8 +120,8 @@ updates:
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: "deps(example)"
+      prefix-development: "deps(example)"
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
As mentioned on the team call, I want to group all dependency updates within our example apps to make the updates easier.

We'll continue to have the SDK dependencies submitted one-by-one so they can be reviewed individually.