### PR TITLE
chore(ci): Avoid upgrading Tailwind where it breaks things

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -407,8 +407,8 @@ updates:
       # Headers in DOM.
       - dependency-name: "@types/node"
         versions: [">18.18"]
-      # Tailwind v4 is not supported by shadcn/ui
-      # See: https://github.com/shadcn-ui/ui/discussions/2996
+      # Tailwind v4 is not supported by shadcn/ui. See:
+      # https://github.com/shadcn-ui/ui/discussions/2996
       - dependency-name: tailwindcss
         versions: [">=4"]
       # TODO(#539): Upgrade to eslint 9

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -407,7 +407,8 @@ updates:
       # Headers in DOM.
       - dependency-name: "@types/node"
         versions: [">18.18"]
-      # Tailwind v4 breaks behavior this example depended upon
+      # Tailwind v4 is not supported by shadcn/ui
+      # See: https://github.com/shadcn-ui/ui/discussions/2996
       - dependency-name: tailwindcss
         versions: [">=4"]
       # TODO(#539): Upgrade to eslint 9

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -407,6 +407,9 @@ updates:
       # Headers in DOM.
       - dependency-name: "@types/node"
         versions: [">18.18"]
+      # Tailwind v4 breaks behavior this example depended upon
+      - dependency-name: tailwindcss
+        versions: [">4"]
       # TODO(#539): Upgrade to eslint 9
       - dependency-name: eslint
         versions: [">=9"]
@@ -677,6 +680,11 @@ updates:
       # Headers in DOM.
       - dependency-name: "@types/node"
         versions: [">18.18"]
+      # Ignore tailwind updates while eslint-plugin-tailwindcss does not work
+      # with Tailwind v4. See:
+      # https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/381
+      - dependency-name: tailwindcss
+        versions: [">4"]
       # TODO(#539): Upgrade to eslint 9
       - dependency-name: eslint
         versions: [">=9"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -681,8 +681,7 @@ updates:
       # Headers in DOM.
       - dependency-name: "@types/node"
         versions: [">18.18"]
-      # Tailwind v4 is not supported by eslint-plugin-tailwindcss
-      # See:
+      # Tailwind v4 is not supported by eslint-plugin-tailwindcss. See:
       # https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/381
       - dependency-name: tailwindcss
         versions: [">=4"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -409,7 +409,7 @@ updates:
         versions: [">18.18"]
       # Tailwind v4 breaks behavior this example depended upon
       - dependency-name: tailwindcss
-        versions: [">4"]
+        versions: [">=4"]
       # TODO(#539): Upgrade to eslint 9
       - dependency-name: eslint
         versions: [">=9"]
@@ -684,7 +684,7 @@ updates:
       # with Tailwind v4. See:
       # https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/381
       - dependency-name: tailwindcss
-        versions: [">4"]
+        versions: [">=4"]
       # TODO(#539): Upgrade to eslint 9
       - dependency-name: eslint
         versions: [">=9"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -681,8 +681,8 @@ updates:
       # Headers in DOM.
       - dependency-name: "@types/node"
         versions: [">18.18"]
-      # Ignore tailwind updates while eslint-plugin-tailwindcss does not work
-      # with Tailwind v4. See:
+      # Tailwind v4 is not supported by eslint-plugin-tailwindcss
+      # See:
       # https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/381
       - dependency-name: tailwindcss
         versions: [">=4"]


### PR DESCRIPTION
Both #3054 and #3080 are broken by tailwind v4. This disables the upgrade on those 2 examples.