### PR TITLE
fix(analyze): Leverage string interpolation to import Wasm files on edge runtime

### DIFF
--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -18,23 +18,27 @@ async function moduleFromPath(path: string): Promise<WebAssembly.Module> {
   }
 
   if (process.env["NEXT_RUNTIME"] === "edge") {
+    const wasmPrefix = "arcjet_analyze_js_req.component";
     if (path === "arcjet_analyze_js_req.component.core.wasm") {
       const mod = await import(
-        "./wasm/arcjet_analyze_js_req.component.core.wasm?module"
+        /* @vite-ignore */
+        `./wasm/${wasmPrefix}.core.wasm?module`
       );
       wasmCache.set(path, mod.default);
       return mod.default;
     }
     if (path === "arcjet_analyze_js_req.component.core2.wasm") {
       const mod = await import(
-        "./wasm/arcjet_analyze_js_req.component.core2.wasm?module"
+        /* @vite-ignore */
+        `./wasm/${wasmPrefix}.core2.wasm?module`
       );
       wasmCache.set(path, mod.default);
       return mod.default;
     }
     if (path === "arcjet_analyze_js_req.component.core3.wasm") {
       const mod = await import(
-        "./wasm/arcjet_analyze_js_req.component.core3.wasm?module"
+        /* @vite-ignore */
+        `./wasm/${wasmPrefix}.core3.wasm?module`
       );
       wasmCache.set(path, mod.default);
       return mod.default;


### PR DESCRIPTION
While working on #775, I found that Vite doesn't support the `?module` syntax that we use for loading Wasm files in the edge runtime. Instead, we can use the `/* @vite-ignore */` comment but it only applies to imports using string interpolation.

I checked the output of `next build` and it seems to prepare all the `.wasm` files in our `./wasm/` directory as "edge chunks" when I use this syntax, so I think we should be good in both scenarios.