### PR TITLE
feat: show isSpoofed() in bot examples

### DIFF
--- a/examples/express-bots/index.js
+++ b/examples/express-bots/index.js
@@ -24,17 +24,27 @@ const aj = arcjet({
 
 app.get('/', async (req, res) => {
   const decision = await aj.protect(req);
-
-  if (decision.isDenied() && decision.reason.isBot()) {
-    res.writeHead(400, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({
-      error: "You are a bot",
-      detected: decision.reason.denied[0]
-    }));
-  } else {
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ message: `Hello world!` }));
+  // We need to check that the bot is who they say they are.
+  if (decision.reason.isSpoofed()) {
+    return NextResponse.json(
+      { error: "You are pretending to be a good bot!" },
+      { status: 403, headers },
+    );
   }
+
+  if (decision.isBot()) {
+    // We want to check for disallowed bots, or spoofed bots
+    if (decision.isDenied() || decision.reason.isSpoofed()) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        error: "You are a bot",
+        detected: decision.reason.denied[0]
+      }));
+    }
+  }
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ message: `Hello world!` }));
 })
 
 app.listen(port, () => {

--- a/examples/nextjs-bot-categories/app/api/arcjet/route.ts
+++ b/examples/nextjs-bot-categories/app/api/arcjet/route.ts
@@ -37,8 +37,16 @@ export async function GET(req: Request) {
   if (decision.reason.isBot()) {
     // WARNING: This is illustrative! Don't share this metadata with users;
     // otherwise they may use it to subvert bot detection!
-    headers.set("X-Arcjet-Bot-Allowed",  decision.reason.allowed.join(", "))
-    headers.set("X-Arcjet-Bot-Denied",  decision.reason.denied.join(", "))
+    headers.set("X-Arcjet-Bot-Allowed", decision.reason.allowed.join(", "))
+    headers.set("X-Arcjet-Bot-Denied", decision.reason.denied.join(", "))
+
+    // We need to check that the bot is who they say they are.
+    if (decision.reason.isSpoofed()) {
+      return NextResponse.json(
+        { error: "You are pretending to be a good bot!" },
+        { status: 403, headers },
+      );
+    }
   }
 
   if (decision.isDenied()) {


### PR DESCRIPTION
This PR updates the examples for bot detection to show the proper use of `.isSpoofed()` to detect if a bot is not who they say they are.
