### PR TITLE
fix!: Required of props should always be required

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -496,7 +496,7 @@ export type ExtraProps<Rules> = Rules extends []
       : never;
 
 export type ArcjetRequest<Props extends PlainObject> = Simplify<
-  Partial<ArcjetRequestDetails & Props>
+  Partial<ArcjetRequestDetails> & Props
 >;
 
 // Primitives and Products are the external names for Rules even though they are defined the same


### PR DESCRIPTION
I previously over-applied the `Partial` in that extra props required by rules would be made optional at the `protect()` function. This changes makes it so the requiredness of props aren't changed.