### PR TITLE
chore: Update trunk, linters, and allowed workflow endpoints

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -187,6 +187,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -229,6 +230,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -271,6 +273,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -313,6 +316,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -357,6 +361,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -401,6 +406,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -443,6 +449,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -488,6 +495,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -533,6 +541,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -575,6 +584,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -617,6 +627,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -659,6 +670,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -701,6 +713,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -746,6 +759,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -788,6 +802,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first
@@ -908,6 +923,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
+            decide.arcjet.com:443
 
       # Checkout
       # Most toolchains require checkout first

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -4,6 +4,11 @@ name: Reusable examples workflow
 
 on: [workflow_call]
 
+env:
+  DO_NOT_TRACK: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+  TURBO_TELEMETRY_DISABLED: "1"
+
 jobs:
   nestjs:
     name: NestJS

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -4,6 +4,11 @@ name: Reusable test workflow
 
 on: [workflow_call]
 
+env:
+  DO_NOT_TRACK: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+  TURBO_TELEMETRY_DISABLED: "1"
+
 jobs:
   test:
     name: "Run tests (OS: ${{matrix.os}}, Node: ${{ matrix.node }})"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,35 +2,35 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.2
+  version: 1.22.10
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.0
+      ref: v1.6.7
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - go@1.21.0
-    - node@18.12.1
+    - node@18.20.5
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trivy@0.52.1
+    - trivy@0.59.1
     - yamllint@1.35.1
-    - semgrep@1.75.0
-    - gitleaks@8.18.3
-    - actionlint@1.7.1
+    - semgrep@1.107.0
+    - gitleaks@8.23.3
+    - actionlint@1.7.7
     - git-diff-check
-    - markdownlint@0.41.0
-    - osv-scanner@1.7.4
-    - prettier@3.3.2
+    - markdownlint@0.44.0
+    - osv-scanner@1.9.2
+    - prettier@3.4.2
     - svgo@3.3.2
-    - trufflehog@3.78.1
+    - trufflehog@3.88.4
   disabled:
     # tfsec and checkov are replaced by Trivy
     - tfsec


### PR DESCRIPTION
This updates trunk and the linters. I've also fixed some CI stuff related to Harden Runner's allowed endpoints.