### PR TITLE
fix(arcjet): Ensure Characteristics are readonly type on protect signup options

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1242,7 +1242,7 @@ export function shield(options: ShieldOptions): Primitive<{}> {
   ];
 }
 
-export type ProtectSignupOptions<Characteristics extends string[]> = {
+export type ProtectSignupOptions<Characteristics extends readonly string[]> = {
   rateLimit: SlidingWindowRateLimitOptions<Characteristics>;
   bots: BotOptions;
   email: EmailOptions;


### PR DESCRIPTION
Cherry-picked from #2992 

This fixes a problem I found where the definition of `Characteristics` was different on `protectSignup`. By aligning the type as `readonly`, the same type can be used everywhere.