### PR TITLE
chore(arcjet): Reduce timeouts and other transport issues to info log

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -2460,7 +2460,7 @@ export default function arcjet<
 
       return decision;
     } catch (err) {
-      log.error(
+      log.info(
         "Encountered problem getting remote decision: %s",
         errorMessage(err),
       );


### PR DESCRIPTION
This changes the log level of an inactionable error from our transport from being logged in users' error logs. I noticed that SDK timeout errors were showing up in our system but they are inactionable. This indicates to me that this should be at a lower log level. I chose `INFO` because that is the same level that used by the Report RPC call to log any transport errors.