### PR TITLE
chore(transport): Reduce idle timeout for AWS Global Accelerator

### DIFF
--- a/transport/index.ts
+++ b/transport/index.ts
@@ -6,8 +6,10 @@ import {
 export function createTransport(baseUrl: string) {
   // We create our own session manager so we can attempt to pre-connect
   const sessionManager = new Http2SessionManager(baseUrl, {
-    // AWS ALB doesn't support PING so we use a very high idle timeout
-    idleConnectionTimeoutMs: 600 * 1000,
+    // AWS Global Accelerator doesn't support PING so we use a very high idle
+    // timeout. Ref:
+    // https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout
+    idleConnectionTimeoutMs: 340 * 1000,
   });
 
   // We ignore the promise result because this is an optimistic pre-connect


### PR DESCRIPTION
Closes #1478 

This reduces the idle timeout we use for persistent HTTP/2 connections to 340 seconds. This is the value specified by AWS Global Accelerator for TCP connections.