### PR TITLE
feat(nosecone-next): Keep `'self'` script-src in defaults

### DIFF
--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -8,15 +8,13 @@ export const defaults = {
   contentSecurityPolicy: {
     directives: {
       ...baseDefaults.contentSecurityPolicy.directives,
-      scriptSrc:
-        // Replace the defaults to remove `'self'`
-        process.env.NODE_ENV === "development"
-          ? // Next.js hot reloading relies on `eval` so we enable it in development
-            ([nonce, "'unsafe-eval'"] as const)
-          : ([nonce] as const),
+      scriptSrc: [
+        ...baseDefaults.contentSecurityPolicy.directives.scriptSrc,
+        ...nextScriptSrc(),
+      ],
       styleSrc: [
         ...baseDefaults.contentSecurityPolicy.directives.styleSrc,
-        "'unsafe-inline'",
+        ...nextStyleSrc(),
       ],
     },
   },
@@ -27,6 +25,17 @@ export default nosecone;
 
 function nonce() {
   return `'nonce-${btoa(crypto.randomUUID())}'` as const;
+}
+
+function nextScriptSrc() {
+  return process.env.NODE_ENV === "development"
+    ? // Next.js hot reloading relies on `eval` so we enable it in development
+      ([nonce, "'unsafe-eval'"] as const)
+    : ([nonce] as const);
+}
+
+function nextStyleSrc() {
+  return ["'unsafe-inline'"] as const;
 }
 
 /**


### PR DESCRIPTION
This refactors the Nosecone Next.js adapter to keep `'self'` in the script-src CSP directive. Generally `'self'` is a warning but it makes integration easier. If `'strict-dynamic'` is specified `'self'` will be ignored as part of the fallback mechanism of CSP so it is fine for us to specify.