### PR TITLE
fix: Only call decide endpoint when a local rule is in dry run mode

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -2095,20 +2095,22 @@ export default function arcjet<
         }
 
         if (results[idx].isDenied()) {
-          const decision = new ArcjetDenyDecision({
-            ttl: results[idx].ttl,
-            reason: results[idx].reason,
-            results,
-          });
-
-          // Only a DENY decision is reported to avoid creating 2 entries for a
-          // request. Upon ALLOW, the `decide` call will create an entry for the
-          // request.
-          client.report(context, details, decision, rules);
-
-          // If we're not in DRY_RUN mode, we want to cache non-zero TTL results
-          // and return this DENY decision.
+          // If the rule is not a DRY_RUN, we want to cache non-zero TTL results
+          // and return a DENY decision.
+          // TODO: The local rules should set `state` correctly as DRY_RUN if in
+          // that mode.
           if (rule.mode !== "DRY_RUN") {
+            const decision = new ArcjetDenyDecision({
+              ttl: results[idx].ttl,
+              reason: results[idx].reason,
+              results,
+            });
+
+            // Only a DENY decision is reported to avoid creating 2 entries for
+            // a request. Upon ALLOW, the `decide` call will create an entry for
+            // the request.
+            client.report(context, details, decision, rules);
+
             if (results[idx].ttl > 0) {
               log.debug(
                 {
@@ -2131,9 +2133,8 @@ export default function arcjet<
           }
 
           log.warn(
-            `Dry run mode is enabled for "%s" rule. Overriding decision. Decision was: %s`,
+            `Dry run mode is enabled for "%s" rule. Overriding decision. Decision was: DENY`,
             rule.type,
-            decision.conclusion,
           );
         }
       }

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -3743,7 +3743,6 @@ describe("SDK", () => {
 
     const _ = await aj.protect(context, request);
 
-    console.log(log.error.mock.calls);
     expect(log.error.mock.callCount()).toEqual(1);
     expect(log.error.mock.calls[0].arguments).toEqual([
       "Failure running rule: %s due to %s",
@@ -3790,14 +3789,14 @@ describe("SDK", () => {
     expect(decision.isDenied()).toBe(false);
 
     expect(client.decide.mock.callCount()).toEqual(1);
-    expect(client.report.mock.callCount()).toEqual(1);
+    expect(client.report.mock.callCount()).toEqual(0);
 
     const decision2 = await aj.protect(context, request);
 
     expect(decision2.isDenied()).toBe(false);
 
     expect(client.decide.mock.callCount()).toEqual(2);
-    expect(client.report.mock.callCount()).toEqual(2);
+    expect(client.report.mock.callCount()).toEqual(0);
   });
 
   test("processes a single rule from a REMOTE ArcjetRule", async () => {


### PR DESCRIPTION
This fixes a bug where we were calling the Report endpoint before overriding a dry run result and then calling Decide later. I think I was actually debugging this at some point because there was a `console.log` in the related test but I forgot about it 😬 

Fixes #3821 