### PR TITLE
chore(analyze-wasm): Exclude TypeScript files

### DIFF
--- a/analyze-wasm/package.json
+++ b/analyze-wasm/package.json
@@ -36,7 +36,6 @@
     "wasm/",
     "*.js",
     "*.d.ts",
-    "*.ts",
     "!*.config.js"
   ],
   "scripts": {


### PR DESCRIPTION
I noticed that `.ts` files were being published with `@arcjet/analyze-wasm` package. We've removed them from all other packages so we can remove them here too.