### PR TITLE
feat: Support CIDR strings as proxies

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -202,6 +202,10 @@ export function createArcjetClient<
         level: logLevel(env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -228,7 +232,7 @@ export function createArcjetClient<
         ip: clientAddress,
         headers,
       },
-      { platform: platform(env), proxies: options.proxies },
+      { platform: platform(env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -10,7 +10,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import type { Server } from "bun";
 import { env } from "bun";
@@ -203,6 +203,10 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -227,7 +231,7 @@ export default function arcjet<
         ip: ipCache.get(request),
         headers,
       },
-      { platform: platform(env), proxies: options.proxies },
+      { platform: platform(env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -10,7 +10,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -205,6 +205,10 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -229,7 +233,7 @@ export default function arcjet<
         ip: ipCache.get(request),
         headers,
       },
-      { platform: platform(env), proxies: options.proxies },
+      { platform: platform(env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -13,7 +13,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -222,6 +222,10 @@ function arcjet<
         level: logLevel(process.env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -244,7 +248,7 @@ function arcjet<
         socket: request.socket,
         headers,
       },
-      { platform: platform(process.env), proxies: options.proxies },
+      { platform: platform(process.env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -18,7 +18,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -419,6 +419,10 @@ export default function arcjet<
         level: logLevel(process.env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -440,7 +444,7 @@ export default function arcjet<
         requestContext: request.requestContext,
         headers,
       },
-      { platform: platform(process.env), proxies: options.proxies },
+      { platform: platform(process.env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import type { Env } from "@arcjet/env";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
@@ -244,6 +244,10 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -265,7 +269,7 @@ export default function arcjet<
         socket: request.socket,
         headers,
       },
-      { platform: platform(env), proxies: options.proxies },
+      { platform: platform(env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -182,6 +182,10 @@ export default function arcjet<
         level: logLevel(process.env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -204,7 +208,7 @@ export default function arcjet<
         ip: context?.ip,
         headers,
       },
-      { platform: platform(process.env), proxies: options.proxies },
+      { platform: platform(process.env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP from "@arcjet/ip";
+import findIP, { parseProxy } from "@arcjet/ip";
 import ArcjetHeaders from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -199,6 +199,10 @@ export default function arcjet<
         level: logLevel(env),
       });
 
+  const proxies = Array.isArray(options.proxies)
+    ? options.proxies.map(parseProxy)
+    : undefined;
+
   if (isDevelopment(process.env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
@@ -219,7 +223,7 @@ export default function arcjet<
         ip: event.getClientAddress(),
         headers,
       },
-      { platform: platform(env), proxies: options.proxies },
+      { platform: platform(env), proxies },
     );
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import { expect } from "expect";
 import type { Options, RequestLike } from "../index";
-import ip from "../index";
+import ip, { parseProxy } from "../index";
 
 type MakeTest = (ip: unknown) => [RequestLike, Options | undefined];
 
@@ -172,7 +172,29 @@ function suite(make: MakeTest) {
 
   test("returns empty string if the ip is a trusted proxy", () => {
     const [request, options] = make("1.1.1.1");
-    expect(ip(request, { ...options, proxies: ["1.1.1.1"] }));
+    expect(ip(request, { ...options, proxies: ["1.1.1.1"] })).toEqual("");
+    expect(
+      ip(request, { ...options, proxies: [parseProxy("1.1.1.1/32")] }),
+    ).toEqual("");
+  });
+
+  test("returns the string if the ip is not a trusted proxy", () => {
+    const [request, options] = make("1.1.1.1");
+    expect(ip(request, { ...options, proxies: ["1.1.1.2"] })).toEqual(
+      "1.1.1.1",
+    );
+    expect(
+      ip(request, { ...options, proxies: [parseProxy("1.1.1.2/32")] }),
+    ).toEqual("1.1.1.1");
+    expect(
+      ip(request, {
+        ...options,
+        proxies: [
+          // @ts-ignore
+          1234,
+        ],
+      }),
+    ).toEqual("1.1.1.1");
   });
 }
 

--- a/ip/test/proxies.test.ts
+++ b/ip/test/proxies.test.ts
@@ -1,0 +1,150 @@
+import { describe, test } from "node:test";
+import { expect } from "expect";
+import { parseProxy } from "../index";
+
+describe("parseProxy", () => {
+  test("handles strings proxies without parsing", () => {
+    const proxy = parseProxy("127.0.0.1");
+    expect(proxy).toEqual("127.0.0.1");
+  });
+
+  test("parses IPv4 CIDR address", () => {
+    const proxy = parseProxy("1.1.1.1/22");
+    // @ts-ignore
+    expect(proxy.type).toEqual("v4");
+    // @ts-ignore
+    expect(proxy.parts).toHaveLength(4);
+    // @ts-ignore
+    expect(proxy.partSize).toEqual(8);
+    // @ts-ignore
+    expect(proxy.bits).toEqual(22);
+  });
+
+  test("fails to parse IPv4 CIDR address if bits is out of range", () => {
+    expect(() => {
+      parseProxy("103.21.244.0/99");
+    }).toThrow("invalid CIDR address: incorrect amount of bits");
+  });
+
+  test("fails to parse IPv4 CIDR address if bits is not numeric", () => {
+    expect(() => {
+      parseProxy("103.21.244.0/aa");
+    }).toThrow("invalid CIDR address: incorrect amount of bits");
+  });
+
+  test("fails to parse IPv4 CIDR address if contains more than one `/`", () => {
+    expect(() => {
+      parseProxy("103.21.244.0/1/2");
+    }).toThrow("invalid CIDR address: must be exactly 2 parts");
+  });
+
+  test("fails if cannot parse IPv4 address", () => {
+    expect(() => {
+      parseProxy("103.a.244.0/1");
+    }).toThrow("invalid CIDR address: could not parse IP address");
+  });
+
+  test("parses IPv6 CIDR address", () => {
+    const proxy = parseProxy("2400:cb00::/32");
+    // @ts-ignore
+    expect(proxy.type).toEqual("v6");
+    // @ts-ignore
+    expect(proxy.parts).toHaveLength(8);
+    // @ts-ignore
+    expect(proxy.partSize).toEqual(16);
+    // @ts-ignore
+    expect(proxy.bits).toEqual(32);
+  });
+
+  test("fails to parse IPv6 CIDR address if bits is out of range", () => {
+    expect(() => {
+      parseProxy("2400:cb00::/256");
+    }).toThrow("invalid CIDR address: incorrect amount of bits");
+  });
+
+  test("fails to parse IPv6 CIDR address if bits is not numeric", () => {
+    expect(() => {
+      parseProxy("2400:cb00::/aa");
+    }).toThrow("invalid CIDR address: incorrect amount of bits");
+  });
+
+  test("fails to parse IPv6 CIDR address if bits is not numeric", () => {
+    expect(() => {
+      parseProxy("2400:cb00::/1/2");
+    }).toThrow("invalid CIDR address: must be exactly 2 parts");
+  });
+
+  test("fails if cannot parse IPv6 address", () => {
+    expect(() => {
+      parseProxy("2400:cx00::/1");
+    }).toThrow("invalid CIDR address: could not parse IP address");
+  });
+
+  const ipv4Ranges = [
+    // Cloudflare IPv4 ranges via https://www.cloudflare.com/ips-v4/
+    { cidr: "173.245.48.0/20", ip: [173, 245, 63, 254] },
+    { cidr: "103.21.244.0/22", ip: [103, 21, 247, 254] },
+    { cidr: "103.22.200.0/22", ip: [103, 22, 203, 254] },
+    { cidr: "103.31.4.0/22", ip: [103, 31, 7, 254] },
+    { cidr: "141.101.64.0/18", ip: [141, 101, 127, 254] },
+    { cidr: "108.162.192.0/18", ip: [108, 162, 255, 254] },
+    { cidr: "190.93.240.0/20", ip: [190, 93, 255, 254] },
+    { cidr: "188.114.96.0/20", ip: [188, 114, 111, 254] },
+    { cidr: "197.234.240.0/22", ip: [197, 234, 243, 254] },
+    { cidr: "198.41.128.0/17", ip: [198, 41, 255, 254] },
+    { cidr: "162.158.0.0/15", ip: [162, 159, 255, 254] },
+    { cidr: "104.16.0.0/13", ip: [104, 23, 255, 254] },
+    { cidr: "104.24.0.0/14", ip: [104, 27, 255, 254] },
+    { cidr: "172.64.0.0/13", ip: [172, 71, 255, 254] },
+    { cidr: "131.0.72.0/22", ip: [131, 0, 75, 254] },
+  ];
+  const ipv6Ranges = [
+    // Cloudflare IPv6 ranges via https://www.cloudflare.com/ips-v6/
+    {
+      cidr: "2400:cb00::/32",
+      ip: [0x2400, 0xcb00, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+    {
+      cidr: "2606:4700::/32",
+      ip: [0x2606, 0x4700, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+    {
+      cidr: "2803:f800::/32",
+      ip: [0x2803, 0xf800, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+    {
+      cidr: "2405:b500::/32",
+      ip: [0x2405, 0xb500, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+    {
+      cidr: "2405:8100::/32",
+      ip: [0x2405, 0x8100, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+    {
+      cidr: "2a06:98c0::/29",
+      ip: [0x2a06, 0x98c7, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+    {
+      cidr: "2c0f:f248::/32",
+      ip: [0x2c0f, 0xf248, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xfffe],
+    },
+  ];
+
+  for (const { cidr, ip } of ipv4Ranges) {
+    const readableIP = ip.join(".");
+    test(`knows ${readableIP} is in ${cidr} range`, () => {
+      const proxy = parseProxy(cidr);
+      // @ts-ignore
+      expect(proxy.contains(ip)).toEqual(true);
+    });
+  }
+
+  for (const { cidr, ip } of ipv6Ranges) {
+    const readableIP = ip.map((val) => val.toString(16)).join(":");
+    test(`knows ${readableIP} is in ${cidr} range`, () => {
+      const proxy = parseProxy(cidr);
+      // @ts-ignore
+      expect(proxy.contains(ip)).toEqual(true);
+    });
+  }
+});


### PR DESCRIPTION
This adds CIDR parsing and matching to our `@arcjet/ip` package. I've also update all adapters to consume the `parseProxy` function when instantiating the SDK. If a CIDR matcher is encountered during the proxy comparison, the CIDR range is checked to see if it contains the IP segments.

I've chosen to implement this way because non-CIDR addresses remain the fastest, since it is just a string comparison and we want to pre-parse the CIDR addresses upon startup to ensure the fastest IP lookup we can achieve while still supporting CIDR proxies.

I've also tested all the Cloudflare ranges that they publish and I used https://ipinfo.io/tools/cidr-to-ip-range-converter to find the last address. Another utility that helped me explore CIDR was https://cidr.xyz/

Closes #2402 