### PR TITLE
chore!: Deprecate calling `protect()` with no rules

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1140,6 +1140,13 @@ export default function arcjet<
 
     const context: ArcjetContext = { key, fingerprint };
 
+    if (rules.length < 1) {
+      // TODO(#607): Error if no rules configured after deprecation period
+      logger.warn(
+        "Calling `protect()` with no rules is deprecated. Did you mean to configure the Shield rule?",
+      );
+    }
+
     if (rules.length > 10) {
       logger.error("Failure running rules. Only 10 rules may be specified.");
 


### PR DESCRIPTION
Closes #605 

This adds a warning log if `protect()` is called with no rules configured that lets users know they should be configuring at least one rule, and suggests Shield because that is the common case where no rule would be specified before this behavior change.