### PR TITLE
chore(logger): Update description to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ find a specific one through the categories and descriptions below.
 - [`arcjet`](./arcjet/README.md): JS SDK core.
 - [`@arcjet/protocol`](./protocol/README.md): JS interface
   into the Arcjet protocol.
-- [`@arcjet/logger`](./logger/README.md): Logging interface which mirrors the
-  console interface but allows log levels.
+- [`@arcjet/logger`](./logger/README.md): Lightweight logger which mirrors the
+  Pino structured logger interface.
 - [`@arcjet/decorate`](./decorate/README.md): Utilities for decorating responses
   with information.
 - [`@arcjet/duration`](./duration/README.md): Utilities for parsing duration

--- a/logger/README.md
+++ b/logger/README.md
@@ -16,8 +16,8 @@
   </a>
 </p>
 
-[Arcjet][arcjet] logging interface which mirrors the `console` interface but
-allows log levels.
+[Arcjet][arcjet] lightweight logger which mirrors the [Pino][pino-api]
+structured logger interface.
 
 ## Installation
 
@@ -47,4 +47,5 @@ to one of: `"DEBUG"`, `"LOG"`, `"WARN"`, or `"ERROR"`.
 Licensed under the [Apache License, Version 2.0][apache-license].
 
 [arcjet]: https://arcjet.com
+[pino-api]: https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/logger/package.json
+++ b/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcjet/logger",
   "version": "1.0.0-alpha.13",
-  "description": "Arcjet logging interface which mirrors the console interface but allows log levels",
+  "description": "Arcjet lightweight logger which mirrors the Pino structured logger interface",
   "license": "Apache-2.0",
   "homepage": "https://arcjet.com",
   "repository": {


### PR DESCRIPTION
I noticed that the description of our logger doesn't match the implementation anymore.