### PR TITLE
chore(astro): Increase minimum peerDependency

### DIFF
--- a/arcjet-astro/package.json
+++ b/arcjet-astro/package.json
@@ -46,7 +46,7 @@
     "arcjet": "1.0.0-beta.8"
   },
   "peerDependencies": {
-    "astro": "^5"
+    "astro": "^5.9.3"
   },
   "devDependencies": {
     "@arcjet/eslint-config": "1.0.0-beta.8",


### PR DESCRIPTION
This increases the minimum peerDep recommendation for Astro in our SDK adapter to v5.9.3

This version included @qw-in's fix for static redirects, which ensures the Arcjet integration doesn't crash on all static sites which contain redirects.

Closes #3094 