### PR TITLE
chore: Enable declaration maps for TypeScript definition files

### DIFF
--- a/analyze-wasm/.gitignore
+++ b/analyze-wasm/.gitignore
@@ -132,9 +132,12 @@ dist
 # Generated files
 edge-light.js
 edge-light.d.ts
+edge-light.d.ts.map
 index.js
 index.d.ts
+index.d.ts.map
 workerd.js
 workerd.d.ts
+workerd.d.ts.map
 test/*.js
 _virtual/*.js

--- a/analyze/.gitignore
+++ b/analyze/.gitignore
@@ -132,9 +132,12 @@ dist
 # Generated files
 edge-light.js
 edge-light.d.ts
+edge-light.d.ts.map
 index.js
 index.d.ts
+index.d.ts.map
 workerd.js
 workerd.d.ts
+workerd.d.ts.map
 test/*.js
 _virtual/*.js

--- a/arcjet-astro/.gitignore
+++ b/arcjet-astro/.gitignore
@@ -132,8 +132,11 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 internal.js
 internal.d.ts
+internal.d.ts.map
 middleware.js
 middleware.d.ts
+middleware.d.ts.map
 test/*.js

--- a/arcjet-bun/.gitignore
+++ b/arcjet-bun/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet-deno/.gitignore
+++ b/arcjet-deno/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet-nest/.gitignore
+++ b/arcjet-nest/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet-next/.gitignore
+++ b/arcjet-next/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet-node/.gitignore
+++ b/arcjet-node/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet-remix/.gitignore
+++ b/arcjet-remix/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet-sveltekit/.gitignore
+++ b/arcjet-sveltekit/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/arcjet/.gitignore
+++ b/arcjet/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/body/.gitignore
+++ b/body/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/decorate/.gitignore
+++ b/decorate/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/duration/.gitignore
+++ b/duration/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/env/.gitignore
+++ b/env/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/headers/.gitignore
+++ b/headers/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/inspect/.gitignore
+++ b/inspect/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/ip/.gitignore
+++ b/ip/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/logger/.gitignore
+++ b/logger/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/nosecone-next/.gitignore
+++ b/nosecone-next/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/nosecone-sveltekit/.gitignore
+++ b/nosecone-sveltekit/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/nosecone/.gitignore
+++ b/nosecone/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/protocol/.gitignore
+++ b/protocol/.gitignore
@@ -132,10 +132,14 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 client.js
 client.d.ts
+client.d.ts.map
 convert.js
 convert.d.ts
+convert.d.ts.map
 well-known-bots.js
 well-known-bots.d.ts
+well-known-bots.d.ts.map
 test/*.js

--- a/redact-wasm/.gitignore
+++ b/redact-wasm/.gitignore
@@ -132,9 +132,12 @@ dist
 # Generated files
 edge-light.js
 edge-light.d.ts
+edge-light.d.ts.map
 index.js
 index.d.ts
+index.d.ts.map
 workerd.js
 workerd.d.ts
+workerd.d.ts.map
 test/*.js
 _virtual/*.js

--- a/redact/.gitignore
+++ b/redact/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -185,6 +185,7 @@ export function createConfig(root, { plugins = [] } = {}) {
         // generate definition files for our tests
         exclude: ["node_modules", "test/*.ts"],
         declaration: true,
+        declarationMap: true,
         declarationDir: ".",
         noEmitOnError: true,
       }),

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -132,6 +132,8 @@ dist
 # Generated files
 edge-light.js
 edge-light.d.ts
+edge-light.d.ts.map
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/sprintf/.gitignore
+++ b/sprintf/.gitignore
@@ -132,4 +132,5 @@ dist
 # Generated files
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js

--- a/transport/.gitignore
+++ b/transport/.gitignore
@@ -132,8 +132,11 @@ dist
 # Generated files
 bun.js
 bun.d.ts
+bun.d.ts.map
 edge-light.js
 edge-light.d.ts
+edge-light.d.ts.map
 index.js
 index.d.ts
+index.d.ts.map
 test/*.js


### PR DESCRIPTION
Was having a poke around and noticed [go to definition](https://code.visualstudio.com/docs/editing/editingevolved#_go-to-definition) was targeting declaration files. Here is a quick patch that enables [declaration maps](https://www.typescriptlang.org/tsconfig/#declarationMap).

Only logic is in the rollup config (see below comment). The rest is `.gitignore` patching for the additional generated map files (I tried to follow the existing pattern)

Feel free to close if you have them intentionally disabled. Had a quick search of the repo and couldn't find anything :)