### PR TITLE
fix!: Ensure performance metrics are scoped to same call

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -200,6 +200,24 @@ function isEmailType(type: string): type is ArcjetEmailType {
   );
 }
 
+class Performance {
+  log: ArcjetLogger;
+
+  constructor(logger: ArcjetLogger) {
+    this.log = logger;
+  }
+
+  // TODO: We should no-op this if loglevel is not `debug` to do less work
+  measure(label: string) {
+    const start = performance.now();
+    return () => {
+      const end = performance.now();
+      const diff = end - start;
+      this.log.debug("LATENCY %s: %sms", label, diff.toFixed(3));
+    };
+  }
+}
+
 function toString(value: unknown) {
   if (typeof value === "string") {
     return value;
@@ -1193,6 +1211,8 @@ export default function arcjet<
   }
   const log = options.log;
 
+  const perf = new Performance(log);
+
   // TODO(#207): Remove this when we can default the transport so client is not required
   // It is currently optional in the options so the Next SDK can override it for the user
   if (typeof options.client === "undefined") {
@@ -1247,8 +1267,9 @@ export default function arcjet<
     };
 
     let fingerprint = "";
+
+    const logFingerprintPerf = perf.measure("fingerprint");
     try {
-      log.time?.("fingerprint");
       fingerprint = await analyze.generateFingerprint(
         baseContext,
         toAnalyzeRequest(details),
@@ -1273,7 +1294,7 @@ export default function arcjet<
 
       return decision;
     } finally {
-      log.timeEnd?.("fingerprint");
+      logFingerprintPerf();
     }
 
     const context: ArcjetContext = Object.freeze({
@@ -1333,16 +1354,15 @@ export default function arcjet<
       }
     }
 
+    const logLocalPerf = perf.measure("local");
     try {
-      log.time?.("local");
-
       // We have our own local cache which we check first. This doesn't work in
       // serverless environments where every request is isolated, but there may be
       // some instances where the instance is not recycled immediately. If so, we
       // can take advantage of that.
-      log.time?.("cache");
+      const logCachePerf = perf.measure("cache");
       const existingBlockReason = blockCache.get(fingerprint);
-      log.timeEnd?.("cache");
+      logCachePerf();
 
       // If already blocked then we can async log to the API and return the
       // decision immediately.
@@ -1380,9 +1400,8 @@ export default function arcjet<
           continue;
         }
 
+        const logRulePerf = perf.measure(rule.type);
         try {
-          log.time?.(rule.type);
-
           localRule.validate(context, details);
           results[idx] = await localRule.protect(context, details);
 
@@ -1413,7 +1432,7 @@ export default function arcjet<
             reason: new ArcjetErrorReason(err),
           });
         } finally {
-          log.timeEnd?.(rule.type);
+          logRulePerf();
         }
 
         if (results[idx].isDenied()) {
@@ -1460,19 +1479,18 @@ export default function arcjet<
         }
       }
     } finally {
-      log.timeEnd?.("local");
+      logLocalPerf();
     }
 
     // With no cached values, we take a decision remotely. We use a timeout to
     // fail open.
+    const logRemotePerf = perf.measure("remote");
     try {
-      log.time?.("remote");
-
-      log.time?.("decideApi");
+      const logDediceApiPerf = perf.measure("decideApi");
       const decision = await client
         .decide(context, details, rules)
         .finally(() => {
-          log.timeEnd?.("decideApi");
+          logDediceApiPerf();
         });
 
       // If the decision is to block and we have a non-zero TTL, we cache the
@@ -1503,7 +1521,7 @@ export default function arcjet<
 
       return decision;
     } finally {
-      log.timeEnd?.("remote");
+      logRemotePerf();
     }
   }
 

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -207,7 +207,7 @@ class Performance {
     this.log = logger;
   }
 
-  // TODO: We should no-op this if loglevel is not `debug` to do less work
+  // TODO(#2020): We should no-op this if loglevel is not `debug` to do less work
   measure(label: string) {
     const start = performance.now();
     return () => {

--- a/logger/index.ts
+++ b/logger/index.ts
@@ -94,18 +94,6 @@ export class Logger {
     }
   }
 
-  time(label: string) {
-    if (this.#logLevel <= 0) {
-      console.time(getTimeLabel(label));
-    }
-  }
-
-  timeEnd(label: string) {
-    if (this.#logLevel <= 0) {
-      console.timeEnd(getTimeLabel(label));
-    }
-  }
-
   debug(msg: string, ...args: unknown[]): void;
   debug(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
   debug(obj: unknown, msg?: unknown, ...args: unknown[]): void {

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -774,10 +774,6 @@ export interface ArcjetShieldRule<Props extends {}> extends ArcjetRule<Props> {
 }
 
 export interface ArcjetLogger {
-  // Latency logs will be emitted if `time` and `timeEnd` calls exist on the
-  // logger interface, but they are optional since Pino doesn't have them.
-  time?(label: string): void;
-  timeEnd?(label: string): void;
   // Pino-compatible logging functions are required.
   debug(msg: string, ...args: unknown[]): void;
   debug(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;


### PR DESCRIPTION
This implements performance logging with our own functions instead of using `console.time()` and `console.timeEnd()` so we can keep them correctly scoped to the `protect()` call. Prior to this, if 2 calls to `protect()` were racing, one might call `time()` first and the other may call `timeEnd()` which would mess up all the labels.

There are opportunities for performance improvements here, especially if the loglevel isn't `debug`, but we should also check if using closures is more performant than building a map with unique symbols.

Fixes #1865