### PR TITLE
deps: Update undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9549,9 +9549,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"


### PR DESCRIPTION
This updates undici in our lockfile. We don't use it for webhooks so https://github.com/arcjet/arcjet-js/security/dependabot/331 doesn't apply but it's fine to upgrade.