### PR TITLE
ci: Add merge queue workflow

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,18 @@
+name: Merge Queue
+
+on:
+  # We use Trunk Merge Queues so we use this `push` event instead of the
+  # `merge_queue` event, as per
+  # https://docs.trunk.io/merge/set-up-trunk-merge#configure-merge-requirements
+  push:
+    branches:
+      - trunk-merge/**
+
+jobs:
+  test:
+    name: Run tests
+    uses: ./.github/workflows/reusable-test.yml
+
+  examples:
+    name: Build examples
+    uses: ./.github/workflows/reusable-examples.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,19 @@
+name: Pull Request
+
+on:
+  pull_request:
+    # Recommended by Graphite: https://graphite.dev/docs/github-configuration-guidelines#github-actions
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run tests
+    uses: ./.github/workflows/reusable-test.yml
+
+  examples:
+    name: Build examples
+    uses: ./.github/workflows/reusable-examples.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,20 +1,32 @@
-name: "Create release"
+name: Push
 
 on:
   push:
+    # Only ever run `push` events against protected branches, likely just `main`
     branches:
       - main
 
-# Release Please creates a Pull Request with changes to files
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  test:
+    name: Run tests
+    uses: ./.github/workflows/reusable-test.yml
+
+  examples:
+    name: Build examples
+    uses: ./.github/workflows/reusable-examples.yml
+
   release:
     runs-on: ubuntu-latest
     # Release Please is very fast, so we set a tiny timeout
     timeout-minutes: 1
+    # Release Please creates a Pull Request with changes to files
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Release Please
         uses: google-github-actions/release-please-action@a2d8d683f209466ee8c695cd994ae2cf08b1642d

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -1,14 +1,12 @@
-name: "Build examples"
+# Our reusable workflow files only use the `workflow_call` event and don't
+# specify a `concurrency` limit so those things can be managed by the caller.
+name: Reusable examples workflow
 
-on: [push, pull_request]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [workflow_call]
 
 jobs:
   nextjs-13-pages-wrap:
-    name: "Next.js 13 + Page Router + withArcjet"
+    name: Next.js 13 + Page Router + withArcjet
     runs-on: ubuntu-latest
     steps:
       # Environment security
@@ -42,7 +40,7 @@ jobs:
         run: npm run build
 
   nextjs-14-app-dir-rl:
-    name: "Next.js 14 + App Router + Rate Limit"
+    name: Next.js 14 + App Router + Rate Limit
     runs-on: ubuntu-latest
     steps:
       # Environment security
@@ -76,7 +74,7 @@ jobs:
         run: npm run build
 
   nextjs-14-app-dir-validate-email:
-    name: "Next.js 14 + App Router + Validate Email"
+    name: Next.js 14 + App Router + Validate Email
     runs-on: ubuntu-latest
     steps:
       # Environment security
@@ -110,7 +108,7 @@ jobs:
         run: npm run build
 
   nextjs-14-openai:
-    name: "Next.js 14 + OpenAI"
+    name: Next.js 14 + OpenAI
     runs-on: ubuntu-latest
     steps:
       # Environment security
@@ -144,7 +142,7 @@ jobs:
         run: npm run build
 
   nextjs-14-pages-wrap:
-    name: "Next.js 14 + Page Router + withArcjet"
+    name: Next.js 14 + Page Router + withArcjet
     runs-on: ubuntu-latest
     steps:
       # Environment security

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,10 +1,8 @@
-name: "Run tests"
+# Our reusable workflow files only use the `workflow_call` event and don't
+# specify a `concurrency` limit so those things can be managed by the caller.
+name: Reusable test workflow
 
-on: [push, pull_request]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: [workflow_call]
 
 jobs:
   test:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -53,3 +53,13 @@ actions:
     - trunk-check-pre-push
     - trunk-announce
     - trunk-upgrade-available
+merge:
+  required_statuses:
+    - Trunk Check
+    - "Run tests / Run tests (OS: ubuntu-latest, Node: 18)"
+    - "Run tests / Run tests (OS: ubuntu-latest, Node: 20)"
+    - Build examples / Next.js 13 + Page Router + withArcjet
+    - Build examples / Next.js 14 + App Router + Rate Limit
+    - Build examples / Next.js 14 + App Router + Validate Email
+    - Build examples / Next.js 14 + OpenAI
+    - Build examples / Next.js 14 + Page Router + withArcjet


### PR DESCRIPTION
This attempts to configure the [Trunk Merge Queue](https://docs.trunk.io/merge/set-up-trunk-merge) in a way that would allow us to have separate required checks for Pull Requests and the Merge Queue. I've refactored the jobs into `reusable-test.yml` and `reusable-examples.yml` workflows and then consume them via `push.yml`, `pull-request.yml` and `merge-queue.yml`.

I'm experimenting with this separation because it seems easier to manage the context per event instead of "per task".