### PR TITLE
chore(ci): Change the dependabot commit prefix for Actions PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - blaine-arcjet
     reviewers:
       - blaine-arcjet
+    commit-message:
+      prefix: deps(ci)
+      prefix-development: deps(ci)
 
   # Dependencies in our packages
 


### PR DESCRIPTION
The PRs it opened yesterday weren't in the format I wanted. I didn't realize until I merged a few so those showed up in the "Misc Chores" section of the changelog.