### PR TITLE
feat(ip)!: Accept Request or IncomingMessage directly

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -203,8 +203,8 @@ export default function arcjet<
         // workaround to the API design in Bun that requires access to the
         // `Server` to lookup an IP.
         ip: ipCache.get(request),
+        headers,
       },
-      headers,
       { platform: platform(env) },
     );
     if (ip === "") {

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -205,8 +205,8 @@ export default function arcjet<
         // workaround to the API design in Deno that requires access to the
         // `ServeHandlerInfo` to lookup an IP.
         ip: ipCache.get(request),
+        headers,
       },
-      headers,
       { platform: platform(env) },
     );
     if (ip === "") {

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -216,7 +216,14 @@ function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    let ip = findIP(request, headers, { platform: platform(process.env) });
+    let ip = findIP(
+      {
+        ip: request.ip,
+        socket: request.socket,
+        headers,
+      },
+      { platform: platform(process.env) },
+    );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -255,7 +255,16 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    let ip = findIP(request, headers, { platform: platform(process.env) });
+    let ip = findIP(
+      {
+        ip: request.ip,
+        socket: request.socket,
+        info: request.info,
+        requestContext: request.requestContext,
+        headers,
+      },
+      { platform: platform(process.env) },
+    );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -205,7 +205,13 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    let ip = findIP(request, headers, { platform: platform(process.env) });
+    let ip = findIP(
+      {
+        socket: request.socket,
+        headers,
+      },
+      { platform: platform(process.env) },
+    );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -180,8 +180,8 @@ export default function arcjet<
       {
         // The `getLoadContext` API will attach the `ip` to the context
         ip: context?.ip,
+        headers,
       },
-      headers,
       { platform: platform(process.env) },
     );
     if (ip === "") {

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -194,8 +194,8 @@ export default function arcjet<
     let ip = findIP(
       {
         ip: event.getClientAddress(),
+        headers,
       },
-      headers,
       { platform: platform(process.env) },
     );
     if (ip === "") {

--- a/examples/nextjs-14-clerk-rl/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-clerk-rl/app/api/arcjet/route.ts
@@ -1,6 +1,7 @@
 import arcjet, { ArcjetDecision, tokenBucket, shield } from "@arcjet/next";
 import { NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
+import ip from "@arcjet/ip";
 
 // The root Arcjet client is created outside of the handler.
 const aj = arcjet({
@@ -49,7 +50,7 @@ export async function GET(req: NextRequest) {
       })
     );
 
-    const fingerprint = req.ip!
+    const fingerprint = ip(req);
 
     // Deduct 5 tokens from the token bucket
     decision = await rl.protect(req, { fingerprint, requested: 5 });

--- a/examples/nextjs-14-clerk-rl/package-lock.json
+++ b/examples/nextjs-14-clerk-rl/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-14-clerk-rl",
       "version": "0.1.0",
       "dependencies": {
+        "@arcjet/ip": "file:../../ip",
         "@arcjet/next": "file:../../arcjet-next",
         "@clerk/nextjs": "^5.7.5",
         "next": "^14.2.15",
@@ -56,6 +57,23 @@
         "next": ">=13"
       }
     },
+    "../../ip": {
+      "version": "1.0.0-alpha.27",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@arcjet/eslint-config": "1.0.0-alpha.27",
+        "@arcjet/rollup-config": "1.0.0-alpha.27",
+        "@arcjet/tsconfig": "1.0.0-alpha.27",
+        "@jest/globals": "29.7.0",
+        "@rollup/wasm-node": "4.24.0",
+        "@types/node": "18.18.0",
+        "jest": "29.7.0",
+        "typescript": "5.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -67,6 +85,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@arcjet/ip": {
+      "resolved": "../../ip",
+      "link": true
     },
     "node_modules/@arcjet/next": {
       "resolved": "../../arcjet-next",

--- a/examples/nextjs-14-clerk-rl/package.json
+++ b/examples/nextjs-14-clerk-rl/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@arcjet/ip": "file:../../ip",
     "@arcjet/next": "file:../../arcjet-next",
     "@clerk/nextjs": "^5.7.5",
     "next": "^14.2.15",

--- a/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
@@ -1,3 +1,4 @@
+import ip from "@arcjet/ip";
 import arcjet, { ArcjetDecision, tokenBucket, detectBot, shield} from "@arcjet/next";
 import { getServerSession } from "next-auth";
 import GithubProvider from "next-auth/providers/github";
@@ -64,7 +65,7 @@ export async function GET(req: NextRequest, res: Response) {
     decision = await rl.protect(req, { fingerprint, requested: 5 });
     console.log("Arcjet logged in decision", decision)
   } else {
-    const fingerprint = req.ip!;
+    const fingerprint = ip(req);
 
     // Limit the amount of requests for anonymous users.
     const rl = aj.withRule(

--- a/examples/nextjs-14-nextauth-4/package-lock.json
+++ b/examples/nextjs-14-nextauth-4/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@arcjet/ip": "file:../../ip",
         "@arcjet/next": "file:../../arcjet-next",
         "next": "^14.2.15",
         "next-auth": "^4.24.8",
@@ -46,13 +47,30 @@
         "@rollup/wasm-node": "4.24.0",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.6.2"
+        "typescript": "5.6.3"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "next": ">=13"
+      }
+    },
+    "../../ip": {
+      "version": "1.0.0-alpha.27",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@arcjet/eslint-config": "1.0.0-alpha.27",
+        "@arcjet/rollup-config": "1.0.0-alpha.27",
+        "@arcjet/tsconfig": "1.0.0-alpha.27",
+        "@jest/globals": "29.7.0",
+        "@rollup/wasm-node": "4.24.0",
+        "@types/node": "18.18.0",
+        "jest": "29.7.0",
+        "typescript": "5.6.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -75,6 +93,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@arcjet/ip": {
+      "resolved": "../../ip",
+      "link": true
     },
     "node_modules/@arcjet/next": {
       "resolved": "../../arcjet-next",

--- a/examples/nextjs-14-nextauth-4/package.json
+++ b/examples/nextjs-14-nextauth-4/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@arcjet/ip": "file:../../ip",
     "@arcjet/next": "file:../../arcjet-next",
     "next": "^14.2.15",
     "next-auth": "^4.24.8",

--- a/examples/nextjs-14-permit/package-lock.json
+++ b/examples/nextjs-14-permit/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-14-permit",
       "version": "0.1.0",
       "dependencies": {
+        "@arcjet/ip": "file:../../ip",
         "@arcjet/next": "file:../../arcjet-next",
         "@clerk/nextjs": "^5.7.5",
         "next": "14.2.15",
@@ -53,6 +54,27 @@
       "peerDependencies": {
         "next": ">=13"
       }
+    },
+    "../../ip": {
+      "version": "1.0.0-alpha.27",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@arcjet/eslint-config": "1.0.0-alpha.27",
+        "@arcjet/rollup-config": "1.0.0-alpha.27",
+        "@arcjet/tsconfig": "1.0.0-alpha.27",
+        "@jest/globals": "29.7.0",
+        "@rollup/wasm-node": "4.24.0",
+        "@types/node": "18.18.0",
+        "jest": "29.7.0",
+        "typescript": "5.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@arcjet/ip": {
+      "resolved": "../../ip",
+      "link": true
     },
     "node_modules/@arcjet/next": {
       "resolved": "../../arcjet-next",

--- a/examples/nextjs-14-permit/package.json
+++ b/examples/nextjs-14-permit/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@arcjet/ip": "file:../../ip",
     "@arcjet/next": "file:../../arcjet-next",
     "@clerk/nextjs": "^5.7.5",
     "next": "14.2.15",

--- a/examples/nextjs-14-permit/src/app/api/stats/route.ts
+++ b/examples/nextjs-14-permit/src/app/api/stats/route.ts
@@ -5,6 +5,7 @@ import { arcjet } from "@/lib/arcjet";
 import { permit } from "@/lib/permit";
 import { getLastFriday } from "@/lib/dateHelper";
 import { getOrderCount, getToppings } from "@/data/stats";
+import ip from "@arcjet/ip";
 
 // Returns ad-hoc rules depending on whether the user is logged in, and if they
 // are, whether they have permission to update stats.
@@ -41,7 +42,7 @@ export async function GET(req: NextRequest) {
   // Get the user's ID if they are logged in, otherwise use
   // their IP address as a fingerprint
   const user = await currentUser();
-  const fingerprint: string = user ? user.id : req.ip!;
+  const fingerprint: string = user ? user.id : ip(req);
 
   // Get the Arcjet client and request a decision
   const aj = await getClient();

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -17,13 +17,44 @@ function suite(make: MakeTest) {
     ).toEqual("");
   });
 
-  test("returns empty string if headers is not a Headers object", () => {
+  test("returns empty string if headers is null", () => {
     expect(
       ip({
         // @ts-expect-error
-        headers: {},
+        headers: null,
       }),
     ).toEqual("");
+  });
+
+  test("returns empty string if headers is not object", () => {
+    expect(
+      ip({
+        // @ts-expect-error
+        headers: "",
+      }),
+    ).toEqual("");
+  });
+
+  // Support for Node.js IncomingRequest
+  test("supports plain object headers with single value", () => {
+    const request = {
+      headers: {
+        // Node.js lowercases the header keys
+        "x-real-ip": "1.1.1.1",
+      },
+    };
+    expect(ip(request)).toEqual("1.1.1.1");
+  });
+
+  // Support for Node.js IncomingRequest
+  test("supports plain object headers with array value", () => {
+    const request = {
+      headers: {
+        // Node.js lowercases the header keys
+        "x-forwarded-for": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
+      },
+    };
+    expect(ip(request)).toEqual("3.3.3.3");
   });
 
   test("returns empty string if unspecified", () => {

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -35,7 +35,7 @@ function suite(make: MakeTest) {
     ).toEqual("");
   });
 
-  // Support for Node.js IncomingRequest
+  // Support for Node.js IncomingMessage
   test("supports plain object headers with single value", () => {
     const request = {
       headers: {
@@ -46,7 +46,7 @@ function suite(make: MakeTest) {
     expect(ip(request)).toEqual("1.1.1.1");
   });
 
-  // Support for Node.js IncomingRequest
+  // Support for Node.js IncomingMessage
   test("supports plain object headers with array value", () => {
     const request = {
       headers: {

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -5,122 +5,140 @@ import { describe, expect, test } from "@jest/globals";
 import type { Options, RequestLike } from "../index";
 import ip from "../index";
 
-type MakeTest = (ip: unknown) => [RequestLike, Headers, Options | undefined];
+type MakeTest = (ip: unknown) => [RequestLike, Options | undefined];
 
 function suite(make: MakeTest) {
+  test("returns empty string if headers not set", () => {
+    expect(
+      ip(
+        // @ts-expect-error
+        {},
+      ),
+    ).toEqual("");
+  });
+
+  test("returns empty string if headers is not a Headers object", () => {
+    expect(
+      ip({
+        // @ts-expect-error
+        headers: {},
+      }),
+    ).toEqual("");
+  });
+
   test("returns empty string if unspecified", () => {
-    const [request, headers, options] = make("0.0.0.0");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("0.0.0.0");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if 'this network' address", () => {
-    const [request, headers, options] = make("0.1.2.3");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("0.1.2.3");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the shared address range", () => {
-    const [request, headers, options] = make("100.127.255.255");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("100.127.255.255");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the link local address range", () => {
-    const [request, headers, options] = make("169.254.255.255");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("169.254.255.255");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the future protocol range", () => {
-    const [request, headers, options] = make("192.0.0.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("192.0.0.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the 192.0.2.x documentation range", () => {
-    const [request, headers, options] = make("192.0.2.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("192.0.2.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the 198.51.100.x documentation range", () => {
-    const [request, headers, options] = make("198.51.100.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("198.51.100.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the 203.0.113.x documentation range", () => {
-    const [request, headers, options] = make("203.0.113.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("203.0.113.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the benchmarking range", () => {
-    const [request, headers, options] = make("198.19.255.255");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("198.19.255.255");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the reserved range", () => {
-    const [request, headers, options] = make("240.0.0.0");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("240.0.0.0");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the broadcast address", () => {
-    const [request, headers, options] = make("255.255.255.255");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("255.255.255.255");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if loopback", () => {
-    const [request, headers, options] = make("127.0.0.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("127.0.0.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if not full ip", () => {
-    const [request, headers, options] = make("12.3.4");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("12.3.4");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if more than 3 digits in an octet", () => {
-    const [request, headers, options] = make("1111.2.3.4");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("1111.2.3.4");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if more than full ip", () => {
-    const [request, headers, options] = make("1.2.3.4.5");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("1.2.3.4.5");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if any octet has leading 0", () => {
-    const [request, headers, options] = make("1.02.3.4");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("1.02.3.4");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if not a string", () => {
-    const [request, headers, options] = make(["12", "3", "4"]);
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make(["12", "3", "4"]);
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the 10.x.x.x private range", () => {
-    const [request, headers, options] = make("10.1.1.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("10.1.1.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the 172.16.x.x-172.31.x.x private range", () => {
-    const [request, headers, options] = make("172.18.1.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("172.18.1.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if in the 192.168.x.x private range", () => {
-    const [request, headers, options] = make("192.168.1.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("192.168.1.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string outside of the valid range", () => {
-    const [request, headers, options] = make("1.1.1.256");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("1.1.1.256");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns the ip if valid", () => {
-    const [request, headers, options] = make("1.1.1.1");
-    expect(ip(request, headers, options)).toEqual("1.1.1.1");
+    const [request, options] = make("1.1.1.1");
+    expect(ip(request, options)).toEqual("1.1.1.1");
   });
 
   test("returns the full ip if valid, after ignoring port", () => {
-    const [request, headers, options] = make("1.1.1.1:443");
-    expect(ip(request, headers, options)).toEqual("1.1.1.1:443");
+    const [request, options] = make("1.1.1.1:443");
+    expect(ip(request, options)).toEqual("1.1.1.1:443");
   });
 }
 
@@ -130,14 +148,20 @@ function requestSuite(...keys: string[]) {
       // Create a nested request-like object based on the keys passed to the function
       function nested(keys: string[]): RequestLike {
         if (keys.length > 1) {
-          return Object.fromEntries([[keys[0], nested(keys.slice(1))]]);
+          return {
+            ...Object.fromEntries([[keys[0], nested(keys.slice(1))]]),
+            headers: new Headers(),
+          };
         } else {
-          return Object.fromEntries([[keys[0], ip]]);
+          return {
+            ...Object.fromEntries([[keys[0], ip]]),
+            headers: new Headers(),
+          };
         }
       }
 
       const req = nested(keys);
-      return [req, new Headers(), undefined];
+      return [req, undefined];
     });
   });
 }
@@ -146,17 +170,18 @@ function headerSuite(key: string, options?: Options) {
   describe(`header: ${key}`, () => {
     suite((ip: unknown) => {
       if (typeof ip === "string") {
-        return [{}, new Headers([[key, ip]]), options];
+        return [{ headers: new Headers([[key, ip]]) }, options];
       } else {
         return [
-          {},
-          new Headers([
-            [
-              key,
-              // @ts-expect-error
-              ip,
-            ],
-          ]),
+          {
+            headers: new Headers([
+              [
+                key,
+                // @ts-expect-error
+                ip,
+              ],
+            ]),
+          },
           options,
         ];
       }
@@ -189,27 +214,30 @@ describe("find public IPv4", () => {
 
   describe("X-Forwarded-For with multiple IP", () => {
     test("returns the last public IP", () => {
-      const request = {};
-      const headers = new Headers([
-        ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3"],
-      ]);
-      expect(ip(request, headers)).toEqual("3.3.3.3");
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3"],
+        ]),
+      };
+      expect(ip(request)).toEqual("3.3.3.3");
     });
 
     test("skips any `unknown` IP", () => {
-      const request = {};
-      const headers = new Headers([
-        ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3, unknown"],
-      ]);
-      expect(ip(request, headers)).toEqual("3.3.3.3");
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3, unknown"],
+        ]),
+      };
+      expect(ip(request)).toEqual("3.3.3.3");
     });
 
     test("skips any private IP", () => {
-      const request = {};
-      const headers = new Headers([
-        ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3, 127.0.0.1"],
-      ]);
-      expect(ip(request, headers)).toEqual("3.3.3.3");
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3, 127.0.0.1"],
+        ]),
+      };
+      expect(ip(request)).toEqual("3.3.3.3");
     });
   });
 });

--- a/ip/test/ipv6.test.ts
+++ b/ip/test/ipv6.test.ts
@@ -5,99 +5,99 @@ import { describe, expect, test } from "@jest/globals";
 import type { Options, RequestLike } from "../index";
 import ip from "../index";
 
-type MakeTest = (ip: unknown) => [RequestLike, Headers, Options | undefined];
+type MakeTest = (ip: unknown) => [RequestLike, Options | undefined];
 
 function suite(make: MakeTest) {
   test("returns empty string if unspecified", () => {
-    const [request, headers, options] = make("::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if loopback address", () => {
-    const [request, headers, options] = make("::1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("::1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if ipv4 mapped address", () => {
-    const [request, headers, options] = make("::ffff:127.0.0.1");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("::ffff:127.0.0.1");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if ipv4-ipv6 translat range", () => {
-    const [request, headers, options] = make("64:ff9b:1::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("64:ff9b:1::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if discard range", () => {
-    const [request, headers, options] = make("100::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("100::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if documentation range", () => {
-    const [request, headers, options] = make("2001:db8::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("2001:db8::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if benchmarking range", () => {
-    const [request, headers, options] = make("2001:2::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("2001:2::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if unique local range", () => {
-    const [request, headers, options] = make("fc02::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("fc02::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if unicast link local range", () => {
-    const [request, headers, options] = make("fe80::");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("fe80::");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if the ip address is too short", () => {
-    const [request, headers, options] = make("ffff:ffff:");
-    expect(ip(request, headers, options)).toEqual("");
+    const [request, options] = make("ffff:ffff:");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns empty string if the ip address is too long", () => {
-    const [request, headers, options] = make(
+    const [request, options] = make(
       "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
     );
-    expect(ip(request, headers, options)).toEqual("");
+    expect(ip(request, options)).toEqual("");
   });
 
   test("returns the ip if it is 'Port Control Protocol Anycast' address", () => {
-    const [request, headers, options] = make("2001:1::1");
-    expect(ip(request, headers, options)).toEqual("2001:1::1");
+    const [request, options] = make("2001:1::1");
+    expect(ip(request, options)).toEqual("2001:1::1");
   });
 
   test("returns the ip if it is 'Traversal Using Relays around NAT Anycast' address", () => {
-    const [request, headers, options] = make("2001:1::2");
-    expect(ip(request, headers, options)).toEqual("2001:1::2");
+    const [request, options] = make("2001:1::2");
+    expect(ip(request, options)).toEqual("2001:1::2");
   });
 
   test("returns the ip if it is 'AMT' address", () => {
-    const [request, headers, options] = make("2001:3::");
-    expect(ip(request, headers, options)).toEqual("2001:3::");
+    const [request, options] = make("2001:3::");
+    expect(ip(request, options)).toEqual("2001:3::");
   });
 
   test("returns the ip if it is 'AS112-v6' address", () => {
-    const [request, headers, options] = make("2001:4:112::");
-    expect(ip(request, headers, options)).toEqual("2001:4:112::");
+    const [request, options] = make("2001:4:112::");
+    expect(ip(request, options)).toEqual("2001:4:112::");
   });
 
   test("returns the ip if it is 'ORCHIDv2' address", () => {
-    const [request, headers, options] = make("2001:20::");
-    expect(ip(request, headers, options)).toEqual("2001:20::");
+    const [request, options] = make("2001:20::");
+    expect(ip(request, options)).toEqual("2001:20::");
   });
 
   test("returns the ip if valid", () => {
-    const [request, headers, options] = make("::abcd:c00a:2ff");
-    expect(ip(request, headers, options)).toEqual("::abcd:c00a:2ff");
+    const [request, options] = make("::abcd:c00a:2ff");
+    expect(ip(request, options)).toEqual("::abcd:c00a:2ff");
   });
 
   test("returns the ip if valid, after ignoring scope", () => {
-    const [request, headers, options] = make("::abcd:c00a:2ff%1");
-    expect(ip(request, headers, options)).toEqual("::abcd:c00a:2ff%1");
+    const [request, options] = make("::abcd:c00a:2ff%1");
+    expect(ip(request, options)).toEqual("::abcd:c00a:2ff%1");
   });
 }
 
@@ -107,14 +107,20 @@ function requestSuite(...keys: string[]) {
       // Create a nested request-like object based on the keys passed to the function
       function nested(keys: string[]): RequestLike {
         if (keys.length > 1) {
-          return Object.fromEntries([[keys[0], nested(keys.slice(1))]]);
+          return {
+            ...Object.fromEntries([[keys[0], nested(keys.slice(1))]]),
+            headers: new Headers(),
+          };
         } else {
-          return Object.fromEntries([[keys[0], ip]]);
+          return {
+            ...Object.fromEntries([[keys[0], ip]]),
+            headers: new Headers(),
+          };
         }
       }
 
       const req = nested(keys);
-      return [req, new Headers(), undefined];
+      return [req, undefined];
     });
   });
 }
@@ -123,17 +129,18 @@ function headerSuite(key: string, options?: Options) {
   describe(`header: ${key}`, () => {
     suite((ip: unknown) => {
       if (typeof ip === "string") {
-        return [{}, new Headers([[key, ip]]), options];
+        return [{ headers: new Headers([[key, ip]]) }, options];
       } else {
         return [
-          {},
-          new Headers([
-            [
-              key,
-              // @ts-expect-error
-              ip,
-            ],
-          ]),
+          {
+            headers: new Headers([
+              [
+                key,
+                // @ts-expect-error
+                ip,
+              ],
+            ]),
+          },
           options,
         ];
       }
@@ -167,27 +174,28 @@ describe("find public IPv6", () => {
 
   describe("X-Forwarded-For with multiple IP", () => {
     test("returns the first public IP", () => {
-      const request = {};
-      const headers = new Headers([
-        ["X-Forwarded-For", "e123::, 3.3.3.3, abcd::"],
-      ]);
-      expect(ip(request, headers)).toEqual("abcd::");
+      const request = {
+        headers: new Headers([["X-Forwarded-For", "e123::, 3.3.3.3, abcd::"]]),
+      };
+      expect(ip(request)).toEqual("abcd::");
     });
 
     test("skips any `unknown` IP", () => {
-      const request = {};
-      const headers = new Headers([
-        ["X-Forwarded-For", "e123::, 3.3.3.3, abcd::, unknown"],
-      ]);
-      expect(ip(request, headers)).toEqual("abcd::");
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "e123::, 3.3.3.3, abcd::, unknown"],
+        ]),
+      };
+      expect(ip(request)).toEqual("abcd::");
     });
 
     test("skips any private IP", () => {
-      const request = {};
-      const headers = new Headers([
-        ["X-Forwarded-For", "e123::, 3.3.3.3, abcd::, ::1"],
-      ]);
-      expect(ip(request, headers)).toEqual("abcd::");
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "e123::, 3.3.3.3, abcd::, ::1"],
+        ]),
+      };
+      expect(ip(request)).toEqual("abcd::");
     });
   });
 });


### PR DESCRIPTION
This changes the `findIP` API so it can accept a `Request` object directly. This is achieved by requiring the `headers` field on the first argument. I've combined the separate "request-like" and "headers" argument into one.

This is primarily being done so `@arcjet/ip` can be used with Next.js 15 which [removed the `ip` property from `NextRequest`](https://nextjs.org/docs/canary/app/building-your-application/upgrading/version-15#nextrequest-geolocation).

Ref #1904