### PR TITLE
docs: Add node SDK and move core to utility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ find a specific one through the categories and descriptions below.
 
 ### SDKs
 
-- [`arcjet`](./arcjet/README.md): TypeScript and JavaScript SDK core.
 - [`@arcjet/next`](./arcjet-next/README.md): SDK for the Next.js framework.
+- [`@arcjet/node`](./arcjet-node/README.md): SDK for Node.js.
 
 ### Analysis
 
@@ -44,6 +44,7 @@ find a specific one through the categories and descriptions below.
 
 ### Utilities
 
+- [`arcjet`](./arcjet/README.md): TypeScript and JavaScript SDK core.
 - [`@arcjet/protocol`](./protocol/README.md): TypeScript & JavaScript interface
   into the Arcjet protocol.
 - [`@arcjet/logger`](./logger/README.md): Logging interface which mirrors the


### PR DESCRIPTION
Since we generally don't want people using the root `arcjet` package over one of the SDKs, I've moved it to the utility section. I've also added the node SDK to the SDK section.