### PR TITLE
fix!: Stop publishing TypeScript source files

### DIFF
--- a/analyze/package.json
+++ b/analyze/package.json
@@ -36,7 +36,6 @@
     "wasm/",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-bun/package.json
+++ b/arcjet-bun/package.json
@@ -27,7 +27,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-deno/package.json
+++ b/arcjet-deno/package.json
@@ -27,7 +27,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-nest/package.json
+++ b/arcjet-nest/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-next/package.json
+++ b/arcjet-next/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-node/package.json
+++ b/arcjet-node/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-remix/package.json
+++ b/arcjet-remix/package.json
@@ -27,7 +27,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet-sveltekit/package.json
+++ b/arcjet-sveltekit/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/body/package.json
+++ b/body/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/decorate/package.json
+++ b/decorate/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/duration/package.json
+++ b/duration/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/env/package.json
+++ b/env/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/headers/package.json
+++ b/headers/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/ip/package.json
+++ b/ip/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/logger/package.json
+++ b/logger/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/nosecone-next/package.json
+++ b/nosecone-next/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/nosecone/package.json
+++ b/nosecone/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -30,7 +30,6 @@
     "proto/",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/redact-wasm/package.json
+++ b/redact-wasm/package.json
@@ -36,7 +36,6 @@
     "wasm/",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/redact/package.json
+++ b/redact/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/rollup-config/package.json
+++ b/rollup-config/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/sprintf/package.json
+++ b/sprintf/package.json
@@ -29,7 +29,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {

--- a/transport/package.json
+++ b/transport/package.json
@@ -34,7 +34,6 @@
     "README.md",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {


### PR DESCRIPTION
This removes the source TypeScript files from our published packages. We've run into some issues where the tools in projects try to process these files with the tsconfig inside the project itself; when that configuration differs from our configuration, the project fails to build.

We're going to stop publishing these files since we already include the compiled JavaScript and type definition files.

Closes #1836 