### PR TITLE
fix(analyze): Disable cache during base64 decode

### DIFF
--- a/analyze/rollup.config.js
+++ b/analyze/rollup.config.js
@@ -37,8 +37,9 @@ const wasmBase64 = "data:application/wasm;base64,${wasm.toString("base64")}";
  */
 // TODO: Switch back to top-level await when our platforms all support it
 export async function wasm() {
-  // This uses fetch to decode the wasm data url
-  const wasmDecode = await fetch(wasmBase64);
+  // This uses fetch to decode the wasm data url, but disabling cache so files
+  // larger than 2mb don't fail to parse in the Next.js App Router
+  const wasmDecode = await fetch(wasmBase64, { cache: "no-store" });
   const buf = await wasmDecode.arrayBuffer();
   // And then we return it as a WebAssembly.Module
   return WebAssembly.compile(buf);


### PR DESCRIPTION
Closes #836 

We are using `fetch` to base64 decode our Analyze Wasm files in certain runtimes. However, when this is used in the Next.js App Router, it fails because the URL is larger than 2mb. We don't actually need these to go through the `fetch` cache since it isn't making a network call, so we just disable it everywhere.