### PR TITLE
deps: Add turborepo as a root devDependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 
 # macOS
 .DS_Store
+
+# turborepo
+.turbo/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "*"
       ],
+      "devDependencies": {
+        "turbo": "^2.0.14"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -6267,6 +6270,101 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "peer": true
+    },
+    "node_modules/turbo": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.14.tgz",
+      "integrity": "sha512-00JjdCMD/cpsjP0Izkjcm8Oaor5yUCfDwODtaLb+WyblyadkaDEisGhy3Dbd5az9n+5iLSPiUgf+WjPbns6MRg==",
+      "dev": true,
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.0.14",
+        "turbo-darwin-arm64": "2.0.14",
+        "turbo-linux-64": "2.0.14",
+        "turbo-linux-arm64": "2.0.14",
+        "turbo-windows-64": "2.0.14",
+        "turbo-windows-arm64": "2.0.14"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.14.tgz",
+      "integrity": "sha512-kwfDmjNwlNfvtrvT29+ZBg5n1Wvxl891bFHchMJyzMoR0HOE9N1NSNdSZb9wG3e7sYNIu4uDkNk+VBEqJW0HzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.14.tgz",
+      "integrity": "sha512-m3LXYEshCx3wc4ZClM6gb01KYpFmtjQ9IBF3A7ofjb6ahux3xlYZJZ3uFCLAGHuvGLuJ3htfiPbwlDPTdknqqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.14.tgz",
+      "integrity": "sha512-7vBzCPdoTtR92SNn2JMgj1FlMmyonGmpMaQdgAB1OVYtuQ6NVGoh7/lODfaILqXjpvmFSVbpBIDrKOT6EvcprQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.14.tgz",
+      "integrity": "sha512-jwH+c0bfjpBf26K/tdEFatmnYyXwGROjbr6bZmNcL8R+IkGAc/cglL+OToqJnQZTgZvH7uDGbeSyUo7IsHyjuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.14.tgz",
+      "integrity": "sha512-w9/XwkHSzvLjmioo6cl3S1yRfI6swxsV1j1eJwtl66JM4/pn0H2rBa855R0n7hZnmI6H5ywLt/nLt6Ae8RTDmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.14.tgz",
+      "integrity": "sha512-XaQlyYk+Rf4xS5XWCo8XCMIpssgGGy8blzLfolN6YBp4baElIWMlkLZHDbGyiFmCbNf9I9gJI64XGRG+LVyyjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
   "engines": {
     "node": ">=18"
   },
+  "packageManager": "npm@10.8.1",
   "workspaces": [
     "*"
   ],
   "scripts": {
-    "prepare": "npm run build -ws --if-present --foreground-scripts",
-    "lint": "npm run lint -ws -if-present",
-    "test": "npm test -ws --if-present"
+    "prepare": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo test"
+  },
+  "devDependencies": {
+    "turbo": "^2.0.14"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,5 +12,21 @@
     "OPENAI_API_KEY",
     "FLY_APP_NAME"
   ],
-  "tasks": {}
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "outputLogs": "none"
+    },
+    "lint": {
+      "dependsOn": ["^lint"],
+      "cache": false,
+      "outputLogs": "none"
+    },
+    "test": {
+      "dependsOn": ["^test"],
+      "cache": false,
+      "outputLogs": "none"
+    }
+  }
 }


### PR DESCRIPTION
This adds turborepo as a devDependency at the root of our monorepo. This will allow us to build the packages in order, which fixes an issue @e-moran encountered with the redact packages.

I chose turborepo because we already depend on some vercel packages so adding another doesn't expand our supply chain dependence.

Also, I've aliased all the npm scripts in our root to the turbo commands to make sure nothing changes from a usability standpoint.

Unfortunately, turborepo doesn't have a Wasm build so we need to allow optional dependencies again.