### PR TITLE
deps(example): Update sveltekit to resolve security notices

### DIFF
--- a/examples/sveltekit/package-lock.json
+++ b/examples/sveltekit/package-lock.json
@@ -52,7 +52,7 @@
         "@rollup/wasm-node": "4.27.4",
         "@types/node": "18.18.0",
         "jest": "29.7.0",
-        "typescript": "5.6.3"
+        "typescript": "5.7.2"
       },
       "engines": {
         "node": ">=18"
@@ -72,7 +72,7 @@
         "@rollup/wasm-node": "4.27.4",
         "@sveltejs/kit": "^2.8.3",
         "@types/node": "18.18.0",
-        "typescript": "5.6.3"
+        "typescript": "5.7.2"
       },
       "engines": {
         "node": ">=18"
@@ -915,11 +915,12 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.0.tgz",
-      "integrity": "sha512-HCiWupCuKJQ3aPaC4Xc6lpPdjOOnoGzEiYjOqMqppdtfGtY2ABrx932Vw66ZwS2RGXc0BmZvFvNq5SzqlmDVLg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.3.tgz",
+      "integrity": "sha512-DVBVwugfzzn0SxKA+eAmKqcZ7aHZROCHxH7/pyrOi+HLtQ721eEsctGb9MkhEuqj6q/9S/OFYdn37vdxzFPdvw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
         "cookie": "^0.6.0",


### PR DESCRIPTION
For some reason, dependabot got into a messed up state last night. This resolves the security notices by upgrading SvelteKit in the example app.