### PR TITLE
docs: Add headers package to root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ find a specific one through the categories and descriptions below.
 ### Analysis
 
 - [`@arcjet/analyze`](./analyze/README.md): Local analysis engine.
+- [`@arcjet/headers`](./headers/README.md): Arcjet extension of the Headers
+  class.
 - [`@arcjet/ip`](./ip/README.md): Utilities for finding the originating IP of a
   request.
 


### PR DESCRIPTION
We want to promote our individual packages that might help others. This adds it to the root README for others to find.