### PR TITLE
chore: Only log development mode IP address warning once

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -202,6 +202,12 @@ export function createArcjetClient<
         level: logLevel(env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     request: Request,
     props: Props,
@@ -228,7 +234,6 @@ export function createArcjetClient<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -203,6 +203,12 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     request: Request,
     props: Props,
@@ -227,7 +233,6 @@ export default function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -205,6 +205,12 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     request: Request,
     props: Props,
@@ -229,7 +235,6 @@ export default function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -222,6 +222,12 @@ function arcjet<
         level: logLevel(process.env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     request: ArcjetNestRequest,
     props: Props,
@@ -244,7 +250,6 @@ function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(process.env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -419,6 +419,12 @@ export default function arcjet<
         level: logLevel(process.env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     request: ArcjetNextRequest,
     props: Props,
@@ -440,7 +446,6 @@ export default function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(process.env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -211,6 +211,12 @@ export default function arcjet<
         level: logLevel(process.env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     request: ArcjetNodeRequest,
     props: Props,
@@ -232,7 +238,6 @@ export default function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(process.env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -182,6 +182,12 @@ export default function arcjet<
         level: logLevel(process.env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     { request, context }: ArcjetRemixRequest,
     props: Props,
@@ -204,7 +210,6 @@ export default function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(process.env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -199,6 +199,12 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  if (isDevelopment(process.env)) {
+    log.warn(
+      "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
+    );
+  }
+
   function toArcjetRequest<Props extends PlainObject>(
     event: ArcjetSvelteKitRequestEvent,
     props: Props,
@@ -219,7 +225,6 @@ export default function arcjet<
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
       if (isDevelopment(env)) {
-        log.warn("Using 127.0.0.1 as IP address in development mode");
         ip = "127.0.0.1";
       } else {
         log.warn(


### PR DESCRIPTION
This moves the warning about using `127.0.0.1` in development mode to the instantiation of the Arcjet SDK. This means it only runs once per instantiation so it is possible to miss it, but it'll reduce console noise during development.

As mentioned at https://github.com/arcjet/arcjet-js/issues/1781#issuecomment-2715458304, we keep the alternate warning logging on each request in production because it either indicates an error case or a misconfiguration.

Closes #1781 