### PR TITLE
chore: Fix `jco` name in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,7 @@ updates:
         versions: [">=2"]
       # Ignore updates for jco above 1.5.0 due to unnecessary deps
       # Ref: https://github.com/bytecodealliance/jco/issues/500
-      - dependency-name: jco
+      - dependency-name: "@bytecodealliance/jco"
         versions: [">1.5.0"]
 
   # Dependencies in our examples


### PR DESCRIPTION
Related-to: e7c8a65.
Related-to: #3446.

Closes #4342.