### PR TITLE
fix(ip)!: Rework priority of IP detection

### DIFF
--- a/ip/jest.config.js
+++ b/ip/jest.config.js
@@ -11,6 +11,9 @@ const config = {
   coverageProvider: "v8",
   verbose: true,
   testEnvironment: "node",
+  globals: {
+    navigator: {},
+  },
 };
 
 export default config;

--- a/ip/test/ipv6.test.ts
+++ b/ip/test/ipv6.test.ts
@@ -1,7 +1,14 @@
 /**
  * @jest-environment node
  */
-import { describe, expect, test, beforeEach, afterEach, jest } from "@jest/globals";
+import {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
 import ip, { RequestLike } from "../index";
 
 type MakeTest = (ip: unknown) => [RequestLike, Headers];


### PR DESCRIPTION
Closes #798 

This is a breaking change to how we detect IP from headers. I've changed it to prefer IP values on a "request-like" object, such as `ip` or `socket.remoteAddress`.

I also prioritized `CF-Connecting-IP` and `Fly-Client-IP` over `X-Forwarded-For` headers but they are only used when actually deployed to Cloudflare or Fly respectively. We'll want to guard other platforms where an environment variable is detectable but I couldn't others in some cursory research.

Additionally, we now iterate the `X-Forwarded-For` IPs in reverse since the first items are the easiest to spoof. For example, a user can just submit whatever IP address as the first entry in `X-Forwarded-For` along with their request.

All of the above should be documented via code comments too.

Oh, and I removed the `CF-Pseudo-IPv4` header because it will always be wrong since Cloudflare generates a non-public IP address as the translation of the IPv6 so we're preferring `CF-Connecting-IPv6` correctly now.