### PR TITLE
chore(examples): Add ARCJET_ENV to Bun and SvelteKit env files

### DIFF
--- a/examples/bun-hono-rl/.env.local.example
+++ b/examples/bun-hono-rl/.env.local.example
@@ -1,1 +1,4 @@
+# Run Arcjet in development mode because Bun.sh doesn't explicitly
+# set an environment variable like Node.js does
+ARCJET_ENV=development
 ARCJET_KEY=

--- a/examples/bun-rl/.env.local.example
+++ b/examples/bun-rl/.env.local.example
@@ -1,1 +1,4 @@
+# Run Arcjet in development mode because Bun.sh doesn't explicitly
+# set an environment variable like Node.js does
+ARCJET_ENV=development
 ARCJET_KEY=

--- a/examples/sveltekit/.env.example
+++ b/examples/sveltekit/.env.example
@@ -1,1 +1,4 @@
+# Run Arcjet in development mode because SvelteKit might not explicitly
+# set an environment variable like Node.js does
+ARCJET_ENV=development
 ARCJET_KEY=


### PR DESCRIPTION
Closes #969 

Localhost IP addresses are only allowed in development mode now. Bun doesn't set `NODE_ENV` for you like Node does, so you need to set `ARCJET_ENV` in your environment file.

The reason this checks **explicitly** for development environment is that we don't want to allow non-global IPs if users deploy there service and forget to set an environment.