### PR TITLE
fix(arcjet): Log error message when fingerprint cannot be built

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1309,15 +1309,19 @@ export default function arcjet<
       );
       log.debug("fingerprint (%s): %s", rt, fingerprint);
     } catch (error) {
+      const errMsg = errorMessage(error);
       log.error(
-        { error },
+        {
+          // Workaround for inability to JSON.stringify Error objects
+          error: errMsg,
+        },
         "Failed to build fingerprint. Please verify your Characteristics.",
       );
 
       const decision = new ArcjetErrorDecision({
         ttl: 0,
         reason: new ArcjetErrorReason(
-          `Failed to build fingerprint - ${errorMessage(error)}`,
+          `Failed to build fingerprint - ${errMsg}`,
         ),
         // No results because we couldn't create a fingerprint
         results: [],


### PR DESCRIPTION
Closes #2138 

We can't `JSON.stringify` an error object, so this pulls the error message out of the object and assigns it to the `error` property on the logger props object.