### PR TITLE
fix(nosecone-next)!: Remove strict-dynamic value in script-src directive

### DIFF
--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -10,8 +10,8 @@ export const defaults = {
         // Replace the defaults to remove `'self'`
         process.env.NODE_ENV === "development"
           ? // Next.js hot reloading relies on `eval` so we enable it in development
-            ([nonce, "'strict-dynamic'", "'unsafe-eval'"] as const)
-          : ([nonce, "'strict-dynamic'"] as const),
+            ([nonce, "'unsafe-eval'"] as const)
+          : ([nonce] as const),
       styleSrc: [
         ...baseDefaults.contentSecurityPolicy.directives.styleSrc,
         "'unsafe-inline'",


### PR DESCRIPTION
When using any sort of allowlist of domains to load external scripts, e.g. Plausible or Vercel Toolbar, you can't add the `'strict-dynamic'` value in `script-src`; otherwise the domain values will be disregarded. Since many of these external scripts aren't made to support strict CSPs, we would need to filter `'strict-dynamic'` from the defaults.

Instead of adding this by default, we should recommend it be added via our docs if nosecone users don't load external scripts.