### PR TITLE
deps(examples): Override cookies in examples

### DIFF
--- a/examples/nestjs-fastify/package-lock.json
+++ b/examples/nestjs-fastify/package-lock.json
@@ -2156,9 +2156,10 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/examples/nestjs-fastify/package.json
+++ b/examples/nestjs-fastify/package.json
@@ -36,5 +36,8 @@
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.3.3",
     "typescript": "^5.1.3"
+  },
+  "overrides": {
+    "cookie": "0.7.1"
   }
 }

--- a/examples/nextjs-14-nextauth-4/package-lock.json
+++ b/examples/nextjs-14-nextauth-4/package-lock.json
@@ -1357,9 +1357,10 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/examples/nextjs-14-nextauth-4/package.json
+++ b/examples/nextjs-14-nextauth-4/package.json
@@ -25,5 +25,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.14",
     "typescript": "^5"
+  },
+  "overrides": {
+    "cookie": "0.7.1"
   }
 }

--- a/examples/remix-express/package-lock.json
+++ b/examples/remix-express/package-lock.json
@@ -3571,9 +3571,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5094,14 +5094,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/cookie-signature": {

--- a/examples/remix-express/package.json
+++ b/examples/remix-express/package.json
@@ -44,6 +44,9 @@
     "typescript": "^5.1.6",
     "vite": "^5.4.9"
   },
+  "overrides": {
+    "cookie": "0.7.1"
+  },
   "engines": {
     "node": ">=20.0.0"
   }

--- a/examples/sveltekit/package-lock.json
+++ b/examples/sveltekit/package-lock.json
@@ -1379,10 +1379,11 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -33,5 +33,8 @@
     "tslib": "^2.8.0",
     "typescript": "^5.0.0",
     "vite": "^5.4.9"
+  },
+  "overrides": {
+    "cookie": "0.7.1"
   }
 }


### PR DESCRIPTION
Overriding the `cookie` dependency in examples to clear out the security warnings.