### PR TITLE
fix: Ensure withRule always contains previous rules in the same chain

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1132,14 +1132,17 @@ export default function arcjet<
   }
 
   // This is a separate function so it can be called recursively
-  function withRule<Rule extends Primitive | Product>(rule: Rule) {
-    const rules = [...rootRules, ...rule].sort(
+  function withRule<Rule extends Primitive | Product>(
+    baseRules: ArcjetRule[],
+    rule: Rule,
+  ) {
+    const rules = [...baseRules, ...rule].sort(
       (a, b) => a.priority - b.priority,
     );
 
     return Object.freeze({
       withRule(rule: Primitive | Product) {
-        return withRule(rule);
+        return withRule(rules, rule);
       },
       async protect(
         ctx: ArcjetAdapterContext,
@@ -1152,7 +1155,7 @@ export default function arcjet<
 
   return Object.freeze({
     withRule(rule: Primitive | Product) {
-      return withRule(rule);
+      return withRule(rootRules, rule);
     },
     async protect(
       ctx: ArcjetAdapterContext,


### PR DESCRIPTION
Fixes #972 

When I originally wrote `withRule` in the arcjet core package, I always applied `rootRules` as the base rules. This meant that there was a bug where multiple calls to `withRule` would drop all rules except the rules on the root client and the most recent rule added with `withRule`.

I've changed some internal logic to ensure we always use the previous rule set as the base rules before adding the new rule via `withRule`.

Additionally, I've added functional tests to what were previously only type assertion tests to verify that the correct rules are being set inside the SDK.