### PR TITLE
feat(redact): Pre-compile WebAssembly on module load

### DIFF
--- a/redact-wasm/index.ts
+++ b/redact-wasm/index.ts
@@ -11,28 +11,19 @@ import { wasm as componentCoreWasm } from "./wasm/arcjet_analyze_bindings_redact
 import { wasm as componentCore2Wasm } from "./wasm/arcjet_analyze_bindings_redact.component.core2.wasm?js";
 import { wasm as componentCore3Wasm } from "./wasm/arcjet_analyze_bindings_redact.component.core3.wasm?js";
 
-const wasmCache = new Map<string, WebAssembly.Module>();
+const componentCoreWasmPromise = componentCoreWasm();
+const componentCore2WasmPromise = componentCore2Wasm();
+const componentCore3WasmPromise = componentCore3Wasm();
 
 async function moduleFromPath(path: string): Promise<WebAssembly.Module> {
-  const cachedModule = wasmCache.get(path);
-  if (typeof cachedModule !== "undefined") {
-    return cachedModule;
-  }
-
   if (path === "arcjet_analyze_bindings_redact.component.core.wasm") {
-    const mod = await componentCoreWasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCoreWasmPromise;
   }
   if (path === "arcjet_analyze_bindings_redact.component.core2.wasm") {
-    const mod = await componentCore2Wasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCore2WasmPromise;
   }
   if (path === "arcjet_analyze_bindings_redact.component.core3.wasm") {
-    const mod = await componentCore3Wasm();
-    wasmCache.set(path, mod);
-    return mod;
+    return componentCore3WasmPromise;
   }
 
   throw new Error(`Unknown path: ${path}`);


### PR DESCRIPTION
This applies the same pre-compile logic we do for the Analyze Wasm to our redact utility library.

