### PR TITLE
chore: Fix missing file extension in test

### DIFF
--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "node:test";
 import { expect } from "expect";
-import * as env from "../index";
+import * as env from "../index.ts";
 
 describe("env", () => {
   test("platform", () => {


### PR DESCRIPTION
These tests run in Node itself, I believe, and so they want an extension. Required in Node 24. `ts` works, so that’s what I used.