### PR TITLE
feat: Filter cookie headers when normalizing with ArcjetHeaders

### DIFF
--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -139,6 +139,9 @@ function toArcjetRequest<Props extends PlainObject>(
   request: ArcjetNodeRequest,
   props: Props,
 ): ArcjetRequest<Props> {
+  // We pull the cookies from the request before wrapping them in ArcjetHeaders
+  const cookies = cookiesToString(request.headers?.cookie);
+
   // We construct an ArcjetHeaders to normalize over Headers
   const headers = new ArcjetHeaders(request.headers);
 
@@ -171,8 +174,6 @@ function toArcjetRequest<Props extends PlainObject>(
   } else {
     path = request.url ?? "";
   }
-
-  const cookies = cookiesToString(request.headers?.cookie);
 
   return {
     ...props,

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -586,6 +586,34 @@ export class ArcjetHeaders extends Headers {
       }
     }
   }
+
+  /**
+   * Append a key and value to the headers, while filtering any key named
+   * `cookie`.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append)
+   *
+   * @param key The key to append in the headers
+   * @param value The value to append for the key in the headers
+   */
+  append(key: string, value: string): void {
+    if (key.toLowerCase() !== "cookie") {
+      super.append(key, value);
+    }
+  }
+  /**
+   * Set a key and value in the headers, but filtering any key named `cookie`.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set)
+   *
+   * @param key The key to set in the headers
+   * @param value The value to set for the key in the headers
+   */
+  set(key: string, value: string): void {
+    if (key.toLowerCase() !== "cookie") {
+      super.set(key, value);
+    }
+  }
 }
 
 const Priority = {


### PR DESCRIPTION
Closes #215

This removes the `cookie` header when we normalize request headers to `ArcjetHeaders`. In #214, we moved the cookies into their own field on the `ArcjetRequest` so we no longer need it inside the `headers` field—sometimes cookies are very long so we should deduplicate that data.

The `ArcjetHeaders` constructor uses `this.append` throughout, so it made sense to put the filter in the `append` and `set` methods.