### PR TITLE
fix(protocol)!: Export only things we use from connect and buf

### DIFF
--- a/protocol/proto.ts
+++ b/protocol/proto.ts
@@ -2,5 +2,9 @@
 export * from "./gen/es/decide/v1alpha1/decide_pb.js";
 export * from "./gen/es/decide/v1alpha1/decide_connect.js";
 
-export * from "@bufbuild/protobuf";
-export * from "@connectrpc/connect";
+export { Timestamp, proto3 } from "@bufbuild/protobuf";
+export {
+  createPromiseClient,
+  createRouterTransport,
+  type Transport,
+} from "@connectrpc/connect";


### PR DESCRIPTION
While working on #775, I found that Vite breaks when we try to bundle `@arcjet/protocol` because these buf and connect dependencies export overlapping identifiers and it doesn't know how to detect the correct one. 

Instead, I slimmed these exports to things that we use. I think I found everything between the various projects but marking this as breaking in case others were being used.