### PR TITLE
feat!: Allow ArcjetContext extension via new argument to core `protect()`

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -197,7 +197,7 @@ function withClient<const Rules extends (Primitive | Product)[]>(
         props ?? {},
       ) as ArcjetRequest<ExtraProps<Rules>>;
 
-      return aj.protect(req);
+      return aj.protect({}, req);
     },
     handler(
       fetch: (

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -300,7 +300,7 @@ function withClient<const Rules extends (Primitive | Product)[]>(
         ExtraProps<Rules>
       >;
 
-      return aj.protect(req);
+      return aj.protect({}, req);
     },
   });
 }

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -212,7 +212,7 @@ function withClient<const Rules extends (Primitive | Product)[]>(
         ExtraProps<Rules>
       >;
 
-      return aj.protect(req);
+      return aj.protect({}, req);
     },
   });
 }

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -215,7 +215,7 @@ function withClient<const Rules extends (Primitive | Product)[]>(
         ExtraProps<Rules>
       >;
 
-      return aj.protect(req);
+      return aj.protect({}, req);
     },
   });
 }

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -62,6 +62,10 @@ const server = http.createServer(async function (
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ) {
+  // Any sort of additional context that might want to be included for the
+  // execution of `protect()`. This is mostly only useful for writing adapters.
+  const ctx = {};
+
   // Construct an object with Arcjet request details
   const path = new URL(req.url || "", `http://${req.headers.host}`);
   const details = {
@@ -71,7 +75,7 @@ const server = http.createServer(async function (
     path: path.pathname,
   };
 
-  const decision = await aj.protect(details);
+  const decision = await aj.protect(ctx, details);
   console.log(decision);
 
   if (decision.isDenied()) {

--- a/arcjet/test/index.edge.test.ts
+++ b/arcjet/test/index.edge.test.ts
@@ -69,20 +69,23 @@ describe("Arcjet: Env = Edge runtime", () => {
 
     const aj2 = aj.withRule(foobarbaz());
 
-    const decision = await aj2.protect({
-      abc: 123,
-      requested: 1,
-      email: "",
-      ip: "",
-      method: "",
-      protocol: "",
-      host: "",
-      path: "",
-      headers: new Headers(),
-      extra: {},
-      userId: "user123",
-      foobar: 123,
-    });
+    const decision = await aj2.protect(
+      {},
+      {
+        abc: 123,
+        requested: 1,
+        email: "",
+        ip: "",
+        method: "",
+        protocol: "",
+        host: "",
+        path: "",
+        headers: new Headers(),
+        extra: {},
+        userId: "user123",
+        foobar: 123,
+      },
+    );
 
     expect(decision.isErrored()).toBe(false);
   });

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -3440,7 +3440,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(decision.conclusion).toEqual("DENY");
 
     expect(allowed.validate).toHaveBeenCalledTimes(1);
@@ -3469,7 +3469,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(decision.conclusion).toEqual("ALLOW");
   });
 
@@ -3522,7 +3522,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(decision.conclusion).toEqual("ERROR");
   });
 
@@ -3556,7 +3556,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(decision.conclusion).toEqual("DENY");
 
     expect(denied.validate).toHaveBeenCalledTimes(1);
@@ -3599,7 +3599,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(client.decide).toHaveBeenCalledTimes(1);
     expect(client.decide).toHaveBeenCalledWith(
       expect.objectContaining(context),
@@ -3652,7 +3652,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(client.decide).toHaveBeenCalledTimes(1);
     expect(client.decide).toHaveBeenCalledWith(
       expect.objectContaining(context),
@@ -3711,7 +3711,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(client.decide).toHaveBeenCalledTimes(1);
     expect(client.decide).toHaveBeenCalledWith(
       expect.objectContaining(context),
@@ -3762,7 +3762,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
     expect(client.report).toHaveBeenCalledTimes(0);
     expect(client.decide).toHaveBeenCalledTimes(1);
     // TODO: Validate correct `ruleResults` are sent with `decide` when available
@@ -3803,7 +3803,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
     expect(client.decide).toHaveBeenCalledTimes(1);
     expect(client.decide).toHaveBeenCalledWith(
       expect.objectContaining(context),
@@ -3857,7 +3857,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
     expect(client.report).toHaveBeenCalledTimes(1);
     expect(client.report).toHaveBeenCalledWith(
       expect.objectContaining(context),
@@ -3908,7 +3908,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
     expect(client.decide).toHaveBeenCalledTimes(0);
   });
 
@@ -3946,7 +3946,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
 
     expect(client.report).toHaveBeenCalledTimes(0);
     expect(client.decide).toHaveBeenCalledTimes(1);
@@ -3995,7 +3995,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
 
     expect(decision.isErrored()).toBe(false);
 
@@ -4004,7 +4004,7 @@ describe("SDK", () => {
 
     expect(decision.conclusion).toEqual("DENY");
 
-    const decision2 = await aj.protect(request);
+    const decision2 = await aj.protect({}, request);
 
     expect(decision2.isErrored()).toBe(false);
     expect(client.decide).toHaveBeenCalledTimes(1);
@@ -4062,7 +4062,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
 
     expect(client.report).toHaveBeenCalledTimes(0);
     expect(client.decide).toHaveBeenCalledTimes(1);
@@ -4111,7 +4111,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
 
     expect(errorLogSpy).toHaveBeenCalledTimes(1);
     expect(errorLogSpy).toHaveBeenCalledWith(
@@ -4163,7 +4163,7 @@ describe("SDK", () => {
       client,
     });
 
-    const _ = await aj.protect(request);
+    const _ = await aj.protect({}, request);
 
     expect(errorLogSpy).toHaveBeenCalledTimes(1);
     expect(errorLogSpy).toHaveBeenCalledWith(
@@ -4201,14 +4201,14 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
 
     expect(decision.isDenied()).toBe(false);
 
     expect(client.decide).toBeCalledTimes(1);
     expect(client.report).toBeCalledTimes(1);
 
-    const decision2 = await aj.protect(request);
+    const decision2 = await aj.protect({}, request);
 
     expect(decision2.isDenied()).toBe(false);
 
@@ -4252,7 +4252,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
 
     expect(decision.isErrored()).toBe(false);
 
@@ -4304,7 +4304,7 @@ describe("SDK", () => {
       client,
     });
 
-    const decision = await aj.protect(request);
+    const decision = await aj.protect({}, request);
 
     expect(decision.isErrored()).toBe(true);
 
@@ -4393,15 +4393,18 @@ describe("Arcjet: Env = Serverless Node runtime on Vercel", () => {
       rules: [rateLimit(config)],
       client,
     });
-    const decision = await aj.protect({
-      ip,
-      method,
-      protocol,
-      host,
-      path,
-      headers,
-      "extra-test": "extra-test-value",
-    });
+    const decision = await aj.protect(
+      {},
+      {
+        ip,
+        method,
+        protocol,
+        host,
+        path,
+        headers,
+        "extra-test": "extra-test-value",
+      },
+    );
 
     // If this fails, check the console an error related to the args passed to
     // the mocked decide service method above.

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -745,6 +745,7 @@ export interface ArcjetShieldRule<Props extends {}> extends ArcjetRule<Props> {
 }
 
 export type ArcjetContext = {
+  [key: string]: unknown;
   key: string;
   fingerprint: string;
 };


### PR DESCRIPTION
This is a breaking change to the core `arcjet` package because it adds a new `ctx` argument as the first parameter to `protect()`. This argument is meant to be used by adapters to provide additional information when calling `protect()`—for example, the `ARCJET_KEY` secret passed into Cloudflare's handler.  Most users won't notice this because they are using an adapter which don't expose the `ctx` argument to the user.