### PR TITLE
deps(example): Override multer in Gatsby example

### DIFF
--- a/examples/gatsby-rate-limit/package-lock.json
+++ b/examples/gatsby-rate-limit/package-lock.json
@@ -22,25 +22,25 @@
     },
     "../../arcjet-node": {
       "name": "@arcjet/node",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.0.0-beta.5",
-        "@arcjet/env": "1.0.0-beta.5",
-        "@arcjet/headers": "1.0.0-beta.5",
-        "@arcjet/ip": "1.0.0-beta.5",
-        "@arcjet/logger": "1.0.0-beta.5",
-        "@arcjet/protocol": "1.0.0-beta.5",
-        "@arcjet/transport": "1.0.0-beta.5",
-        "arcjet": "1.0.0-beta.5"
+        "@arcjet/body": "1.0.0-beta.7",
+        "@arcjet/env": "1.0.0-beta.7",
+        "@arcjet/headers": "1.0.0-beta.7",
+        "@arcjet/ip": "1.0.0-beta.7",
+        "@arcjet/logger": "1.0.0-beta.7",
+        "@arcjet/protocol": "1.0.0-beta.7",
+        "@arcjet/transport": "1.0.0-beta.7",
+        "arcjet": "1.0.0-beta.7"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.0.0-beta.5",
-        "@arcjet/rollup-config": "1.0.0-beta.5",
-        "@arcjet/tsconfig": "1.0.0-beta.5",
-        "@rollup/wasm-node": "4.39.0",
+        "@arcjet/eslint-config": "1.0.0-beta.7",
+        "@arcjet/rollup-config": "1.0.0-beta.7",
+        "@arcjet/tsconfig": "1.0.0-beta.7",
+        "@rollup/wasm-node": "4.40.1",
         "@types/node": "18.18.0",
-        "eslint": "9.24.0",
+        "eslint": "9.26.0",
         "expect": "29.7.0",
         "typescript": "5.8.3"
       },
@@ -12560,9 +12560,9 @@
       }
     },
     "node_modules/multer": {
-      "version": "1.4.5-lts.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
-      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -12574,7 +12574,7 @@
         "xtend": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/mute-stream": {

--- a/examples/gatsby-rate-limit/package.json
+++ b/examples/gatsby-rate-limit/package.json
@@ -28,6 +28,7 @@
   },
   "overrides": {
     "cookie": "^0.7.1",
+    "multer": "^2.0.0",
     "path-to-regexp": "0.1.12"
   }
 }


### PR DESCRIPTION
I needed to override the `multer` dep in Gatsby because [they seem slow](https://github.com/gatsbyjs/gatsby/issues/39304) to upgrade dependencies that are trigger security warnings.