### PR TITLE
fix(protocol): Include `cookies` and `query` fields on reports

### DIFF
--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -144,6 +144,8 @@ export function createClient(options: ClientOptions): Client {
           host: details.host,
           path: details.path,
           headers: Object.fromEntries(details.headers.entries()),
+          cookies: details.cookies,
+          query: details.query,
           // TODO(#208): Re-add body
           // body: details.body,
           extra: details.extra,


### PR DESCRIPTION
While digging into some logs, I noticed that these fields were missing on requests submitted via `Report`. This fixes it by adding them in the protocol package.