### PR TITLE
chore: Regenerate jco bindings

### DIFF
--- a/analyze-wasm/wasm/arcjet_analyze_js_req.component.js
+++ b/analyze-wasm/wasm/arcjet_analyze_js_req.component.js
@@ -268,6 +268,7 @@ function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.insta
       dataView(memory0).setInt32(arg2 + 4, len5, true);
       dataView(memory0).setInt32(arg2 + 0, result5, true);
     }
+    let exports2;
     let postReturn0;
     let postReturn1;
     let postReturn2;
@@ -291,7 +292,7 @@ function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.insta
     }));
     memory0 = exports1.memory;
     realloc0 = exports1.cabi_realloc;
-    (yield instantiateCore(yield module2, {
+    ({ exports: exports2 } = yield instantiateCore(yield module2, {
       '': {
         $imports: exports0.$imports,
         '0': trampoline0,

--- a/redact-wasm/wasm/arcjet_analyze_bindings_redact.component.js
+++ b/redact-wasm/wasm/arcjet_analyze_bindings_redact.component.js
@@ -151,6 +151,7 @@ function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.insta
         dataView(memory0).setInt32(arg3 + 4, ptr2, true);
       }
     }
+    let exports2;
     let postReturn0;
     Promise.all([module0, module1, module2]).catch(() => {});
     ({ exports: exports0 } = yield instantiateCore(yield module1));
@@ -162,7 +163,7 @@ function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.insta
     }));
     memory0 = exports1.memory;
     realloc0 = exports1.cabi_realloc;
-    (yield instantiateCore(yield module2, {
+    ({ exports: exports2 } = yield instantiateCore(yield module2, {
       '': {
         $imports: exports0.$imports,
         '0': trampoline0,


### PR DESCRIPTION
I think trunk was formatting these files before for some reason but the ignore is working now and these changes showed up in my diffs.