### PR TITLE
chore(examples): Disable telemetry to tighten harden-runner

### DIFF
--- a/examples/nextjs-13-pages-wrap/cache/config.json
+++ b/examples/nextjs-13-pages-wrap/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580110570",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-app-dir-rl/cache/config.json
+++ b/examples/nextjs-14-app-dir-rl/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580154634",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-app-dir-validate-email/cache/config.json
+++ b/examples/nextjs-14-app-dir-validate-email/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580162878",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-clerk-rl/cache/config.json
+++ b/examples/nextjs-14-clerk-rl/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580170365",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-clerk-shield/cache/config.json
+++ b/examples/nextjs-14-clerk-shield/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580258944",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-decorate/cache/config.json
+++ b/examples/nextjs-14-decorate/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580269098",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-openai/cache/config.json
+++ b/examples/nextjs-14-openai/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580275487",
+		"enabled": false
+	}
+}

--- a/examples/nextjs-14-pages-wrap/cache/config.json
+++ b/examples/nextjs-14-pages-wrap/cache/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"notifiedAt": "1709580281443",
+		"enabled": false
+	}
+}


### PR DESCRIPTION
This disables telemetry in the nextjs examples following https://nextjs.org/telemetry

I'm doing this to allow us to restrict our harden-runner allowlist further.