### PR TITLE
fix(sdk): Inform type signature of protect via global characteristics

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun-types/bun.d.ts" />
 import { createConnectTransport } from "@connectrpc/connect-node";
-import core, {
+import core from "arcjet";
+import type {
   ArcjetDecision,
   ArcjetOptions,
   Primitive,
@@ -8,6 +9,7 @@ import core, {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
+  PropsForCharacteristic,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -148,9 +150,14 @@ export interface ArcjetBun<Props extends PlainObject> {
  *
  * @param options - Arcjet configuration options to apply to all requests.
  */
-export default function arcjet<const Rules extends (Primitive | Product)[]>(
-  options: ArcjetOptions<Rules>,
-): ArcjetBun<Simplify<ExtraProps<Rules>>> {
+export default function arcjet<
+  const Rules extends (Primitive | Product)[],
+  const Characteristics extends readonly string[],
+>(
+  options: ArcjetOptions<Rules, Characteristics>,
+): ArcjetBun<
+  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+> {
   const client = options.client ?? createRemoteClient();
 
   // Assuming the `handler()` function was used around Bun's fetch handler this

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -9,7 +9,7 @@ import type {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
-  PropsForCharacteristic,
+  CharacteristicProps,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -156,7 +156,7 @@ export default function arcjet<
 >(
   options: ArcjetOptions<Rules, Characteristics>,
 ): ArcjetBun<
-  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+  Simplify<ExtraProps<Rules> & CharacteristicProps<Characteristics>>
 > {
   const client = options.client ?? createRemoteClient();
 

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -7,7 +7,8 @@ import {
   NextResponse,
 } from "next/server.js";
 import type { NextMiddlewareResult } from "next/dist/server/web/types.js";
-import core, {
+import core from "arcjet";
+import type {
   ArcjetDecision,
   ArcjetOptions,
   Primitive,
@@ -15,6 +16,7 @@ import core, {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
+  PropsForCharacteristic,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -210,9 +212,14 @@ export interface ArcjetNext<Props extends PlainObject> {
  *
  * @param options - Arcjet configuration options to apply to all requests.
  */
-export default function arcjet<const Rules extends (Primitive | Product)[]>(
-  options: ArcjetOptions<Rules>,
-): ArcjetNext<Simplify<ExtraProps<Rules>>> {
+export default function arcjet<
+  const Rules extends (Primitive | Product)[],
+  const Characteristics extends readonly string[],
+>(
+  options: ArcjetOptions<Rules, Characteristics>,
+): ArcjetNext<
+  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+> {
   const client = options.client ?? createRemoteClient();
 
   const log = options.log

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -16,7 +16,7 @@ import type {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
-  PropsForCharacteristic,
+  CharacteristicProps,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -218,7 +218,7 @@ export default function arcjet<
 >(
   options: ArcjetOptions<Rules, Characteristics>,
 ): ArcjetNext<
-  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+  Simplify<ExtraProps<Rules> & CharacteristicProps<Characteristics>>
 > {
   const client = options.client ?? createRemoteClient();
 

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -1,5 +1,6 @@
 import { createConnectTransport } from "@connectrpc/connect-node";
-import core, {
+import core from "arcjet";
+import type {
   ArcjetDecision,
   ArcjetOptions,
   Primitive,
@@ -7,6 +8,7 @@ import core, {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
+  PropsForCharacteristic,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -150,9 +152,14 @@ export interface ArcjetNode<Props extends PlainObject> {
  *
  * @param options - Arcjet configuration options to apply to all requests.
  */
-export default function arcjet<const Rules extends (Primitive | Product)[]>(
-  options: ArcjetOptions<Rules>,
-): ArcjetNode<Simplify<ExtraProps<Rules>>> {
+export default function arcjet<
+  const Rules extends (Primitive | Product)[],
+  const Characteristics extends readonly string[],
+>(
+  options: ArcjetOptions<Rules, Characteristics>,
+): ArcjetNode<
+  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+> {
   const client = options.client ?? createRemoteClient();
 
   const log = options.log

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -8,7 +8,7 @@ import type {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
-  PropsForCharacteristic,
+  CharacteristicProps,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -158,7 +158,7 @@ export default function arcjet<
 >(
   options: ArcjetOptions<Rules, Characteristics>,
 ): ArcjetNode<
-  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+  Simplify<ExtraProps<Rules> & CharacteristicProps<Characteristics>>
 > {
   const client = options.client ?? createRemoteClient();
 

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -1,6 +1,7 @@
 import { createConnectTransport as createConnectTransportNode } from "@connectrpc/connect-node";
 import { createConnectTransport as createConnectTransportWeb } from "@connectrpc/connect-web";
-import core, {
+import core from "arcjet";
+import type {
   ArcjetDecision,
   ArcjetOptions,
   Primitive,
@@ -8,6 +9,7 @@ import core, {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
+  PropsForCharacteristic,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -175,9 +177,14 @@ export interface ArcjetSvelteKit<Props extends PlainObject> {
  *
  * @param options - Arcjet configuration options to apply to all requests.
  */
-export default function arcjet<const Rules extends (Primitive | Product)[]>(
-  options: ArcjetOptions<Rules>,
-): ArcjetSvelteKit<Simplify<ExtraProps<Rules>>> {
+export default function arcjet<
+  const Rules extends (Primitive | Product)[],
+  const Characteristics extends readonly string[],
+>(
+  options: ArcjetOptions<Rules, Characteristics>,
+): ArcjetSvelteKit<
+  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+> {
   const client = options.client ?? createRemoteClient();
 
   const log = options.log

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -9,7 +9,7 @@ import type {
   ArcjetRequest,
   ExtraProps,
   Arcjet,
-  PropsForCharacteristic,
+  CharacteristicProps,
 } from "arcjet";
 import findIP from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
@@ -183,7 +183,7 @@ export default function arcjet<
 >(
   options: ArcjetOptions<Rules, Characteristics>,
 ): ArcjetSvelteKit<
-  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
+  Simplify<ExtraProps<Rules> & CharacteristicProps<Characteristics>>
 > {
   const client = options.client ?? createRemoteClient();
 

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -318,7 +318,7 @@ export type Product<Props extends PlainObject = {}> = ArcjetRule<Props>[];
 // Note: If a user doesn't provide the object literal to our primitives
 // directly, we fallback to no required props. They can opt-in by adding the
 // `as const` suffix to the characteristics array.
-export type PropsForCharacteristic<T> =
+type PropsForCharacteristic<T> =
   IsStringLiteral<T> extends true
     ? T extends
         | "ip.src"
@@ -333,6 +333,8 @@ export type PropsForCharacteristic<T> =
         ? Record<T, string | number | boolean>
         : never
     : {};
+export type CharacteristicProps<Characteristics extends readonly string[]> =
+  UnionToIntersection<PropsForCharacteristic<Characteristics[number]>>;
 // Rules can specify they require specific props on an ArcjetRequest
 type PropsForRule<R> = R extends ArcjetRule<infer Props> ? Props : {};
 // We theoretically support an arbitrary amount of rule flattening,
@@ -400,7 +402,7 @@ export function tokenBucket<
 ): Primitive<
   Simplify<
     UnionToIntersection<
-      { requested: number } | PropsForCharacteristic<Characteristics[number]>
+      { requested: number } | CharacteristicProps<Characteristics>
     >
   >
 > {
@@ -442,9 +444,7 @@ export function fixedWindow<
 >(
   options?: FixedWindowRateLimitOptions<Characteristics>,
   ...additionalOptions: FixedWindowRateLimitOptions<Characteristics>[]
-): Primitive<
-  Simplify<UnionToIntersection<PropsForCharacteristic<Characteristics[number]>>>
-> {
+): Primitive<Simplify<CharacteristicProps<Characteristics>>> {
   const rules: ArcjetFixedWindowRateLimitRule<{}>[] = [];
 
   if (typeof options === "undefined") {
@@ -481,9 +481,7 @@ export function slidingWindow<
 >(
   options?: SlidingWindowRateLimitOptions<Characteristics>,
   ...additionalOptions: SlidingWindowRateLimitOptions<Characteristics>[]
-): Primitive<
-  Simplify<UnionToIntersection<PropsForCharacteristic<Characteristics[number]>>>
-> {
+): Primitive<Simplify<CharacteristicProps<Characteristics>>> {
   const rules: ArcjetSlidingWindowRateLimitRule<{}>[] = [];
 
   if (typeof options === "undefined") {
@@ -751,7 +749,7 @@ export function protectSignup<const Characteristics extends string[] = []>(
 ): Product<
   Simplify<
     UnionToIntersection<
-      { email: string } | PropsForCharacteristic<Characteristics[number]>
+      { email: string } | CharacteristicProps<Characteristics>
     >
   >
 > {
@@ -846,9 +844,7 @@ export default function arcjet<
   const Characteristics extends readonly string[] = [],
 >(
   options: ArcjetOptions<Rules, Characteristics>,
-): Arcjet<
-  Simplify<ExtraProps<Rules> & PropsForCharacteristic<Characteristics[number]>>
-> {
+): Arcjet<Simplify<ExtraProps<Rules> & CharacteristicProps<Characteristics>>> {
   // We destructure here to make the function signature neat when viewed by consumers
   const { key, rules } = options;
 

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -3554,7 +3554,7 @@ describe("SDK", () => {
           refillRate: 1,
           capacity: 10,
           characteristics: localCharacteristics,
-        })
+        }),
       ],
       client,
       log,

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -3265,7 +3265,7 @@ describe("SDK", () => {
     );
   });
 
-  test("additional characteristics are propagated to fixedWindow if they aren't separately specified in fixedWindow", async () => {
+  test("global characteristics are propagated if they aren't separately specified in fixedWindow", async () => {
     const client = {
       decide: jest.fn(async () => {
         return new ArcjetAllowDecision({
@@ -3277,120 +3277,17 @@ describe("SDK", () => {
       report: jest.fn(),
     };
 
-    const rateLimitRule = fixedWindow({
-      mode: "LIVE",
-      window: "1h",
-      max: 60,
-    });
-
-    const localCharacteristics = ["someAdditionalCharacteristic"];
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: localCharacteristics,
-      rules: [rateLimitRule],
-      client,
-      log,
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-    };
-
-    const _ = await aj.protect({}, request);
-
-    expect(client.decide).toHaveBeenCalledTimes(1);
-    expect(client.decide).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      [
-        {
-          characteristics: localCharacteristics,
-          ...rateLimitRule[0],
-        },
-      ],
-    );
-  });
-
-  test("Additional characteristics aren't propagated to fixedWindow if they are separately specified in fixedWindow", async () => {
-    const client = {
-      decide: jest.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: jest.fn(),
-    };
-
-    const localCharacteristics = ["someLocalCharacteristic"];
-    const rateLimitRule = fixedWindow({
-      mode: "LIVE",
-      window: "1h",
-      max: 60,
-      characteristics: localCharacteristics,
-    });
-
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: ["someAdditionalCharacteristic"],
-      rules: [rateLimitRule],
-      client,
-      log,
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-    };
-
-    const _ = await aj.protect({}, request);
-
-    expect(client.decide).toHaveBeenCalledTimes(1);
-    expect(client.decide).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      [
-        {
-          characteristics: localCharacteristics,
-          ...rateLimitRule[0],
-        },
-      ],
-    );
-  });
-
-  test("Additional characteristics are propagated to slidingWindow if they aren't separately specified in slidingWindow", async () => {
-    const client = {
-      decide: jest.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: jest.fn(),
-    };
-
-    const rateLimitRule = slidingWindow({
-      mode: "LIVE",
-      interval: "1h",
-      max: 60,
-    });
-
-    const globalCharacteristics = ["someAdditionalCharacteristic"];
+    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
     const aj = arcjet({
       key: "test-key",
       characteristics: globalCharacteristics,
-      rules: [rateLimitRule],
+      rules: [
+        fixedWindow({
+          mode: "LIVE",
+          window: "1h",
+          max: 60,
+        }),
+      ],
       client,
       log,
     });
@@ -3402,6 +3299,7 @@ describe("SDK", () => {
       host: "example.com",
       path: "/",
       headers: new Headers(),
+      someGlobalCharacteristic: "test",
     };
 
     const _ = await aj.protect({}, request);
@@ -3411,15 +3309,14 @@ describe("SDK", () => {
       expect.anything(),
       expect.anything(),
       [
-        {
+        expect.objectContaining({
           characteristics: globalCharacteristics,
-          ...rateLimitRule[0],
-        },
+        }),
       ],
     );
   });
 
-  test("Additional characteristics aren't propagated to slidingWindow if they are separately specified in slidingWindow", async () => {
+  test("local characteristics are prefered on fixedWindow over global characteristics", async () => {
     const client = {
       decide: jest.fn(async () => {
         return new ArcjetAllowDecision({
@@ -3431,18 +3328,19 @@ describe("SDK", () => {
       report: jest.fn(),
     };
 
-    const localCharacteristics = ["someLocalCharacteristic"];
-    const rateLimitRule = slidingWindow({
-      mode: "LIVE",
-      interval: "1h",
-      max: 60,
-      characteristics: localCharacteristics,
-    });
-
+    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
+    const localCharacteristics = ["someLocalCharacteristic"] as const;
     const aj = arcjet({
       key: "test-key",
-      characteristics: ["someAdditionalCharacteristic"],
-      rules: [rateLimitRule],
+      characteristics: globalCharacteristics,
+      rules: [
+        fixedWindow({
+          mode: "LIVE",
+          window: "1h",
+          max: 60,
+          characteristics: localCharacteristics,
+        }),
+      ],
       client,
       log,
     });
@@ -3454,6 +3352,8 @@ describe("SDK", () => {
       host: "example.com",
       path: "/",
       headers: new Headers(),
+      someGlobalCharacteristic: "test",
+      someLocalCharacteristic: "test",
     };
 
     const _ = await aj.protect({}, request);
@@ -3463,15 +3363,14 @@ describe("SDK", () => {
       expect.anything(),
       expect.anything(),
       [
-        {
+        expect.objectContaining({
           characteristics: localCharacteristics,
-          ...rateLimitRule[0],
-        },
+        }),
       ],
     );
   });
 
-  test("Additional characteristics are propagated to tokenBucket if they aren't separately specified in tokenBucket", async () => {
+  test("global characteristics are propagated if they aren't separately specified in slidingWindow", async () => {
     const client = {
       decide: jest.fn(async () => {
         return new ArcjetAllowDecision({
@@ -3483,18 +3382,124 @@ describe("SDK", () => {
       report: jest.fn(),
     };
 
-    const rateLimitRule = tokenBucket({
-      mode: "LIVE",
-      interval: "1h",
-      refillRate: 1,
-      capacity: 10,
-    });
-
-    const globalCharacteristics = ["someAdditionalCharacteristic"];
+    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
     const aj = arcjet({
       key: "test-key",
       characteristics: globalCharacteristics,
-      rules: [rateLimitRule],
+      rules: [
+        slidingWindow({
+          mode: "LIVE",
+          interval: "1h",
+          max: 60,
+        }),
+      ],
+      client,
+      log,
+    });
+
+    const request = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      someGlobalCharacteristic: "test",
+    };
+
+    const _ = await aj.protect({}, request);
+
+    expect(client.decide).toHaveBeenCalledTimes(1);
+    expect(client.decide).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [
+        expect.objectContaining({
+          characteristics: globalCharacteristics,
+        }),
+      ],
+    );
+  });
+
+  test("local characteristics are prefered on slidingWindow over global characteristics", async () => {
+    const client = {
+      decide: jest.fn(async () => {
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      }),
+      report: jest.fn(),
+    };
+
+    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
+    const localCharacteristics = ["someLocalCharacteristic"] as const;
+
+    const aj = arcjet({
+      key: "test-key",
+      characteristics: globalCharacteristics,
+      rules: [
+        slidingWindow({
+          mode: "LIVE",
+          interval: "1h",
+          max: 60,
+          characteristics: localCharacteristics,
+        }),
+      ],
+      client,
+      log,
+    });
+
+    const request = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      someGlobalCharacteristic: "test",
+      someLocalCharacteristic: "test",
+    };
+
+    const _ = await aj.protect({}, request);
+
+    expect(client.decide).toHaveBeenCalledTimes(1);
+    expect(client.decide).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [
+        expect.objectContaining({
+          characteristics: localCharacteristics,
+        }),
+      ],
+    );
+  });
+
+  test("global characteristics are propagated if they aren't separately specified in tokenBucket", async () => {
+    const client = {
+      decide: jest.fn(async () => {
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      }),
+      report: jest.fn(),
+    };
+
+    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
+    const aj = arcjet({
+      key: "test-key",
+      characteristics: globalCharacteristics,
+      rules: [
+        tokenBucket({
+          mode: "LIVE",
+          interval: "1h",
+          refillRate: 1,
+          capacity: 10,
+        }),
+      ],
       client,
       log,
     });
@@ -3507,6 +3512,7 @@ describe("SDK", () => {
       path: "/",
       headers: new Headers(),
       requested: 1,
+      someGlobalCharacteristic: "test",
     };
 
     const _ = await aj.protect({}, request);
@@ -3516,15 +3522,14 @@ describe("SDK", () => {
       expect.anything(),
       expect.anything(),
       [
-        {
+        expect.objectContaining({
           characteristics: globalCharacteristics,
-          ...rateLimitRule[0],
-        },
+        }),
       ],
     );
   });
 
-  test("additional characteristics aren't propagated to tokenBucket if they are separately specified in tokenBucket", async () => {
+  test("local characteristics are prefered on tokenBucket over global characteristics", async () => {
     const client = {
       decide: jest.fn(async () => {
         return new ArcjetAllowDecision({
@@ -3536,19 +3541,21 @@ describe("SDK", () => {
       report: jest.fn(),
     };
 
-    const localCharacteristics = ["someLocalCharacteristic"];
-    const rateLimitRule = tokenBucket({
-      mode: "LIVE",
-      interval: "1h",
-      refillRate: 1,
-      capacity: 10,
-      characteristics: localCharacteristics,
-    });
+    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
+    const localCharacteristics = ["someLocalCharacteristic"] as const;
 
     const aj = arcjet({
       key: "test-key",
-      characteristics: ["someAdditionalCharacteristic"],
-      rules: [rateLimitRule],
+      characteristics: globalCharacteristics,
+      rules: [
+        tokenBucket({
+          mode: "LIVE",
+          interval: "1h",
+          refillRate: 1,
+          capacity: 10,
+          characteristics: localCharacteristics,
+        })
+      ],
       client,
       log,
     });
@@ -3561,6 +3568,8 @@ describe("SDK", () => {
       path: "/",
       headers: new Headers(),
       requested: 1,
+      someGlobalCharacteristic: "test",
+      someLocalCharacteristic: "test",
     };
 
     const _ = await aj.protect({}, request);
@@ -3570,10 +3579,9 @@ describe("SDK", () => {
       expect.anything(),
       expect.anything(),
       [
-        {
+        expect.objectContaining({
           characteristics: localCharacteristics,
-          ...rateLimitRule[0],
-        },
+        }),
       ],
     );
   });


### PR DESCRIPTION
This attaches the `characteristics` key of the SDK configuration into the types of `protect()`. We leverage some type magic to ensure users specify all data needed when they are using user-defined characteristics.

I totally forgot about this when reviewing the initial PR, but we're lucky to have caught it before the release.

I also needed to fix the tests because the way they were originally written allowed the required request fields to be excluded. @e-moran It's worth noting that rules always need to be directly specified in the `rules: []` array for TypeScript's inference to work properly—which avoids the need to annotate your variables. We are able to use `as const` on the characteristic arrays, but that isn't allowed on function calls like `rateLimit()`.

Closes #1042 