### PR TITLE
feat(protocol): Add fingerprints to rule results

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1168,10 +1168,13 @@ export function sensitiveInfo<
     ): Promise<ArcjetRuleResult> {
       const ruleId = await id;
 
+      const { fingerprint } = context;
+
       const body = await context.getBody();
       if (typeof body === "undefined") {
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 0,
           state: "NOT_RUN",
           conclusion: "ERROR",
@@ -1233,6 +1236,7 @@ export function sensitiveInfo<
       if (result.denied.length === 0) {
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 0,
           state,
           conclusion: "ALLOW",
@@ -1241,6 +1245,7 @@ export function sensitiveInfo<
       } else {
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 0,
           state,
           conclusion: "DENY",
@@ -1431,11 +1436,14 @@ export function validateEmail(
     ): Promise<ArcjetRuleResult> {
       const ruleId = await id;
 
+      const { fingerprint } = context;
+
       const result = await analyze.isValidEmail(context, email, config);
       const state = mode === "LIVE" ? "RUN" : "DRY_RUN";
       if (result.validity === "valid") {
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 0,
           state,
           conclusion: "ALLOW",
@@ -1446,6 +1454,7 @@ export function validateEmail(
 
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 0,
           state,
           conclusion: "DENY",
@@ -1630,6 +1639,8 @@ export function detectBot(options: BotOptions): Primitive<{}> {
     ): Promise<ArcjetRuleResult> {
       const ruleId = await id;
 
+      const { fingerprint } = context;
+
       const result = await analyze.detectBot(
         context,
         toAnalyzeRequest(request),
@@ -1642,6 +1653,7 @@ export function detectBot(options: BotOptions): Primitive<{}> {
       if (result.denied.length > 0) {
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 60,
           state,
           conclusion: "DENY",
@@ -1655,6 +1667,7 @@ export function detectBot(options: BotOptions): Primitive<{}> {
       } else {
         return new ArcjetRuleResult({
           ruleId,
+          fingerprint,
           ttl: 0,
           state,
           conclusion: "ALLOW",
@@ -2062,6 +2075,7 @@ export default function arcjet<
       results[idx] = new ArcjetRuleResult({
         // TODO(#4030): Figure out if we can get each Rule ID before they are run
         ruleId: "",
+        fingerprint,
         ttl: 0,
         state: "NOT_RUN",
         conclusion: "ALLOW",
@@ -2138,6 +2152,7 @@ export default function arcjet<
               // TODO(#4030): If we can get the Rule ID before running rules,
               // this can use it
               ruleId: "",
+              fingerprint,
               ttl: 0,
               state: "RUN",
               conclusion: "ERROR",
@@ -2168,6 +2183,7 @@ export default function arcjet<
           results[idx] = new ArcjetRuleResult({
             // TODO(#4030): Figure out if we can get a Rule ID in this error case
             ruleId: "",
+            fingerprint,
             ttl: 0,
             state: "RUN",
             conclusion: "ERROR",

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2549,6 +2549,7 @@ describe("SDK", () => {
         async () =>
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state: "RUN",
             conclusion: "ALLOW",
@@ -2568,6 +2569,7 @@ describe("SDK", () => {
         async () =>
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 5000,
             state: "RUN",
             conclusion: "DENY",
@@ -2636,6 +2638,7 @@ describe("SDK", () => {
       protect: mock.fn(async () => {
         return new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "DRY_RUN",
           conclusion: "DENY",

--- a/decorate/test/decorate.test.ts
+++ b/decorate/test/decorate.test.ts
@@ -35,6 +35,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -61,6 +62,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -92,6 +94,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -123,6 +126,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -152,6 +156,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -164,6 +169,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -195,6 +201,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -227,6 +234,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -259,6 +267,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -291,6 +300,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -440,6 +450,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -471,6 +482,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -483,6 +495,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -514,6 +527,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -526,6 +540,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -557,6 +572,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -569,6 +585,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -600,6 +617,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -612,6 +630,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -643,6 +662,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -655,6 +675,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -686,6 +707,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -698,6 +720,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -732,6 +755,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -767,6 +791,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -815,6 +840,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -837,6 +863,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -864,6 +891,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -892,6 +920,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -904,6 +933,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -935,6 +965,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -967,6 +998,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -999,6 +1031,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1031,6 +1064,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1180,6 +1214,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1211,6 +1246,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1223,6 +1259,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1256,6 +1293,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1268,6 +1306,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1301,6 +1340,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1313,6 +1353,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1346,6 +1387,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1358,6 +1400,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1391,6 +1434,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1403,6 +1447,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1436,6 +1481,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1448,6 +1494,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1484,6 +1531,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1519,6 +1567,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1567,6 +1616,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1600,6 +1650,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1633,6 +1684,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1666,6 +1718,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1701,6 +1754,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1729,6 +1783,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1741,6 +1796,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1772,6 +1828,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1804,6 +1861,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1836,6 +1894,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -1868,6 +1927,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2017,6 +2077,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2048,6 +2109,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2060,6 +2122,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2091,6 +2154,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2103,6 +2167,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2134,6 +2199,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2146,6 +2212,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2179,6 +2246,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2191,6 +2259,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2224,6 +2293,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2236,6 +2306,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2269,6 +2340,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2281,6 +2353,7 @@ describe("setRateLimitHeaders", () => {
             }),
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2317,6 +2390,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
@@ -2352,6 +2426,7 @@ describe("setRateLimitHeaders", () => {
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",

--- a/inspect/test/inspect.test.ts
+++ b/inspect/test/inspect.test.ts
@@ -21,6 +21,7 @@ describe("isSpoofedBot", () => {
         isSpoofedBot(
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state,
             conclusion: "DENY",
@@ -48,6 +49,7 @@ describe("isSpoofedBot", () => {
         isSpoofedBot(
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state,
             conclusion: "DENY",
@@ -68,6 +70,7 @@ describe("isSpoofedBot", () => {
       isSpoofedBot(
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "DRY_RUN",
           conclusion: "DENY",
@@ -86,6 +89,7 @@ describe("isSpoofedBot", () => {
     const results = [
       new ArcjetRuleResult({
         ruleId: "test-rule-id",
+        fingerprint: "test-fingerprint",
         ttl: 0,
         state: "RUN",
         conclusion: "DENY",
@@ -143,6 +147,7 @@ describe("isVerifiedBot", () => {
         isVerifiedBot(
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state,
             conclusion: "DENY",
@@ -170,6 +175,7 @@ describe("isVerifiedBot", () => {
         isVerifiedBot(
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state,
             conclusion: "DENY",
@@ -189,6 +195,7 @@ describe("isVerifiedBot", () => {
     const results = [
       new ArcjetRuleResult({
         ruleId: "test-rule-id",
+        fingerprint: "test-fingerprint",
         ttl: 0,
         state: "RUN",
         conclusion: "DENY",
@@ -210,6 +217,7 @@ describe("isVerifiedBot", () => {
       isVerifiedBot(
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "DRY_RUN",
           conclusion: "DENY",
@@ -266,6 +274,7 @@ describe("isMissingUserAgent", () => {
         isMissingUserAgent(
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state,
             conclusion: "DENY",
@@ -278,6 +287,7 @@ describe("isMissingUserAgent", () => {
         isMissingUserAgent(
           new ArcjetRuleResult({
             ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
             ttl: 0,
             state,
             conclusion: "DENY",
@@ -293,6 +303,7 @@ describe("isMissingUserAgent", () => {
       isMissingUserAgent(
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "DRY_RUN",
           conclusion: "DENY",
@@ -304,6 +315,7 @@ describe("isMissingUserAgent", () => {
       isMissingUserAgent(
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "DRY_RUN",
           conclusion: "DENY",
@@ -317,6 +329,7 @@ describe("isMissingUserAgent", () => {
     const results = [
       new ArcjetRuleResult({
         ruleId: "test-rule-id",
+        fingerprint: "test-fingerprint",
         ttl: 0,
         state: "RUN",
         conclusion: "DENY",

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -375,6 +375,7 @@ export function ArcjetRuleResultToProtocol(
 ): RuleResult {
   return new RuleResult({
     ruleId: ruleResult.ruleId,
+    fingerprint: ruleResult.fingerprint,
     ttl: ruleResult.ttl,
     state: ArcjetRuleStateToProtocol(ruleResult.state),
     conclusion: ArcjetConclusionToProtocol(ruleResult.conclusion),
@@ -387,6 +388,7 @@ export function ArcjetRuleResultFromProtocol(
 ): ArcjetRuleResult {
   return new ArcjetRuleResult({
     ruleId: proto.ruleId,
+    fingerprint: proto.fingerprint,
     ttl: proto.ttl,
     state: ArcjetRuleStateFromProtocol(proto.state),
     conclusion: ArcjetConclusionFromProtocol(proto.conclusion),

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -379,6 +379,11 @@ export class ArcjetRuleResult {
    */
   ruleId: string;
   /**
+   * The fingerprint calculated for this rule, which can be used to cache the
+   * result for the amount of time specified by `ttl`.
+   */
+  fingerprint: string;
+  /**
    * The duration in seconds this result should be considered valid, also known
    * as time-to-live.
    */
@@ -389,12 +394,14 @@ export class ArcjetRuleResult {
 
   constructor(init: {
     ruleId: string;
+    fingerprint: string;
     ttl: number;
     state: ArcjetRuleState;
     conclusion: ArcjetConclusion;
     reason: ArcjetReason;
   }) {
     this.ruleId = init.ruleId;
+    this.fingerprint = init.fingerprint;
     this.ttl = init.ttl;
     this.state = init.state;
     this.conclusion = init.conclusion;

--- a/protocol/proto/decide/v1alpha1/decide_pb.d.ts
+++ b/protocol/proto/decide/v1alpha1/decide_pb.d.ts
@@ -1584,6 +1584,14 @@ export declare class RuleResult extends Message<RuleResult> {
    */
   ttl: number;
 
+  /**
+   * The fingerprint calculated for this rule, which can be used to cache the
+   * result for the amount of time specified by `ttl`.
+   *
+   * @generated from field: string fingerprint = 6;
+   */
+  fingerprint: string;
+
   constructor(data?: PartialMessage<RuleResult>);
 
   static readonly runtime: typeof proto3;

--- a/protocol/proto/decide/v1alpha1/decide_pb.js
+++ b/protocol/proto/decide/v1alpha1/decide_pb.js
@@ -494,6 +494,7 @@ export const RuleResult = /*@__PURE__*/ proto3.makeMessageType(
     { no: 3, name: "conclusion", kind: "enum", T: proto3.getEnumType(Conclusion) },
     { no: 4, name: "reason", kind: "message", T: Reason },
     { no: 5, name: "ttl", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
+    { no: 6, name: "fingerprint", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ],
 );
 

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -1115,6 +1115,7 @@ describe("createClient", () => {
       results: [
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "RUN",
           conclusion: "DENY",
@@ -1148,6 +1149,7 @@ describe("createClient", () => {
           ruleResults: [
             new RuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               state: RuleState.RUN,
               conclusion: Conclusion.DENY,
               reason: new Reason(),
@@ -1314,6 +1316,7 @@ describe("createClient", () => {
       results: [
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "RUN",
           conclusion: "DENY",
@@ -1341,6 +1344,7 @@ describe("createClient", () => {
           ruleResults: [
             new RuleResult({
               ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
               state: RuleState.RUN,
               conclusion: Conclusion.DENY,
               reason: new Reason(),

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -484,6 +484,7 @@ describe("convert", () => {
       ArcjetRuleResultToProtocol(
         new ArcjetRuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           ttl: 0,
           state: "RUN",
           conclusion: "ALLOW",
@@ -493,6 +494,7 @@ describe("convert", () => {
     ).toEqual(
       new RuleResult({
         ruleId: "test-rule-id",
+        fingerprint: "test-fingerprint",
         state: RuleState.RUN,
         conclusion: Conclusion.ALLOW,
         reason: new Reason(),
@@ -505,6 +507,7 @@ describe("convert", () => {
       ArcjetRuleResultFromProtocol(
         new RuleResult({
           ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
           state: RuleState.RUN,
           conclusion: Conclusion.ALLOW,
           reason: new Reason(),
@@ -513,6 +516,7 @@ describe("convert", () => {
     ).toEqual(
       new ArcjetRuleResult({
         ruleId: "test-rule-id",
+        fingerprint: "test-fingerprint",
         ttl: 0,
         state: "RUN",
         conclusion: "ALLOW",


### PR DESCRIPTION
This adds fingerprints to rule results. For local rule results, we attach the fingerprint from the context; however, this will be expanded upon when I implement the per-rule cache. For remote rule results, we just attach the fingerprint that is now sent from the Decide service.