### PR TITLE
feat(ip): Detect Fly-Client-IP header when available

### DIFF
--- a/ip/index.ts
+++ b/ip/index.ts
@@ -637,6 +637,13 @@ function findIP(request: RequestLike, headers: Headers): string {
     return trueClientIP;
   }
 
+  // Fly.io
+  // Fly-Client-IP: https://fly.io/docs/networking/request-headers/#fly-client-ip
+  const flyClientIP = headers.get("fly-client-ip");
+  if (isGlobalIP(flyClientIP)) {
+    return flyClientIP;
+  }
+
   // Default nginx proxy/fcgi; alternative to x-forwarded-for, used by some proxies
   // X-Real-IP
   const xRealIP = headers.get("x-real-ip");

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -206,6 +206,7 @@ describe("find public IPv4", () => {
   headerSuite("CF-Connecting-IP");
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
+  headerSuite("Fly-Client-IP");
   headerSuite("True-Client-IP");
   headerSuite("X-Real-IP");
   headerSuite("X-Cluster-Client-IP");

--- a/ip/test/ipv6.test.ts
+++ b/ip/test/ipv6.test.ts
@@ -169,6 +169,7 @@ describe("find public IPv4", () => {
   headerSuite("CF-Connecting-IP");
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
+  headerSuite("Fly-Client-IP");
   headerSuite("True-Client-IP");
   headerSuite("X-Real-IP");
   headerSuite("X-Cluster-Client-IP");


### PR DESCRIPTION
Closes #558

This detects IP via the `Fly-Client-IP` header if it is available. This follows the same pattern of other providers we support.