### PR TITLE
chore(examples): Correct some usage mistakes in sensitive info examples

### DIFF
--- a/examples/express-sensitive-info/README.md
+++ b/examples/express-sensitive-info/README.md
@@ -39,7 +39,7 @@ This example shows how to use Arcjet to perform Sensitive Information detection 
    [dotenv](https://www.npmjs.com/package/dotenv) to load the environment file.
 
 4. Execute to POST request to `http://localhost:3000/` without any sensitive data.
-   `curl http://localhost:3000/ -X POST --data "hello world!"`
+   `curl http://localhost:3000/ -H "Content-Type: text/plain" -X POST --data "hello world!"`
 5. Execute to POST request to `http://localhost:3000/` with some blocked entities in the body
    and the request should fail.
-   `curl http://localhost:3000/ -X POST --data "my email address is test@example.com"`
+   `curl http://localhost:3000/ -H "Content-Type: text/plain" -X POST --data "my email address is test@example.com"`

--- a/examples/express-sensitive-info/index.js
+++ b/examples/express-sensitive-info/index.js
@@ -22,6 +22,8 @@ const aj = arcjet({
   ],
 });
 
+app.use(express.text());
+
 app.post('/', async (req, res) => {
   const decision = await aj.protect(req);
 
@@ -32,10 +34,8 @@ app.post('/', async (req, res) => {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: `You said: ${req.body}` }));
   }
-})
-
-app.use(express.text());
+});
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
-})
+});

--- a/examples/nextjs-14-sensitive-info/README.md
+++ b/examples/nextjs-14-sensitive-info/README.md
@@ -34,6 +34,6 @@ handler](https://nextjs.org/docs/app/building-your-application/routing/route-han
    ```
 
 5. Curl `http://localhost:3000/api/arcjet` with some data
-   `curl http://localhost:3000/api/arcjet --data "my email is test@example.com"`
-   `curl http://localhost:3000/api/arcjet --data "here's a string that contains-a-dash"`
+   `curl http://localhost:3000/api/arcjet -H "Content-Type: text/plain" -X POST --data "my email is test@example.com"`
+   `curl http://localhost:3000/api/arcjet -H "Content-Type: text/plain" -X POST --data "here's a string that contains-a-dash"`
 6. If the data you sent contains any blocked types then the route will return a 400.


### PR DESCRIPTION
While trying to ensure we're showing correct details in the app UI, I discovered some mistakes with the instructions of the sensitive info examples.