### PR TITLE
chore: Output full logs when turbo runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "*"
   ],
   "scripts": {
-    "prepare": "turbo run build --output-logs full",
-    "lint": "turbo run lint --output-logs full",
-    "test": "turbo test --output-logs full"
+    "prepare": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo test"
   },
   "devDependencies": {
     "turbo": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "*"
   ],
   "scripts": {
-    "prepare": "turbo run build",
-    "lint": "turbo run lint",
-    "test": "turbo test"
+    "prepare": "turbo run build --output-logs full",
+    "lint": "turbo run lint --output-logs full",
+    "test": "turbo test --output-logs full"
   },
   "devDependencies": {
     "turbo": "^2.5.3"

--- a/turbo.json
+++ b/turbo.json
@@ -19,17 +19,17 @@
     "build": {
       "dependsOn": ["^build"],
       "cache": false,
-      "outputLogs": "none"
+      "outputLogs": "full"
     },
     "lint": {
       "dependsOn": ["^lint"],
       "cache": false,
-      "outputLogs": "none"
+      "outputLogs": "full"
     },
     "test": {
       "dependsOn": ["^test"],
       "cache": false,
-      "outputLogs": "none"
+      "outputLogs": "full"
     }
   }
 }


### PR DESCRIPTION
There seems to be a flakey test on Node 18 in the Cache package. It only happens in CI and I can't debug because our turbo config didn't allow outputting logs.