### PR TITLE
chore!: Remove `match` option from rate limit rules

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -364,7 +364,6 @@ const validateTokenBucketOptions = createValidator({
       required: false,
       validate: validateMode,
     },
-    { key: "match", required: false, validate: validateString },
     {
       key: "characteristics",
       validate: validateStringArray,
@@ -380,7 +379,6 @@ const validateFixedWindowOptions = createValidator({
   rule: "fixedWindow",
   validations: [
     { key: "mode", required: false, validate: validateMode },
-    { key: "match", required: false, validate: validateString },
     {
       key: "characteristics",
       validate: validateStringArray,
@@ -395,7 +393,6 @@ const validateSlidingWindowOptions = createValidator({
   rule: "slidingWindow",
   validations: [
     { key: "mode", required: false, validate: validateMode },
-    { key: "match", required: false, validate: validateString },
     {
       key: "characteristics",
       validate: validateStringArray,
@@ -447,7 +444,6 @@ const validateShieldOptions = createValidator({
 
 type TokenBucketRateLimitOptions<Characteristics extends readonly string[]> = {
   mode?: ArcjetMode;
-  match?: string;
   characteristics?: Characteristics;
   refillRate: number;
   interval: string | number;
@@ -456,7 +452,6 @@ type TokenBucketRateLimitOptions<Characteristics extends readonly string[]> = {
 
 type FixedWindowRateLimitOptions<Characteristics extends readonly string[]> = {
   mode?: ArcjetMode;
-  match?: string;
   characteristics?: Characteristics;
   window: string | number;
   max: number;
@@ -465,7 +460,6 @@ type FixedWindowRateLimitOptions<Characteristics extends readonly string[]> = {
 type SlidingWindowRateLimitOptions<Characteristics extends readonly string[]> =
   {
     mode?: ArcjetMode;
-    match?: string;
     characteristics?: Characteristics;
     interval: string | number;
     max: number;
@@ -643,7 +637,6 @@ export function tokenBucket<
   validateTokenBucketOptions(options);
 
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
-  const match = options.match;
   const characteristics = options.characteristics;
 
   const refillRate = options.refillRate;
@@ -655,7 +648,6 @@ export function tokenBucket<
       type: "RATE_LIMIT",
       priority: Priority.RateLimit,
       mode,
-      match,
       characteristics,
       algorithm: "TOKEN_BUCKET",
       refillRate,
@@ -673,7 +665,6 @@ export function fixedWindow<
   validateFixedWindowOptions(options);
 
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
-  const match = options.match;
   const characteristics = Array.isArray(options.characteristics)
     ? options.characteristics
     : undefined;
@@ -686,7 +677,6 @@ export function fixedWindow<
       type: "RATE_LIMIT",
       priority: Priority.RateLimit,
       mode,
-      match,
       characteristics,
       algorithm: "FIXED_WINDOW",
       max,
@@ -703,7 +693,6 @@ export function slidingWindow<
   validateSlidingWindowOptions(options);
 
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
-  const match = options.match;
   const characteristics = Array.isArray(options.characteristics)
     ? options.characteristics
     : undefined;
@@ -716,7 +705,6 @@ export function slidingWindow<
       type: "RATE_LIMIT",
       priority: Priority.RateLimit,
       mode,
-      match,
       characteristics,
       algorithm: "SLIDING_WINDOW",
       max,

--- a/arcjet/test/index.node.test.ts
+++ b/arcjet/test/index.node.test.ts
@@ -621,20 +621,6 @@ describe("Primitive > tokenBucket", () => {
     );
   });
 
-  test("validates `match` option if it is set", async () => {
-    expect(() => {
-      tokenBucket({
-        // @ts-expect-error
-        match: /foobar/,
-        refillRate: 1,
-        interval: 1,
-        capacity: 1,
-      });
-    }).toThrow(
-      "`tokenBucket` options error: invalid type for `match` - expected string",
-    );
-  });
-
   test("validates `characteristics` items are strings if it is set", async () => {
     expect(() => {
       tokenBucket({
@@ -741,7 +727,6 @@ describe("Primitive > tokenBucket", () => {
   test("sets mode as `LIVE` if specified", async () => {
     const [rule] = tokenBucket({
       mode: "LIVE",
-      match: "/test",
       characteristics: ["ip.src"],
       refillRate: 1,
       interval: 1,
@@ -816,7 +801,6 @@ describe("Primitive > tokenBucket", () => {
 
   test("produces a rules based on configuration specified", async () => {
     const options = {
-      match: "/test",
       characteristics: ["ip.src"],
       refillRate: 1,
       interval: 1,
@@ -827,7 +811,6 @@ describe("Primitive > tokenBucket", () => {
     expect(rules).toHaveLength(1);
     expect(rules[0].type).toEqual("RATE_LIMIT");
     expect(rules[0]).toHaveProperty("mode", "DRY_RUN");
-    expect(rules[0]).toHaveProperty("match", "/test");
     expect(rules[0]).toHaveProperty("characteristics", ["ip.src"]);
     expect(rules[0]).toHaveProperty("algorithm", "TOKEN_BUCKET");
     expect(rules[0]).toHaveProperty("refillRate", 1);
@@ -835,7 +818,7 @@ describe("Primitive > tokenBucket", () => {
     expect(rules[0]).toHaveProperty("capacity", 1);
   });
 
-  test("does not default `match` and `characteristics` if not specified", async () => {
+  test("does not default `characteristics` if not specified", async () => {
     const options = {
       refillRate: 1,
       interval: 1,
@@ -844,7 +827,6 @@ describe("Primitive > tokenBucket", () => {
 
     const [rule] = tokenBucket(options);
     expect(rule.type).toEqual("RATE_LIMIT");
-    expect(rule).toHaveProperty("match", undefined);
     expect(rule).toHaveProperty("characteristics", undefined);
   });
 });
@@ -860,19 +842,6 @@ describe("Primitive > fixedWindow", () => {
       });
     }).toThrow(
       "`fixedWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
-    );
-  });
-
-  test("validates `match` option if it is set", async () => {
-    expect(() => {
-      fixedWindow({
-        // @ts-expect-error
-        match: /foobar/,
-        window: "1h",
-        max: 1,
-      });
-    }).toThrow(
-      "`fixedWindow` options error: invalid type for `match` - expected string",
     );
   });
 
@@ -925,7 +894,6 @@ describe("Primitive > fixedWindow", () => {
   test("sets mode as `LIVE` if specified", async () => {
     const [rule] = fixedWindow({
       mode: "LIVE",
-      match: "/test",
       characteristics: ["ip.src"],
       window: "1h",
       max: 1,
@@ -990,7 +958,6 @@ describe("Primitive > fixedWindow", () => {
 
   test("produces a rules based on configuration specified", async () => {
     const options = {
-      match: "/test",
       characteristics: ["ip.src"],
       window: "1h",
       max: 1,
@@ -1000,14 +967,13 @@ describe("Primitive > fixedWindow", () => {
     expect(rules).toHaveLength(1);
     expect(rules[0].type).toEqual("RATE_LIMIT");
     expect(rules[0]).toHaveProperty("mode", "DRY_RUN");
-    expect(rules[0]).toHaveProperty("match", "/test");
     expect(rules[0]).toHaveProperty("characteristics", ["ip.src"]);
     expect(rules[0]).toHaveProperty("algorithm", "FIXED_WINDOW");
     expect(rules[0]).toHaveProperty("window", 3600);
     expect(rules[0]).toHaveProperty("max", 1);
   });
 
-  test("does not default `match` and `characteristics` if not specified", async () => {
+  test("does not default `characteristics` if not specified", async () => {
     const options = {
       window: "1h",
       max: 1,
@@ -1015,7 +981,6 @@ describe("Primitive > fixedWindow", () => {
 
     const [rule] = fixedWindow(options);
     expect(rule.type).toEqual("RATE_LIMIT");
-    expect(rule).toHaveProperty("match", undefined);
     expect(rule).toHaveProperty("characteristics", undefined);
   });
 });
@@ -1031,19 +996,6 @@ describe("Primitive > slidingWindow", () => {
       });
     }).toThrow(
       "`slidingWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'",
-    );
-  });
-
-  test("validates `match` option if it is set", async () => {
-    expect(() => {
-      slidingWindow({
-        // @ts-expect-error
-        match: /foobar/,
-        interval: 3600,
-        max: 1,
-      });
-    }).toThrow(
-      "`slidingWindow` options error: invalid type for `match` - expected string",
     );
   });
 
@@ -1096,7 +1048,6 @@ describe("Primitive > slidingWindow", () => {
   test("sets mode as `LIVE` if specified", async () => {
     const [rule] = slidingWindow({
       mode: "LIVE",
-      match: "/test",
       characteristics: ["ip.src"],
       interval: 3600,
       max: 1,
@@ -1161,7 +1112,6 @@ describe("Primitive > slidingWindow", () => {
 
   test("produces a rules based on configuration specified", async () => {
     const options = {
-      match: "/test",
       characteristics: ["ip.src"],
       interval: 3600,
       max: 1,
@@ -1171,14 +1121,13 @@ describe("Primitive > slidingWindow", () => {
     expect(rules).toHaveLength(1);
     expect(rules[0].type).toEqual("RATE_LIMIT");
     expect(rules[0]).toHaveProperty("mode", "DRY_RUN");
-    expect(rules[0]).toHaveProperty("match", "/test");
     expect(rules[0]).toHaveProperty("characteristics", ["ip.src"]);
     expect(rules[0]).toHaveProperty("algorithm", "SLIDING_WINDOW");
     expect(rules[0]).toHaveProperty("interval", 3600);
     expect(rules[0]).toHaveProperty("max", 1);
   });
 
-  test("does not default `match` and `characteristics` if not specified", async () => {
+  test("does not default `characteristics` if not specified", async () => {
     const options = {
       interval: 3600,
       max: 1,
@@ -1186,7 +1135,6 @@ describe("Primitive > slidingWindow", () => {
 
     const [rule] = slidingWindow(options);
     expect(rule.type).toEqual("RATE_LIMIT");
-    expect(rule).toHaveProperty("match", undefined);
     expect(rule).toHaveProperty("characteristics", undefined);
   });
 });
@@ -2200,7 +2148,6 @@ describe("Products > protectSignup", () => {
     const rules = protectSignup({
       rateLimit: {
         mode: ArcjetMode.DRY_RUN,
-        match: "/test",
         characteristics: ["ip.src"],
         interval: 60 /* minutes */ * 60 /* seconds */,
         max: 1,

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -572,7 +572,6 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
         case: "rateLimit",
         value: {
           mode: ArcjetModeToProtocol(rule.mode),
-          match: rule.match,
           characteristics: rule.characteristics,
           algorithm: RateLimitAlgorithm.TOKEN_BUCKET,
           refillRate: rule.refillRate,
@@ -589,7 +588,6 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
         case: "rateLimit",
         value: {
           mode: ArcjetModeToProtocol(rule.mode),
-          match: rule.match,
           characteristics: rule.characteristics,
           algorithm: RateLimitAlgorithm.FIXED_WINDOW,
           max: rule.max,
@@ -605,7 +603,6 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
         case: "rateLimit",
         value: {
           mode: ArcjetModeToProtocol(rule.mode),
-          match: rule.match,
           characteristics: rule.characteristics,
           algorithm: RateLimitAlgorithm.SLIDING_WINDOW,
           max: rule.max,

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -721,7 +721,6 @@ export interface ArcjetTokenBucketRateLimitRule<Props extends {}>
   extends ArcjetRateLimitRule<Props> {
   algorithm: "TOKEN_BUCKET";
 
-  match?: string;
   refillRate: number;
   interval: number;
   capacity: number;
@@ -731,7 +730,6 @@ export interface ArcjetFixedWindowRateLimitRule<Props extends {}>
   extends ArcjetRateLimitRule<Props> {
   algorithm: "FIXED_WINDOW";
 
-  match?: string;
   max: number;
   window: number;
 }
@@ -740,7 +738,6 @@ export interface ArcjetSlidingWindowRateLimitRule<Props extends {}>
   extends ArcjetRateLimitRule<Props> {
   algorithm: "SLIDING_WINDOW";
 
-  match?: string;
   max: number;
   interval: number;
 }


### PR DESCRIPTION
This removes the `match` option in the SDK so we don't need a request to have a `path`. It is not removed in the Decide service to support older SDKs that still might supply it.

Closes #1810 