### PR TITLE
chore: Fix Rollup on Node 24

### DIFF
--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -131,7 +131,7 @@ export function createConfig(root, { plugins = [] } = {}) {
     // Node lower than 18 used `path` which is now removed in favor of
     // `parentPath`.
     // See: <https://nodejs.org/api/deprecations.html#dep0178-direntpath>.
-    const parentPath = file.parentPath || file.path
+    const parentPath = file.parentPath || file.path;
     return [
       path.relative(rootDir, `${parentPath}${removeExtension(file.name)}`),
       path.relative(rootDir, `${parentPath}${file.name}`),

--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -128,9 +128,13 @@ export function createConfig(root, { plugins = [] } = {}) {
 
   // Creates a Rollup input entry that can be used with `Object.fromEntries()`
   function toEntry(file) {
+    // Node lower than 18 used `path` which is now removed in favor of
+    // `parentPath`.
+    // See: <https://nodejs.org/api/deprecations.html#dep0178-direntpath>.
+    const parentPath = file.parentPath || file.path
     return [
-      path.relative(rootDir, `${file.path}${removeExtension(file.name)}`),
-      path.relative(rootDir, `${file.path}${file.name}`),
+      path.relative(rootDir, `${parentPath}${removeExtension(file.name)}`),
+      path.relative(rootDir, `${parentPath}${file.name}`),
     ];
   }
 


### PR DESCRIPTION
There was a docs deprecation in 18-20, on 22 an actual deprecation warning, and on 24 it was removed.

This PR should work everywhere.

In the future, the value `path` could be removed.