### PR TITLE
chore: Remove Dependencies section from release notes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,7 +7,6 @@
     { "type": "feat", "section": "🚀 New Features" },
     { "type": "fix", "section": "🪲 Bug Fixes" },
     { "type": "perf", "section": "🏎️ Performance Improvements" },
-    { "type": "deps", "section": "📦 Dependencies" },
     { "type": "revert", "section": "↩️ Reverts" },
     { "type": "docs", "section": "📝 Documentation" },
     { "type": "chore", "section": "🧹 Miscellaneous Chores" },


### PR DESCRIPTION
Now that our examples have grown, I feel like the "📦 Dependencies" section of the Release Notes is too noisy. Let's remove this type of semantic commits from the changelog.