### PR TITLE
feat: Attempt to warm http2 connection upon SDK startup

### DIFF
--- a/transport/index.ts
+++ b/transport/index.ts
@@ -7,7 +7,7 @@ export function createTransport(baseUrl: string) {
   // We create our own session manager so we can attempt to pre-connect
   const sessionManager = new Http2SessionManager(baseUrl, {
     // AWS ALB doesn't support PING so we use a very high idle timeout
-    idleConnectionTimeoutMs: 4000 * 1000,
+    idleConnectionTimeoutMs: 600 * 1000,
   });
 
   // We ignore the promise result because this is an optimistic pre-connect

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -1,8 +1,21 @@
-import { createConnectTransport } from "@connectrpc/connect-node";
+import {
+  createConnectTransport,
+  Http2SessionManager,
+} from "@connectrpc/connect-node";
 
 export function createTransport(baseUrl: string) {
+  // We create our own session manager so we can attempt to pre-connect
+  const sessionManager = new Http2SessionManager(baseUrl, {
+    // AWS ALB doesn't support PING so we use a very high idle timeout
+    idleConnectionTimeoutMs: 4000 * 1000,
+  });
+
+  // We ignore the promise result because this is an optimistic pre-connect
+  sessionManager.connect();
+
   return createConnectTransport({
     baseUrl,
     httpVersion: "2",
+    sessionManager,
   });
 }


### PR DESCRIPTION
This updates our HTTP2 transport to attempt the `connect()` of the HTTP2 connection upon initialization. It also sets a 600 second timeout on the connection.

This most benefits long-running servers, but improvements can also be seen in warm serverless functions.