### PR TITLE
chore(rollup-config): Allow more builtins to avoid warnings

### DIFF
--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -34,6 +34,14 @@ export function createConfig(root, { plugins = [] } = {}) {
     return peerDependencies.some((dep) => id.startsWith(dep));
   }
 
+  function isBunBuiltin(id) {
+    return id === "bun";
+  }
+
+  function isSvelteKitBuiltin(id) {
+    return id === "$env/dynamic/private";
+  }
+
   const rootDir = fileURLToPath(new URL(".", root));
   const testDir = fileURLToPath(new URL("test/", root));
 
@@ -76,7 +84,9 @@ export function createConfig(root, { plugins = [] } = {}) {
         isBuiltin(id) ||
         isDependency(id) ||
         isDevDependency(id) ||
-        isPeerDependency(id)
+        isPeerDependency(id) ||
+        isBunBuiltin(id) ||
+        isSvelteKitBuiltin(id)
       );
     },
     plugins: [


### PR DESCRIPTION
I was noticing warnings for some imports, so I've updated our externalize functions to include bun and sveltekit ambient modules.