### PR TITLE
chore: Restrict jco in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,10 @@ updates:
         versions: [">=2"]
       - dependency-name: "@connectrpc/connect-web"
         versions: [">=2"]
+      # Ignore updates for jco above 1.5.0 due to unnecessary deps
+      # Ref: https://github.com/bytecodealliance/jco/issues/500
+      - dependency-name: jco
+        versions: [">1.5.0"]
 
   # Dependencies in our examples
 


### PR DESCRIPTION
This restricts jco until https://github.com/bytecodealliance/jco/issues/500 is resolved.

If they don't resolve it, perhaps we need to pull the transpilation logic into gravity.