### PR TITLE
chore(ci): Disable next.js 13 required check

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -59,7 +59,8 @@ merge:
     - Trunk Check
     - "Run tests / Run tests (OS: ubuntu-latest, Node: 18)"
     - "Run tests / Run tests (OS: ubuntu-latest, Node: 20)"
-    - Build examples / Next.js 13 + Page Router + withArcjet
+    # Next.js 13 is flakey when it downloads swc so we don't require this
+    # - Build examples / Next.js 13 + Page Router + withArcjet
     - Build examples / Next.js 14 + App Router + Rate Limit
     - Build examples / Next.js 14 + App Router + Validate Email
     - Build examples / Next.js 14 + OpenAI


### PR DESCRIPTION
This example is massively flakey due to the swc download logic in Next.js 13

I found a way to disable the swc download for `next dev` but not for `next build` so let's just disable this required check.