### PR TITLE
fix(nosecone): Re-export default configuration from adapters

### DIFF
--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -1,6 +1,9 @@
 import nosecone, { defaults } from "nosecone";
 import type { CspDirectives, NoseconeOptions } from "nosecone";
 
+// Re-exports the defaults for easier overrides
+export { defaults };
+
 // We export `nosecone` as the default so it can be used with `new Response()`
 export default nosecone;
 

--- a/nosecone-sveltekit/index.ts
+++ b/nosecone-sveltekit/index.ts
@@ -7,6 +7,9 @@ import nosecone, {
 import type { CspDirectives, NoseconeOptions } from "nosecone";
 import type { Handle, KitConfig } from "@sveltejs/kit";
 
+// Re-exports the defaults for easier overrides
+export { defaults };
+
 // We export `nosecone` as the default so it can be used with `new Response()`
 export default nosecone;
 


### PR DESCRIPTION
This re-exports the `defaults` object to make merging defaults and custom settings easier.