### PR TITLE
chore(examples): Restrict React to v18 in Next 14 example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -298,6 +298,14 @@ updates:
       # restricted.
       - dependency-name: next
         versions: [">=15"]
+      - dependency-name: react
+        versions: [">=19"]
+      - dependency-name: "@types/react"
+        versions: [">=19"]
+      - dependency-name: react-dom
+        versions: [">=19"]
+      - dependency-name: "@types/react-dom"
+        versions: [">=19"]
       - dependency-name: eslint
         versions: [">=9"]
       - dependency-name: eslint-config-next


### PR DESCRIPTION
This restricts dependabot from updating React to v19 in our Next 14 example since Next 14 doesn't support React 19.

#2773 was failing peerDep resolution due to this.