### PR TITLE
feat(decorate): Allow decorating Headers object directly

### DIFF
--- a/decorate/test/decorate.test.ts
+++ b/decorate/test/decorate.test.ts
@@ -20,6 +20,761 @@ afterEach(() => {
 function noop() {}
 
 describe("setRateLimitHeaders", () => {
+  describe("Header object", () => {
+    test("empty results do not set headers", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("no rate limit results do not set headers", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetReason(),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("does not error if headers is missing `has` function", () => {
+      const headers = {
+        get: jest.fn((name: string) => null),
+        set: jest.fn((name: string, value: string) => null),
+      };
+
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.get).not.toHaveBeenCalled();
+      expect(headers.set).not.toHaveBeenCalled();
+    });
+
+    test("does not error if headers is missing `get` function", () => {
+      const headers = {
+        has: jest.fn((name: string) => false),
+        set: jest.fn((name: string, value: string) => null),
+      };
+
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has).not.toHaveBeenCalled();
+      expect(headers.set).not.toHaveBeenCalled();
+    });
+
+    test("does not error if headers is missing `set` function", () => {
+      const headers = {
+        has: jest.fn((name: string) => false),
+        get: jest.fn((name: string) => null),
+      };
+
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has).not.toHaveBeenCalled();
+      expect(headers.get).not.toHaveBeenCalled();
+    });
+
+    test("duplicate rate limit policies do not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit result `max` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                // @ts-expect-error
+                max: { abc: "xyz" },
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit result `window` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                // @ts-expect-error
+                window: { abc: "xyz" },
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit result `remaining` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                // @ts-expect-error
+                remaining: { abc: "xyz" },
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit result `reset` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                // @ts-expect-error
+                reset: { abc: "xyz" },
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("adds rate limit headers when only top-level reason exists", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [],
+          ttl: 0,
+          reason: new ArcjetRateLimitReason({
+            max: 1,
+            remaining: 0,
+            reset: 100,
+            window: 100,
+          }),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=1, remaining=0, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("1;w=100");
+    });
+
+    test("invalid rate limit reason `max` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [],
+          ttl: 0,
+          reason: new ArcjetRateLimitReason({
+            // @ts-expect-error
+            max: { abc: "xyz" },
+            remaining: 0,
+            reset: 100,
+            window: 100,
+          }),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit reason `window` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [],
+          ttl: 0,
+          reason: new ArcjetRateLimitReason({
+            max: 1,
+            remaining: 0,
+            reset: 100,
+            // @ts-expect-error
+            window: { abc: "xyz" },
+          }),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit reason `remaining` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [],
+          ttl: 0,
+          reason: new ArcjetRateLimitReason({
+            max: 1,
+            // @ts-expect-error
+            remaining: { abc: "xyz" },
+            reset: 100,
+            window: 100,
+          }),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("invalid rate limit reason `reset` does not set headers", () => {
+      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [],
+          ttl: 0,
+          reason: new ArcjetRateLimitReason({
+            max: 1,
+            remaining: 0,
+            // @ts-expect-error
+            reset: { abc: "xyz" },
+            window: 100,
+          }),
+        }),
+      );
+
+      expect(errorLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(false);
+      expect(headers.has("RateLimit-Policy")).toEqual(false);
+    });
+
+    test("adds rate limit headers when result exists", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=1, remaining=0, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("1;w=100");
+    });
+
+    test("selects nearest limit and sets multiple policies when multiple rate limit headers results exist", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 100,
+                remaining: 99,
+                reset: 1000,
+                window: 1000,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=1, remaining=0, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("1;w=100, 100;w=1000");
+    });
+
+    test("selects nearest limit in any order", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 100,
+                remaining: 99,
+                reset: 1000,
+                window: 1000,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=1, remaining=0, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("1;w=100, 100;w=1000");
+    });
+
+    test("selects nearest reset if remaining are equal", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 100,
+                remaining: 99,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1000,
+                remaining: 99,
+                reset: 1000,
+                window: 1000,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=100, remaining=99, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("100;w=100, 1000;w=1000");
+    });
+
+    test("selects nearest reset in any order", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1000,
+                remaining: 99,
+                reset: 1000,
+                window: 1000,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 100,
+                remaining: 99,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=100, remaining=99, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("100;w=100, 1000;w=1000");
+    });
+
+    test("selects lowest max if reset are equal", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 100,
+                remaining: 99,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1000,
+                remaining: 99,
+                reset: 100,
+                window: 1000,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=100, remaining=99, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("100;w=100, 1000;w=1000");
+    });
+
+    test("selects lowest max in any order", () => {
+      const headers = new Headers();
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1000,
+                remaining: 99,
+                reset: 100,
+                window: 1000,
+              }),
+            }),
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 100,
+                remaining: 99,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=100, remaining=99, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("100;w=100, 1000;w=1000");
+    });
+
+    test("warns but adds the rate limit header if RateLimit already exists", () => {
+      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+
+      const headers = new Headers();
+      headers.set("RateLimit", "abcXYZ");
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(warnLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=1, remaining=0, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("1;w=100");
+    });
+
+    test("warns but adds the rate limit header if RateLimit-Policy already exists", () => {
+      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+
+      const headers = new Headers();
+      headers.set("RateLimit-Policy", "abcXYZ");
+      setRateLimitHeaders(
+        headers,
+        new ArcjetAllowDecision({
+          results: [
+            new ArcjetRuleResult({
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetRateLimitReason({
+                max: 1,
+                remaining: 0,
+                reset: 100,
+                window: 100,
+              }),
+            }),
+          ],
+          ttl: 0,
+          reason: new ArcjetReason(),
+        }),
+      );
+      expect(warnLogSpy).toHaveBeenCalled();
+      expect(headers.has("RateLimit")).toEqual(true);
+      expect(headers.get("RateLimit")).toEqual(
+        "limit=1, remaining=0, reset=100",
+      );
+      expect(headers.has("RateLimit-Policy")).toEqual(true);
+      expect(headers.get("RateLimit-Policy")).toEqual("1;w=100");
+    });
+  });
+
   describe("Response object", () => {
     test("empty results do not set headers", () => {
       const resp = new Response();

--- a/examples/nextjs-14-decorate/app/api-app/arcjet/route.ts
+++ b/examples/nextjs-14-decorate/app/api-app/arcjet/route.ts
@@ -23,24 +23,22 @@ const aj = arcjet({
 export async function GET(req: Request) {
   const decision = await aj.protect(req);
 
-  let response: NextResponse;
+  const headers = new Headers();
+
+  setRateLimitHeaders(headers, decision);
+
   if (decision.isDenied()) {
-    response = NextResponse.json(
+    return NextResponse.json(
       {
         error: "Too Many Requests",
         reason: decision.reason,
       },
       {
         status: 429,
+        headers
       },
     );
-  } else {
-    response = NextResponse.json({
-      message: "Hello World"
-    });
   }
 
-  setRateLimitHeaders(response, decision);
-
-  return response;
+  return NextResponse.json({ message: "Hello World" }, { headers });
 }


### PR DESCRIPTION
This allows decorating a `Header` object directly. This really cleans up the App Router example 🎉 