### PR TITLE
chore(ci): Update dependabot to check all examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,18 @@ version: 2
 updates:
   # Dependencies in our packages
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
       # Our dependencies should be checked daily
-      interval: "daily"
+      interval: daily
     assignees:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps(dev)"
+      prefix: deps
+      prefix-development: deps(dev)
     ignore:
       # Ignore updates to the @types/node package due to conflict between
       # Headers in DOM.
@@ -22,18 +22,18 @@ updates:
 
   # Dependencies in our examples
 
-  - package-ecosystem: "npm"
-    directory: "/examples/nextjs-13-pages-wrap"
+  - package-ecosystem: npm
+    directory: /examples/nextjs-13-pages-wrap
     schedule:
       # Our dependencies should be checked daily
-      interval: "daily"
+      interval: daily
     assignees:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps(example)"
-      prefix-development: "deps(example)"
+      prefix: deps(example)
+      prefix-development: deps(example)
     groups:
       dependencies:
         patterns:
@@ -45,17 +45,17 @@ updates:
         versions: [">18.18"]
 
   - package-ecosystem: "npm"
-    directory: "/examples/nextjs-14-app-dir-rl"
+    directory: /examples/nextjs-14-app-dir-rl
     schedule:
       # Our dependencies should be checked daily
-      interval: "daily"
+      interval: daily
     assignees:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps(example)"
-      prefix-development: "deps(example)"
+      prefix: deps(example)
+      prefix-development: deps(example)
     groups:
       dependencies:
         patterns:
@@ -66,18 +66,18 @@ updates:
       - dependency-name: "@types/node"
         versions: [">18.18"]
 
-  - package-ecosystem: "npm"
-    directory: "/examples/nextjs-14-app-dir-validate-email"
+  - package-ecosystem: npm
+    directory: /examples/nextjs-14-app-dir-validate-email
     schedule:
       # Our dependencies should be checked daily
-      interval: "daily"
+      interval: daily
     assignees:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps(example)"
-      prefix-development: "deps(example)"
+      prefix: deps(example)
+      prefix-development: deps(example)
     groups:
       dependencies:
         patterns:
@@ -88,18 +88,18 @@ updates:
       - dependency-name: "@types/node"
         versions: [">18.18"]
 
-  - package-ecosystem: "npm"
-    directory: "/examples/nextjs-14-openai"
+  - package-ecosystem: npm
+    directory: /examples/nextjs-14-clerk-rl
     schedule:
       # Our dependencies should be checked daily
-      interval: "daily"
+      interval: daily
     assignees:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps(example)"
-      prefix-development: "deps(example)"
+      prefix: deps(example)
+      prefix-development: deps(example)
     groups:
       dependencies:
         patterns:
@@ -110,18 +110,106 @@ updates:
       - dependency-name: "@types/node"
         versions: [">18.18"]
 
-  - package-ecosystem: "npm"
-    directory: "/examples/nextjs-14-pages-wrap"
+  - package-ecosystem: npm
+    directory: /examples/nextjs-14-clerk-shield
     schedule:
       # Our dependencies should be checked daily
-      interval: "daily"
+      interval: daily
     assignees:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
     commit-message:
-      prefix: "deps(example)"
-      prefix-development: "deps(example)"
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Ignore updates to the @types/node package due to conflict between
+      # Headers in DOM.
+      - dependency-name: "@types/node"
+        versions: [">18.18"]
+
+  - package-ecosystem: npm
+    directory: /examples/nextjs-14-decorate
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Ignore updates to the @types/node package due to conflict between
+      # Headers in DOM.
+      - dependency-name: "@types/node"
+        versions: [">18.18"]
+
+  - package-ecosystem: npm
+    directory: /examples/nextjs-14-openai
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Ignore updates to the @types/node package due to conflict between
+      # Headers in DOM.
+      - dependency-name: "@types/node"
+        versions: [">18.18"]
+
+  - package-ecosystem: npm
+    directory: /examples/nextjs-14-pages-wrap
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Ignore updates to the @types/node package due to conflict between
+      # Headers in DOM.
+      - dependency-name: "@types/node"
+        versions: [">18.18"]
+
+  - package-ecosystem: npm
+    directory: /examples/nextjs-example
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
I noticed that we don't have dependabot enabled for all our examples. This adds the missing ones and cleans up some trunk warnings.