### PR TITLE
chore: Remove reviewers config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(ci)
       prefix-development: deps(ci)
@@ -23,8 +21,6 @@ updates:
       # Our dependencies should be checked daily
       interval: daily
     open-pull-requests-limit: 20
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
@@ -54,8 +50,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -71,8 +65,6 @@ updates:
   #   schedule:
   #     # Our dependencies should be checked daily
   #     interval: daily
-  #   reviewers:
-  #     - arcjet/js-sdk-team
   #   commit-message:
   #     prefix: deps(example)
   #     prefix-development: deps(example)
@@ -88,8 +80,6 @@ updates:
   #   schedule:
   #     # Our dependencies should be checked daily
   #     interval: daily
-  #   reviewers:
-  #     - arcjet/js-sdk-team
   #   commit-message:
   #     prefix: deps(example)
   #     prefix-development: deps(example)
@@ -105,8 +95,6 @@ updates:
   #   schedule:
   #     # Our dependencies should be checked daily
   #     interval: daily
-  #   reviewers:
-  #     - arcjet/js-sdk-team
   #   commit-message:
   #     prefix: deps(example)
   #     prefix-development: deps(example)
@@ -120,8 +108,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -135,8 +121,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -150,8 +134,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -165,8 +147,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -191,8 +171,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -206,8 +184,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -221,8 +197,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -236,8 +210,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -251,8 +223,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -287,8 +257,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -307,8 +275,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -327,8 +293,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -353,8 +317,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -373,8 +335,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -393,8 +353,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -413,8 +371,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -433,8 +389,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -453,8 +407,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -473,8 +425,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -493,8 +443,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -513,8 +461,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -533,8 +479,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -553,8 +497,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -579,8 +521,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -599,8 +539,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -619,8 +557,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -634,8 +570,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -649,8 +583,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -664,8 +596,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -679,8 +609,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -694,8 +622,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)
@@ -728,8 +654,6 @@ updates:
     schedule:
       # Our dependencies should be checked daily
       interval: daily
-    reviewers:
-      - arcjet/js-sdk-team
     commit-message:
       prefix: deps(example)
       prefix-development: deps(example)


### PR DESCRIPTION
[Dependabot is deprecating](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) the reviewers config.