### PR TITLE
feat(ip): Add Vercel platform-specific IP header detection

### DIFF
--- a/env/index.ts
+++ b/env/index.ts
@@ -1,6 +1,7 @@
 export type Env = {
   [key: string]: unknown;
   FLY_APP_NAME?: string;
+  VERCEL?: string;
   NODE_ENV?: string;
   ARCJET_KEY?: string;
   ARCJET_ENV?: string;
@@ -11,6 +12,10 @@ export type Env = {
 export function platform(env: Env) {
   if (typeof env["FLY_APP_NAME"] === "string" && env["FLY_APP_NAME"] !== "") {
     return "fly-io" as const;
+  }
+
+  if (typeof env["VERCEL"] === "string" && env["VERCEL"] === "1") {
+    return "vercel" as const;
   }
 }
 

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -173,6 +173,9 @@ describe("find public IPv4", () => {
   headerSuite("X-Client-IP");
   headerSuite("X-Forwarded-For");
   headerSuite("CF-Connecting-IP", { platform: "cloudflare" });
+  headerSuite("X-Real-IP", { platform: "vercel" });
+  headerSuite("X-Vercel-Forwarded-For", { platform: "vercel" });
+  headerSuite("X-Forwarded-For", { platform: "vercel" });
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
   headerSuite("Fly-Client-IP", { platform: "fly-io" });

--- a/ip/test/ipv6.test.ts
+++ b/ip/test/ipv6.test.ts
@@ -151,6 +151,9 @@ describe("find public IPv6", () => {
   headerSuite("X-Forwarded-For");
   headerSuite("CF-Connecting-IPv6", { platform: "cloudflare" });
   headerSuite("CF-Connecting-IP", { platform: "cloudflare" });
+  headerSuite("X-Real-IP", { platform: "vercel" });
+  headerSuite("X-Vercel-Forwarded-For", { platform: "vercel" });
+  headerSuite("X-Forwarded-For", { platform: "vercel" });
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
   headerSuite("Fly-Client-IP", { platform: "fly-io" });


### PR DESCRIPTION
This adds platform-specific IP header detection for Vercel. I've chosen to detect via `X-Real-IP` first since that is the header used by `@vercel/functions` and then I've fallen back to `x-vercel-forwarded-for` and finally `x-forwarded-for` based on my interpretation of their documentation.