### PR TITLE
chore!: Switch Next.js to peer dependency

### DIFF
--- a/arcjet-next/package.json
+++ b/arcjet-next/package.json
@@ -42,8 +42,10 @@
   "dependencies": {
     "@arcjet/ip": "1.0.0-alpha.9",
     "@connectrpc/connect-web": "1.4.0",
-    "arcjet": "1.0.0-alpha.9",
-    "next": "14.1.1"
+    "arcjet": "1.0.0-alpha.9"
+  },
+  "peerDependencies": {
+    "next": ">=13"
   },
   "devDependencies": {
     "@arcjet/eslint-config": "1.0.0-alpha.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,8 +66,7 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
@@ -81,6 +80,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "arcjet-node": {

--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -20,6 +20,7 @@ export function createConfig(root, { plugins = [] } = {}) {
   const pkg = JSON.parse(fs.readFileSync(packageJson));
   const dependencies = Object.keys(pkg.dependencies ?? {});
   const devDependencies = Object.keys(pkg.devDependencies ?? {});
+  const peerDependencies = Object.keys(pkg.peerDependencies ?? {});
 
   function isDependency(id) {
     return dependencies.some((dep) => id.startsWith(dep));
@@ -27,6 +28,10 @@ export function createConfig(root, { plugins = [] } = {}) {
 
   function isDevDependency(id) {
     return devDependencies.some((dep) => id.startsWith(dep));
+  }
+
+  function isPeerDependency(id) {
+    return peerDependencies.some((dep) => id.startsWith(dep));
   }
 
   const rootDir = fileURLToPath(new URL(".", root));
@@ -67,7 +72,12 @@ export function createConfig(root, { plugins = [] } = {}) {
       preserveModules: true,
     },
     external(id) {
-      return isBuiltin(id) || isDependency(id) || isDevDependency(id);
+      return (
+        isBuiltin(id) ||
+        isDependency(id) ||
+        isDevDependency(id) ||
+        isPeerDependency(id)
+      );
     },
     plugins: [
       // Replace always comes first to ensure the replaced values exist for all


### PR DESCRIPTION
Closes #336

Next.js uses symbols on their objects, which breaks TypeScript compilation if you have version mismatches. This moves it to a peer dependency so the application version is always used. The peer dep version range is anything from 13, 14, and up because I don't really like putting an upper cap on it (what if Next.js 15 releases and it doesn't break our usage... it shouldn't cause churn for our users).