### PR TITLE
docs: Update HTTP version

### DIFF
--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -51,7 +51,7 @@ const aj = arcjet({
   client: createRemoteClient({
     transport: createConnectTransport({
       baseUrl: defaultBaseUrl(),
-      httpVersion: "1.1",
+      httpVersion: "2",
     }),
   }),
 });


### PR DESCRIPTION
We're now only supporting HTTP2. This is handled automatically by the Next.js SDK (which uses gRPC by default), but update the readme for the plain JS SDK.