### PR TITLE
fix(transport): Add direct dependency on buf peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8973,6 +8973,7 @@
       "version": "1.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
         "@connectrpc/connect": "1.6.1",
         "@connectrpc/connect-node": "1.6.1",
         "@connectrpc/connect-web": "1.6.1"

--- a/transport/package.json
+++ b/transport/package.json
@@ -44,6 +44,7 @@
     "test": "node --test --experimental-test-coverage"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "1.10.0",
     "@connectrpc/connect": "1.6.1",
     "@connectrpc/connect-node": "1.6.1",
     "@connectrpc/connect-web": "1.6.1"


### PR DESCRIPTION
Closes #3555

This adds `@bufbuild/protobuf` as a direct dependency of `@arcjet/transport`. This avoids a problem when a newer version of buf exists in the dependency tree.