### PR TITLE
feat(ip)!: Allow platform to be specified when looking up IP

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -131,6 +131,12 @@ export interface ArcjetBun<Props extends PlainObject> {
   ) => Response | Promise<Response>;
 }
 
+function detectPlatform() {
+  if (typeof env["FLY_APP_NAME"] === "string" && env["FLY_APP_NAME"] !== "") {
+    return "fly-io" as const;
+  }
+}
+
 // This is provided with an `ipCache` where it attempts to lookup the IP. This
 // is primarily a workaround to the API design in Bun that requires access to
 // the `Server` to lookup an IP.
@@ -150,6 +156,7 @@ function toArcjetRequest<Props extends PlainObject>(
       ip: ipCache.get(request),
     },
     headers,
+    { platform: detectPlatform() },
   );
   if (ip === "") {
     // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -193,6 +193,15 @@ export interface ArcjetNext<Props extends PlainObject> {
   ): ArcjetNext<Simplify<Props & ExtraProps<Rule>>>;
 }
 
+function detectPlatform() {
+  if (
+    typeof process.env["FLY_APP_NAME"] === "string" &&
+    process.env["FLY_APP_NAME"] !== ""
+  ) {
+    return "fly-io" as const;
+  }
+}
+
 function toArcjetRequest<Props extends PlainObject>(
   request: ArcjetNextRequest,
   props: Props,
@@ -200,7 +209,7 @@ function toArcjetRequest<Props extends PlainObject>(
   // We construct an ArcjetHeaders to normalize over Headers
   const headers = new ArcjetHeaders(request.headers);
 
-  let ip = findIP(request, headers);
+  let ip = findIP(request, headers, { platform: detectPlatform() });
   if (ip === "") {
     // If the `ip` is empty but we're in development mode, we default the IP
     // so the request doesn't fail.

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -133,6 +133,15 @@ export interface ArcjetNode<Props extends PlainObject> {
   ): ArcjetNode<Simplify<Props & ExtraProps<Rule>>>;
 }
 
+function detectPlatform() {
+  if (
+    typeof process.env["FLY_APP_NAME"] === "string" &&
+    process.env["FLY_APP_NAME"] !== ""
+  ) {
+    return "fly-io" as const;
+  }
+}
+
 function toArcjetRequest<Props extends PlainObject>(
   request: ArcjetNodeRequest,
   props: Props,
@@ -143,7 +152,7 @@ function toArcjetRequest<Props extends PlainObject>(
   // We construct an ArcjetHeaders to normalize over Headers
   const headers = new ArcjetHeaders(request.headers);
 
-  let ip = findIP(request, headers);
+  let ip = findIP(request, headers, { platform: detectPlatform() });
   if (ip === "") {
     // If the `ip` is empty but we're in development mode, we default the IP
     // so the request doesn't fail.

--- a/arcjet-sveltekit/env.d.ts
+++ b/arcjet-sveltekit/env.d.ts
@@ -2,5 +2,6 @@ declare module "$env/dynamic/private" {
   export const env: {
     NODE_ENV?: string;
     ARCJET_ENV?: string;
+    FLY_APP_NAME?: string;
   };
 }

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -157,6 +157,12 @@ export interface ArcjetSvelteKit<Props extends PlainObject> {
   ): ArcjetSvelteKit<Simplify<Props & ExtraProps<Rule>>>;
 }
 
+function detectPlatform() {
+  if (typeof env["FLY_APP_NAME"] === "string" && env["FLY_APP_NAME"] !== "") {
+    return "fly-io" as const;
+  }
+}
+
 function toArcjetRequest<Props extends PlainObject>(
   event: ArcjetSvelteKitRequestEvent,
   props: Props,
@@ -171,6 +177,7 @@ function toArcjetRequest<Props extends PlainObject>(
       ip: event.getClientAddress(),
     },
     headers,
+    { platform: detectPlatform() },
   );
   if (ip === "") {
     // If the `ip` is empty but we're in development mode, we default the IP

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -1,150 +1,125 @@
 /**
  * @jest-environment node
  */
-import {
-  describe,
-  expect,
-  test,
-  beforeEach,
-  afterEach,
-  jest,
-} from "@jest/globals";
-import ip, { RequestLike } from "../index";
+import { describe, expect, test } from "@jest/globals";
+import ip, { Options, RequestLike } from "../index";
 
-type MakeTest = (ip: unknown) => [RequestLike, Headers];
-
-beforeEach(() => {
-  jest.replaceProperty(process, "env", {
-    ...process.env,
-    FLY_APP_NAME: "testing",
-  });
-  // We inject an empty `navigator` object via jest.config.js to act like
-  // Cloudflare Workers
-  jest.replaceProperty(globalThis, "navigator", {
-    ...globalThis.navigator,
-    userAgent: "Cloudflare-Workers",
-  });
-});
-
-afterEach(() => {
-  jest.clearAllMocks();
-  jest.restoreAllMocks();
-});
+type MakeTest = (ip: unknown) => [RequestLike, Headers, Options | undefined];
 
 function suite(make: MakeTest) {
   test("returns empty string if unspecified", () => {
-    const [request, headers] = make("0.0.0.0");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("0.0.0.0");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if 'this network' address", () => {
-    const [request, headers] = make("0.1.2.3");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("0.1.2.3");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the shared address range", () => {
-    const [request, headers] = make("100.127.255.255");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("100.127.255.255");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the link local address range", () => {
-    const [request, headers] = make("169.254.255.255");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("169.254.255.255");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the future protocol range", () => {
-    const [request, headers] = make("192.0.0.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("192.0.0.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the 192.0.2.x documentation range", () => {
-    const [request, headers] = make("192.0.2.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("192.0.2.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the 198.51.100.x documentation range", () => {
-    const [request, headers] = make("198.51.100.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("198.51.100.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the 203.0.113.x documentation range", () => {
-    const [request, headers] = make("203.0.113.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("203.0.113.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the benchmarking range", () => {
-    const [request, headers] = make("198.19.255.255");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("198.19.255.255");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the reserved range", () => {
-    const [request, headers] = make("240.0.0.0");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("240.0.0.0");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the broadcast address", () => {
-    const [request, headers] = make("255.255.255.255");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("255.255.255.255");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if loopback", () => {
-    const [request, headers] = make("127.0.0.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("127.0.0.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if not full ip", () => {
-    const [request, headers] = make("12.3.4");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("12.3.4");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if more than 3 digits in an octet", () => {
-    const [request, headers] = make("1111.2.3.4");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("1111.2.3.4");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if more than full ip", () => {
-    const [request, headers] = make("1.2.3.4.5");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("1.2.3.4.5");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if any octet has leading 0", () => {
-    const [request, headers] = make("1.02.3.4");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("1.02.3.4");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if not a string", () => {
-    const [request, headers] = make(["12", "3", "4"]);
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make(["12", "3", "4"]);
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the 10.x.x.x private range", () => {
-    const [request, headers] = make("10.1.1.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("10.1.1.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the 172.16.x.x-172.31.x.x private range", () => {
-    const [request, headers] = make("172.18.1.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("172.18.1.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string if in the 192.168.x.x private range", () => {
-    const [request, headers] = make("192.168.1.1");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("192.168.1.1");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns empty string outside of the valid range", () => {
-    const [request, headers] = make("1.1.1.256");
-    expect(ip(request, headers)).toEqual("");
+    const [request, headers, options] = make("1.1.1.256");
+    expect(ip(request, headers, options)).toEqual("");
   });
 
   test("returns the ip if valid", () => {
-    const [request, headers] = make("1.1.1.1");
-    expect(ip(request, headers)).toEqual("1.1.1.1");
+    const [request, headers, options] = make("1.1.1.1");
+    expect(ip(request, headers, options)).toEqual("1.1.1.1");
   });
 
   test("returns the full ip if valid, after ignoring port", () => {
-    const [request, headers] = make("1.1.1.1:443");
-    expect(ip(request, headers)).toEqual("1.1.1.1:443");
+    const [request, headers, options] = make("1.1.1.1:443");
+    expect(ip(request, headers, options)).toEqual("1.1.1.1:443");
   });
 }
 
@@ -161,16 +136,16 @@ function requestSuite(...keys: string[]) {
       }
 
       const req = nested(keys);
-      return [req, new Headers()];
+      return [req, new Headers(), undefined];
     });
   });
 }
 
-function headerSuite(key: string) {
+function headerSuite(key: string, options?: Options) {
   describe(`header: ${key}`, () => {
     suite((ip: unknown) => {
       if (typeof ip === "string") {
-        return [{}, new Headers([[key, ip]])];
+        return [{}, new Headers([[key, ip]]), options];
       } else {
         return [
           {},
@@ -181,6 +156,7 @@ function headerSuite(key: string) {
               ip,
             ],
           ]),
+          options,
         ];
       }
     });
@@ -195,10 +171,10 @@ describe("find public IPv4", () => {
 
   headerSuite("X-Client-IP");
   headerSuite("X-Forwarded-For");
-  headerSuite("CF-Connecting-IP");
+  headerSuite("CF-Connecting-IP", { platform: "cloudflare" });
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
-  headerSuite("Fly-Client-IP");
+  headerSuite("Fly-Client-IP", { platform: "fly-io" });
   headerSuite("True-Client-IP");
   headerSuite("X-Real-IP");
   headerSuite("X-Cluster-Client-IP");


### PR DESCRIPTION
Depends upon #895 

Towards #51 
Towards #885 

This removes the platform detection inside the `@arcjet/ip` package and instead allows the platform to be selected by the caller and passed in via an options argument. This allows us to discover the platform from different types of environments based on the adapter