### PR TITLE
deps(examples): Restrict Vite version in Remix example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -811,6 +811,10 @@ updates:
       # TODO(#539): Upgrade to eslint 9
       - dependency-name: eslint
         versions: [">=9"]
+      # Remix 2 doesn't support Vite 6 so the dependencies below are
+      # restricted.
+      - dependency-name: vite
+        versions: [">=6"]
 
   - package-ecosystem: npm
     directory: /examples/sveltekit


### PR DESCRIPTION
Remix doesn't support Vite 6 yet so this restricts it.