### PR TITLE
chore(ci): Sort dependabot projects and add missing nestjs example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -167,31 +167,6 @@ updates:
         versions: [">=9"]
 
   - package-ecosystem: npm
-    directory: /examples/nextjs-14-sensitive-info
-    schedule:
-      # Our dependencies should be checked daily
-      interval: daily
-    assignees:
-      - blaine-arcjet
-    reviewers:
-      - blaine-arcjet
-    commit-message:
-      prefix: deps(example)
-      prefix-development: deps(example)
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-    ignore:
-      # Ignore updates to the @types/node package due to conflict between
-      # Headers in DOM.
-      - dependency-name: "@types/node"
-        versions: [">18.18"]
-      # TODO(#539): Upgrade to eslint 9
-      - dependency-name: eslint
-        versions: [">=9"]
-
-  - package-ecosystem: npm
     directory: /examples/nextjs-14-app-dir-validate-email
     schedule:
       # Our dependencies should be checked daily
@@ -471,7 +446,32 @@ updates:
         versions: [">=8"]
 
   - package-ecosystem: npm
-    directory: /examples/nodejs-express-rl
+    directory: /examples/nextjs-14-sensitive-info
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Ignore updates to the @types/node package due to conflict between
+      # Headers in DOM.
+      - dependency-name: "@types/node"
+        versions: [">18.18"]
+      # TODO(#539): Upgrade to eslint 9
+      - dependency-name: eslint
+        versions: [">=9"]
+
+  - package-ecosystem: npm
+    directory: /examples/nodejs-express-launchdarkly
     schedule:
       # Our dependencies should be checked daily
       interval: daily
@@ -488,7 +488,7 @@ updates:
           - "*"
 
   - package-ecosystem: npm
-    directory: /examples/nodejs-express-launchdarkly
+    directory: /examples/nodejs-express-rl
     schedule:
       # Our dependencies should be checked daily
       interval: daily
@@ -523,6 +523,23 @@ updates:
 
   - package-ecosystem: npm
     directory: /examples/nodejs-hono-rl
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /examples/nodejs-nestjs
     schedule:
       # Our dependencies should be checked daily
       interval: daily


### PR DESCRIPTION
I noticed that nestjs is a big focus of our current alerts and then noticed we don't actually have it added to the dependabot config.

This adds it so we can do updates. I also sorted the items so we can more easily compare in the future.