### PR TITLE
feat(env): Support MODE environment variable for `isDevelopment` detection

### DIFF
--- a/env/index.ts
+++ b/env/index.ts
@@ -2,6 +2,7 @@ export type Env = {
   [key: string]: unknown;
   FLY_APP_NAME?: string;
   VERCEL?: string;
+  MODE?: string;
   NODE_ENV?: string;
   ARCJET_KEY?: string;
   ARCJET_ENV?: string;
@@ -20,7 +21,7 @@ export function platform(env: Env) {
 }
 
 export function isDevelopment(env: Env) {
-  return env.NODE_ENV === "development" || env.ARCJET_ENV === "development";
+  return env.NODE_ENV === "development" || env.MODE === "development" || env.ARCJET_ENV === "development";
 }
 
 export function logLevel(env: Env) {

--- a/env/index.ts
+++ b/env/index.ts
@@ -21,7 +21,11 @@ export function platform(env: Env) {
 }
 
 export function isDevelopment(env: Env) {
-  return env.NODE_ENV === "development" || env.MODE === "development" || env.ARCJET_ENV === "development";
+  return (
+    env.NODE_ENV === "development" ||
+    env.MODE === "development" ||
+    env.ARCJET_ENV === "development"
+  );
 }
 
 export function logLevel(env: Env) {

--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -7,6 +7,8 @@ describe("env", () => {
     expect(env.platform({})).toBeUndefined();
     expect(env.platform({ FLY_APP_NAME: "" })).toBeUndefined();
     expect(env.platform({ FLY_APP_NAME: "foobar" })).toEqual("fly-io");
+    expect(env.platform({ VERCEL: "" })).toBeUndefined();
+    expect(env.platform({ VERCEL: "1" })).toEqual("vercel");
   });
 
   test("isDevelopment", () => {

--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -13,6 +13,8 @@ describe("env", () => {
     expect(env.isDevelopment({})).toEqual(false);
     expect(env.isDevelopment({ NODE_ENV: "production" })).toEqual(false);
     expect(env.isDevelopment({ NODE_ENV: "development" })).toEqual(true);
+    expect(env.isDevelopment({ MODE: "production" })).toEqual(false);
+    expect(env.isDevelopment({ MODE: "development" })).toEqual(true);
     expect(env.isDevelopment({ ARCJET_ENV: "production" })).toEqual(false);
     expect(env.isDevelopment({ ARCJET_ENV: "development" })).toEqual(true);
   });

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,8 @@
     "ARCJET_RUNTIME",
     "ARCJET_LOG_LEVEL",
     "OPENAI_API_KEY",
-    "FLY_APP_NAME"
+    "FLY_APP_NAME",
+    "MODE"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
I've cherry-picked this out of #2992 so it can have a separate changelog entry.

This adds `MODE` as another variable we use to detect the development environment. This value is set by Vite on `import.meta.env` so I think it is valuable to support.