### PR TITLE
chore: Make next a peerDep in our eslint package

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -36,11 +36,11 @@
     "eslint-config-next": "14.1.3",
     "eslint-config-prettier": "9.1.0",
     "eslint-config-turbo": "1.12.4",
-    "eslint-plugin-react": "7.34.0",
-    "next": "14.1.1"
+    "eslint-plugin-react": "7.34.0"
   },
   "peerDependencies": {
-    "eslint": "^8"
+    "eslint": "^8",
+    "next": ">=14"
   },
   "devDependencies": {
     "eslint": "8.57.0"


### PR DESCRIPTION
This makes next a peerDep in our eslint package (similar to #339). I've made the version `>=14` because we only use this with next 14.

This is might be removed completely when we decide on #337