### PR TITLE
chore: remove sideEffects from analyze

### DIFF
--- a/analyze/package.json
+++ b/analyze/package.json
@@ -47,9 +47,6 @@
     "pretest": "npm run build",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
   },
-  "sideEffects": [
-    "./wasm/arcjet_analyze_js_req_bg.js"
-  ],
   "dependencies": {
     "@arcjet/protocol": "1.0.0-alpha.22"
   },


### PR DESCRIPTION
This PR removes the `sideEffects` from analyze's `package.json`. This is unused and is an artefact from when we used to use wasm-bindgen.
