### PR TITLE
fix(arcjet): Infer types when no detect function is specified

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -336,38 +336,39 @@ type DetectSensitiveInfoEntities<T> = (
   tokens: string[],
 ) => Array<ArcjetSensitiveInfoType | T | undefined>;
 
-type SensitiveInfoOptionsAllow<
-  Detect extends DetectSensitiveInfoEntities<CustomEntities>,
-  CustomEntities extends string,
-> = {
-  allow: Array<
-    ArcjetSensitiveInfoType | Exclude<ReturnType<Detect>[number], undefined>
-  >;
+type ValidEntities<Detect> = Array<
+  // Via https://www.reddit.com/r/typescript/comments/17up72w/comment/k958cb0/
+  // Conditional types distribute over unions. If you have ((string | undefined)
+  // extends undefined ? 1 : 0) it is evaluated separately for each member of
+  // the union, then union-ed together again. The result is (string extends
+  // undefined ? 1 : 0) | (undefined extends undefined ? 1 : 0) which simplifies
+  // to 0 | 1
+  undefined extends Detect
+    ? ArcjetSensitiveInfoType
+    : Detect extends DetectSensitiveInfoEntities<infer CustomEntities>
+      ? ArcjetSensitiveInfoType | CustomEntities
+      : never
+>;
+
+type SensitiveInfoOptionsAllow<Detect> = {
+  allow: ValidEntities<Detect>;
   deny?: never;
   contextWindowSize?: number;
   mode?: ArcjetMode;
   detect?: Detect;
 };
 
-type SensitiveInfoOptionsDeny<
-  Detect extends DetectSensitiveInfoEntities<CustomEntities>,
-  CustomEntities extends string,
-> = {
+type SensitiveInfoOptionsDeny<Detect> = {
   allow?: never;
-  deny: Array<
-    ArcjetSensitiveInfoType | Exclude<ReturnType<Detect>[number], undefined>
-  >;
+  deny: ValidEntities<Detect>;
   contextWindowSize?: number;
   mode?: ArcjetMode;
   detect?: Detect;
 };
 
-export type SensitiveInfoOptions<
-  Detect extends DetectSensitiveInfoEntities<CustomEntities>,
-  CustomEntities extends string,
-> =
-  | SensitiveInfoOptionsAllow<Detect, CustomEntities>
-  | SensitiveInfoOptionsDeny<Detect, CustomEntities>;
+export type SensitiveInfoOptions<Detect> =
+  | SensitiveInfoOptionsAllow<Detect>
+  | SensitiveInfoOptionsDeny<Detect>;
 
 const Priority = {
   SensitiveInfo: 1,
@@ -652,11 +653,11 @@ function convertAnalyzeDetectedSensitiveInfoEntity(
 }
 
 export function sensitiveInfo<
-  const Detect extends DetectSensitiveInfoEntities<CustomEntities>,
+  const Detect extends DetectSensitiveInfoEntities<CustomEntities> | undefined,
   const CustomEntities extends string,
 >(
-  options: SensitiveInfoOptions<Detect, CustomEntities>,
-  ...additionalOptions: SensitiveInfoOptions<Detect, CustomEntities>[]
+  options: SensitiveInfoOptions<Detect>,
+  ...additionalOptions: SensitiveInfoOptions<Detect>[]
 ): Primitive<{}> {
   const rules: ArcjetSensitiveInfoRule<{}>[] = [];
 

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -4202,12 +4202,12 @@ describe("SDK", () => {
 
       const customDetect = (tokens: string[]) => {
         expect(tokens).toHaveLength(3);
-        return new Array(tokens.length).fill(undefined);
+        return tokens.map(() => undefined);
       };
 
       const [rule] = sensitiveInfo({
         mode: "LIVE",
-        allow: ["custom"],
+        allow: [],
         detect: customDetect,
         contextWindowSize: 3,
       });


### PR DESCRIPTION
While trying to improve the type inference on #1358, I found that we weren't providing the correct type inference on the `sensitiveInfo` rule when a user **does not** specify a `detect()` function. This is likely the most common scenario so we want to have proper type inference here.

To solve this, I made `Detect` very generic throughout the types and then used some techniques (commented inline) to figure out if the function was specified in the options.