### PR TITLE
chore(docs): Add live example app to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,19 @@ support](https://docs.arcjet.com/support).
 
 - [Next.js rate limits](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-app-dir-rl)
 - [Next.js email validation](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-app-dir-validate-email)
+- [Bun rate
+  limits](https://github.com/arcjet/arcjet-js/tree/main/examples/bun-rl)
 - [Protect NextAuth login routes](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-nextauth-4)
 - [OpenAI chatbot protection](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-openai)
 - [Express.js rate limits](https://github.com/arcjet/arcjet-js/tree/main/examples/nodejs-express-rl)
+- [SvelteKit](https://github.com/arcjet/arcjet-js/tree/main/examples/sveltekit)
 - ... [more examples](https://github.com/arcjet/arcjet-js/tree/main/examples)
+
+### Example app
+
+Try an Arcjet protected app live at
+[https://example.arcjet.com](https://example.arcjet.com) ([source
+code](https://github.com/arcjet/arcjet-js-example)).
 
 ## Usage
 

--- a/arcjet-bun/README.md
+++ b/arcjet-bun/README.md
@@ -22,6 +22,12 @@ against common attacks.
 
 This is the [Arcjet][arcjet] SDK for [Bun.sh][bun-sh].
 
+## Example app
+
+Try an Arcjet protected app live at
+[https://example.arcjet.com](https://example.arcjet.com) ([source
+code](https://github.com/arcjet/arcjet-js-example)).
+
 ## Installation
 
 ```shell

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -30,6 +30,12 @@ This is the [Arcjet][arcjet] SDK for the [Next.js][next-js] framework.
 Visit [docs.arcjet.com](https://docs.arcjet.com/get-started/nextjs) to get
 started.
 
+## Example app
+
+Try an Arcjet protected app live at
+[https://example.arcjet.com](https://example.arcjet.com) ([source
+code](https://github.com/arcjet/arcjet-js-example)).
+
 ## Installation
 
 ```shell

--- a/arcjet-node/README.md
+++ b/arcjet-node/README.md
@@ -25,6 +25,12 @@ This is the [Arcjet][arcjet] SDK for [Node.js][node-js].
 **Looking for our Next.js framework SDK?** Check out the
 [`@arcjet/next`](https://www.npmjs.com/package/@arcjet/next) package.
 
+## Example app
+
+Try an Arcjet protected app live at
+[https://example.arcjet.com](https://example.arcjet.com) ([source
+code](https://github.com/arcjet/arcjet-js-example)).
+
 ## Installation
 
 ```shell

--- a/arcjet-sveltekit/README.md
+++ b/arcjet-sveltekit/README.md
@@ -22,6 +22,12 @@ against common attacks.
 
 This is the [Arcjet][arcjet] SDK for [SvelteKit][sveltekit].
 
+## Example app
+
+Try an Arcjet protected app live at
+[https://example.arcjet.com](https://example.arcjet.com) ([source
+code](https://github.com/arcjet/arcjet-js-example)).
+
 ## Installation
 
 ```shell

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,12 @@
 
 This directory contains examples of how to use Arcjet.
 
+## Example app
+
+Try an Arcjet protected app live at
+[https://example.arcjet.com](https://example.arcjet.com) ([source
+code](https://github.com/arcjet/arcjet-js-example)).
+
 ## Arcjet development
 
 To develop Arcjet, use the following commands before starting the example:


### PR DESCRIPTION
Adds the link to each README. Although the example is built with Next.js, it still shows the key features live, so it's useful for all SDKs.