### PR TITLE
feat: Add configurable shield rule

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -20,6 +20,7 @@ import {
   ArcjetTokenBucketRateLimitRule,
   ArcjetFixedWindowRateLimitRule,
   ArcjetSlidingWindowRateLimitRule,
+  ArcjetShieldRule,
 } from "@arcjet/protocol";
 import {
   ArcjetBotTypeToProtocol,
@@ -566,9 +567,10 @@ export class ArcjetHeaders extends Headers {
 }
 
 const Priority = {
-  RateLimit: 1,
-  BotDetection: 2,
-  EmailValidation: 3,
+  Shield: 1,
+  RateLimit: 2,
+  BotDetection: 3,
+  EmailValidation: 4,
 };
 
 type PlainObject = { [key: string]: unknown };
@@ -978,6 +980,29 @@ export function detectBot(
           });
         }
       },
+    });
+  }
+
+  return rules;
+}
+
+export type ShieldOptions = {
+  mode?: ArcjetMode;
+};
+
+export function shield(
+  options?: ShieldOptions,
+  ...additionalOptions: ShieldOptions[]
+): Primitive {
+  const rules: ArcjetShieldRule<{}>[] = [];
+
+  // Always create at least one Shield rule
+  for (const opt of [options ?? {}, ...additionalOptions]) {
+    const mode = opt.mode === "LIVE" ? "LIVE" : "DRY_RUN";
+    rules.push({
+      type: "SHIELD",
+      priority: Priority.Shield,
+      mode,
     });
   }
 

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -304,7 +304,6 @@ export function createRemoteClient(
       const decideRequest = new DecideRequest({
         sdkStack,
         sdkVersion,
-        fingerprint: context.fingerprint,
         details: {
           ip: details.ip,
           method: details.method,
@@ -355,7 +354,6 @@ export function createRemoteClient(
       const reportRequest = new ReportRequest({
         sdkStack,
         sdkVersion,
-        fingerprint: context.fingerprint,
         details: {
           ip: details.ip,
           method: details.method,

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -57,6 +57,7 @@ import arcjet, {
   slidingWindow,
   Primitive,
   Arcjet,
+  shield,
 } from "../index";
 
 // Type helpers from https://github.com/sindresorhus/type-fest but adjusted for
@@ -2990,6 +2991,31 @@ describe("Primitive > validateEmail", () => {
         emailTypes: [],
       }),
     });
+  });
+});
+
+describe("Primitive > shield", () => {
+  test("provides a default rule with no options specified", async () => {
+    const [rule] = shield();
+    expect(rule.type).toEqual("SHIELD");
+    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  });
+
+  test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
+    const [rule] = shield({
+      // @ts-expect-error
+      mode: "INVALID",
+    });
+    expect(rule.type).toEqual("SHIELD");
+    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  });
+
+  test("sets mode as `LIVE` if specified", async () => {
+    const [rule] = shield({
+      mode: "LIVE",
+    });
+    expect(rule.type).toEqual("SHIELD");
+    expect(rule).toHaveProperty("mode", "LIVE");
   });
 });
 

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -283,7 +283,6 @@ describe("createRemoteClient", () => {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
         },
-        fingerprint,
         rules: [],
         sdkStack: SDKStack.SDK_STACK_NEXTJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
@@ -338,7 +337,6 @@ describe("createRemoteClient", () => {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
         },
-        fingerprint,
         rules: [],
         sdkStack: SDKStack.SDK_STACK_UNSPECIFIED,
         sdkVersion: "__ARCJET_SDK_VERSION__",
@@ -391,7 +389,6 @@ describe("createRemoteClient", () => {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
         },
-        fingerprint,
         rules: [],
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
@@ -445,7 +442,6 @@ describe("createRemoteClient", () => {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
         },
-        fingerprint,
         rules: [],
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
@@ -504,7 +500,6 @@ describe("createRemoteClient", () => {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
         },
-        fingerprint,
         rules: [new Rule()],
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
@@ -817,7 +812,6 @@ describe("createRemoteClient", () => {
       new ReportRequest({
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
-        fingerprint,
         details: {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
@@ -881,7 +875,6 @@ describe("createRemoteClient", () => {
     expect(router.report).toHaveBeenCalledTimes(1);
     expect(router.report).toHaveBeenCalledWith(
       new ReportRequest({
-        fingerprint,
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
         details: {
@@ -949,7 +942,6 @@ describe("createRemoteClient", () => {
       new ReportRequest({
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
-        fingerprint,
         details: {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
@@ -1022,7 +1014,6 @@ describe("createRemoteClient", () => {
       new ReportRequest({
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
-        fingerprint,
         details: {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
@@ -1084,7 +1075,6 @@ describe("createRemoteClient", () => {
       new ReportRequest({
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
-        fingerprint,
         details: {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },
@@ -1164,7 +1154,6 @@ describe("createRemoteClient", () => {
       new ReportRequest({
         sdkStack: SDKStack.SDK_STACK_NODEJS,
         sdkVersion: "__ARCJET_SDK_VERSION__",
-        fingerprint,
         details: {
           ...details,
           headers: { "user-agent": "curl/8.1.2" },

--- a/examples/nextjs-13-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-13-pages-wrap/pages/api/arcjet-edge.ts
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import arcjet, { fixedWindow, withArcjet } from "@arcjet/next";
+import arcjet, { fixedWindow, shield, withArcjet } from "@arcjet/next";
 import { NextRequest, NextResponse } from "next/server";
 
 export const config = {
@@ -12,6 +12,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/examples/nextjs-13-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-13-pages-wrap/pages/api/arcjet.ts
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import arcjet, { fixedWindow, withArcjet } from "@arcjet/next";
+import arcjet, { fixedWindow, shield, withArcjet } from "@arcjet/next";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const aj = arcjet({
@@ -8,6 +8,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/examples/nextjs-14-app-dir-rl/middleware.ts
+++ b/examples/nextjs-14-app-dir-rl/middleware.ts
@@ -1,4 +1,4 @@
-import arcjet, { createMiddleware } from "@arcjet/next";
+import arcjet, { createMiddleware, shield } from "@arcjet/next";
 
 export const config = {
   // matcher tells Next.js which routes to run the middleware on
@@ -10,7 +10,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  rules: [],
+  rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
 });
 
 export default createMiddleware(aj);

--- a/examples/nextjs-14-app-dir-validate-email/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-app-dir-validate-email/app/api/arcjet/route.ts
@@ -1,4 +1,4 @@
-import arcjet, { validateEmail } from "@arcjet/next";
+import arcjet, { shield, validateEmail } from "@arcjet/next";
 import { NextResponse } from "next/server";
 
 const aj = arcjet({
@@ -7,6 +7,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     validateEmail({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       block: ["NO_MX_RECORDS"], // block email addresses with no MX records

--- a/examples/nextjs-14-authjs-5/app/api/protected/route.ts
+++ b/examples/nextjs-14-authjs-5/app/api/protected/route.ts
@@ -1,10 +1,14 @@
-import arcjet, { tokenBucket } from "@arcjet/next";
+import arcjet, { shield, tokenBucket } from "@arcjet/next";
 import { auth } from "auth";
 
 // The arcjet instance is created outside of the handler
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only

--- a/examples/nextjs-14-authjs-5/app/auth/[...nextauth]/route.ts
+++ b/examples/nextjs-14-authjs-5/app/auth/[...nextauth]/route.ts
@@ -1,10 +1,13 @@
-import arcjet, { detectBot, slidingWindow } from "@arcjet/next";
+import arcjet, { detectBot, shield, slidingWindow } from "@arcjet/next";
 import { handlers } from "auth";
 import { NextRequest, NextResponse } from "next/server";
 
 const aj = arcjet({
     key: process.env.ARCJET_KEY,
     rules: [
+      shield({
+        mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      }),
       slidingWindow({
         mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
         interval: 60, // tracks requests across a 60 second sliding window

--- a/examples/nextjs-14-authjs-5/middleware.ts
+++ b/examples/nextjs-14-authjs-5/middleware.ts
@@ -1,9 +1,13 @@
-import arcjet, { tokenBucket } from "@arcjet/next";
+import arcjet, { shield, tokenBucket } from "@arcjet/next";
 import { auth } from "auth";
 
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only

--- a/examples/nextjs-14-clerk-rl/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-clerk-rl/app/api/arcjet/route.ts
@@ -1,4 +1,4 @@
-import arcjet, { ArcjetDecision, tokenBucket, detectBot } from "@arcjet/next";
+import arcjet, { ArcjetDecision, tokenBucket, detectBot, shield } from "@arcjet/next";
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs";
 
@@ -6,6 +6,9 @@ import { currentUser } from "@clerk/nextjs";
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
   rules: [
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       block: ["AUTOMATED"], // blocks all automated clients

--- a/examples/nextjs-14-clerk-shield/middleware.ts
+++ b/examples/nextjs-14-clerk-shield/middleware.ts
@@ -1,5 +1,5 @@
 import { authMiddleware } from "@clerk/nextjs";
-import arcjet, { createMiddleware } from "@arcjet/next";
+import arcjet, { createMiddleware, shield } from "@arcjet/next";
 
 export const config = {
   // Protects all routes, including api/trpc.
@@ -19,9 +19,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // No rules are required for Arcjet Shield - it runs on every request.
-  // You can also add other rules, such as bot protection, here.
-  rules: [],
+  rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
 });
 
 // Clerk middleware will run after the Arcjet middleware. You could also use

--- a/examples/nextjs-14-decorate/app/api-app/arcjet/route.ts
+++ b/examples/nextjs-14-decorate/app/api-app/arcjet/route.ts
@@ -1,4 +1,4 @@
-import arcjet, { fixedWindow } from "@arcjet/next";
+import arcjet, { fixedWindow, shield } from "@arcjet/next";
 import { setRateLimitHeaders } from "@arcjet/decorate";
 import { NextResponse } from "next/server";
 
@@ -8,6 +8,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/examples/nextjs-14-ip-details/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-14-ip-details/pages/api/arcjet-edge.ts
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import arcjet from "@arcjet/next";
+import arcjet, { shield } from "@arcjet/next";
 import { NextRequest, NextResponse } from "next/server";
 
 export const config = {
@@ -11,7 +11,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  rules: [],
+  rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
 });
 
 export default async function handler(req: NextRequest) {

--- a/examples/nextjs-14-ip-details/pages/api/arcjet.ts
+++ b/examples/nextjs-14-ip-details/pages/api/arcjet.ts
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import arcjet from "@arcjet/next";
+import arcjet, { shield } from "@arcjet/next";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const aj = arcjet({
@@ -7,7 +7,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  rules: [],
+  rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
 });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
@@ -1,4 +1,4 @@
-import arcjet, { ArcjetDecision, tokenBucket, detectBot} from "@arcjet/next";
+import arcjet, { ArcjetDecision, tokenBucket, detectBot, shield} from "@arcjet/next";
 import { getServerSession } from "next-auth";
 import GithubProvider from "next-auth/providers/github";
 import { NextResponse } from "next/server";
@@ -18,6 +18,10 @@ const authOptions = {
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       block: ["AUTOMATED"], // blocks all automated clients

--- a/examples/nextjs-14-nextauth-4/app/api/auth/[...nextauth]/route.ts
+++ b/examples/nextjs-14-nextauth-4/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,5 @@
 // This example is for NextAuth 4, the current stable version
-import arcjet, { detectBot, slidingWindow } from "@arcjet/next";
+import arcjet, { detectBot, shield, slidingWindow } from "@arcjet/next";
 import NextAuth from "next-auth";
 import GithubProvider from "next-auth/providers/github";
 import { NextResponse } from "next/server";
@@ -20,6 +20,10 @@ const handler = NextAuth(authOptions);
 const aj = arcjet({
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     slidingWindow({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       interval: 60, // tracks requests across a 60 second sliding window

--- a/examples/nextjs-14-openai/app/api/chat/route.ts
+++ b/examples/nextjs-14-openai/app/api/chat/route.ts
@@ -15,7 +15,7 @@
  adding custom characteristics so you could use a user ID to track authenticated
  users instead. See the `chat_userid` example for an example of this.
 */
-import arcjet, { tokenBucket } from "@arcjet/next";
+import arcjet, { shield, tokenBucket } from "@arcjet/next";
 import { OpenAIStream, StreamingTextResponse } from "ai";
 import OpenAI from "openai";
 import { promptTokensEstimate } from "openai-chat-tokens";
@@ -26,6 +26,9 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
   rules: [
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     tokenBucket({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       characteristics: ["ip.src"], // track requests by IP address

--- a/examples/nextjs-14-openai/app/api/chat_userid/route.ts
+++ b/examples/nextjs-14-openai/app/api/chat_userid/route.ts
@@ -16,7 +16,7 @@
  rate limit rule. The value is then passed as a string, number or boolean when
  calling the protect method. You can use any string value for the key.
 */
-import arcjet, { tokenBucket } from "@arcjet/next";
+import arcjet, { shield, tokenBucket } from "@arcjet/next";
 import { OpenAIStream, StreamingTextResponse } from "ai";
 import OpenAI from "openai";
 import { promptTokensEstimate } from "openai-chat-tokens";
@@ -27,6 +27,9 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
   rules: [
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     tokenBucket({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       characteristics: ["userId"], // track requests by user ID

--- a/examples/nextjs-14-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-14-pages-wrap/pages/api/arcjet-edge.ts
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import arcjet, { fixedWindow, withArcjet } from "@arcjet/next";
+import arcjet, { fixedWindow, shield, withArcjet } from "@arcjet/next";
 import { NextRequest, NextResponse } from "next/server";
 
 export const config = {
@@ -12,6 +12,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/examples/nextjs-14-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-14-pages-wrap/pages/api/arcjet.ts
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import arcjet, { fixedWindow, withArcjet } from "@arcjet/next";
+import arcjet, { fixedWindow, shield, withArcjet } from "@arcjet/next";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const aj = arcjet({
@@ -8,6 +8,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/examples/nextjs-14-react-hook-form/app/api/submit/route.ts
+++ b/examples/nextjs-14-react-hook-form/app/api/submit/route.ts
@@ -1,5 +1,5 @@
 import { formSchema } from "@/lib/formSchema";
-import arcjet, { protectSignup } from "@arcjet/next";
+import arcjet, { protectSignup, shield } from "@arcjet/next";
 import { NextResponse } from "next/server";
 
 const aj = arcjet({
@@ -8,6 +8,10 @@ const aj = arcjet({
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Arcjet's protectSignup rule is a combination of email validation, bot
     // protection and rate limiting. Each of these can also be used separately
     // on other routes e.g. rate limiting on a login route. See

--- a/examples/nextjs-example/app/api/arcjet/route.ts
+++ b/examples/nextjs-example/app/api/arcjet/route.ts
@@ -1,4 +1,4 @@
-import arcjet, { tokenBucket } from "@arcjet/next";
+import arcjet, { shield, tokenBucket } from "@arcjet/next";
 import { NextResponse } from "next/server";
 
 const aj = arcjet({
@@ -8,6 +8,10 @@ const aj = arcjet({
   // Arcjet supports multiple rules including bot protection and email
   // validation. See https://docs.arcjet.com
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Create a token bucket rate limit. Fixed and sliding window rate limits
     // are also supported. See https://docs.arcjet.com/rate-limiting/algorithms
     tokenBucket({

--- a/examples/nodejs-express-rl/index.js
+++ b/examples/nodejs-express-rl/index.js
@@ -1,4 +1,4 @@
-import arcjet, { fixedWindow } from "@arcjet/node";
+import arcjet, { fixedWindow, shield } from "@arcjet/node";
 import express from "express";
 
 const app = express();
@@ -9,6 +9,10 @@ const aj = arcjet({
   // variable rather than hard coding.
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/examples/nodejs-express-validate-email/index.js
+++ b/examples/nodejs-express-validate-email/index.js
@@ -1,4 +1,4 @@
-import arcjet, { validateEmail } from "@arcjet/node";
+import arcjet, { shield, validateEmail } from "@arcjet/node";
 import express from "express";
 
 const app = express();
@@ -11,6 +11,9 @@ const aj = arcjet({
   // variable rather than hard coding.
   key: process.env.ARCJET_KEY,
   rules: [
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     validateEmail({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       block: ["NO_MX_RECORDS"], // block email addresses with no MX records

--- a/examples/nodejs-hono-rl/index.ts
+++ b/examples/nodejs-hono-rl/index.ts
@@ -1,10 +1,14 @@
-import arcjet, { tokenBucket } from "@arcjet/node";
+import arcjet, { shield, tokenBucket } from "@arcjet/node";
 import { serve, type HttpBindings } from "@hono/node-server";
 import { Hono } from "hono";
 
 const aj = arcjet({
   key: process.env.ARCJET_KEY!,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only

--- a/examples/nodejs-rl/index.js
+++ b/examples/nodejs-rl/index.js
@@ -1,4 +1,4 @@
-import arcjet, { fixedWindow } from "@arcjet/node";
+import arcjet, { fixedWindow, shield } from "@arcjet/node";
 import * as http from "node:http";
 
 const aj = arcjet({
@@ -6,6 +6,10 @@ const aj = arcjet({
   // variable rather than hard coding.
   key: process.env.ARCJET_KEY,
   rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -27,6 +27,7 @@ import {
   ArcjetFixedWindowRateLimitRule,
   ArcjetSlidingWindowRateLimitRule,
   ArcjetIpDetails,
+  ArcjetShieldRule,
 } from "./index";
 import {
   BotReason,
@@ -558,6 +559,12 @@ function isEmailRule<Props extends { email: string }>(
   return rule.type === "EMAIL";
 }
 
+function isShieldRule<Props extends { email: string }>(
+  rule: ArcjetRule<Props>,
+): rule is ArcjetShieldRule<Props> {
+  return rule.type === "SHIELD";
+}
+
 export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
   rule: ArcjetRule<Props>,
 ): Rule {
@@ -647,6 +654,18 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
             add: Object.fromEntries(add),
             remove: rule.remove,
           },
+        },
+      },
+    });
+  }
+
+  if (isShieldRule(rule)) {
+    return new Rule({
+      rule: {
+        case: "shield",
+        value: {
+          mode: ArcjetModeToProtocol(rule.mode),
+          autoAdded: false,
         },
       },
     });

--- a/protocol/gen/es/decide/v1alpha1/decide_pb.d.ts
+++ b/protocol/gen/es/decide/v1alpha1/decide_pb.d.ts
@@ -833,7 +833,7 @@ export declare class ErrorReason extends Message<ErrorReason> {
 }
 
 /**
- * The rate limit configuration for a path.
+ * The configuration for a rate limit rule.
  *
  * @generated from message proto.decide.v1alpha1.RateLimitRule
  */
@@ -961,7 +961,7 @@ export declare class RateLimitRule extends Message<RateLimitRule> {
 }
 
 /**
- * The bot detection configuration.
+ * The configuration for a bot rule.
  *
  * @generated from message proto.decide.v1alpha1.BotRule
  */
@@ -1033,7 +1033,7 @@ export declare class BotRule_Patterns extends Message<BotRule_Patterns> {
 }
 
 /**
- * The signup protection configuration.
+ * The configuration for an email rule.
  *
  * @generated from message proto.decide.v1alpha1.EmailRule
  */
@@ -1077,6 +1077,37 @@ export declare class EmailRule extends Message<EmailRule> {
 }
 
 /**
+ * The configuration for a shield rule.
+ *
+ * @generated from message proto.decide.v1alpha1.ShieldRule
+ */
+export declare class ShieldRule extends Message<ShieldRule> {
+  /**
+   * @generated from field: proto.decide.v1alpha1.Mode mode = 1;
+   */
+  mode: Mode;
+
+  /**
+   * @generated from field: bool auto_added = 2;
+   */
+  autoAdded: boolean;
+
+  constructor(data?: PartialMessage<ShieldRule>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "proto.decide.v1alpha1.ShieldRule";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ShieldRule;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ShieldRule;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ShieldRule;
+
+  static equals(a: ShieldRule | PlainMessage<ShieldRule> | undefined, b: ShieldRule | PlainMessage<ShieldRule> | undefined): boolean;
+}
+
+/**
  * The configuration for Arcjet.
  *
  * @generated from message proto.decide.v1alpha1.Rule
@@ -1103,6 +1134,12 @@ export declare class Rule extends Message<Rule> {
      */
     value: EmailRule;
     case: "email";
+  } | {
+    /**
+     * @generated from field: proto.decide.v1alpha1.ShieldRule shield = 4;
+     */
+    value: ShieldRule;
+    case: "shield";
   } | { case: undefined; value?: undefined };
 
   constructor(data?: PartialMessage<Rule>);
@@ -1338,13 +1375,6 @@ export declare class DecideRequest extends Message<DecideRequest> {
   sdkVersion: string;
 
   /**
-   * The fingerprint of the request
-   *
-   * @generated from field: string fingerprint = 3;
-   */
-  fingerprint: string;
-
-  /**
    * The information provided via an SDK about a request under investigation.
    *
    * @generated from field: proto.decide.v1alpha1.RequestDetails details = 4;
@@ -1423,13 +1453,6 @@ export declare class ReportRequest extends Message<ReportRequest> {
    * @generated from field: string sdk_version = 2;
    */
   sdkVersion: string;
-
-  /**
-   * The fingerprint of the request.
-   *
-   * @generated from field: string fingerprint = 3;
-   */
-  fingerprint: string;
 
   /**
    * The information provided via an SDK about a request under investigation.

--- a/protocol/gen/es/decide/v1alpha1/decide_pb.js
+++ b/protocol/gen/es/decide/v1alpha1/decide_pb.js
@@ -255,7 +255,7 @@ export const ErrorReason = /*@__PURE__*/ proto3.makeMessageType(
 );
 
 /**
- * The rate limit configuration for a path.
+ * The configuration for a rate limit rule.
  *
  * @generated from message proto.decide.v1alpha1.RateLimitRule
  */
@@ -277,7 +277,7 @@ export const RateLimitRule = /*@__PURE__*/ proto3.makeMessageType(
 );
 
 /**
- * The bot detection configuration.
+ * The configuration for a bot rule.
  *
  * @generated from message proto.decide.v1alpha1.BotRule
  */
@@ -303,7 +303,7 @@ export const BotRule_Patterns = /*@__PURE__*/ proto3.makeMessageType(
 );
 
 /**
- * The signup protection configuration.
+ * The configuration for an email rule.
  *
  * @generated from message proto.decide.v1alpha1.EmailRule
  */
@@ -318,6 +318,19 @@ export const EmailRule = /*@__PURE__*/ proto3.makeMessageType(
 );
 
 /**
+ * The configuration for a shield rule.
+ *
+ * @generated from message proto.decide.v1alpha1.ShieldRule
+ */
+export const ShieldRule = /*@__PURE__*/ proto3.makeMessageType(
+  "proto.decide.v1alpha1.ShieldRule",
+  () => [
+    { no: 1, name: "mode", kind: "enum", T: proto3.getEnumType(Mode) },
+    { no: 2, name: "auto_added", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+  ],
+);
+
+/**
  * The configuration for Arcjet.
  *
  * @generated from message proto.decide.v1alpha1.Rule
@@ -328,6 +341,7 @@ export const Rule = /*@__PURE__*/ proto3.makeMessageType(
     { no: 1, name: "rate_limit", kind: "message", T: RateLimitRule, oneof: "rule" },
     { no: 2, name: "bots", kind: "message", T: BotRule, oneof: "rule" },
     { no: 3, name: "email", kind: "message", T: EmailRule, oneof: "rule" },
+    { no: 4, name: "shield", kind: "message", T: ShieldRule, oneof: "rule" },
   ],
 );
 
@@ -394,7 +408,6 @@ export const DecideRequest = /*@__PURE__*/ proto3.makeMessageType(
   () => [
     { no: 1, name: "sdk_stack", kind: "enum", T: proto3.getEnumType(SDKStack) },
     { no: 2, name: "sdk_version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "fingerprint", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "details", kind: "message", T: RequestDetails },
     { no: 5, name: "rules", kind: "message", T: Rule, repeated: true },
   ],
@@ -423,7 +436,6 @@ export const ReportRequest = /*@__PURE__*/ proto3.makeMessageType(
   () => [
     { no: 1, name: "sdk_stack", kind: "enum", T: proto3.getEnumType(SDKStack) },
     { no: 2, name: "sdk_version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "fingerprint", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "details", kind: "message", T: RequestDetails },
     { no: 5, name: "decision", kind: "message", T: Decision },
     { no: 6, name: "rules", kind: "message", T: Rule, repeated: true },

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -663,7 +663,7 @@ export interface ArcjetRequestDetails {
 }
 
 export type ArcjetRule<Props extends {} = {}> = {
-  type: "RATE_LIMIT" | "BOT" | "EMAIL" | string;
+  type: "RATE_LIMIT" | "BOT" | "EMAIL" | "SHIELD" | string;
   mode: ArcjetMode;
   priority: number;
 };
@@ -736,6 +736,10 @@ export interface ArcjetBotRule<Props extends {}>
   block: ArcjetBotType[];
   add: [string, ArcjetBotType][];
   remove: string[];
+}
+
+export interface ArcjetShieldRule<Props extends {}> extends ArcjetRule<Props> {
+  type: "SHIELD";
 }
 
 export type ArcjetContext = {

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -53,6 +53,7 @@ import {
   ArcjetFixedWindowRateLimitRule,
   ArcjetSlidingWindowRateLimitRule,
   ArcjetIpDetails,
+  ArcjetShieldRule,
 } from "../index.js";
 import { Timestamp } from "@bufbuild/protobuf";
 
@@ -729,6 +730,23 @@ describe("convert", () => {
               },
               remove: [],
             },
+          },
+        },
+      }),
+    );
+    expect(
+      ArcjetRuleToProtocol(<ArcjetShieldRule<{}>>{
+        type: "SHIELD",
+        mode: "DRY_RUN",
+        priority: 1,
+      }),
+    ).toEqual(
+      new Rule({
+        rule: {
+          case: "shield",
+          value: {
+            mode: Mode.DRY_RUN,
+            autoAdded: false,
           },
         },
       }),


### PR DESCRIPTION
This adds the configurable shield rule for users to add to their rules.

I also updated the protobuf generated code and cleaned up the fingerprint stuff that was removed.

@davidmytton I modified most examples to add `shield()` since we generally want people to enable it, but let me know if you had something else in mind.

Closes #606 
