### PR TITLE
chore(rollup): Externalize all imports that end with `.wasm?module`

### DIFF
--- a/analyze/rollup.config.js
+++ b/analyze/rollup.config.js
@@ -13,12 +13,6 @@ export default createConfig(import.meta.url, {
             external: true,
           };
         }
-        if (source === "./wasm/arcjet_analyze_js_req_bg.wasm?module") {
-          return {
-            id: "./wasm/arcjet_analyze_js_req_bg.wasm?module",
-            external: true,
-          };
-        }
         // TODO: Generation of this file can be handled via rollup plugin so we
         // wouldn't need to externalize here
         if (source === "./wasm/arcjet.wasm.js") {

--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -96,6 +96,19 @@ export function createConfig(root, { plugins = [] } = {}) {
         include: "test/*.ts",
         noEmitOnError: true,
       }),
+      {
+        name: "externalize-edge-wasm",
+        resolveId(id) {
+          // Cloudflare uses the `.wasm?module` suffix to make WebAssembly
+          // available in their Workers product. This is documented at
+          // https://developers.cloudflare.com/workers/runtime-apis/webassembly/javascript/#bundling
+          // Next.js supports the same syntax, but it is undocumented.
+          if (id.endsWith(".wasm?module")) {
+            return { id, external: true };
+          }
+          return null;
+        },
+      },
       ...plugins,
     ],
   };


### PR DESCRIPTION
This change externalizes any file we import that ends in `.wasm?module` and links to the cloudflare worker documentation. This is a cleaner solution than what existed once we start adding more wasm modules, such as [Rate Limit](https://github.com/arcjet/arcjet-js/pull/205).