### PR TITLE
chore(ci): Increase our dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
+    open-pull-requests-limit: 20
     assignees:
       - blaine-arcjet
     reviewers:


### PR DESCRIPTION
Since we're keeping some dependencies in draft until the updates stabilize, I'm noticing issues where dependabot won't open enough PRs to update everything. This increases the default limit of 5 to 20.