### PR TITLE
chore(ci): Switch release-please-action location & update to latest version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Release Please
-        uses: google-github-actions/release-please-action@a2d8d683f209466ee8c695cd994ae2cf08b1642d
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json


### PR DESCRIPTION
Following the deprecation guidance at https://github.com/google-github-actions/release-please-action/pull/1, this updates the location we pull the action from and updates to the latest version.