### PR TITLE
chore(ci): Update harden-runner, set policy to block, restrict permissions

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -92,6 +92,8 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
 
@@ -132,6 +134,8 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
 
@@ -172,6 +176,8 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
 

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -8,12 +8,18 @@ jobs:
   nextjs-13-pages-wrap:
     name: Next.js 13 + Page Router + withArcjet
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Environment security
-      - name: Step Security
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -76,12 +82,18 @@ jobs:
   nextjs-14-app-dir-validate-email:
     name: Next.js 14 + App Router + Validate Email
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Environment security
-      - name: Step Security
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -110,12 +122,18 @@ jobs:
   nextjs-14-openai:
     name: Next.js 14 + OpenAI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Environment security
-      - name: Step Security
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -144,12 +162,18 @@ jobs:
   nextjs-14-pages-wrap:
     name: Next.js 14 + Page Router + withArcjet
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Environment security
-      - name: Step Security
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
 
       # Checkout
       # Most toolchains require checkout first

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -18,6 +18,8 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -13,12 +13,18 @@ jobs:
       matrix:
         node: [18, 20]
         os: [ubuntu-latest]
+    permissions:
+      contents: read
     steps:
       # Environment security
-      - name: Step Security
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
 
       # Checkout
       # Most toolchains require checkout first


### PR DESCRIPTION
Follow up to #296 

This updates harden-runner and sets our policy to block anything that isn't the npm registry or github.