### PR TITLE
chore(ci): Enable Bun Dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,43 +75,39 @@ updates:
         patterns:
           - "*"
 
-  # Bun isn't supported by Dependabot
-  # Ref: https://github.com/dependabot/dependabot-core/issues/6528
-  # - package-ecosystem: npm
-  #   directory: /examples/bun-hono-rate-limit
-  #   schedule:
-  #     # Our dependencies should be checked daily
-  #     interval: daily
-  #   assignees:
-  #     - blaine-arcjet
-  #   reviewers:
-  #     - blaine-arcjet
-  #   commit-message:
-  #     prefix: deps(example)
-  #     prefix-development: deps(example)
-  #   groups:
-  #     dependencies:
-  #       patterns:
-  #         - "*"
+  - package-ecosystem: bun
+    directory: /examples/bun-hono-rate-limit
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 
-  # Bun isn't supported by Dependabot
-  # Ref: https://github.com/dependabot/dependabot-core/issues/6528
-  # - package-ecosystem: npm
-  #   directory: /examples/bun-rate-limit
-  #   schedule:
-  #     # Our dependencies should be checked daily
-  #     interval: daily
-  #   assignees:
-  #     - blaine-arcjet
-  #   reviewers:
-  #     - blaine-arcjet
-  #   commit-message:
-  #     prefix: deps(example)
-  #     prefix-development: deps(example)
-  #   groups:
-  #     dependencies:
-  #       patterns:
-  #         - "*"
+  - package-ecosystem: bun
+    directory: /examples/bun-rate-limit
+    schedule:
+      # Our dependencies should be checked daily
+      interval: daily
+    assignees:
+      - blaine-arcjet
+    reviewers:
+      - blaine-arcjet
+    commit-message:
+      prefix: deps(example)
+      prefix-development: deps(example)
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 
   # Deno isn't supported by Dependabot
   # Ref: https://github.com/dependabot/dependabot-core/issues/2417


### PR DESCRIPTION
This enables Dependabot updates for our Bun examples.

Ref https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/
Ref https://github.com/dependabot/dependabot-core/issues/6528