### PR TITLE
fix(protocol): Ensure sensitiveInfo rule sends mode

### DIFF
--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -673,6 +673,7 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
       rule: {
         case: "sensitiveInfo",
         value: {
+          mode: ArcjetModeToProtocol(rule.mode),
           allow: rule.allow,
           deny: rule.deny,
         },


### PR DESCRIPTION
This fixes the `sensitiveInfo` rule which wasn't sending the `mode` field when converted to the Protobuf.

I've also refactored the way types were being specified to avoid casting rules. I found this while adding the `version` field but wanted to add it to this PR because it ensures the `ArcjetSensitiveInfoRule` is constructed correctly.