### PR TITLE
fix(nosecone-next): Avoid overriding original headers

### DIFF
--- a/examples/nextjs-bot-categories/app/api/arcjet/route.ts
+++ b/examples/nextjs-bot-categories/app/api/arcjet/route.ts
@@ -26,6 +26,13 @@ const aj = arcjet({
 export async function GET(req: Request) {
   const decision = await aj.protect(req);
 
+  if (decision.isErrored()) {
+    return NextResponse.json(
+      { error: decision.reason.message },
+      { status: 500, statusText: "Internal Server Error" },
+    )
+  }
+
   const headers = new Headers();
   if (decision.reason.isBot()) {
     // WARNING: This is illustrative! Don't share this metadata with users;

--- a/examples/nextjs-bot-categories/middleware.ts
+++ b/examples/nextjs-bot-categories/middleware.ts
@@ -1,0 +1,8 @@
+import { createMiddleware } from "@nosecone/next";
+
+export const config = {
+  // matcher tells Next.js which routes to run the middleware on
+  matcher: ["/(.*)"],
+};
+
+export default createMiddleware();


### PR DESCRIPTION
I found this problem with my implementation while trying to integrate `@nosecone/next` into our application. When using `x-middleware-override-headers` is set, Next.js removes all other headers, which meant that the original Request headers were removed.

I also added the adapter to the bot example to make sure the original headers still exist.