### PR TITLE
fix(sveltekit): Load env from `node:process`

### DIFF
--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -15,6 +15,7 @@ import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
+import { env } from "node:process";
 
 // Re-export all named exports from the generic SDK
 export * from "arcjet";
@@ -83,11 +84,11 @@ export type RemoteClientOptions = {
 export function createRemoteClient(options?: RemoteClientOptions) {
   // The base URL for the Arcjet API. Will default to the standard production
   // API unless environment variable `ARCJET_BASE_URL` is set.
-  const url = options?.baseUrl ?? baseUrl(process.env);
+  const url = options?.baseUrl ?? baseUrl(env);
 
   // The timeout for the Arcjet API in milliseconds. This is set to a low value
   // in production so calls fail open.
-  const timeout = options?.timeout ?? (isDevelopment(process.env) ? 1000 : 500);
+  const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);
@@ -179,7 +180,7 @@ export default function arcjet<
   const log = options.log
     ? options.log
     : new Logger({
-        level: logLevel(process.env),
+        level: logLevel(env),
       });
 
   function toArcjetRequest<Props extends PlainObject>(
@@ -196,12 +197,12 @@ export default function arcjet<
         ip: event.getClientAddress(),
         headers,
       },
-      { platform: platform(process.env) },
+      { platform: platform(env) },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
-      if (isDevelopment(process.env)) {
+      if (isDevelopment(env)) {
         log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {


### PR DESCRIPTION
This loads `env` from the `node:process` import. We want to do this because some runtimes, like Netlify Edge Functions, don't provide the global `process.env` but instead will shim the `node:process` import to provide the environment.

Closes #2154