### PR TITLE
fix(arcjet): Default to client characteristics if not specified on rule

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1049,8 +1049,6 @@ export function slidingWindow<
         hasher.uint32("version", version),
         hasher.string("mode", mode),
         hasher.string("algorithm", "SLIDING_WINDOW"),
-        // TODO(#4203): Rules need to receive characteristics via options while
-        // falling back to characteristics defined on the client
         hasher.stringSliceOrdered("characteristics", localCharacteristics),
         // Match is deprecated so it is always an empty string in the newest SDKs
         hasher.string("match", ""),


### PR DESCRIPTION
While working on the segmented caching logic, I found that we already attach top-level characteristics to the context passed to each rule. This meant I could move the rule ID logic into `protect()` and default the local characteristics with them if unset. Landing these changes before #4191 will make the segmented cache work correctly, even in some edge cases.

There is a small performance hit in calculating the rule in each `protect()` function but using the context is currently the only way to get access to values set on the SDK. However, when we bring on another SDK engineer, we probably want to have a larger discussion about the return value from our rule constructors—for example, we could return a function that receives the global configuration.

Closes #4203