### PR TITLE
chore!: Remove timeout property on ArcjetRateLimitRule

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -377,7 +377,6 @@ export type RateLimitOptions = {
   characteristics?: string[];
   window: string;
   max: number;
-  timeout: string;
 };
 
 /**
@@ -539,7 +538,6 @@ export function rateLimit(
       characteristics: opt.characteristics,
       window: opt.window,
       max: opt.max,
-      timeout: opt.timeout,
     });
   }
 

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -1907,7 +1907,6 @@ describe("Primitive > rateLimit", () => {
       characteristics: ["ip.src"],
       window: "1h",
       max: 1,
-      timeout: "10m",
     });
     expect(rule.type).toEqual("RATE_LIMIT");
     expect(rule).toHaveProperty("mode", "DRY_RUN");
@@ -1919,7 +1918,6 @@ describe("Primitive > rateLimit", () => {
       characteristics: ["ip.src"],
       window: "1h",
       max: 1,
-      timeout: "10m",
     };
 
     const rules = rateLimit(options);
@@ -1930,7 +1928,6 @@ describe("Primitive > rateLimit", () => {
     expect(rules[0]).toHaveProperty("characteristics", ["ip.src"]);
     expect(rules[0]).toHaveProperty("window", "1h");
     expect(rules[0]).toHaveProperty("max", 1);
-    expect(rules[0]).toHaveProperty("timeout", "10m");
   });
 
   test("produces a multiple rules based on multiple `limit` specified", async () => {
@@ -1940,14 +1937,12 @@ describe("Primitive > rateLimit", () => {
         characteristics: ["ip.src"],
         window: "1h",
         max: 1,
-        timeout: "10m",
       },
       {
         match: "/test-double",
         characteristics: ["ip.src"],
         window: "2h",
         max: 2,
-        timeout: "20m",
       },
     ];
 
@@ -1961,7 +1956,6 @@ describe("Primitive > rateLimit", () => {
         characteristics: ["ip.src"],
         window: "1h",
         max: 1,
-        timeout: "10m",
       }),
       expect.objectContaining({
         type: "RATE_LIMIT",
@@ -1970,7 +1964,6 @@ describe("Primitive > rateLimit", () => {
         characteristics: ["ip.src"],
         window: "2h",
         max: 2,
-        timeout: "20m",
       }),
     ]);
   });
@@ -1979,7 +1972,6 @@ describe("Primitive > rateLimit", () => {
     const options = {
       window: "1h",
       max: 1,
-      timeout: "10m",
     };
 
     const [rule] = rateLimit(options);
@@ -1993,12 +1985,10 @@ describe("Primitive > rateLimit", () => {
       {
         window: "1h",
         max: 1,
-        timeout: "10m",
       },
       {
         window: "2h",
         max: 2,
-        timeout: "20m",
       },
     ];
 
@@ -2011,7 +2001,6 @@ describe("Primitive > rateLimit", () => {
         characteristics: undefined,
         window: "1h",
         max: 1,
-        timeout: "10m",
       }),
       expect.objectContaining({
         type: "RATE_LIMIT",
@@ -2020,7 +2009,6 @@ describe("Primitive > rateLimit", () => {
         characteristics: undefined,
         window: "2h",
         max: 2,
-        timeout: "20m",
       }),
     ]);
   });
@@ -2360,7 +2348,6 @@ describe("Products > protectSignup", () => {
         characteristics: ["ip.src"],
         window: "1h",
         max: 1,
-        timeout: "10m",
       },
       bots: {
         mode: ArcjetMode.DRY_RUN,
@@ -2381,14 +2368,12 @@ describe("Products > protectSignup", () => {
           characteristics: ["ip.src"],
           window: "1h",
           max: 1,
-          timeout: "10m",
         },
         {
           match: "/test",
           characteristics: ["ip.src"],
           window: "2h",
           max: 2,
-          timeout: "20m",
         },
       ],
     });
@@ -3440,7 +3425,6 @@ describe("Arcjet: Env = Serverless Node runtime on Vercel", () => {
       characteristics: ["ip.src"],
       window: "1h",
       max: 1,
-      timeout: "10m",
     };
     const fingerprint =
       "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";

--- a/examples/nextjs-13-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-13-pages-wrap/pages/api/arcjet-edge.ts
@@ -18,7 +18,6 @@ const aj = arcjet({
       //characteristics: ["ip.src"],
       window: "1m",
       max: 1,
-      timeout: "10m",
     }),
   ],
 });

--- a/examples/nextjs-13-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-13-pages-wrap/pages/api/arcjet.ts
@@ -14,7 +14,6 @@ const aj = arcjet({
       //characteristics: ["ip.src"],
       window: "1m",
       max: 1,
-      timeout: "10m",
     }),
   ],
 });

--- a/examples/nextjs-14-app-dir-rl/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-app-dir-rl/app/api/arcjet/route.ts
@@ -12,7 +12,6 @@ const aj = arcjet({
       characteristics: ["ip.src"],
       window: "1h",
       max: 1,
-      timeout: "10m",
     }),
   ],
 });

--- a/examples/nextjs-14-openai/app/api/chat/route.ts
+++ b/examples/nextjs-14-openai/app/api/chat/route.ts
@@ -16,7 +16,6 @@ const aj = arcjet({
       characteristics: ["ip.src"],
       window: "1m",
       max: 60,
-      timeout: "10m",
     }),
   ],
 });

--- a/examples/nextjs-14-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-14-pages-wrap/pages/api/arcjet-edge.ts
@@ -18,7 +18,6 @@ const aj = arcjet({
       //characteristics: ["ip.src"],
       window: "1m",
       max: 1,
-      timeout: "10m",
     }),
   ],
 });

--- a/examples/nextjs-14-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-14-pages-wrap/pages/api/arcjet.ts
@@ -14,7 +14,6 @@ const aj = arcjet({
       //characteristics: ["ip.src"],
       window: "1m",
       max: 1,
-      timeout: "10m",
     }),
   ],
 });

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -487,7 +487,6 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
           characteristics: rule.characteristics,
           window: rule.window,
           max: rule.max,
-          timeout: rule.timeout,
         },
       },
     });

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -404,7 +404,6 @@ export interface ArcjetRateLimitRule<Props extends {}>
   characteristics?: string[];
   window: string;
   max: number;
-  timeout: string;
 }
 
 export interface ArcjetEmailRule<Props extends { email: string }>


### PR DESCRIPTION
This removes the `timeout` property on `ArcjetRateLimitRule`. Having timeout on rate limits is confusing because each rate limit has a reset time based on the configuration. If we kept timeout ("block duration") around, it would be very confusing to determine when a user will be able to access the resource again.

We're tracking the concept of timeout ("block duration") in https://github.com/arcjet/arcjet/issues/567.