### PR TITLE
feat: Support Render deployments

### DIFF
--- a/env/index.ts
+++ b/env/index.ts
@@ -2,6 +2,7 @@ export type Env = {
   [key: string]: unknown;
   FLY_APP_NAME?: string;
   VERCEL?: string;
+  RENDER?: string;
   MODE?: string;
   NODE_ENV?: string;
   ARCJET_KEY?: string;
@@ -17,6 +18,11 @@ export function platform(env: Env) {
 
   if (typeof env["VERCEL"] === "string" && env["VERCEL"] === "1") {
     return "vercel" as const;
+  }
+
+  // https://render.com/docs/environment-variables
+  if (typeof env["RENDER"] === "string" && env["RENDER"] === "true") {
+    return "render" as const;
   }
 }
 

--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -9,6 +9,8 @@ describe("env", () => {
     expect(env.platform({ FLY_APP_NAME: "foobar" })).toEqual("fly-io");
     expect(env.platform({ VERCEL: "" })).toBeUndefined();
     expect(env.platform({ VERCEL: "1" })).toEqual("vercel");
+    expect(env.platform({ RENDER: "" })).toBeUndefined();
+    expect(env.platform({ RENDER: "true" })).toEqual("render");
   });
 
   test("isDevelopment", () => {

--- a/ip/index.ts
+++ b/ip/index.ts
@@ -768,7 +768,7 @@ export type RequestLike = {
   requestContext?: PartialRequestContext;
 } & HeaderLike;
 
-export type Platform = "cloudflare" | "fly-io" | "vercel";
+export type Platform = "cloudflare" | "fly-io" | "vercel" | "render";
 
 export interface Options {
   platform?: Platform;
@@ -926,6 +926,19 @@ function findIP(request: RequestLike, options: Options = {}): string {
       if (isGlobalIP(item, proxies)) {
         return item;
       }
+    }
+
+    // If we are using a platform check and don't have a Global IP, we exit
+    // early with an empty IP since the more generic headers shouldn't be
+    // trusted over the platform-specific headers.
+    return "";
+  }
+
+  if (platform === "render") {
+    // True-Client-IP: https://community.render.com/t/what-number-of-proxies-sit-in-front-of-an-express-app-deployed-on-render/35981/2
+    const trueClientIP = getHeader(request.headers, "true-client-ip");
+    if (isGlobalIP(trueClientIP, proxies)) {
+      return trueClientIP;
     }
 
     // If we are using a platform check and don't have a Global IP, we exit

--- a/ip/test/ipv4.test.ts
+++ b/ip/test/ipv4.test.ts
@@ -257,6 +257,7 @@ describe("find public IPv4", () => {
   headerSuite("X-Real-IP", { platform: "vercel" });
   headerSuite("X-Vercel-Forwarded-For", { platform: "vercel" });
   headerSuite("X-Forwarded-For", { platform: "vercel" });
+  headerSuite("True-Client-IP", { platform: "render" });
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
   headerSuite("Fly-Client-IP", { platform: "fly-io" });

--- a/ip/test/ipv6.test.ts
+++ b/ip/test/ipv6.test.ts
@@ -188,6 +188,7 @@ describe("find public IPv6", () => {
   headerSuite("X-Real-IP", { platform: "vercel" });
   headerSuite("X-Vercel-Forwarded-For", { platform: "vercel" });
   headerSuite("X-Forwarded-For", { platform: "vercel" });
+  headerSuite("True-Client-IP", { platform: "render" });
   headerSuite("DO-Connecting-IP");
   headerSuite("Fastly-Client-IP");
   headerSuite("Fly-Client-IP", { platform: "fly-io" });


### PR DESCRIPTION
This adds support for detecting the IP address in Render deployments. As noted in #3899, Render sets the `RENDER=true` environment variable. It is fronted by Cloudflare, so [they suggest](https://community.render.com/t/what-number-of-proxies-sit-in-front-of-an-express-app-deployed-on-render/35981) using `True-Client-IP` from the headers.

Closes #3899 