### PR TITLE
fix(transport): Add connect as a direct dependency to satisfy peerDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8989,6 +8989,7 @@
       "version": "1.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@connectrpc/connect": "1.6.1",
         "@connectrpc/connect-node": "1.6.1",
         "@connectrpc/connect-web": "1.6.1"
       },

--- a/transport/package.json
+++ b/transport/package.json
@@ -44,6 +44,7 @@
     "test": "node --test --experimental-test-coverage"
   },
   "dependencies": {
+    "@connectrpc/connect": "1.6.1",
     "@connectrpc/connect-node": "1.6.1",
     "@connectrpc/connect-web": "1.6.1"
   },


### PR DESCRIPTION
Closes #3415 

It looks like whichever package manager is being used by the end-user is nesting the ConnectRPC dependencies which means that that `@connectrpc/connect` dependency included by the `@arcjet/protocol` package. This embeds the peerDependency as a direct dependency to ensure it is available even when package managers are being weird.