### PR TITLE
feat: Support trusted proxy configuration on each adapter

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -2,7 +2,7 @@
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -108,6 +108,22 @@ export function createRemoteClient(options?: RemoteClientOptions) {
 }
 
 /**
+ * The options used to configure an {@link ArcjetBun} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetBun client provides a public `protect()` method to
  * make a decision about how a Bun.sh request should be handled.
  */
@@ -205,7 +221,7 @@ export default function arcjet<
         ip: ipCache.get(request),
         headers,
       },
-      { platform: platform(env) },
+      { platform: platform(env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -2,7 +2,7 @@
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -109,6 +109,22 @@ export function createRemoteClient(options?: RemoteClientOptions) {
 }
 
 /**
+ * The options used to configure an {@link ArcjetDeno} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetDeno client provides a public `protect()` method to
  * make a decision about how a Deno request should be handled.
  */
@@ -207,7 +223,7 @@ export default function arcjet<
         ip: ipCache.get(request),
         headers,
       },
-      { platform: platform(env) },
+      { platform: platform(env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -5,7 +5,7 @@ import "reflect-metadata";
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -158,6 +158,22 @@ function cookiesToString(cookies: string | string[] | undefined): string {
 }
 
 /**
+ * The options used to configure an {@link ArcjetNest} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetNest client provides a public `protect()` method to
  * make a decision about how a NestJS request should be handled.
  */
@@ -222,7 +238,7 @@ function arcjet<
         socket: request.socket,
         headers,
       },
-      { platform: platform(process.env) },
+      { platform: platform(process.env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -10,7 +10,7 @@ import type { NextMiddlewareResult } from "next/dist/server/web/types.js";
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -191,6 +191,22 @@ function cookiesToString(cookies?: ArcjetNextRequest["cookies"]): string {
 }
 
 /**
+ * The options used to configure an {@link ArcjetNest} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetNext client provides a public `protect()` method to
  * make a decision about how a Next.js request should be handled.
  */
@@ -263,7 +279,7 @@ export default function arcjet<
         requestContext: request.requestContext,
         headers,
       },
-      { platform: platform(process.env) },
+      { platform: platform(process.env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -1,7 +1,7 @@
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -139,6 +139,22 @@ function cookiesToString(cookies: string | string[] | undefined): string {
 }
 
 /**
+ * The options used to configure an {@link ArcjetNode} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetNode client provides a public `protect()` method to
  * make a decision about how a Node.js request should be handled.
  */
@@ -210,7 +226,7 @@ export default function arcjet<
         socket: request.socket,
         headers,
       },
-      { platform: platform(process.env) },
+      { platform: platform(process.env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -1,7 +1,7 @@
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -110,6 +110,22 @@ export type ArcjetRemixRequest = {
 };
 
 /**
+ * The options used to configure an {@link ArcjetRemix} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetRemix client provides a public `protect()` method to
  * make a decision about how a Remix request should be handled.
  */
@@ -182,7 +198,7 @@ export default function arcjet<
         ip: context?.ip,
         headers,
       },
-      { platform: platform(process.env) },
+      { platform: platform(process.env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -1,7 +1,7 @@
 import core from "arcjet";
 import type {
   ArcjetDecision,
-  ArcjetOptions,
+  ArcjetOptions as CoreOptions,
   Primitive,
   Product,
   ArcjetRequest,
@@ -127,6 +127,22 @@ function cookiesToString(
 }
 
 /**
+ * The options used to configure an {@link ArcjetSvelteKit} client.
+ */
+export type ArcjetOptions<
+  Rules extends [...Array<Primitive | Product>],
+  Characteristics extends readonly string[],
+> = Simplify<
+  CoreOptions<Rules, Characteristics> & {
+    /**
+     * One or more IP Address of trusted proxies in front of the application.
+     * These addresses will be excluded when Arcjet detects a public IP address.
+     */
+    proxies?: Array<string>;
+  }
+>;
+
+/**
  * The ArcjetSvelteKit client provides a public `protect()` method to
  * make a decision about how a SvelteKit request should be handled.
  */
@@ -197,7 +213,7 @@ export default function arcjet<
         ip: event.getClientAddress(),
         headers,
       },
-      { platform: platform(env) },
+      { platform: platform(env), proxies: options.proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP


### PR DESCRIPTION
This builds upon #2393 and allows trusted proxies to be configured when setting up the Arcjet SDK.

This is only done in each adapter because the core `arcjet` package doesn't do IP lookups. Instead, each adapter uses `@arcjet/ip` to detect the IP address for that specific framework.

This required me to change the way we import the core options and then we need to export a new `ArcjetOptions` type which will override any other export, such as the `export * from "arcjet"`, from the core package.

By configuring trusted proxies on the SDK, the proxy IP addresses will be excluded from any detected IP.

Closes #2346