### PR TITLE
fix: Include turbo plugin correctly

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "turbo",
+    "plugin:turbo/recommended",
     "prettier",
   ],
   rules: {


### PR DESCRIPTION
This includes the turbo plugin correctly following [this comment](https://github.com/vercel/turborepo/pull/9978#discussion_r1974406494) from a user experiencing the same issue we encountered in #3337