### PR TITLE
chore(trunk): Avoid linting the release-please-manifest

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -43,6 +43,7 @@ lint:
         - "**/LICENSE"
         - "**/CHANGELOG.md"
         - .github/CODEOWNERS
+        - .github/.release-please-manifest.json
         - examples/**
   threshold:
     - linters: [markdownlint]


### PR DESCRIPTION
I believe this is the last failing thing for `trunk check` on the release PR.