### PR TITLE
chore: Regenerate the protobuf bindings

### DIFF
--- a/protocol/gen/es/decide/v1alpha1/decide_pb.d.ts
+++ b/protocol/gen/es/decide/v1alpha1/decide_pb.d.ts
@@ -287,6 +287,31 @@ export declare enum SDKStack {
 }
 
 /**
+ * @generated from enum proto.decide.v1alpha1.RateLimitAlgorithm
+ */
+export declare enum RateLimitAlgorithm {
+  /**
+   * @generated from enum value: RATE_LIMIT_ALGORITHM_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * @generated from enum value: RATE_LIMIT_ALGORITHM_TOKEN_BUCKET = 1;
+   */
+  TOKEN_BUCKET = 1,
+
+  /**
+   * @generated from enum value: RATE_LIMIT_ALGORITHM_FIXED_WINDOW = 2;
+   */
+  FIXED_WINDOW = 2,
+
+  /**
+   * @generated from enum value: RATE_LIMIT_ALGORITHM_SLIDING_WINDOW = 3;
+   */
+  SLIDING_WINDOW = 3,
+}
+
+/**
  * The reason for the decision. This is populated based on the selected rules
  * for deny or challenge responses. Additional details can be found in the
  * field and by logging into the Arcjet dashboard and searching for the
@@ -376,21 +401,23 @@ export declare class RateLimitReason extends Message<RateLimitReason> {
   /**
    * The configured maximum number of requests allowed in the current window.
    *
-   * @generated from field: int32 max = 1;
+   * @generated from field: uint32 max = 1;
    */
   max: number;
 
   /**
-   * The number of requests which have been made in the current window.
+   * Deprecated: Always empty. Previously, the number of requests which have
+   * been made in the current window.
    *
-   * @generated from field: int32 count = 2;
+   * @generated from field: int32 count = 2 [deprecated = true];
+   * @deprecated
    */
   count: number;
 
   /**
    * The number of requests remaining in the current window.
    *
-   * @generated from field: int32 remaining = 3;
+   * @generated from field: uint32 remaining = 3;
    */
   remaining: number;
 
@@ -653,10 +680,12 @@ export declare class RateLimitRule extends Message<RateLimitRule> {
   window: string;
 
   /**
-   * The maximum number of requests allowed in the time period. This is an
-   * integer value e.g. 100.
+   * The maximum number of requests allowed in the time period. This is a
+   * positive integer value e.g. 100.
    *
-   * @generated from field: int32 max = 5;
+   * Required by "fixed window", "sliding window", and unspecified algorithms.
+   *
+   * @generated from field: uint32 max = 5;
    */
   max: number;
 
@@ -672,6 +701,42 @@ export declare class RateLimitRule extends Message<RateLimitRule> {
    * @generated from field: string timeout = 6;
    */
   timeout: string;
+
+  /**
+   * The algorithm to use for rate limiting a request. If unspecified, we will
+   * fallback to the "fixed window" algorithm. The chosen algorithm will
+   * affect which other fields must be specified to be a valid configuration.
+   *
+   * @generated from field: proto.decide.v1alpha1.RateLimitAlgorithm algorithm = 7;
+   */
+  algorithm: RateLimitAlgorithm;
+
+  /**
+   * The amount of tokens that are refilled at the provided interval.
+   *
+   * Required by "token bucket" algorithm.
+   *
+   * @generated from field: uint32 refill_rate = 8;
+   */
+  refillRate: number;
+
+  /**
+   * The interval in which a rate limit is applied or tokens refilled.
+   *
+   * Required by "token bucket" and "sliding window" algorithms.
+   *
+   * @generated from field: uint32 interval = 9;
+   */
+  interval: number;
+
+  /**
+   * The maximum number of tokens that can exist in a token bucket.
+   *
+   * Required by "token bucket" algorithm.
+   *
+   * @generated from field: uint32 capacity = 10;
+   */
+  capacity: number;
 
   constructor(data?: PartialMessage<RateLimitRule>);
 
@@ -953,6 +1018,21 @@ export declare class RequestDetails extends Message<RequestDetails> {
    * @generated from field: string email = 9;
    */
   email: string;
+
+  /**
+   * The string representing semicolon-separated Cookies for a request.
+   *
+   * @generated from field: string cookies = 10;
+   */
+  cookies: string;
+
+  /**
+   * The `?`-prefixed string representing the Query for a request. Commonly
+   * referred to as a "querystring".
+   *
+   * @generated from field: string query = 11;
+   */
+  query: string;
 
   constructor(data?: PartialMessage<RequestDetails>);
 

--- a/protocol/gen/es/decide/v1alpha1/decide_pb.js
+++ b/protocol/gen/es/decide/v1alpha1/decide_pb.js
@@ -106,6 +106,19 @@ export const SDKStack = proto3.makeEnum(
 );
 
 /**
+ * @generated from enum proto.decide.v1alpha1.RateLimitAlgorithm
+ */
+export const RateLimitAlgorithm = proto3.makeEnum(
+  "proto.decide.v1alpha1.RateLimitAlgorithm",
+  [
+    {no: 0, name: "RATE_LIMIT_ALGORITHM_UNSPECIFIED", localName: "UNSPECIFIED"},
+    {no: 1, name: "RATE_LIMIT_ALGORITHM_TOKEN_BUCKET", localName: "TOKEN_BUCKET"},
+    {no: 2, name: "RATE_LIMIT_ALGORITHM_FIXED_WINDOW", localName: "FIXED_WINDOW"},
+    {no: 3, name: "RATE_LIMIT_ALGORITHM_SLIDING_WINDOW", localName: "SLIDING_WINDOW"},
+  ],
+);
+
+/**
  * The reason for the decision. This is populated based on the selected rules
  * for deny or challenge responses. Additional details can be found in the
  * field and by logging into the Arcjet dashboard and searching for the
@@ -133,9 +146,9 @@ export const Reason = proto3.makeMessageType(
 export const RateLimitReason = proto3.makeMessageType(
   "proto.decide.v1alpha1.RateLimitReason",
   () => [
-    { no: 1, name: "max", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 1, name: "max", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
     { no: 2, name: "count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 3, name: "remaining", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 3, name: "remaining", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
     { no: 4, name: "reset_time", kind: "message", T: Timestamp },
   ],
 );
@@ -218,8 +231,12 @@ export const RateLimitRule = proto3.makeMessageType(
     { no: 2, name: "match", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "characteristics", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 4, name: "window", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 5, name: "max", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 5, name: "max", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
     { no: 6, name: "timeout", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "algorithm", kind: "enum", T: proto3.getEnumType(RateLimitAlgorithm) },
+    { no: 8, name: "refill_rate", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
+    { no: 9, name: "interval", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
+    { no: 10, name: "capacity", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
   ],
 );
 
@@ -309,6 +326,8 @@ export const RequestDetails = proto3.makeMessageType(
     { no: 7, name: "body", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
     { no: 8, name: "extra", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
     { no: 9, name: "email", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 10, name: "cookies", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 11, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ],
 );
 


### PR DESCRIPTION
This regenerates the protobuf bindings.

Depends upon #181 and #182 which remove the uses of the deprecated fields.