### PR TITLE
fix(analyze): Ensure headers are serialized correctly

### DIFF
--- a/analyze/edge-light.ts
+++ b/analyze/edge-light.ts
@@ -1,4 +1,4 @@
-import type { ArcjetLogger, ArcjetRequestDetails } from "@arcjet/protocol";
+import type { ArcjetLogger } from "@arcjet/protocol";
 
 import { instantiate } from "./wasm/arcjet_analyze_js_req.component.js";
 import type {
@@ -17,6 +17,18 @@ import type { ArcjetJsReqSensitiveInformationIdentifier } from "./wasm/interface
 import componentCoreWasm from "./wasm/arcjet_analyze_js_req.component.core.wasm?module";
 import componentCore2Wasm from "./wasm/arcjet_analyze_js_req.component.core2.wasm?module";
 import componentCore3Wasm from "./wasm/arcjet_analyze_js_req.component.core3.wasm?module";
+
+type AnalyzeRequest = {
+  ip?: string;
+  method?: string;
+  protocol?: string;
+  host?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  cookies?: string;
+  query?: string;
+  extra?: Record<string, string>;
+};
 
 const FREE_EMAIL_PROVIDERS = [
   "gmail.com",
@@ -130,7 +142,7 @@ export {
  */
 export async function generateFingerprint(
   context: AnalyzeContext,
-  request: Partial<ArcjetRequestDetails>,
+  request: AnalyzeRequest,
 ): Promise<string> {
   const analyze = await init(context);
 

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -1,4 +1,4 @@
-import type { ArcjetLogger, ArcjetRequestDetails } from "@arcjet/protocol";
+import type { ArcjetLogger } from "@arcjet/protocol";
 
 import { instantiate } from "./wasm/arcjet_analyze_js_req.component.js";
 import type {
@@ -17,6 +17,18 @@ import type { ArcjetJsReqSensitiveInformationIdentifier } from "./wasm/interface
 import { wasm as componentCoreWasm } from "./wasm/arcjet_analyze_js_req.component.core.wasm?js";
 import { wasm as componentCore2Wasm } from "./wasm/arcjet_analyze_js_req.component.core2.wasm?js";
 import { wasm as componentCore3Wasm } from "./wasm/arcjet_analyze_js_req.component.core3.wasm?js";
+
+type AnalyzeRequest = {
+  ip?: string;
+  method?: string;
+  protocol?: string;
+  host?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  cookies?: string;
+  query?: string;
+  extra?: Record<string, string>;
+};
 
 const FREE_EMAIL_PROVIDERS = [
   "gmail.com",
@@ -144,7 +156,7 @@ export {
  */
 export async function generateFingerprint(
   context: AnalyzeContext,
-  request: Partial<ArcjetRequestDetails>,
+  request: AnalyzeRequest,
 ): Promise<string> {
   const analyze = await init(context);
 

--- a/analyze/workerd.ts
+++ b/analyze/workerd.ts
@@ -1,4 +1,4 @@
-import type { ArcjetLogger, ArcjetRequestDetails } from "@arcjet/protocol";
+import type { ArcjetLogger } from "@arcjet/protocol";
 
 import { instantiate } from "./wasm/arcjet_analyze_js_req.component.js";
 import type {
@@ -17,6 +17,18 @@ import type { ArcjetJsReqSensitiveInformationIdentifier } from "./wasm/interface
 import componentCoreWasm from "./wasm/arcjet_analyze_js_req.component.core.wasm";
 import componentCore2Wasm from "./wasm/arcjet_analyze_js_req.component.core2.wasm";
 import componentCore3Wasm from "./wasm/arcjet_analyze_js_req.component.core3.wasm";
+
+type AnalyzeRequest = {
+  ip?: string;
+  method?: string;
+  protocol?: string;
+  host?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  cookies?: string;
+  query?: string;
+  extra?: Record<string, string>;
+};
 
 const FREE_EMAIL_PROVIDERS = [
   "gmail.com",
@@ -130,7 +142,7 @@ export {
  */
 export async function generateFingerprint(
   context: AnalyzeContext,
-  request: Partial<ArcjetRequestDetails>,
+  request: AnalyzeRequest,
 ): Promise<string> {
   const analyze = await init(context);
 

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -217,6 +217,20 @@ function toString(value: unknown) {
   return "<unsupported value>";
 }
 
+function toAnalyzeRequest(request: Partial<ArcjetRequestDetails>) {
+  const headers: Record<string, string> = {};
+  if (typeof request.headers !== "undefined") {
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+  }
+
+  return {
+    ...request,
+    headers,
+  };
+}
+
 function extraProps<Props extends PlainObject>(
   details: ArcjetRequest<Props>,
 ): Record<string, string> {
@@ -1157,7 +1171,10 @@ export default function arcjet<
       ...ctx,
     };
 
-    const fingerprint = await analyze.generateFingerprint(baseContext, details);
+    const fingerprint = await analyze.generateFingerprint(
+      baseContext,
+      toAnalyzeRequest(details),
+    );
     log.debug("fingerprint (%s): %s", rt, fingerprint);
     log.timeEnd?.("fingerprint");
 

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -3390,7 +3390,8 @@ describe("SDK", () => {
     expect(client.decide).toHaveBeenCalledTimes(1);
     expect(client.decide).toHaveBeenCalledWith(
       expect.objectContaining({
-        fingerprint: "fp::2::6f3a3854134fe3d20fe56387bdcb594f18b182683424757b88da75e8f13b92bd",
+        fingerprint:
+          "fp::2::6f3a3854134fe3d20fe56387bdcb594f18b182683424757b88da75e8f13b92bd",
       }),
       expect.anything(),
       expect.anything(),


### PR DESCRIPTION
Closes #1434 

This fixes an issue with generating a fingerprint using headers because the `ArcjetHeaders` or `Headers` would not be serialized with `JSON.stringify`.

I also added a test that produced an empty-string fingerprint before the fix was implemented.