### PR TITLE
chore(example): Allow swc compilers

### DIFF
--- a/examples/nextjs-14-nextauth-4/.npmrc
+++ b/examples/nextjs-14-nextauth-4/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-app-dir-rate-limit/.npmrc
+++ b/examples/nextjs-app-dir-rate-limit/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-app-dir-validate-email/.npmrc
+++ b/examples/nextjs-app-dir-validate-email/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-bot-categories/.npmrc
+++ b/examples/nextjs-bot-categories/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-clerk-rate-limit/.npmrc
+++ b/examples/nextjs-clerk-rate-limit/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-clerk-shield/.npmrc
+++ b/examples/nextjs-clerk-shield/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-decorate/.npmrc
+++ b/examples/nextjs-decorate/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-ip-details/.npmrc
+++ b/examples/nextjs-ip-details/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-pages-wrap/.npmrc
+++ b/examples/nextjs-pages-wrap/.npmrc
@@ -1,1 +1,0 @@
-omit=optional

--- a/examples/nextjs-sensitive-info/.npmrc
+++ b/examples/nextjs-sensitive-info/.npmrc
@@ -1,1 +1,0 @@
-omit=optional


### PR DESCRIPTION
Since we allow the swc compiler in the root of the monorepo, we also need to allow it in our examples so they detect the correct version.

This solves a problem I encountered with merging #2176 