### PR TITLE
chore(decorate)!: Use console to log instead of Arcjet logger

### DIFF
--- a/decorate/index.ts
+++ b/decorate/index.ts
@@ -1,4 +1,4 @@
-import logger from "@arcjet/logger";
+import format from "@arcjet/sprintf";
 import {
   ArcjetDecision,
   ArcjetRateLimitReason,
@@ -182,7 +182,7 @@ export function setRateLimitHeaders(
     const policies = new Map<number, number>();
     for (const reason of rateLimitReasons) {
       if (policies.has(reason.max)) {
-        logger.error(
+        console.error(
           "Invalid rate limit policy—two policies should not share the same limit",
         );
         return;
@@ -194,7 +194,7 @@ export function setRateLimitHeaders(
         typeof reason.remaining !== "number" ||
         typeof reason.reset !== "number"
       ) {
-        logger.error("Invalid rate limit encountered: %s", reason);
+        console.error(format("Invalid rate limit encountered: %o", reason));
         return;
       }
 
@@ -218,7 +218,9 @@ export function setRateLimitHeaders(
         typeof decision.reason.remaining !== "number" ||
         typeof decision.reason.reset !== "number"
       ) {
-        logger.error("Invalid rate limit encountered: %s", decision.reason);
+        console.error(
+          format("Invalid rate limit encountered: %o", decision.reason),
+        );
         return;
       }
 
@@ -231,17 +233,21 @@ export function setRateLimitHeaders(
 
   if (isHeaderLike(value)) {
     if (value.has("RateLimit")) {
-      logger.warn(
-        "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
-        value.get("RateLimit"),
-        limit,
+      console.warn(
+        format(
+          "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
+          value.get("RateLimit"),
+          limit,
+        ),
       );
     }
     if (value.has("RateLimit-Policy")) {
-      logger.warn(
-        "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
-        value.get("RateLimit-Policy"),
-        limit,
+      console.warn(
+        format(
+          "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
+          value.get("RateLimit-Policy"),
+          limit,
+        ),
       );
     }
 
@@ -254,17 +260,21 @@ export function setRateLimitHeaders(
 
   if (isResponseLike(value)) {
     if (value.headers.has("RateLimit")) {
-      logger.warn(
-        "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
-        value.headers.get("RateLimit"),
-        limit,
+      console.warn(
+        format(
+          "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
+          value.headers.get("RateLimit"),
+          limit,
+        ),
       );
     }
     if (value.headers.has("RateLimit-Policy")) {
-      logger.warn(
-        "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
-        value.headers.get("RateLimit-Policy"),
-        limit,
+      console.warn(
+        format(
+          "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
+          value.headers.get("RateLimit-Policy"),
+          limit,
+        ),
       );
     }
 
@@ -277,25 +287,29 @@ export function setRateLimitHeaders(
 
   if (isOutgoingMessageLike(value)) {
     if (value.headersSent) {
-      logger.error(
+      console.error(
         "Headers have already been sent—cannot set RateLimit header",
       );
       return;
     }
 
     if (value.hasHeader("RateLimit")) {
-      logger.warn(
-        "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
-        value.getHeader("RateLimit"),
-        limit,
+      console.warn(
+        format(
+          "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
+          value.getHeader("RateLimit"),
+          limit,
+        ),
       );
     }
 
     if (value.hasHeader("RateLimit-Policy")) {
-      logger.warn(
-        "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
-        value.getHeader("RateLimit-Policy"),
-        limit,
+      console.warn(
+        format(
+          "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
+          value.getHeader("RateLimit-Policy"),
+          limit,
+        ),
       );
     }
 
@@ -306,7 +320,7 @@ export function setRateLimitHeaders(
     return;
   }
 
-  logger.debug(
+  console.debug(
     "Cannot determine if response is Response or OutgoingMessage type",
   );
 }

--- a/decorate/package.json
+++ b/decorate/package.json
@@ -40,8 +40,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
-    "@arcjet/logger": "1.0.0-alpha.13",
-    "@arcjet/protocol": "1.0.0-alpha.13"
+    "@arcjet/protocol": "1.0.0-alpha.13",
+    "@arcjet/sprintf": "1.0.0-alpha.13"
   },
   "devDependencies": {
     "@arcjet/eslint-config": "1.0.0-alpha.13",

--- a/decorate/test/decorate.test.ts
+++ b/decorate/test/decorate.test.ts
@@ -9,7 +9,6 @@ import {
   ArcjetReason,
   ArcjetRuleResult,
 } from "@arcjet/protocol";
-import logger from "@arcjet/logger";
 import { OutgoingMessage } from "http";
 
 afterEach(() => {
@@ -147,7 +146,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("duplicate rate limit policies do not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -188,7 +187,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `max` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -219,7 +218,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `window` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -250,7 +249,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `remaining` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -281,7 +280,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `reset` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -335,7 +334,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `max` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -359,7 +358,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `window` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -383,7 +382,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `remaining` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -407,7 +406,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `reset` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const headers = new Headers();
       setRateLimitHeaders(
@@ -707,7 +706,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("warns but adds the rate limit header if RateLimit already exists", () => {
-      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+      const warnLogSpy = jest.spyOn(console, "warn").mockImplementation(noop);
 
       const headers = new Headers();
       headers.set("RateLimit", "abcXYZ");
@@ -741,7 +740,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("warns but adds the rate limit header if RateLimit-Policy already exists", () => {
-      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+      const warnLogSpy = jest.spyOn(console, "warn").mockImplementation(noop);
 
       const headers = new Headers();
       headers.set("RateLimit-Policy", "abcXYZ");
@@ -863,7 +862,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("duplicate rate limit policies do not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -904,7 +903,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `max` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -935,7 +934,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `window` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -966,7 +965,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `remaining` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -997,7 +996,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `reset` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -1051,7 +1050,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `max` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -1075,7 +1074,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `window` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -1099,7 +1098,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `remaining` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -1123,7 +1122,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `reset` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new Response();
       setRateLimitHeaders(
@@ -1435,7 +1434,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("warns but adds the rate limit header if RateLimit already exists", () => {
-      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+      const warnLogSpy = jest.spyOn(console, "warn").mockImplementation(noop);
 
       const resp = new Response();
       resp.headers.set("RateLimit", "abcXYZ");
@@ -1469,7 +1468,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("warns but adds the rate limit header if RateLimit-Policy already exists", () => {
-      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+      const warnLogSpy = jest.spyOn(console, "warn").mockImplementation(noop);
 
       const resp = new Response();
       resp.headers.set("RateLimit-Policy", "abcXYZ");
@@ -1550,7 +1549,7 @@ describe("setRateLimitHeaders", () => {
         },
         setHeader(name: string, value: string | number | readonly string[]) {},
       };
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       setRateLimitHeaders(
         resp,
@@ -1674,7 +1673,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("duplicate rate limit policies do not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1715,7 +1714,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `max` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1746,7 +1745,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `window` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1777,7 +1776,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `remaining` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1808,7 +1807,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit result `reset` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1862,7 +1861,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `max` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1886,7 +1885,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `window` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1910,7 +1909,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `remaining` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -1934,7 +1933,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("invalid rate limit reason `reset` does not set headers", () => {
-      const errorLogSpy = jest.spyOn(logger, "error").mockImplementation(noop);
+      const errorLogSpy = jest.spyOn(console, "error").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       setRateLimitHeaders(
@@ -2242,7 +2241,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("warns but adds the rate limit header if RateLimit already exists", () => {
-      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+      const warnLogSpy = jest.spyOn(console, "warn").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       resp.setHeader("RateLimit", "abcXYZ");
@@ -2276,7 +2275,7 @@ describe("setRateLimitHeaders", () => {
     });
 
     test("warns but adds the rate limit header if RateLimit-Policy already exists", () => {
-      const warnLogSpy = jest.spyOn(logger, "warn").mockImplementation(noop);
+      const warnLogSpy = jest.spyOn(console, "warn").mockImplementation(noop);
 
       const resp = new OutgoingMessage();
       resp.setHeader("RateLimit-Policy", "abcXYZ");


### PR DESCRIPTION
This switches our `@arcjet/decorate` package to use `console.log` after formatting a string with our new sprintf package. Since I'm removing the singleton logger in #858 and this is a standalone package, it doesn't make sense to require users to inject a logger into this package.

I believe libraries like Pino have a way to intercept `console.log` so this should be fine for most usage.