### PR TITLE
feat(ip): Allow trusted proxies to exclude when looking for global IP

### DIFF
--- a/ip/README.md
+++ b/ip/README.md
@@ -39,6 +39,9 @@ console.log(globalIp);
 
 // Also optionally takes a platform for additional protection
 const platformGuardedGloablIp = ip(request, { platform: "fly-io" });
+
+// You can also pass a list of trusted proxies to ignore
+const proxyExcludedGlobalIp = ip(request, { proxies: ["103.31.4.0"] });
 ```
 
 ## Considerations

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -171,6 +171,11 @@ function suite(make: MakeTest) {
     const [request, options] = make("1.1.1.1:443");
     expect(ip(request, options)).toEqual("1.1.1.1:443");
   });
+
+  test("returns empty string if the ip is a trusted proxy", () => {
+    const [request, options] = make("1.1.1.1");
+    expect(ip(request, { ...options, proxies: ["1.1.1.1"] }));
+  });
 }
 
 function requestSuite(...keys: string[]) {
@@ -269,6 +274,30 @@ describe("find public IPv4", () => {
         ]),
       };
       expect(ip(request)).toEqual("3.3.3.3");
+    });
+
+    test("skips any trusted proxy IP", () => {
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3"],
+        ]),
+      };
+      const options = {
+        proxies: ["3.3.3.3"],
+      };
+      expect(ip(request, options)).toEqual("2.2.2.2");
+    });
+
+    test("skips multiple trusted proxy IPs", () => {
+      const request = {
+        headers: new Headers([
+          ["X-Forwarded-For", "1.1.1.1, 2.2.2.2, 3.3.3.3"],
+        ]),
+      };
+      const options = {
+        proxies: ["3.3.3.3", "2.2.2.2"],
+      };
+      expect(ip(request, options)).toEqual("1.1.1.1");
     });
   });
 });

--- a/ip/test/ipv6.test.ts
+++ b/ip/test/ipv6.test.ts
@@ -99,6 +99,11 @@ function suite(make: MakeTest) {
     const [request, options] = make("::abcd:c00a:2ff%1");
     expect(ip(request, options)).toEqual("::abcd:c00a:2ff%1");
   });
+
+  test("returns empty string if the ip is a trusted proxy", () => {
+    const [request, options] = make("::abcd:c00a:2ff");
+    expect(ip(request, { ...options, proxies: ["::abcd:c00a:2ff"] }));
+  });
 }
 
 function requestSuite(...keys: string[]) {
@@ -196,6 +201,26 @@ describe("find public IPv6", () => {
         ]),
       };
       expect(ip(request)).toEqual("abcd::");
+    });
+
+    test("skips any trusted proxy IP", () => {
+      const request = {
+        headers: new Headers([["X-Forwarded-For", "e123::, 3.3.3.3, abcd::"]]),
+      };
+      const options = {
+        proxies: ["abcd::"],
+      };
+      expect(ip(request, options)).toEqual("3.3.3.3");
+    });
+
+    test("skips multiple trusted proxy IPs", () => {
+      const request = {
+        headers: new Headers([["X-Forwarded-For", "e123::, 3.3.3.3, abcd::"]]),
+      };
+      const options = {
+        proxies: ["3.3.3.3", "abcd::"],
+      };
+      expect(ip(request, options)).toEqual("e123::");
     });
   });
 });


### PR DESCRIPTION
This adds a configuration option to exclude certain trusted proxy addresses when trying to detect a global IP address using `@arcjet/ip`.

This only adds the changes to the library, and I'll be following up with the changes in each adapter as a separate PR.