### PR TITLE
fix(ip)!: Exit early if platform-specific headers are missing IP

### DIFF
--- a/ip/index.ts
+++ b/ip/index.ts
@@ -628,6 +628,11 @@ function findIP(
     if (isGlobalIP(cfConnectingIP)) {
       return cfConnectingIP;
     }
+
+    // If we are using a platform check and don't have a Global IP, we exit
+    // early with an empty IP since the more generic headers shouldn't be
+    // trusted over the platform-specific headers.
+    return "";
   }
 
   // Fly.io: https://fly.io/docs/machines/runtime-environment/#fly_app_name
@@ -637,6 +642,11 @@ function findIP(
     if (isGlobalIP(flyClientIP)) {
       return flyClientIP;
     }
+
+    // If we are using a platform check and don't have a Global IP, we exit
+    // early with an empty IP since the more generic headers shouldn't be
+    // trusted over the platform-specific headers.
+    return "";
   }
 
   // Standard headers used by Amazon EC2, Heroku, and others.


### PR DESCRIPTION
As discussed at https://github.com/arcjet/arcjet-js/pull/2018#discussion_r1811564677, this changes the `findIP` function so it exits early if the platform-specific headers don't have a global IP address. Generally, this should never be the case, but if it somehow happened we would want to return an empty string instead of falling back to a different header that could be spoofed.