### PR TITLE
chore!: Remove count property on ArcjetRateLimitReason

### DIFF
--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -1398,7 +1398,6 @@ describe("ArcjetDecision", () => {
   test("`isRateLimit()` returns true when reason is RATE_LIMIT", () => {
     const reason = new ArcjetRateLimitReason({
       max: 0,
-      count: 0,
       remaining: 0,
     });
     expect(reason.isRateLimit()).toEqual(true);

--- a/examples/nextjs-14-openai/app/api/chat/route.ts
+++ b/examples/nextjs-14-openai/app/api/chat/route.ts
@@ -34,7 +34,6 @@ export async function POST(req: Request) {
   console.log("Arcjet decision", decision.conclusion);
 
   if (decision.reason.isRateLimit()) {
-    console.log("Request count", decision.reason.count);
     console.log("Requests remaining", decision.reason.remaining);
   }
 

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -235,7 +235,6 @@ export function ArcjetReasonFromProtocol(proto?: Reason) {
       const reason = proto.reason.value;
       return new ArcjetRateLimitReason({
         max: reason.max,
-        count: reason.count,
         remaining: reason.remaining,
         resetTime: reason.resetTime?.toDate(),
       });
@@ -289,7 +288,6 @@ export function ArcjetReasonToProtocol(reason: ArcjetReason): Reason {
         case: "rateLimit",
         value: new RateLimitReason({
           max: reason.max,
-          count: reason.count,
           remaining: reason.remaining,
           resetTime: reason.resetTime
             ? Timestamp.fromDate(reason.resetTime)

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -98,20 +98,13 @@ export class ArcjetRateLimitReason extends ArcjetReason {
   type: "RATE_LIMIT" = "RATE_LIMIT";
 
   max: number;
-  count: number;
   remaining: number;
   resetTime?: Date;
 
-  constructor(init: {
-    max: number;
-    count: number;
-    remaining: number;
-    resetTime?: Date;
-  }) {
+  constructor(init: { max: number; remaining: number; resetTime?: Date }) {
     super();
 
     this.max = init.max;
-    this.count = init.count;
     this.remaining = init.remaining;
     this.resetTime = init.resetTime;
   }

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -354,7 +354,6 @@ describe("convert", () => {
       ArcjetReasonToProtocol(
         new ArcjetRateLimitReason({
           max: 1,
-          count: 2,
           remaining: -1,
         }),
       ),
@@ -364,7 +363,6 @@ describe("convert", () => {
           case: "rateLimit",
           value: {
             max: 1,
-            count: 2,
             remaining: -1,
           },
         },
@@ -375,7 +373,6 @@ describe("convert", () => {
       ArcjetReasonToProtocol(
         new ArcjetRateLimitReason({
           max: 1,
-          count: 2,
           remaining: -1,
           resetTime,
         }),
@@ -386,7 +383,6 @@ describe("convert", () => {
           case: "rateLimit",
           value: {
             max: 1,
-            count: 2,
             remaining: -1,
             resetTime: Timestamp.fromDate(resetTime),
           },


### PR DESCRIPTION
This removes the `count` field on `ArcjetRateLimitReason`. This field doesn't make sense for Token Bucket or Sliding Window algorithms since they are based on dynamic calculations. Instead, `remaining` should be the source of truth and a user could do `max - remaining` for a *very rough* count.