### PR TITLE
chore(analyze)!: Leverage conditional exports to load Wasm appropriately

### DIFF
--- a/analyze/.gitignore
+++ b/analyze/.gitignore
@@ -130,7 +130,11 @@ dist
 .pnp.*
 
 # Generated files
+edge-light.js
+edge-light.d.ts
 index.js
 index.d.ts
+workerd.js
+workerd.d.ts
 test/*.js
 _virtual/*.js

--- a/analyze/edge-light.ts
+++ b/analyze/edge-light.ts
@@ -8,37 +8,23 @@ import type {
   BotType,
 } from "./wasm/arcjet_analyze_js_req.component.js";
 
-import { wasm as componentCoreWasm } from "./wasm/arcjet_analyze_js_req.component.core.wasm?js";
-import { wasm as componentCore2Wasm } from "./wasm/arcjet_analyze_js_req.component.core2.wasm?js";
-import { wasm as componentCore3Wasm } from "./wasm/arcjet_analyze_js_req.component.core3.wasm?js";
+import componentCoreWasm from "./wasm/arcjet_analyze_js_req.component.core.wasm?module";
+import componentCore2Wasm from "./wasm/arcjet_analyze_js_req.component.core2.wasm?module";
+import componentCore3Wasm from "./wasm/arcjet_analyze_js_req.component.core3.wasm?module";
 
 interface AnalyzeContext {
   log: ArcjetLogger;
 }
 
-// TODO: Do we actually need this wasmCache or does `import` cache correctly?
-const wasmCache = new Map<string, WebAssembly.Module>();
-
 async function moduleFromPath(path: string): Promise<WebAssembly.Module> {
-  const cachedModule = wasmCache.get(path);
-  if (typeof cachedModule !== "undefined") {
-    return cachedModule;
-  }
-
   if (path === "arcjet_analyze_js_req.component.core.wasm") {
-    const mod = await componentCoreWasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCoreWasm;
   }
   if (path === "arcjet_analyze_js_req.component.core2.wasm") {
-    const mod = await componentCore2Wasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCore2Wasm;
   }
   if (path === "arcjet_analyze_js_req.component.core3.wasm") {
-    const mod = await componentCore3Wasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCore3Wasm;
   }
 
   throw new Error(`Unknown path: ${path}`);

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -24,6 +24,11 @@
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
+  "exports": {
+    "edge-light": "./edge-light.js",
+    "worker": "./workerd.js",
+    "default": "./index.js"
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -26,7 +26,7 @@
   "types": "./index.d.ts",
   "exports": {
     "edge-light": "./edge-light.js",
-    "worker": "./workerd.js",
+    "workerd": "./workerd.js",
     "default": "./index.js"
   },
   "files": [

--- a/analyze/rollup.config.js
+++ b/analyze/rollup.config.js
@@ -53,12 +53,14 @@ function wasmToModule() {
   return {
     name: "base64-wasm",
     resolveId(source) {
-      if (source.endsWith(".wasm")) {
+      if (source.endsWith(".wasm?js")) {
+        // Slice off the `?js` to make it a valid path
+        const filepath = source.slice(0, -3);
         // Create a "virtual module", prefixed with `\0` as per the Rollup docs,
         // for our replacement import
-        const id = `\0${source.replace(/\.wasm$/, ".js")}`;
+        const id = `\0${filepath.replace(/\.wasm$/, ".js")}`;
         // Store the actual Wasm path against the virtual module ID.
-        idToWasmPath.set(id, source);
+        idToWasmPath.set(id, filepath);
         return id;
       }
 

--- a/analyze/tsconfig.json
+++ b/analyze/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "@arcjet/tsconfig/base",
-  "include": ["index.ts", "wasm.d.ts"]
+  "include": ["index.ts", "edge-light.ts", "workerd.ts", "wasm.d.ts"]
 }

--- a/analyze/wasm.d.ts
+++ b/analyze/wasm.d.ts
@@ -1,17 +1,28 @@
 /**
- * Cloudflare uses the `.wasm?module` suffix to make WebAssembly
- * available in their Workers product. This is documented at
- * https://developers.cloudflare.com/workers/runtime-apis/webassembly/javascript/#bundling
- * Next.js supports the same syntax, but it is undocumented.
+ * Vercel uses the `.wasm?module` suffix to make WebAssembly available in their
+ * Vercel Functions product.
+ *
+ * https://vercel.com/docs/functions/wasm#using-a-webassembly-file
  */
 declare module "*.wasm?module" {
   export default WebAssembly.Module;
 }
 
 /**
- * Our Rollup build turns plain `.wasm` imports into JS imports that provide the
- * `wasm()` function which decodes a base64 Data URL into a WebAssembly Module
+ * The Cloudflare docs say they support the `.wasm?module` suffix, but that
+ * seems to no longer be the case with Wrangler 2 so we need to have separate
+ * imports for just the `.wasm` files.
+ *
+ * https://developers.cloudflare.com/workers/runtime-apis/webassembly/javascript/#bundling
  */
 declare module "*.wasm" {
+  export default WebAssembly.Module;
+}
+
+/**
+ * Our Rollup build turns `.wasm?js` imports into JS imports that provide the
+ * `wasm()` function which decodes a base64 Data URL into a WebAssembly Module
+ */
+declare module "*.wasm?js" {
   export function wasm(): Promise<WebAssembly.Module>;
 }

--- a/analyze/workerd.ts
+++ b/analyze/workerd.ts
@@ -8,37 +8,23 @@ import type {
   BotType,
 } from "./wasm/arcjet_analyze_js_req.component.js";
 
-import { wasm as componentCoreWasm } from "./wasm/arcjet_analyze_js_req.component.core.wasm?js";
-import { wasm as componentCore2Wasm } from "./wasm/arcjet_analyze_js_req.component.core2.wasm?js";
-import { wasm as componentCore3Wasm } from "./wasm/arcjet_analyze_js_req.component.core3.wasm?js";
+import componentCoreWasm from "./wasm/arcjet_analyze_js_req.component.core.wasm";
+import componentCore2Wasm from "./wasm/arcjet_analyze_js_req.component.core2.wasm";
+import componentCore3Wasm from "./wasm/arcjet_analyze_js_req.component.core3.wasm";
 
 interface AnalyzeContext {
   log: ArcjetLogger;
 }
 
-// TODO: Do we actually need this wasmCache or does `import` cache correctly?
-const wasmCache = new Map<string, WebAssembly.Module>();
-
 async function moduleFromPath(path: string): Promise<WebAssembly.Module> {
-  const cachedModule = wasmCache.get(path);
-  if (typeof cachedModule !== "undefined") {
-    return cachedModule;
-  }
-
   if (path === "arcjet_analyze_js_req.component.core.wasm") {
-    const mod = await componentCoreWasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCoreWasm;
   }
   if (path === "arcjet_analyze_js_req.component.core2.wasm") {
-    const mod = await componentCore2Wasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCore2Wasm;
   }
   if (path === "arcjet_analyze_js_req.component.core3.wasm") {
-    const mod = await componentCore3Wasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCore3Wasm;
   }
 
   throw new Error(`Unknown path: ${path}`);

--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -107,13 +107,18 @@ export function createConfig(root, { plugins = [] } = {}) {
         noEmitOnError: true,
       }),
       {
-        name: "externalize-edge-wasm",
+        name: "externalize-wasm",
         resolveId(id) {
-          // Cloudflare uses the `.wasm?module` suffix to make WebAssembly
-          // available in their Workers product. This is documented at
+          // Vercel uses the `.wasm?module` suffix to make WebAssembly available
+          // in their Vercel Functions product.
+          // https://vercel.com/docs/functions/wasm#using-a-webassembly-file
+          //
+          // The Cloudflare docs say they support the `.wasm?module` suffix, but
+          // that seems to no longer be the case with Wrangler 2 so we need to
+          // have separate imports for just the `.wasm` files.
+          //
           // https://developers.cloudflare.com/workers/runtime-apis/webassembly/javascript/#bundling
-          // Next.js supports the same syntax, but it is undocumented.
-          if (id.endsWith(".wasm?module")) {
+          if (id.endsWith(".wasm") || id.endsWith(".wasm?module")) {
             return { id, external: true };
           }
           return null;


### PR DESCRIPTION
Closes #35 

This leverages conditional exports for various platforms: `"edge-light"` for Vercel, `"workerd"` for Cloudflare, and `"default"` for our base64 Wasm implementation.

There is a lot of code duplication because it's hard to reason about the exports from inside the package and I didn't want to try to design an API that would be imported into each file.

I also had to rework our Rollup logic because the Cloudflare docs don't match their implementation as of the newest Wrangler.