### PR TITLE
chore!: Add options validation for all rules

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -800,13 +800,17 @@ export function sensitiveInfo<
     typeof options.allow !== "undefined" &&
     typeof options.deny !== "undefined"
   ) {
-    throw new Error("`sensitiveInfo` options error: `allow` and `deny` cannot be provided together");
+    throw new Error(
+      "`sensitiveInfo` options error: `allow` and `deny` cannot be provided together",
+    );
   }
   if (
     typeof options.allow === "undefined" &&
     typeof options.deny === "undefined"
   ) {
-    throw new Error("`sensitiveInfo` options error: either `allow` or `deny` must be specified");
+    throw new Error(
+      "`sensitiveInfo` options error: either `allow` or `deny` must be specified",
+    );
   }
 
   return [

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -331,7 +331,7 @@ function createValidator({
           if (err instanceof Error) {
             throw new Error(`\`${rule}\` options error: ${err.message}`);
           } else {
-            throw new Error(`\`${rule}\` options error: unkonwn failure`);
+            throw new Error(`\`${rule}\` options error: unknown failure`);
           }
         }
       }
@@ -800,13 +800,13 @@ export function sensitiveInfo<
     typeof options.allow !== "undefined" &&
     typeof options.deny !== "undefined"
   ) {
-    throw new Error("Both allow and deny cannot be provided to sensitiveInfo");
+    throw new Error("`sensitiveInfo` options error: `allow` and `deny` cannot be provided together");
   }
   if (
     typeof options.allow === "undefined" &&
     typeof options.deny === "undefined"
   ) {
-    throw new Error("Must specify allow or deny to sensitiveInfo");
+    throw new Error("`sensitiveInfo` options error: either `allow` or `deny` must be specified");
   }
 
   return [
@@ -977,13 +977,17 @@ export function detectBot(options: BotOptions): Primitive<{}> {
     typeof options.allow !== "undefined" &&
     typeof options.deny !== "undefined"
   ) {
-    throw new Error("Both allow and deny cannot be provided to detectBot");
+    throw new Error(
+      "`detectBot` options error: `allow` and `deny` cannot be provided together",
+    );
   }
   if (
     typeof options.allow === "undefined" &&
     typeof options.deny === "undefined"
   ) {
-    throw new Error("Must specify allow or deny to detectBot");
+    throw new Error(
+      "`detectBot` options error: either `allow` or `deny` must be specified",
+    );
   }
 
   let config: BotConfig = {

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -242,6 +242,209 @@ function extraProps<Props extends PlainObject>(
   return Object.fromEntries(extra.entries());
 }
 
+type Validator = (key: string, value: unknown) => void;
+
+type ValidationSchema = {
+  key: string;
+  required: boolean;
+  validate: Validator;
+};
+
+function createTypeValidator(
+  ...types: Array<
+    // These are the types we can compare via `typeof`
+    | "string"
+    | "number"
+    | "bigint"
+    | "boolean"
+    | "symbol"
+    | "undefined"
+    | "object"
+    | "function"
+  >
+): Validator {
+  return (key, value) => {
+    const typeOfValue = typeof value;
+    if (!types.includes(typeOfValue)) {
+      if (types.length === 1) {
+        throw new Error(`invalid type for \`${key}\` - expected ${types[0]}`);
+      } else {
+        throw new Error(
+          `invalid type for \`${key}\` - expected one of ${types.join(", ")}`,
+        );
+      }
+    } else {
+      return false;
+    }
+  };
+}
+
+function createValueValidator(...values: string[]): Validator {
+  return (key, value) => {
+    // We cast the values to unknown because the optionValue isn't known but
+    // we only want to use `values` on string enumerations
+    if (!(values as unknown[]).includes(value)) {
+      if (values.length === 1) {
+        throw new Error(`invalid value for \`${key}\` - expected ${values[0]}`);
+      } else {
+        throw new Error(
+          `invalid value for \`${key}\` - expected one of ${values.map((value) => `'${value}'`).join(", ")}`,
+        );
+      }
+    }
+  };
+}
+
+function createArrayValidator(validate: Validator): Validator {
+  return (key, value) => {
+    if (Array.isArray(value)) {
+      for (const [idx, item] of value.entries()) {
+        validate(`${key}[${idx}]`, item);
+      }
+    } else {
+      throw new Error(`invalid type for \`${key}\` - expected an array`);
+    }
+  };
+}
+
+function createValidator({
+  rule,
+  validations,
+}: {
+  rule: string;
+  validations: ValidationSchema[];
+}) {
+  return (options: Record<string, unknown>) => {
+    for (const { key, validate, required } of validations) {
+      if (required && !Object.hasOwn(options, key)) {
+        throw new Error(`\`${rule}\` options error: \`${key}\` is required`);
+      }
+
+      const value = options[key];
+
+      // The `required` flag is checked above, so these should only be validated
+      // if the value is not undefined.
+      if (typeof value !== "undefined") {
+        try {
+          validate(key, value);
+        } catch (err) {
+          if (err instanceof Error) {
+            throw new Error(`\`${rule}\` options error: ${err.message}`);
+          } else {
+            throw new Error(`\`${rule}\` options error: unkonwn failure`);
+          }
+        }
+      }
+    }
+  };
+}
+
+const validateString = createTypeValidator("string");
+const validateNumber = createTypeValidator("number");
+const validateBoolean = createTypeValidator("boolean");
+const validateFunction = createTypeValidator("function");
+const validateStringOrNumber = createTypeValidator("string", "number");
+const validateStringArray = createArrayValidator(validateString);
+const validateMode = createValueValidator("LIVE", "DRY_RUN");
+const validateEmailTypes = createArrayValidator(
+  createValueValidator(
+    "DISPOSABLE",
+    "FREE",
+    "NO_MX_RECORDS",
+    "NO_GRAVATAR",
+    "INVALID",
+  ),
+);
+
+const validateTokenBucketOptions = createValidator({
+  rule: "tokenBucket",
+  validations: [
+    {
+      key: "mode",
+      required: false,
+      validate: validateMode,
+    },
+    { key: "match", required: false, validate: validateString },
+    {
+      key: "characteristics",
+      validate: validateStringArray,
+      required: false,
+    },
+    { key: "refillRate", required: true, validate: validateNumber },
+    { key: "interval", required: true, validate: validateStringOrNumber },
+    { key: "capacity", required: true, validate: validateNumber },
+  ],
+});
+
+const validateFixedWindowOptions = createValidator({
+  rule: "fixedWindow",
+  validations: [
+    { key: "mode", required: false, validate: validateMode },
+    { key: "match", required: false, validate: validateString },
+    {
+      key: "characteristics",
+      validate: validateStringArray,
+      required: false,
+    },
+    { key: "max", required: true, validate: validateNumber },
+    { key: "window", required: true, validate: validateStringOrNumber },
+  ],
+});
+
+const validateSlidingWindowOptions = createValidator({
+  rule: "slidingWindow",
+  validations: [
+    { key: "mode", required: false, validate: validateMode },
+    { key: "match", required: false, validate: validateString },
+    {
+      key: "characteristics",
+      validate: validateStringArray,
+      required: false,
+    },
+    { key: "max", required: true, validate: validateNumber },
+    { key: "interval", required: true, validate: validateStringOrNumber },
+  ],
+});
+
+const validateSensitiveInfoOptions = createValidator({
+  rule: "sensitiveInfo",
+  validations: [
+    { key: "mode", required: false, validate: validateMode },
+    { key: "allow", required: false, validate: validateStringArray },
+    { key: "deny", required: false, validate: validateStringArray },
+    { key: "contextWindowSize", required: false, validate: validateNumber },
+    { key: "detect", required: false, validate: validateFunction },
+  ],
+});
+
+const validateEmailOptions = createValidator({
+  rule: "validateEmail",
+  validations: [
+    { key: "mode", required: false, validate: validateMode },
+    { key: "block", required: false, validate: validateEmailTypes },
+    {
+      key: "requireTopLevelDomain",
+      required: false,
+      validate: validateBoolean,
+    },
+    { key: "allowDomainLiteral", required: false, validate: validateBoolean },
+  ],
+});
+
+const validateBotOptions = createValidator({
+  rule: "detectBot",
+  validations: [
+    { key: "mode", required: false, validate: validateMode },
+    { key: "allow", required: false, validate: validateStringArray },
+    { key: "deny", required: false, validate: validateStringArray },
+  ],
+});
+
+const validateShieldOptions = createValidator({
+  rule: "shield",
+  validations: [{ key: "mode", required: false, validate: validateMode }],
+});
+
 type TokenBucketRateLimitOptions<Characteristics extends readonly string[]> = {
   mode?: ArcjetMode;
   match?: string;
@@ -437,11 +640,11 @@ export function tokenBucket<
     >
   >
 > {
+  validateTokenBucketOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   const match = options.match;
-  const characteristics = Array.isArray(options.characteristics)
-    ? options.characteristics
-    : undefined;
+  const characteristics = options.characteristics;
 
   const refillRate = options.refillRate;
   const interval = duration.parse(options.interval);
@@ -467,6 +670,8 @@ export function fixedWindow<
 >(
   options: FixedWindowRateLimitOptions<Characteristics>,
 ): Primitive<Simplify<CharacteristicProps<Characteristics>>> {
+  validateFixedWindowOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   const match = options.match;
   const characteristics = Array.isArray(options.characteristics)
@@ -495,6 +700,8 @@ export function slidingWindow<
 >(
   options: SlidingWindowRateLimitOptions<Characteristics>,
 ): Primitive<Simplify<CharacteristicProps<Characteristics>>> {
+  validateSlidingWindowOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   const match = options.match;
   const characteristics = Array.isArray(options.characteristics)
@@ -586,6 +793,8 @@ export function sensitiveInfo<
   const Detect extends DetectSensitiveInfoEntities<CustomEntities> | undefined,
   const CustomEntities extends string,
 >(options: SensitiveInfoOptions<Detect>): Primitive<{}> {
+  validateSensitiveInfoOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   if (
     typeof options.allow !== "undefined" &&
@@ -699,6 +908,8 @@ export function sensitiveInfo<
 export function validateEmail(
   options: EmailOptions,
 ): Primitive<{ email: string }> {
+  validateEmailOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   const block = options.block ?? [];
   const requireTopLevelDomain = options.requireTopLevelDomain ?? true;
@@ -759,6 +970,8 @@ export function validateEmail(
 }
 
 export function detectBot(options: BotOptions): Primitive<{}> {
+  validateBotOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   if (
     typeof options.allow !== "undefined" &&
@@ -780,13 +993,7 @@ export function detectBot(options: BotOptions): Primitive<{}> {
       skipCustomDetect: true,
     },
   };
-  if (Array.isArray(options.allow)) {
-    for (const allow of options.allow) {
-      if (typeof allow !== "string") {
-        throw new Error("all values in `allow` must be a string");
-      }
-    }
-
+  if (typeof options.allow !== "undefined") {
     config = {
       tag: "allowed-bot-config",
       val: {
@@ -796,13 +1003,7 @@ export function detectBot(options: BotOptions): Primitive<{}> {
     };
   }
 
-  if (Array.isArray(options.deny)) {
-    for (const deny of options.deny) {
-      if (typeof deny !== "string") {
-        throw new Error("all values in `allow` must be a string");
-      }
-    }
-
+  if (typeof options.deny !== "undefined") {
     config = {
       tag: "denied-bot-config",
       val: {
@@ -882,6 +1083,8 @@ export type ShieldOptions = {
 };
 
 export function shield(options: ShieldOptions): Primitive<{}> {
+  validateShieldOptions(options);
+
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
   return [
     <ArcjetShieldRule<{}>>{

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -306,7 +306,7 @@ describe("ArcjetDecision", () => {
 });
 
 describe("Primitive > detectBot", () => {
-  test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
+  test("validates `mode` option if it is set", async () => {
     expect(() => {
       detectBot({
         // @ts-expect-error
@@ -318,7 +318,51 @@ describe("Primitive > detectBot", () => {
     );
   });
 
-  test("throws if `allow` and `deny` are both defined", async () => {
+  test("validates `allow` option is array if set", async () => {
+    expect(() => {
+      const _ = detectBot({
+        // @ts-expect-error
+        allow: "abc",
+      });
+    }).toThrow(
+      "detectBot` options error: invalid type for `allow` - expected an array",
+    );
+  });
+
+  test("validates `allow` option only contains strings", async () => {
+    expect(() => {
+      const _ = detectBot({
+        // @ts-expect-error
+        allow: [/abc/],
+      });
+    }).toThrow(
+      "detectBot` options error: invalid type for `allow[0]` - expected string",
+    );
+  });
+
+  test("validates `deny` option is an array if set", async () => {
+    expect(() => {
+      const _ = detectBot({
+        // @ts-expect-error
+        deny: "abc",
+      });
+    }).toThrow(
+      "detectBot` options error: invalid type for `deny` - expected an array",
+    );
+  });
+
+  test("validates `deny` option only contains strings", async () => {
+    expect(() => {
+      const _ = detectBot({
+        // @ts-expect-error
+        deny: [/abc/],
+      });
+    }).toThrow(
+      "detectBot` options error: invalid type for `deny[0]` - expected string",
+    );
+  });
+
+  test("validates `allow` and `deny` options are not specified together", async () => {
     expect(() => {
       const _ = detectBot(
         // @ts-expect-error
@@ -327,25 +371,20 @@ describe("Primitive > detectBot", () => {
           deny: ["GOOGLE_ADSBOT"],
         },
       );
-    }).toThrow();
+    }).toThrow(
+      "`detectBot` options error: `allow` and `deny` cannot be provided together",
+    );
   });
 
-  test("throws if `allow` contains non-strings", async () => {
+  test("validates either `allow` or `deny` option is specified", async () => {
     expect(() => {
-      const _ = detectBot({
+      const _ = detectBot(
         // @ts-expect-error
-        allow: [/abc/],
-      });
-    }).toThrow();
-  });
-
-  test("throws if `deny` contains non-strings", async () => {
-    expect(() => {
-      const _ = detectBot({
-        // @ts-expect-error
-        deny: [/abc/],
-      });
-    }).toThrow();
+        {},
+      );
+    }).toThrow(
+      "`detectBot` options error: either `allow` or `deny` must be specified",
+    );
   });
 
   test("throws via `validate()` if headers is undefined", () => {
@@ -568,19 +607,134 @@ describe("Primitive > detectBot", () => {
 });
 
 describe("Primitive > tokenBucket", () => {
-  test("validates `mode` if it is set", async () => {
+  test("validates `mode` option if it is set", async () => {
     expect(() => {
       tokenBucket({
         // @ts-expect-error
         mode: "INVALID",
-        match: "/test",
-        characteristics: ["ip.src"],
         refillRate: 1,
         interval: 1,
         capacity: 1,
       });
     }).toThrow(
       "`tokenBucket` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
+  });
+
+  test("validates `match` option if it is set", async () => {
+    expect(() => {
+      tokenBucket({
+        // @ts-expect-error
+        match: /foobar/,
+        refillRate: 1,
+        interval: 1,
+        capacity: 1,
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid type for `match` - expected string",
+    );
+  });
+
+  test("validates `characteristics` items are strings if it is set", async () => {
+    expect(() => {
+      tokenBucket({
+        // @ts-expect-error
+        characteristics: [/foobar/],
+        refillRate: 1,
+        interval: 1,
+        capacity: 1,
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid type for `characteristics[0]` - expected string",
+    );
+  });
+
+  test("validates `characteristics` option is an array if set", async () => {
+    expect(() => {
+      tokenBucket({
+        // @ts-expect-error
+        characteristics: 12345,
+        refillRate: 1,
+        interval: 1,
+        capacity: 1,
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid type for `characteristics` - expected an array",
+    );
+  });
+
+  test("validates `refillRate` option is required", async () => {
+    expect(() => {
+      tokenBucket(
+        // @ts-expect-error
+        {
+          interval: 1,
+          capacity: 1,
+        },
+      );
+    }).toThrow("`tokenBucket` options error: `refillRate` is required");
+  });
+
+  test("validates `refillRate` option is a number", async () => {
+    expect(() => {
+      tokenBucket({
+        // @ts-expect-error
+        refillRate: "abc",
+        interval: 1,
+        capacity: 1,
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid type for `refillRate` - expected number",
+    );
+  });
+
+  test("validates `interval` option is required", async () => {
+    expect(() => {
+      tokenBucket(
+        // @ts-expect-error
+        {
+          refillRate: 1,
+          capacity: 1,
+        },
+      );
+    }).toThrow("`tokenBucket` options error: `interval` is required");
+  });
+
+  test("validates `interval` option is a number or string", async () => {
+    expect(() => {
+      tokenBucket({
+        refillRate: 1,
+        // @ts-expect-error
+        interval: /foobar/,
+        capacity: 1,
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid type for `interval` - expected one of string, number",
+    );
+  });
+
+  test("validates `capacity` option is required", async () => {
+    expect(() => {
+      tokenBucket(
+        // @ts-expect-error
+        {
+          refillRate: 1,
+          interval: 1,
+        },
+      );
+    }).toThrow("`tokenBucket` options error: `capacity` is required");
+  });
+
+  test("validates `capacity` option is a number", async () => {
+    expect(() => {
+      tokenBucket({
+        refillRate: 1,
+        interval: 1,
+        // @ts-expect-error
+        capacity: "abc",
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid type for `capacity` - expected number",
     );
   });
 
@@ -696,18 +850,75 @@ describe("Primitive > tokenBucket", () => {
 });
 
 describe("Primitive > fixedWindow", () => {
-  test("validates `mode` if it is set", async () => {
+  test("validates `mode` option if it is set", async () => {
     expect(() => {
       fixedWindow({
         // @ts-expect-error
         mode: "INVALID",
-        match: "/test",
-        characteristics: ["ip.src"],
         window: "1h",
         max: 1,
       });
     }).toThrow(
       "`fixedWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
+  });
+
+  test("validates `match` option if it is set", async () => {
+    expect(() => {
+      fixedWindow({
+        // @ts-expect-error
+        match: /foobar/,
+        window: "1h",
+        max: 1,
+      });
+    }).toThrow(
+      "`fixedWindow` options error: invalid type for `match` - expected string",
+    );
+  });
+
+  test("validates `window` option is required", async () => {
+    expect(() => {
+      fixedWindow(
+        // @ts-expect-error
+        {
+          max: 1,
+        },
+      );
+    }).toThrow("`fixedWindow` options error: `window` is required");
+  });
+
+  test("validates `window` option is string or number", async () => {
+    expect(() => {
+      fixedWindow({
+        // @ts-expect-error
+        window: /foobar/,
+        max: 1,
+      });
+    }).toThrow(
+      "`fixedWindow` options error: invalid type for `window` - expected one of string, number",
+    );
+  });
+
+  test("validates `max` option is required", async () => {
+    expect(() => {
+      fixedWindow(
+        // @ts-expect-error
+        {
+          window: 1,
+        },
+      );
+    }).toThrow("`fixedWindow` options error: `max` is required");
+  });
+
+  test("validates `max` option is number", async () => {
+    expect(() => {
+      fixedWindow({
+        window: 1,
+        // @ts-expect-error
+        max: "abc",
+      });
+    }).toThrow(
+      "`fixedWindow` options error: invalid type for `max` - expected number",
     );
   });
 
@@ -810,18 +1021,75 @@ describe("Primitive > fixedWindow", () => {
 });
 
 describe("Primitive > slidingWindow", () => {
-  test("validates `mode` if it is set", async () => {
+  test("validates `mode` option if it is set", async () => {
     expect(() => {
       slidingWindow({
         // @ts-expect-error
         mode: "INVALID",
-        match: "/test",
-        characteristics: ["ip.src"],
         interval: 3600,
         max: 1,
       });
     }).toThrow(
       "`slidingWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
+  });
+
+  test("validates `match` option if it is set", async () => {
+    expect(() => {
+      slidingWindow({
+        // @ts-expect-error
+        match: /foobar/,
+        interval: 3600,
+        max: 1,
+      });
+    }).toThrow(
+      "`slidingWindow` options error: invalid type for `match` - expected string",
+    );
+  });
+
+  test("validates `interval` option is required", async () => {
+    expect(() => {
+      slidingWindow(
+        // @ts-expect-error
+        {
+          max: 1,
+        },
+      );
+    }).toThrow("`slidingWindow` options error: `interval` is required");
+  });
+
+  test("validates `interval` option is string or number", async () => {
+    expect(() => {
+      slidingWindow({
+        // @ts-expect-error
+        interval: /foobar/,
+        max: 1,
+      });
+    }).toThrow(
+      "`slidingWindow` options error: invalid type for `interval` - expected one of string, number",
+    );
+  });
+
+  test("validates `max` option is required", async () => {
+    expect(() => {
+      slidingWindow(
+        // @ts-expect-error
+        {
+          interval: 1,
+        },
+      );
+    }).toThrow("`slidingWindow` options error: `max` is required");
+  });
+
+  test("validates `max` option is number", async () => {
+    expect(() => {
+      slidingWindow({
+        interval: 1,
+        // @ts-expect-error
+        max: "abc",
+      });
+    }).toThrow(
+      "`slidingWindow` options error: invalid type for `max` - expected number",
     );
   });
 
@@ -924,7 +1192,7 @@ describe("Primitive > slidingWindow", () => {
 });
 
 describe("Primitive > validateEmail", () => {
-  test("validates `mode` if it is set", async () => {
+  test("validates `mode` option if it is set", async () => {
     expect(() => {
       validateEmail({
         // @ts-expect-error
@@ -932,6 +1200,50 @@ describe("Primitive > validateEmail", () => {
       });
     }).toThrow(
       "`validateEmail` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
+  });
+
+  test("validates `block` option is array if it is set", async () => {
+    expect(() => {
+      validateEmail({
+        // @ts-expect-error
+        block: 1234,
+      });
+    }).toThrow(
+      "`validateEmail` options error: invalid type for `block` - expected an array",
+    );
+  });
+
+  test("validates `block` option only contains specific values", async () => {
+    expect(() => {
+      validateEmail({
+        // @ts-expect-error
+        block: ["FOOBAR"],
+      });
+    }).toThrow(
+      "`validateEmail` options error: invalid value for `block[0]` - expected one of 'DISPOSABLE', 'FREE', 'NO_MX_RECORDS', 'NO_GRAVATAR', 'INVALID'",
+    );
+  });
+
+  test("validates `requireTopLevelDomain` option if it is set", async () => {
+    expect(() => {
+      validateEmail({
+        // @ts-expect-error
+        requireTopLevelDomain: "abc",
+      });
+    }).toThrow(
+      "`validateEmail` options error: invalid type for `requireTopLevelDomain` - expected boolean",
+    );
+  });
+
+  test("validates `allowDomainLiteral` option if it is set", async () => {
+    expect(() => {
+      validateEmail({
+        // @ts-expect-error
+        allowDomainLiteral: "abc",
+      });
+    }).toThrow(
+      "`validateEmail` options error: invalid type for `allowDomainLiteral` - expected boolean",
     );
   });
 
@@ -1287,7 +1599,7 @@ describe("Primitive > validateEmail", () => {
 });
 
 describe("Primitive > shield", () => {
-  test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
+  test("validates `mode` option if it is set", async () => {
     expect(() => {
       shield({
         // @ts-expect-error
@@ -1304,6 +1616,582 @@ describe("Primitive > shield", () => {
     });
     expect(rule.type).toEqual("SHIELD");
     expect(rule).toHaveProperty("mode", "LIVE");
+  });
+
+  test("sets mode as `DRY_RUN` if not specified", async () => {
+    const [rule] = shield({});
+    expect(rule.type).toEqual("SHIELD");
+    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  });
+});
+
+describe("Primitive > sensitiveInfo", () => {
+  test("validates `mode` option if it is set", async () => {
+    expect(() => {
+      sensitiveInfo({
+        // @ts-expect-error
+        mode: "INVALID",
+        allow: [],
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
+  });
+
+  test("validates `allow` option is an array if set", async () => {
+    expect(() => {
+      sensitiveInfo({
+        // @ts-expect-error
+        allow: "abc",
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid type for `allow` - expected an array",
+    );
+  });
+
+  test("validates `allow` option only contains strings", async () => {
+    expect(() => {
+      sensitiveInfo({
+        // @ts-expect-error
+        allow: [/foo/],
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid type for `allow[0]` - expected string",
+    );
+  });
+
+  test("validates `deny` option is an array if set", async () => {
+    expect(() => {
+      sensitiveInfo({
+        // @ts-expect-error
+        deny: "abc",
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid type for `deny` - expected an array",
+    );
+  });
+
+  test("validates `deny` option only contains strings", async () => {
+    expect(() => {
+      sensitiveInfo({
+        // @ts-expect-error
+        deny: [/foo/],
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid type for `deny[0]` - expected string",
+    );
+  });
+
+  test("validates `contextWindowSize` option if set", async () => {
+    expect(() => {
+      sensitiveInfo({
+        allow: [],
+        // @ts-expect-error
+        contextWindowSize: "abc"
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid type for `contextWindowSize` - expected number",
+    );
+  });
+
+  test("validates `detect` option if set", async () => {
+    expect(() => {
+      sensitiveInfo({
+        allow: [],
+        // @ts-expect-error
+        detect: "abc"
+      });
+    }).toThrow(
+      "`sensitiveInfo` options error: invalid type for `detect` - expected function",
+    );
+  });
+
+  test("validates `allow` and `deny` options are not specified together", async () => {
+    expect(() => {
+      const _ = sensitiveInfo(
+        // @ts-expect-error
+        {
+          allow: [],
+          deny: [],
+        },
+      );
+    }).toThrow(
+      "`sensitiveInfo` options error: `allow` and `deny` cannot be provided together",
+    );
+  });
+
+  test("validates either `allow` or `deny` option is specified", async () => {
+    expect(() => {
+      const _ = sensitiveInfo(
+        // @ts-expect-error
+        {},
+      );
+    }).toThrow(
+      "`sensitiveInfo` options error: either `allow` or `deny` must be specified",
+    );
+  });
+
+  test("allows specifying sensitive info entities to allow", async () => {
+    const [rule] = sensitiveInfo({
+      allow: ["EMAIL", "CREDIT_CARD_NUMBER"],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+  });
+
+  test("it doesnt detect any entities in a non sensitive body", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("none of this is sensitive"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      allow: [],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "ALLOW",
+      reason: new ArcjetSensitiveInfoReason({
+        denied: [],
+        allowed: [],
+      }),
+    });
+  });
+
+  test("it identifies built-in entities", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () =>
+        Promise.resolve(
+          "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
+        ),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      allow: [],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "DENY",
+      reason: new ArcjetSensitiveInfoReason({
+        denied: [
+          {
+            start: 0,
+            end: 9,
+            identifiedType: "IP_ADDRESS",
+          },
+          {
+            start: 10,
+            end: 26,
+            identifiedType: "EMAIL",
+          },
+          {
+            start: 27,
+            end: 43,
+            identifiedType: "CREDIT_CARD_NUMBER",
+          },
+          {
+            start: 44,
+            end: 60,
+            identifiedType: "PHONE_NUMBER",
+          },
+        ],
+        allowed: [],
+      }),
+    });
+  });
+
+  test("it allows entities on the allow list", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () =>
+        Promise.resolve(
+          "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
+        ),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      allow: ["EMAIL", "PHONE_NUMBER"],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "DENY",
+      reason: new ArcjetSensitiveInfoReason({
+        denied: [
+          {
+            start: 0,
+            end: 9,
+            identifiedType: "IP_ADDRESS",
+          },
+          {
+            start: 27,
+            end: 43,
+            identifiedType: "CREDIT_CARD_NUMBER",
+          },
+        ],
+        allowed: [
+          {
+            start: 10,
+            end: 26,
+            identifiedType: "EMAIL",
+          },
+          {
+            start: 44,
+            end: 60,
+            identifiedType: "PHONE_NUMBER",
+          },
+        ],
+      }),
+    });
+  });
+
+  test("it returns an allow decision when all identified types are allowed", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      allow: ["EMAIL", "PHONE_NUMBER"],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "ALLOW",
+      reason: new ArcjetSensitiveInfoReason({
+        denied: [],
+        allowed: [
+          {
+            start: 0,
+            end: 16,
+            identifiedType: "EMAIL",
+          },
+          {
+            start: 17,
+            end: 33,
+            identifiedType: "PHONE_NUMBER",
+          },
+        ],
+      }),
+    });
+  });
+
+  test("it only denies listed entities when deny mode is set", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      deny: ["CREDIT_CARD_NUMBER"],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "ALLOW",
+      reason: new ArcjetSensitiveInfoReason({
+        denied: [],
+        allowed: [
+          {
+            start: 0,
+            end: 16,
+            identifiedType: "EMAIL",
+          },
+          {
+            start: 17,
+            end: 33,
+            identifiedType: "PHONE_NUMBER",
+          },
+        ],
+      }),
+    });
+  });
+
+  test("it returns a deny decision in deny mode when an entity is matched", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      deny: ["EMAIL"],
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "DENY",
+      reason: new ArcjetSensitiveInfoReason({
+        denied: [
+          {
+            start: 0,
+            end: 16,
+            identifiedType: "EMAIL",
+          },
+        ],
+        allowed: [
+          {
+            start: 17,
+            end: 33,
+            identifiedType: "PHONE_NUMBER",
+          },
+        ],
+      }),
+    });
+  });
+
+  test("it blocks entities identified by a custom function", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("this is bad"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const customDetect = (tokens: string[]) => {
+      return tokens.map((token) => {
+        if (token === "bad") {
+          return "CUSTOM";
+        }
+      });
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      deny: ["CUSTOM"],
+      contextWindowSize: 1,
+      detect: customDetect,
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "DENY",
+      reason: new ArcjetSensitiveInfoReason({
+        allowed: [],
+        denied: [
+          {
+            start: 8,
+            end: 11,
+            identifiedType: "CUSTOM",
+          },
+        ],
+      }),
+    });
+  });
+
+  test("it allows custom entities identified by a function that would have otherwise been blocked", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("my email is test@example.com"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const customDetect = (tokens: string[]) => {
+      return tokens.map((token) => {
+        if (token === "test@example.com") {
+          return "custom";
+        }
+      });
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      allow: ["custom"],
+      detect: customDetect,
+      contextWindowSize: 1,
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    const result = await rule.protect(context, details);
+    expect(result).toMatchObject({
+      state: "RUN",
+      conclusion: "ALLOW",
+      reason: new ArcjetSensitiveInfoReason({
+        allowed: [
+          {
+            start: 12,
+            end: 28,
+            identifiedType: "custom",
+          },
+        ],
+        denied: [],
+      }),
+    });
+  });
+
+  test("it provides the right size context window", async () => {
+    const context = {
+      key: "test-key",
+      fingerprint: "test-fingerprint",
+      runtime: "test",
+      log,
+      characteristics: [],
+      getBody: () => Promise.resolve("my email is test@example.com"),
+    };
+    const details = {
+      ip: "172.100.1.1",
+      method: "GET",
+      protocol: "http",
+      host: "example.com",
+      path: "/",
+      headers: new Headers(),
+      cookies: "",
+      query: "",
+      extra: {},
+    };
+
+    const customDetect = (tokens: string[]) => {
+      expect(tokens).toHaveLength(3);
+      return tokens.map(() => undefined);
+    };
+
+    const [rule] = sensitiveInfo({
+      mode: "LIVE",
+      allow: [],
+      detect: customDetect,
+      contextWindowSize: 3,
+    });
+    expect(rule.type).toEqual("SENSITIVE_INFO");
+    assertIsLocalRule(rule);
+    await rule.protect(context, details);
   });
 });
 
@@ -3184,482 +4072,5 @@ describe("SDK", () => {
         }),
       ],
     );
-  });
-
-  describe("Primitive > sensitiveInfo", () => {
-    test("validates `mode` if it is set", async () => {
-      expect(() => {
-        sensitiveInfo({
-          // @ts-expect-error
-          mode: "INVALID",
-          allow: [],
-        });
-      }).toThrow(
-        "`sensitiveInfo` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
-      );
-    });
-
-    test("allows specifying sensitive info entities to allow", async () => {
-      const [rule] = sensitiveInfo({
-        allow: ["EMAIL", "CREDIT_CARD_NUMBER"],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-    });
-
-    test("it doesnt detect any entities in a non sensitive body", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("none of this is sensitive"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        allow: [],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "ALLOW",
-        reason: new ArcjetSensitiveInfoReason({
-          denied: [],
-          allowed: [],
-        }),
-      });
-    });
-
-    test("it identifies built-in entities", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () =>
-          Promise.resolve(
-            "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
-          ),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        allow: [],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "DENY",
-        reason: new ArcjetSensitiveInfoReason({
-          denied: [
-            {
-              start: 0,
-              end: 9,
-              identifiedType: "IP_ADDRESS",
-            },
-            {
-              start: 10,
-              end: 26,
-              identifiedType: "EMAIL",
-            },
-            {
-              start: 27,
-              end: 43,
-              identifiedType: "CREDIT_CARD_NUMBER",
-            },
-            {
-              start: 44,
-              end: 60,
-              identifiedType: "PHONE_NUMBER",
-            },
-          ],
-          allowed: [],
-        }),
-      });
-    });
-
-    test("it allows entities on the allow list", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () =>
-          Promise.resolve(
-            "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
-          ),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        allow: ["EMAIL", "PHONE_NUMBER"],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "DENY",
-        reason: new ArcjetSensitiveInfoReason({
-          denied: [
-            {
-              start: 0,
-              end: 9,
-              identifiedType: "IP_ADDRESS",
-            },
-            {
-              start: 27,
-              end: 43,
-              identifiedType: "CREDIT_CARD_NUMBER",
-            },
-          ],
-          allowed: [
-            {
-              start: 10,
-              end: 26,
-              identifiedType: "EMAIL",
-            },
-            {
-              start: 44,
-              end: 60,
-              identifiedType: "PHONE_NUMBER",
-            },
-          ],
-        }),
-      });
-    });
-
-    test("it returns an allow decision when all identified types are allowed", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        allow: ["EMAIL", "PHONE_NUMBER"],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "ALLOW",
-        reason: new ArcjetSensitiveInfoReason({
-          denied: [],
-          allowed: [
-            {
-              start: 0,
-              end: 16,
-              identifiedType: "EMAIL",
-            },
-            {
-              start: 17,
-              end: 33,
-              identifiedType: "PHONE_NUMBER",
-            },
-          ],
-        }),
-      });
-    });
-
-    test("it only denies listed entities when deny mode is set", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        deny: ["CREDIT_CARD_NUMBER"],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "ALLOW",
-        reason: new ArcjetSensitiveInfoReason({
-          denied: [],
-          allowed: [
-            {
-              start: 0,
-              end: 16,
-              identifiedType: "EMAIL",
-            },
-            {
-              start: 17,
-              end: 33,
-              identifiedType: "PHONE_NUMBER",
-            },
-          ],
-        }),
-      });
-    });
-
-    test("it returns a deny decision in deny mode when an entity is matched", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        deny: ["EMAIL"],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "DENY",
-        reason: new ArcjetSensitiveInfoReason({
-          denied: [
-            {
-              start: 0,
-              end: 16,
-              identifiedType: "EMAIL",
-            },
-          ],
-          allowed: [
-            {
-              start: 17,
-              end: 33,
-              identifiedType: "PHONE_NUMBER",
-            },
-          ],
-        }),
-      });
-    });
-
-    test("it blocks entities identified by a custom function", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("this is bad"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const customDetect = (tokens: string[]) => {
-        return tokens.map((token) => {
-          if (token === "bad") {
-            return "CUSTOM";
-          }
-        });
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        deny: ["CUSTOM"],
-        contextWindowSize: 1,
-        detect: customDetect,
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "DENY",
-        reason: new ArcjetSensitiveInfoReason({
-          allowed: [],
-          denied: [
-            {
-              start: 8,
-              end: 11,
-              identifiedType: "CUSTOM",
-            },
-          ],
-        }),
-      });
-    });
-
-    test("it allows custom entities identified by a function that would have otherwise been blocked", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("my email is test@example.com"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const customDetect = (tokens: string[]) => {
-        return tokens.map((token) => {
-          if (token === "test@example.com") {
-            return "custom";
-          }
-        });
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        allow: ["custom"],
-        detect: customDetect,
-        contextWindowSize: 1,
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      const result = await rule.protect(context, details);
-      expect(result).toMatchObject({
-        state: "RUN",
-        conclusion: "ALLOW",
-        reason: new ArcjetSensitiveInfoReason({
-          allowed: [
-            {
-              start: 12,
-              end: 28,
-              identifiedType: "custom",
-            },
-          ],
-          denied: [],
-        }),
-      });
-    });
-
-    test("it provides the right size context window", async () => {
-      const context = {
-        key: "test-key",
-        fingerprint: "test-fingerprint",
-        runtime: "test",
-        log,
-        characteristics: [],
-        getBody: () => Promise.resolve("my email is test@example.com"),
-      };
-      const details = {
-        ip: "172.100.1.1",
-        method: "GET",
-        protocol: "http",
-        host: "example.com",
-        path: "/",
-        headers: new Headers(),
-        cookies: "",
-        query: "",
-        extra: {},
-      };
-
-      const customDetect = (tokens: string[]) => {
-        expect(tokens).toHaveLength(3);
-        return tokens.map(() => undefined);
-      };
-
-      const [rule] = sensitiveInfo({
-        mode: "LIVE",
-        allow: [],
-        detect: customDetect,
-        contextWindowSize: 3,
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      assertIsLocalRule(rule);
-      await rule.protect(context, details);
-    });
   });
 });

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -307,13 +307,15 @@ describe("ArcjetDecision", () => {
 
 describe("Primitive > detectBot", () => {
   test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
-    const [rule] = detectBot({
-      // @ts-expect-error
-      mode: "INVALID",
-      allow: [],
-    });
-    expect(rule.type).toEqual("BOT");
-    expect(rule).toHaveProperty("mode", "DRY_RUN");
+    expect(() => {
+      detectBot({
+        // @ts-expect-error
+        mode: "INVALID",
+        allow: [],
+      });
+    }).toThrow(
+      "`detectBot` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
   });
 
   test("throws if `allow` and `deny` are both defined", async () => {
@@ -566,18 +568,20 @@ describe("Primitive > detectBot", () => {
 });
 
 describe("Primitive > tokenBucket", () => {
-  test("sets mode as `DRY_RUN` if not 'LIVE' or 'DRY_RUN'", async () => {
-    const [rule] = tokenBucket({
-      // @ts-expect-error
-      mode: "INVALID",
-      match: "/test",
-      characteristics: ["ip.src"],
-      refillRate: 1,
-      interval: 1,
-      capacity: 1,
-    });
-    expect(rule.type).toEqual("RATE_LIMIT");
-    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  test("validates `mode` if it is set", async () => {
+    expect(() => {
+      tokenBucket({
+        // @ts-expect-error
+        mode: "INVALID",
+        match: "/test",
+        characteristics: ["ip.src"],
+        refillRate: 1,
+        interval: 1,
+        capacity: 1,
+      });
+    }).toThrow(
+      "`tokenBucket` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
   });
 
   test("sets mode as `LIVE` if specified", async () => {
@@ -692,17 +696,19 @@ describe("Primitive > tokenBucket", () => {
 });
 
 describe("Primitive > fixedWindow", () => {
-  test("sets mode as `DRY_RUN` if not 'LIVE' or 'DRY_RUN'", async () => {
-    const [rule] = fixedWindow({
-      // @ts-expect-error
-      mode: "INVALID",
-      match: "/test",
-      characteristics: ["ip.src"],
-      window: "1h",
-      max: 1,
-    });
-    expect(rule.type).toEqual("RATE_LIMIT");
-    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  test("validates `mode` if it is set", async () => {
+    expect(() => {
+      fixedWindow({
+        // @ts-expect-error
+        mode: "INVALID",
+        match: "/test",
+        characteristics: ["ip.src"],
+        window: "1h",
+        max: 1,
+      });
+    }).toThrow(
+      "`fixedWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
   });
 
   test("sets mode as `LIVE` if specified", async () => {
@@ -804,17 +810,19 @@ describe("Primitive > fixedWindow", () => {
 });
 
 describe("Primitive > slidingWindow", () => {
-  test("sets mode as `DRY_RUN` if not 'LIVE' or 'DRY_RUN'", async () => {
-    const [rule] = slidingWindow({
-      // @ts-expect-error
-      mode: "INVALID",
-      match: "/test",
-      characteristics: ["ip.src"],
-      interval: 3600,
-      max: 1,
-    });
-    expect(rule.type).toEqual("RATE_LIMIT");
-    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  test("validates `mode` if it is set", async () => {
+    expect(() => {
+      slidingWindow({
+        // @ts-expect-error
+        mode: "INVALID",
+        match: "/test",
+        characteristics: ["ip.src"],
+        interval: 3600,
+        max: 1,
+      });
+    }).toThrow(
+      "`slidingWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
   });
 
   test("sets mode as `LIVE` if specified", async () => {
@@ -916,13 +924,15 @@ describe("Primitive > slidingWindow", () => {
 });
 
 describe("Primitive > validateEmail", () => {
-  test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
-    const [rule] = validateEmail({
-      // @ts-expect-error
-      mode: "INVALID",
-    });
-    expect(rule.type).toEqual("EMAIL");
-    expect(rule).toHaveProperty("mode", "DRY_RUN");
+  test("validates `mode` if it is set", async () => {
+    expect(() => {
+      validateEmail({
+        // @ts-expect-error
+        mode: "INVALID",
+      });
+    }).toThrow(
+      "`validateEmail` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
   });
 
   test("allows specifying EmailTypes to block", async () => {
@@ -1278,12 +1288,14 @@ describe("Primitive > validateEmail", () => {
 
 describe("Primitive > shield", () => {
   test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
-    const [rule] = shield({
-      // @ts-expect-error
-      mode: "INVALID",
-    });
-    expect(rule.type).toEqual("SHIELD");
-    expect(rule).toHaveProperty("mode", "DRY_RUN");
+    expect(() => {
+      shield({
+        // @ts-expect-error
+        mode: "INVALID",
+      });
+    }).toThrow(
+      "`shield` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+    );
   });
 
   test("sets mode as `LIVE` if specified", async () => {
@@ -3175,14 +3187,16 @@ describe("SDK", () => {
   });
 
   describe("Primitive > sensitiveInfo", () => {
-    test("sets mode as 'DRY_RUN' if not 'LIVE' or 'DRY_RUN'", async () => {
-      const [rule] = sensitiveInfo({
-        // @ts-expect-error
-        mode: "INVALID",
-        allow: [],
-      });
-      expect(rule.type).toEqual("SENSITIVE_INFO");
-      expect(rule).toHaveProperty("mode", "DRY_RUN");
+    test("validates `mode` if it is set", async () => {
+      expect(() => {
+        sensitiveInfo({
+          // @ts-expect-error
+          mode: "INVALID",
+          allow: [],
+        });
+      }).toThrow(
+        "`sensitiveInfo` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
+      );
     });
 
     test("allows specifying sensitive info entities to allow", async () => {

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -1687,7 +1687,7 @@ describe("Primitive > sensitiveInfo", () => {
       sensitiveInfo({
         allow: [],
         // @ts-expect-error
-        contextWindowSize: "abc"
+        contextWindowSize: "abc",
       });
     }).toThrow(
       "`sensitiveInfo` options error: invalid type for `contextWindowSize` - expected number",
@@ -1699,7 +1699,7 @@ describe("Primitive > sensitiveInfo", () => {
       sensitiveInfo({
         allow: [],
         // @ts-expect-error
-        detect: "abc"
+        detect: "abc",
       });
     }).toThrow(
       "`sensitiveInfo` options error: invalid type for `detect` - expected function",


### PR DESCRIPTION
This adds option validation on all of our rules. We've relied too heavily on TypeScript types to ensure that all options are passed correctly, but that has lead to issues when TypeScript is configured less strictly or JavaScript is used.

I've written some very simple validation machinery in our core package and implemented for all our rules.

Closes #992 