### PR TITLE
chore(protocol)!: Remove received_at and decision fields from Report

### DIFF
--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -1,6 +1,5 @@
 import type { Transport } from "@connectrpc/connect";
 import { createPromiseClient } from "@connectrpc/connect";
-import { Timestamp } from "@bufbuild/protobuf";
 import {
   ArcjetDecisionFromProtocol,
   ArcjetDecisionToProtocol,
@@ -152,7 +151,6 @@ export function createClient(options: ClientOptions): Client {
         },
         decision: ArcjetDecisionToProtocol(decision),
         rules: rules.map(ArcjetRuleToProtocol),
-        receivedAt: Timestamp.now(),
       });
 
       log.debug("Report request to %s", baseUrl);
@@ -167,7 +165,7 @@ export function createClient(options: ClientOptions): Client {
         .then((response) => {
           log.debug(
             {
-              id: response.decision?.id,
+              id: decision.id,
               fingerprint: context.fingerprint,
               path: details.path,
               runtime: context.runtime,

--- a/protocol/proto/decide/v1alpha1/decide_pb.d.ts
+++ b/protocol/proto/decide/v1alpha1/decide_pb.d.ts
@@ -1733,11 +1733,6 @@ export declare class ReportRequest extends Message<ReportRequest> {
   rules: Rule[];
 
   /**
-   * @generated from field: google.protobuf.Timestamp received_at = 7;
-   */
-  receivedAt?: Timestamp;
-
-  /**
    * The characteristics that should be used for fingerprinting.
    *
    * @generated from field: repeated string characteristics = 8;
@@ -1765,13 +1760,6 @@ export declare class ReportRequest extends Message<ReportRequest> {
  * @generated from message proto.decide.v1alpha1.ReportResponse
  */
 export declare class ReportResponse extends Message<ReportResponse> {
-  /**
-   * The decision reported about the request under investigation.
-   *
-   * @generated from field: proto.decide.v1alpha1.Decision decision = 1;
-   */
-  decision?: Decision;
-
   /**
    * Any extra information returned by the Arcjet analysis.
    *

--- a/protocol/proto/decide/v1alpha1/decide_pb.js
+++ b/protocol/proto/decide/v1alpha1/decide_pb.js
@@ -518,7 +518,6 @@ export const ReportRequest = /*@__PURE__*/ proto3.makeMessageType(
     { no: 4, name: "details", kind: "message", T: RequestDetails },
     { no: 5, name: "decision", kind: "message", T: Decision },
     { no: 6, name: "rules", kind: "message", T: Rule, repeated: true },
-    { no: 7, name: "received_at", kind: "message", T: Timestamp },
     { no: 8, name: "characteristics", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
   ],
 );
@@ -531,7 +530,6 @@ export const ReportRequest = /*@__PURE__*/ proto3.makeMessageType(
 export const ReportResponse = /*@__PURE__*/ proto3.makeMessageType(
   "proto.decide.v1alpha1.ReportResponse",
   () => [
-    { no: 1, name: "decision", kind: "message", T: Decision },
     { no: 2, name: "extra", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
   ],
 );

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -33,7 +33,6 @@ import {
   ArcjetReason,
   ArcjetRuleResult,
 } from "../index.js";
-import { Timestamp } from "@bufbuild/protobuf";
 
 function deferred(): [Promise<void>, () => void, (reason?: unknown) => void] {
   let resolve: () => void;
@@ -700,7 +699,6 @@ describe("createClient", () => {
       characteristics: [],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -753,7 +751,6 @@ describe("createClient", () => {
           reason: new Reason(),
           ruleResults: [],
         },
-        receivedAt,
       }),
       expect.anything(),
     );
@@ -771,7 +768,6 @@ describe("createClient", () => {
       characteristics: [],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -823,7 +819,6 @@ describe("createClient", () => {
           reason: new Reason(),
           ruleResults: [],
         },
-        receivedAt,
       }),
       expect.anything(),
     );
@@ -841,7 +836,6 @@ describe("createClient", () => {
       characteristics: [],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -900,7 +894,6 @@ describe("createClient", () => {
           }),
           ruleResults: [],
         },
-        receivedAt,
       }),
       expect.anything(),
     );
@@ -918,7 +911,6 @@ describe("createClient", () => {
       characteristics: [],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -970,7 +962,6 @@ describe("createClient", () => {
           reason: new Reason(),
           ruleResults: [],
         },
-        receivedAt,
       }),
       expect.anything(),
     );
@@ -988,7 +979,6 @@ describe("createClient", () => {
       characteristics: [],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1036,7 +1026,6 @@ describe("createClient", () => {
           reason: new Reason(),
           ruleResults: [],
         },
-        receivedAt,
       }),
       expect.anything(),
     );
@@ -1054,7 +1043,6 @@ describe("createClient", () => {
       characteristics: [],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1128,7 +1116,6 @@ describe("createClient", () => {
           ],
         },
         rules: [new Rule()],
-        receivedAt,
       }),
       expect.anything(),
     );
@@ -1253,7 +1240,6 @@ describe("createClient", () => {
       characteristics: ["ip.src"],
       getBody: () => Promise.resolve(undefined),
     };
-    const receivedAt = Timestamp.now();
     const details = {
       ip: "172.100.1.1",
       method: "GET",
@@ -1322,7 +1308,6 @@ describe("createClient", () => {
           ],
         },
         rules: [],
-        receivedAt,
         characteristics: ["ip.src"],
       }),
       expect.anything(),


### PR DESCRIPTION
This updates our protocol package to the latest protobuf definition which removes the `decision` from `ReportResponse` to send less data down the wire which also reduces the amount of data we need to deserialize.

This means that the decision `id` field in the report log will be undefined in older SDKs so I've marked this as breaking.

It also removed `received_at` because our usage was inconsistent. We may revisit this in the future.