### PR TITLE
chore(examples): Leverage semver so next gets updated by dependabot

### DIFF
--- a/examples/nextjs-13-pages-wrap/package-lock.json
+++ b/examples/nextjs-13-pages-wrap/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
-        "next": "13.5.6",
+        "next": "^13.5.6",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -32,21 +32,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-13-pages-wrap/package.json
+++ b/examples/nextjs-13-pages-wrap/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
-    "next": "13.5.6",
+    "next": "^13.5.6",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/nextjs-14-app-dir-rl/package-lock.json
+++ b/examples/nextjs-14-app-dir-rl/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -32,21 +32,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-14-app-dir-rl/package.json
+++ b/examples/nextjs-14-app-dir-rl/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/nextjs-14-app-dir-validate-email/package-lock.json
+++ b/examples/nextjs-14-app-dir-validate-email/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -32,21 +32,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-14-app-dir-validate-email/package.json
+++ b/examples/nextjs-14-app-dir-validate-email/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/nextjs-14-clerk-rl/package-lock.json
+++ b/examples/nextjs-14-clerk-rl/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
         "@clerk/nextjs": "^4.29.9",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -33,21 +33,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-14-clerk-rl/package.json
+++ b/examples/nextjs-14-clerk-rl/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
     "@clerk/nextjs": "^4.29.9",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/nextjs-14-clerk-shield/package-lock.json
+++ b/examples/nextjs-14-clerk-shield/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
         "@clerk/nextjs": "^4.29.9",
-        "next": "14.1.1",
+        "next": "^14.1.1",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -33,21 +33,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-14-clerk-shield/package.json
+++ b/examples/nextjs-14-clerk-shield/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
     "@clerk/nextjs": "^4.29.9",
-    "next": "14.1.1",
+    "next": "^14.1.1",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/nextjs-14-decorate/package-lock.json
+++ b/examples/nextjs-14-decorate/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@arcjet/decorate": "file:../../decorate",
         "@arcjet/next": "file:../../arcjet-next",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -33,21 +33,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "../../decorate": {
@@ -63,10 +65,10 @@
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"

--- a/examples/nextjs-14-decorate/package.json
+++ b/examples/nextjs-14-decorate/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@arcjet/decorate": "file:../../decorate",
     "@arcjet/next": "file:../../arcjet-next",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/nextjs-14-openai/package-lock.json
+++ b/examples/nextjs-14-openai/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
         "ai": "^3.0.7",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "openai": "^4.28.4",
         "openai-chat-tokens": "^0.2.8",
         "react": "^18",
@@ -35,21 +35,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-14-openai/package.json
+++ b/examples/nextjs-14-openai/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
     "ai": "^3.0.7",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "openai": "^4.28.4",
     "openai-chat-tokens": "^0.2.8",
     "react": "^18",

--- a/examples/nextjs-14-pages-wrap/package-lock.json
+++ b/examples/nextjs-14-pages-wrap/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@arcjet/next": "file:../../arcjet-next",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -32,21 +32,23 @@
       "dependencies": {
         "@arcjet/ip": "1.0.0-alpha.9",
         "@connectrpc/connect-web": "1.4.0",
-        "arcjet": "1.0.0-alpha.9",
-        "next": "14.1.1"
+        "arcjet": "1.0.0-alpha.9"
       },
       "devDependencies": {
         "@arcjet/eslint-config": "1.0.0-alpha.9",
         "@arcjet/rollup-config": "1.0.0-alpha.9",
         "@arcjet/tsconfig": "1.0.0-alpha.9",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.12.0",
+        "@rollup/wasm-node": "4.12.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/examples/nextjs-14-pages-wrap/package.json
+++ b/examples/nextjs-14-pages-wrap/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18"
   },


### PR DESCRIPTION
There's still a failure in #323 with one of the examples. I'm trying to use a semver range so dependabot will actually update the nextjs version in our examples.