### PR TITLE
chore(example): Remove env package usage

### DIFF
--- a/examples/nextjs-14-app-dir-rl/app/api/custom_timeout/route.ts
+++ b/examples/nextjs-14-app-dir-rl/app/api/custom_timeout/route.ts
@@ -1,9 +1,7 @@
 import arcjet, { validateEmail, createRemoteClient } from "@arcjet/next";
-import { baseUrl } from "@arcjet/env";
 import { NextResponse } from "next/server";
 
 const client = createRemoteClient({
-  baseUrl: baseUrl(process.env),
   timeout: 10,
 });
 

--- a/examples/nextjs-14-app-dir-rl/package-lock.json
+++ b/examples/nextjs-14-app-dir-rl/package-lock.json
@@ -8,7 +8,6 @@
       "name": "nextjs-14-app-dir-rl",
       "version": "0.1.0",
       "dependencies": {
-        "@arcjet/env": "file:../../env",
         "@arcjet/next": "file:../../arcjet-next",
         "next": "^14.2.6",
         "react": "^18",
@@ -28,23 +27,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.22",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/env": "1.0.0-alpha.21",
-        "@arcjet/headers": "1.0.0-alpha.21",
-        "@arcjet/ip": "1.0.0-alpha.21",
-        "@arcjet/logger": "1.0.0-alpha.21",
-        "@arcjet/protocol": "1.0.0-alpha.21",
-        "@arcjet/transport": "1.0.0-alpha.21",
-        "arcjet": "1.0.0-alpha.21"
+        "@arcjet/env": "1.0.0-alpha.22",
+        "@arcjet/headers": "1.0.0-alpha.22",
+        "@arcjet/ip": "1.0.0-alpha.22",
+        "@arcjet/logger": "1.0.0-alpha.22",
+        "@arcjet/protocol": "1.0.0-alpha.22",
+        "@arcjet/transport": "1.0.0-alpha.22",
+        "arcjet": "1.0.0-alpha.22"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.0.0-alpha.21",
-        "@arcjet/rollup-config": "1.0.0-alpha.21",
-        "@arcjet/tsconfig": "1.0.0-alpha.21",
+        "@arcjet/eslint-config": "1.0.0-alpha.22",
+        "@arcjet/rollup-config": "1.0.0-alpha.22",
+        "@arcjet/tsconfig": "1.0.0-alpha.22",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.21.0",
+        "@rollup/wasm-node": "4.21.1",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
         "typescript": "5.5.4"
@@ -58,14 +57,15 @@
     },
     "../../env": {
       "name": "@arcjet/env",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.22",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@arcjet/eslint-config": "1.0.0-alpha.21",
-        "@arcjet/rollup-config": "1.0.0-alpha.21",
-        "@arcjet/tsconfig": "1.0.0-alpha.21",
+        "@arcjet/eslint-config": "1.0.0-alpha.22",
+        "@arcjet/rollup-config": "1.0.0-alpha.22",
+        "@arcjet/tsconfig": "1.0.0-alpha.22",
         "@jest/globals": "29.7.0",
-        "@rollup/wasm-node": "4.21.0",
+        "@rollup/wasm-node": "4.21.1",
         "jest": "29.7.0",
         "typescript": "5.5.4"
       },
@@ -93,10 +93,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@arcjet/env": {
-      "resolved": "../../env",
-      "link": true
     },
     "node_modules/@arcjet/next": {
       "resolved": "../../arcjet-next",

--- a/examples/nextjs-14-app-dir-rl/package.json
+++ b/examples/nextjs-14-app-dir-rl/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@arcjet/env": "file:../../env",
     "@arcjet/next": "file:../../arcjet-next",
     "next": "^14.2.6",
     "react": "^18",


### PR DESCRIPTION
Closes #1400 

We no longer need to provide the `baseUrl` just to override the timeout.