### PR TITLE
feat: Use `waitUntil` for Report call if available

### DIFF
--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -155,9 +155,9 @@ export function createClient(options: ClientOptions): Client {
 
       log.debug("Report request to %s", baseUrl);
 
-      // We use the promise API directly to avoid returning a promise from this function so execution can't be paused with `await`
-      // TODO(#884): Leverage `waitUntil` if the function is attached to the context
-      client
+      // We use the promise API directly to avoid returning a promise from this
+      // function so execution can't be paused with `await`
+      const reportPromise = client
         .report(reportRequest, {
           headers: { Authorization: `Bearer ${context.key}` },
           timeoutMs: 2_000, // 2 seconds
@@ -177,6 +177,10 @@ export function createClient(options: ClientOptions): Client {
         .catch((err: unknown) => {
           log.info("Encountered problem sending report: %s", errorMessage(err));
         });
+
+      if (typeof context.waitUntil === "function") {
+        context.waitUntil(reportPromise);
+      }
     },
   });
 }

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -797,4 +797,5 @@ export type ArcjetContext = {
   log: ArcjetLogger;
   characteristics: string[];
   getBody: () => Promise<string | undefined>;
+  waitUntil?: (promise: Promise<unknown>) => void;
 };


### PR DESCRIPTION
This attaches a `waitUntil` function to the SDK context and uses it on the call to Report if it is available. I've added the lookup of the `waitUntil` function on Vercel in Arcjet core, since Vercel supports many frameworks.

Closes #884 