### PR TITLE
docs: Rename AJ_KEY to ARCJET_KEY & switch to next.js app dir example

### DIFF
--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -35,29 +35,27 @@ npm install -S @arcjet/next
 
 ```ts
 import arcjet from "@arcjet/next";
-import { NextApiRequest, NextApiResponse } from "next";
+import { NextResponse } from "next/server";
 
 const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY,
+  key: process.env.ARCJET_KEY,
   rules: [],
 });
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
+export async function GET(req: Request) {
   const decision = await aj.protect(req);
 
   if (decision.isDenied()) {
-    return res
-      .status(403)
-      .json({ error: "Forbidden", reason: decision.reason });
+    return NextResponse.json(
+      { error: "Too Many Requests", reason: decision.reason },
+      { status: 429 },
+    );
   }
 
-  res.status(200).json({ name: "Hello world" });
+  return NextResponse.json({ message: "Hello world" });
 }
 ```
 

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -46,7 +46,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://www.npmjs.com/package/dotenv
-  key: process.env.AJ_KEY,
+  key: process.env.ARCJET_KEY,
   rules: [],
   client: createRemoteClient({
     transport: createConnectTransport({

--- a/examples/nextjs-13-pages-wrap/README.md
+++ b/examples/nextjs-13-pages-wrap/README.md
@@ -28,7 +28,7 @@ Route](https://nextjs.org/docs/pages/building-your-application/routing/api-route
 3. Add your Arcjet key to `.env.local`
 
    ```env
-   AJ_KEY=
+   ARCJET_KEY=
    ```
 
 4. Start the dev server.

--- a/examples/nextjs-13-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-13-pages-wrap/pages/api/arcjet-edge.ts
@@ -10,7 +10,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     fixedWindow({
       mode: "LIVE",

--- a/examples/nextjs-13-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-13-pages-wrap/pages/api/arcjet.ts
@@ -6,7 +6,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     fixedWindow({
       mode: "LIVE",

--- a/examples/nextjs-14-app-dir-rl/README.md
+++ b/examples/nextjs-14-app-dir-rl/README.md
@@ -28,7 +28,7 @@ handler](https://nextjs.org/docs/app/building-your-application/routing/route-han
 3. Add your Arcjet key to `.env.local`
 
    ```env
-   AJ_KEY=
+   ARCJET_KEY=
    ```
 
 4. Start the dev server.

--- a/examples/nextjs-14-app-dir-rl/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-app-dir-rl/app/api/arcjet/route.ts
@@ -5,7 +5,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     fixedWindow({
       mode: "LIVE",

--- a/examples/nextjs-14-app-dir-rl/app/api/custom_timeout/route.ts
+++ b/examples/nextjs-14-app-dir-rl/app/api/custom_timeout/route.ts
@@ -14,7 +14,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     validateEmail({
       mode: "LIVE",

--- a/examples/nextjs-14-app-dir-rl/middleware.ts
+++ b/examples/nextjs-14-app-dir-rl/middleware.ts
@@ -9,7 +9,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [],
 });
 

--- a/examples/nextjs-14-app-dir-validate-email/README.md
+++ b/examples/nextjs-14-app-dir-validate-email/README.md
@@ -28,7 +28,7 @@ handler](https://nextjs.org/docs/app/building-your-application/routing/route-han
 3. Add your Arcjet key to `.env.local`
 
    ```env
-   AJ_KEY=
+   ARCJET_KEY=
    ```
 
 4. Start the dev server.

--- a/examples/nextjs-14-app-dir-validate-email/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-app-dir-validate-email/app/api/arcjet/route.ts
@@ -5,7 +5,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     validateEmail({
       mode: "LIVE",

--- a/examples/nextjs-14-openai/README.md
+++ b/examples/nextjs-14-openai/README.md
@@ -28,7 +28,7 @@ uses the OpenAI chat API.
 3. Add your Arcjet & OpenAI keys to `.env.local`
 
    ```env
-   AJ_KEY=
+   ARCJET_KEY=
    OPENAI_API_KEY=
    ```
 

--- a/examples/nextjs-14-openai/app/api/chat/route.ts
+++ b/examples/nextjs-14-openai/app/api/chat/route.ts
@@ -9,7 +9,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     tokenBucket({
       mode: "LIVE",

--- a/examples/nextjs-14-pages-wrap/README.md
+++ b/examples/nextjs-14-pages-wrap/README.md
@@ -28,7 +28,7 @@ Route](https://nextjs.org/docs/pages/building-your-application/routing/api-route
 3. Add your Arcjet key to `.env.local`
 
    ```env
-   AJ_KEY=
+   ARCJET_KEY=
    ```
 
 4. Start the dev server.

--- a/examples/nextjs-14-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-14-pages-wrap/pages/api/arcjet-edge.ts
@@ -10,7 +10,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     fixedWindow({
       mode: "LIVE",

--- a/examples/nextjs-14-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-14-pages-wrap/pages/api/arcjet.ts
@@ -6,7 +6,7 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
-  key: process.env.AJ_KEY!,
+  key: process.env.ARCJET_KEY!,
   rules: [
     fixedWindow({
       mode: "LIVE",


### PR DESCRIPTION
- Replaces `AJ_KEY` with `ARCJET_KEY` to be consistent with the docs.
- Replaces the Next.js readme pages router example with an app router example because that is now the default and most common for new apps.