### PR TITLE
fix: Ensure instantiation throws if WebAssembly is unavailable

### DIFF
--- a/analyze/edge-light.ts
+++ b/analyze/edge-light.ts
@@ -106,7 +106,8 @@ async function init(
   };
 
   try {
-    return instantiate(moduleFromPath, coreImports);
+    // Await the instantiation to catch the failure
+    return await instantiate(moduleFromPath, coreImports);
   } catch {
     log.debug("WebAssembly is not supported in this runtime");
   }

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -120,7 +120,8 @@ async function init(
   };
 
   try {
-    return instantiate(moduleFromPath, coreImports);
+    // Await the instantiation to catch the failure
+    return await instantiate(moduleFromPath, coreImports);
   } catch {
     log.debug("WebAssembly is not supported in this runtime");
   }

--- a/analyze/workerd.ts
+++ b/analyze/workerd.ts
@@ -106,7 +106,8 @@ async function init(
   };
 
   try {
-    return instantiate(moduleFromPath, coreImports);
+    // Await the instantiation to catch the failure
+    return await instantiate(moduleFromPath, coreImports);
   } catch {
     log.debug("WebAssembly is not supported in this runtime");
   }

--- a/redact-wasm/edge-light.ts
+++ b/redact-wasm/edge-light.ts
@@ -1,4 +1,4 @@
-import * as core from "./wasm/arcjet_analyze_bindings_redact.component.js";
+import { instantiate } from "./wasm/arcjet_analyze_bindings_redact.component.js";
 import type {
   ImportObject,
   RedactedSensitiveInfoEntity,
@@ -37,7 +37,8 @@ export async function initializeWasm(
   };
 
   try {
-    return core.instantiate(moduleFromPath, coreImports);
+    // Await the instantiation to catch the failure
+    return await instantiate(moduleFromPath, coreImports);
   } catch {
     console.debug("WebAssembly is not supported in this runtime");
   }

--- a/redact-wasm/index.ts
+++ b/redact-wasm/index.ts
@@ -1,4 +1,4 @@
-import * as core from "./wasm/arcjet_analyze_bindings_redact.component.js";
+import { instantiate } from "./wasm/arcjet_analyze_bindings_redact.component.js";
 import type {
   ImportObject,
   RedactedSensitiveInfoEntity,
@@ -51,8 +51,7 @@ export async function initializeWasm(
 
   try {
     // Await the instantiation to catch the failure
-    const api = await core.instantiate(moduleFromPath, coreImports);
-    return api;
+    return await instantiate(moduleFromPath, coreImports);
   } catch {
     console.debug("WebAssembly is not supported in this runtime");
   }

--- a/redact-wasm/workerd.ts
+++ b/redact-wasm/workerd.ts
@@ -1,4 +1,4 @@
-import * as core from "./wasm/arcjet_analyze_bindings_redact.component.js";
+import { instantiate } from "./wasm/arcjet_analyze_bindings_redact.component.js";
 import type {
   ImportObject,
   RedactedSensitiveInfoEntity,
@@ -37,7 +37,8 @@ export async function initializeWasm(
   };
 
   try {
-    return core.instantiate(moduleFromPath, coreImports);
+    // Await the instantiation to catch the failure
+    return await instantiate(moduleFromPath, coreImports);
   } catch {
     console.debug("WebAssembly is not supported in this runtime");
   }


### PR DESCRIPTION
Closes #1454

When writing tests for redact and reach 100% coverage, I noticed that the Wasm errors weren't be raised correctly. This fixes it everywhere and normalizes the way we call instantiate.