### PR TITLE
chore(ci): Ignore eslint 9 in SvelteKit example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -409,3 +409,7 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      # TODO(#539): Upgrade to eslint 9
+      - dependency-name: eslint
+        versions: [">=9"]


### PR DESCRIPTION
I forgot to add this ignore when I created the dependabot entry.