### PR TITLE
fix(protocol): Ensure relative imports have extensions

### DIFF
--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -9,7 +9,7 @@ import type {
   ArcjetSlidingWindowRateLimitRule,
   ArcjetShieldRule,
   ArcjetSensitiveInfoRule,
-} from "./index";
+} from "./index.js";
 import {
   ArcjetAllowDecision,
   ArcjetBotReason,
@@ -31,7 +31,7 @@ import {
   ArcjetStack,
   ArcjetIpDetails,
   ArcjetSensitiveInfoReason,
-} from "./index";
+} from "./index.js";
 import type { IpDetails } from "./proto/decide/v1alpha1/decide_pb.js";
 import {
   BotV2Reason,


### PR DESCRIPTION
It seems that there's a difference between `moduleResolution: "node"` and `"moduleResolution": "node16"` in that you need to always have an extension for `node16` to resolve a relative filepath.

This adds some missing extensions to the relative filepaths in our protocol package to resolve this issue.

Fixes #1720 