### PR TITLE
docs: Remove wording that implies is Shield is added by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 [Arcjet][arcjet] helps developers protect their apps in just a few lines of
-code. Implement rate limiting, bot protection, email verification & defend
+code. Implement rate limiting, bot protection, email verification & defense
 against common attacks.
 
 This is the monorepo containing various [Arcjet][arcjet] open source packages

--- a/README.md
+++ b/README.md
@@ -23,12 +23,17 @@ for JS.
 
 ## Quick start
 
+- **Bun?** Use the [`@arcjet/bun`](https://www.npmjs.com/package/@arcjet/bun)
+  package.
 - **Next.js?** Use the
   [`@arcjet/next`](https://www.npmjs.com/package/@arcjet/next) package with our
   [Next.js quick start guide](https://docs.arcjet.com/get-started/nextjs).
 - **Node.js?** Use the
   [`@arcjet/node`](https://www.npmjs.com/package/@arcjet/node) package with our
   [Node.js quick start guide](https://docs.arcjet.com/get-started/nodejs).
+- **SvelteKit?** Use the
+  [`@arcjet/sveltekit`](https://www.npmjs.com/package/@arcjet/sveltekit)
+  package.
 
 ## Get help
 
@@ -145,9 +150,10 @@ find a specific one through the categories and descriptions below.
 
 ### SDKs
 
+- [`@arcjet/bun`](./arcjet-bun/README.md): SDK for Bun.sh.
 - [`@arcjet/next`](./arcjet-next/README.md): SDK for the Next.js framework.
 - [`@arcjet/node`](./arcjet-node/README.md): SDK for Node.js.
-- [`@arcjet/bun`](./arcjet-bun/README.md): SDK for Bun.sh.
+- [`@arcjet/sveltekit`](./arcjet-sveltekit/README.md): SDK for SvelteKit.
 
 ### Analysis
 

--- a/analyze/README.md
+++ b/analyze/README.md
@@ -17,7 +17,7 @@
 </p>
 
 [Arcjet][arcjet] helps developers protect their apps in just a few lines of
-code. Implement rate limiting, bot protection, email verification & defend
+code. Implement rate limiting, bot protection, email verification & defense
 against common attacks.
 
 This is the [Arcjet][arcjet] local analysis engine.

--- a/arcjet-bun/README.md
+++ b/arcjet-bun/README.md
@@ -75,8 +75,8 @@ export default {
 ## Shield example
 
 [Arcjet Shield][shield-concepts-docs] protects your application against common
-attacks, including the OWASP Top 10. It’s enabled by default and runs on every
-request with negligible performance impact.
+attacks, including the OWASP Top 10. You can run Shield on every request with
+negligible performance impact.
 
 ```ts
 import arcjet, { shield } from "@arcjet/bun";

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -17,7 +17,7 @@
 </p>
 
 [Arcjet][arcjet] helps developers protect their apps in just a few lines of
-code. Implement rate limiting, bot protection, email verification & defend
+code. Implement rate limiting, bot protection, email verification & defense
 against common attacks.
 
 This is the [Arcjet][arcjet] SDK for the [Next.js][next-js] framework.

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -86,22 +86,23 @@ export async function GET(req: Request) {
 ## Shield example
 
 [Arcjet Shield](https://docs.arcjet.com/shield/concepts) protects your
-application against common attacks, including the OWASP Top 10. It’s enabled by
-default and runs on every request with negligible performance impact.
+application against common attacks, including the OWASP Top 10. You can run
+Shield on every request with negligible performance impact.
 
 See the [Arcjet Shield
 documentation](https://docs.arcjet.com/shield/quick-start/nextjs) for details.
 
 ```ts
-import arcjet from "@arcjet/next";
+import arcjet, { shield } from "@arcjet/next";
 import { NextResponse } from "next/server";
 
 const aj = arcjet({
-  // Get your site key from https://app.arcjet.com
-  // and set it as an environment variable rather than hard coding.
-  // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.ARCJET_KEY,
-  rules: [], // Shield requires no rule configuration
+  key: process.env.ARCJET_KEY, // Get your site key from https://app.arcjet.com
+  rules: [
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
 });
 
 export async function GET(req: Request) {
@@ -109,8 +110,8 @@ export async function GET(req: Request) {
 
   if (decision.isDenied()) {
     return NextResponse.json(
-      { error: "Too Many Requests", reason: decision.reason },
-      { status: 429 },
+      { error: "Forbidden", reason: decision.reason },
+      { status: 403 },
     );
   }
 

--- a/arcjet-node/README.md
+++ b/arcjet-node/README.md
@@ -17,7 +17,7 @@
 </p>
 
 [Arcjet][arcjet] helps developers protect their apps in just a few lines of
-code. Implement rate limiting, bot protection, email verification & defend
+code. Implement rate limiting, bot protection, email verification & defense
 against common attacks.
 
 This is the [Arcjet][arcjet] SDK for [Node.js][node-js].

--- a/arcjet-node/README.md
+++ b/arcjet-node/README.md
@@ -82,19 +82,20 @@ server.listen(8000);
 ## Shield example
 
 [Arcjet Shield][shield-concepts-docs] protects your application against common
-attacks, including the OWASP Top 10. It’s enabled by default and runs on every
-request with negligible performance impact.
+attacks, including the OWASP Top 10. You can run Shield on every request with
+negligible performance impact.
 
 ```ts
-import arcjet from "@arcjet/node";
+import arcjet, { shield } from "@arcjet/node";
 import http from "node:http";
 
 const aj = arcjet({
-  // Get your site key from https://app.arcjet.com
-  // and set it as an environment variable rather than hard coding.
-  // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.ARCJET_KEY,
-  rules: [], // Shield requires no rule configuration
+  key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
+  rules: [
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
 });
 
 const server = http.createServer(async function (

--- a/arcjet-sveltekit/README.md
+++ b/arcjet-sveltekit/README.md
@@ -72,8 +72,8 @@ export async function load(event: RequestEvent) {
 ## Shield example
 
 [Arcjet Shield][shield-concepts-docs] protects your application against common
-attacks, including the OWASP Top 10. It’s enabled by default and runs on every
-request with negligible performance impact.
+attacks, including the OWASP Top 10. You can run Shield on every request with
+negligible performance impact.
 
 ```ts
 // In your `hooks.server.ts` file

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -17,7 +17,7 @@
 </p>
 
 [Arcjet][arcjet] helps developers protect their apps in just a few lines of
-code. Implement rate limiting, bot protection, email verification & defend
+code. Implement rate limiting, bot protection, email verification & defense
 against common attacks.
 
 This is the [Arcjet][arcjet] TypeScript and JavaScript SDK core.

--- a/examples/nextjs-example/README.md
+++ b/examples/nextjs-example/README.md
@@ -7,8 +7,8 @@ This example uses the [Arcjet](https://arcjet.com/) SDK to implement a token
 bucket rate limit for API routes. It does not require any additional
 infrastructure e.g. Redis.
 
-The Arcjet SDK allows you to Implement rate limiting, bot protection, email
-verification & defend against common attacks. See [the
+The Arcjet SDK allows you to implement rate limiting, bot protection, email
+verification & defense against common attacks. See [the
 docs](https://docs.arcjet.com/) for details.
 
 ## Deploy your own

--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -42,7 +42,7 @@ This example shows how to use Arcjet to protect [SvelteKit](https://kit.svelte.d
 
 ## How it works
 
-The `arcjet` instance is created in the server-only module `/src/lib/server/arcjet.ts` and is configured to enable [Shield](https://docs.arcjet.com/shield) by default.
+The `arcjet` instance is created in the server-only module `/src/lib/server/arcjet.ts` and is configured to enable [Shield](https://docs.arcjet.com/shield).
 
 `/src/hooks.server.ts` imports the `arcjet` instance and runs the `protect()` method on all requests. The only exception is any requests who's pathanme is listed in `filteredRoutes`, in which case protection is left to that route's server code.
 


### PR DESCRIPTION
This updates the wording when describing shield to avoid implying it is added by default. While it is true through the deprecation period, we want people to update their configuration to explicitly opt-in to shield.

I also cleaned up other various typos and wording.