### PR TITLE
test: clean protocol tests

### DIFF
--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -103,6 +103,7 @@ export function createClient(options: ClientOptions): Client {
           cookies: details.cookies,
           query: details.query,
           // TODO(#208): Re-add body
+          // TODO(@wooorm-arcjet): `#208` refers to a dependabot PR: figure out why the above TODO exists.
           // body: details.body,
           extra: details.extra,
           email: details.email,
@@ -161,6 +162,7 @@ export function createClient(options: ClientOptions): Client {
           cookies: details.cookies,
           query: details.query,
           // TODO(#208): Re-add body
+          // TODO(@wooorm-arcjet): `#208` refers to a dependabot PR: figure out why the above TODO exists.
           // body: details.body,
           extra: details.extra,
           email: details.email,

--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -105,8 +105,7 @@ export function createClient(options: ClientOptions): Client {
           // TODO(#208): Re-add body
           // body: details.body,
           extra: details.extra,
-          // TODO(@wooorm-arcjet): uncovered.
-          email: typeof details.email === "string" ? details.email : undefined,
+          email: details.email,
         },
         rules: protoRules,
       });
@@ -164,7 +163,7 @@ export function createClient(options: ClientOptions): Client {
           // TODO(#208): Re-add body
           // body: details.body,
           extra: details.extra,
-          email: typeof details.email === "string" ? details.email : undefined,
+          email: details.email,
         },
         decision: ArcjetDecisionToProtocol(decision),
         rules: rules.map(ArcjetRuleToProtocol),

--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -78,7 +78,6 @@ export function createClient(options: ClientOptions): Client {
     ): Promise<ArcjetDecision> {
       const { log } = context;
 
-      // TODO(@wooorm-arcjet): uncovered.
       let hasValidateEmail = false;
       const protoRules: Rule[] = [];
       for (const rule of rules) {
@@ -118,7 +117,6 @@ export function createClient(options: ClientOptions): Client {
         headers: { Authorization: `Bearer ${context.key}` },
         // If an email rule is configured, we double the timeout.
         // See https://github.com/arcjet/arcjet-js/issues/1697
-        // TODO(@wooorm-arcjet): uncovered.
         timeoutMs: hasValidateEmail ? timeout * 2 : timeout,
       });
 

--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -78,6 +78,7 @@ export function createClient(options: ClientOptions): Client {
     ): Promise<ArcjetDecision> {
       const { log } = context;
 
+      // TODO(@wooorm-arcjet): uncovered.
       let hasValidateEmail = false;
       const protoRules: Rule[] = [];
       for (const rule of rules) {
@@ -105,6 +106,7 @@ export function createClient(options: ClientOptions): Client {
           // TODO(#208): Re-add body
           // body: details.body,
           extra: details.extra,
+          // TODO(@wooorm-arcjet): uncovered.
           email: typeof details.email === "string" ? details.email : undefined,
         },
         rules: protoRules,
@@ -116,6 +118,7 @@ export function createClient(options: ClientOptions): Client {
         headers: { Authorization: `Bearer ${context.key}` },
         // If an email rule is configured, we double the timeout.
         // See https://github.com/arcjet/arcjet-js/issues/1697
+        // TODO(@wooorm-arcjet): uncovered.
         timeoutMs: hasValidateEmail ? timeout * 2 : timeout,
       });
 

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -264,6 +264,7 @@ export function ArcjetReasonFromProtocol(proto?: Reason) {
         denied: reason.denied,
       });
     }
+    // TODO(@wooorm-arcjet): uncovered.
     case "bot": {
       return new ArcjetErrorReason("bot detection v1 is deprecated");
     }
@@ -412,6 +413,7 @@ export function ArcjetIpDetailsFromProtocol(
   if (!ipDetails) {
     return new ArcjetIpDetails();
   }
+  // TODO(@wooorm-arcjet): uncovered.
 
   // A default value from the Decide service means we don't have data for the
   // field so we translate to `undefined`. Some fields have interconnected logic

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -412,7 +412,6 @@ export function ArcjetIpDetailsFromProtocol(
   if (!ipDetails) {
     return new ArcjetIpDetails();
   }
-  // TODO(@wooorm-arcjet): uncovered.
 
   // A default value from the Decide service means we don't have data for the
   // field so we translate to `undefined`. Some fields have interconnected logic

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -264,7 +264,6 @@ export function ArcjetReasonFromProtocol(proto?: Reason) {
         denied: reason.denied,
       });
     }
-    // TODO(@wooorm-arcjet): uncovered.
     case "bot": {
       return new ArcjetErrorReason("bot detection v1 is deprecated");
     }

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -288,10 +288,12 @@ export class ArcjetBotReason extends ArcjetReason {
     this.spoofed = init.spoofed;
   }
 
+  // TODO(@wooorm-arcjet): uncovered.
   isVerified(): boolean {
     return this.verified;
   }
 
+  // TODO(@wooorm-arcjet): uncovered.
   isSpoofed(): boolean {
     return this.spoofed;
   }
@@ -309,6 +311,7 @@ export class ArcjetShieldReason extends ArcjetReason {
   constructor(init: { shieldTriggered?: boolean }) {
     super();
 
+    // TODO(@wooorm-arcjet): uncovered.
     this.shieldTriggered = init.shieldTriggered ?? false;
   }
 }
@@ -321,8 +324,10 @@ export class ArcjetEmailReason extends ArcjetReason {
   constructor(init: { emailTypes?: ArcjetEmailType[] }) {
     super();
     if (typeof init === "undefined") {
+      // TODO(@wooorm-arcjet): uncovered.
       this.emailTypes = [];
     } else {
+      // TODO(@wooorm-arcjet): uncovered.
       this.emailTypes = init.emailTypes ?? [];
     }
   }
@@ -348,6 +353,7 @@ export class ArcjetErrorReason extends ArcjetReason {
 
     // TODO: Get rid of instanceof check
     if (error instanceof Error) {
+      // TODO(@wooorm-arcjet): uncovered.
       this.message = error.message;
       return;
     }
@@ -398,6 +404,7 @@ export class ArcjetRuleResult {
   }
 
   isDenied() {
+    // TODO(@wooorm-arcjet): uncovered.
     return this.conclusion === "DENY";
   }
 }
@@ -558,10 +565,12 @@ export class ArcjetIpDetails {
   }
 
   hasLatitude(): this is RequiredProps<this, "latitude" | "accuracyRadius"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.latitude !== "undefined";
   }
 
   hasLongitude(): this is RequiredProps<this, "longitude" | "accuracyRadius"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.longitude !== "undefined";
   }
 
@@ -569,35 +578,42 @@ export class ArcjetIpDetails {
     this,
     "latitude" | "longitude" | "accuracyRadius"
   > {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.accuracyRadius !== "undefined";
   }
 
   hasTimezone(): this is RequiredProps<this, "timezone"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.timezone !== "undefined";
   }
 
   hasPostalCode(): this is RequiredProps<this, "postalCode"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.postalCode !== "undefined";
   }
 
   // TODO: If we have city, what other data are we sure to have?
   hasCity(): this is RequiredProps<this, "city"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.city !== "undefined";
   }
 
   // TODO: If we have region, what other data are we sure to have?
   hasRegion(): this is RequiredProps<this, "region"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.region !== "undefined";
   }
 
   // If we have country, we should have country name
   // TODO: If we have country, should we also have continent?
   hasCountry(): this is RequiredProps<this, "country" | "countryName"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.country !== "undefined";
   }
 
   // If we have continent, we should have continent name
   hasContintent(): this is RequiredProps<this, "continent" | "continentName"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.continent !== "undefined";
   }
 
@@ -606,10 +622,12 @@ export class ArcjetIpDetails {
     this,
     "asn" | "asnName" | "asnDomain" | "asnType" | "asnCountry"
   > {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.asn !== "undefined";
   }
 
   hasService(): this is RequiredProps<this, "service"> {
+    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.service !== "undefined";
   }
 
@@ -617,6 +635,7 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a hosting provider.
    */
   isHosting(): boolean {
+    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isHosting;
   }
@@ -625,6 +644,7 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a VPN provider.
    */
   isVpn(): boolean {
+    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isVpn;
   }
@@ -633,6 +653,7 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a proxy provider.
    */
   isProxy(): boolean {
+    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isProxy;
   }
@@ -641,6 +662,7 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a Tor node.
    */
   isTor(): boolean {
+    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isTor;
   }
@@ -649,6 +671,7 @@ export class ArcjetIpDetails {
    * @returns `true` if the the IP address belongs to a relay service.
    */
   isRelay(): boolean {
+    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isRelay;
   }

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -320,13 +320,7 @@ export class ArcjetEmailReason extends ArcjetReason {
 
   constructor(init: { emailTypes?: ArcjetEmailType[] }) {
     super();
-
-    // TODO(@wooorm-arcjet): this is impossible per the types.
-    if (typeof init === "undefined") {
-      this.emailTypes = [];
-    } else {
-      this.emailTypes = init.emailTypes ?? [];
-    }
+    this.emailTypes = init.emailTypes ?? [];
   }
 }
 

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -799,8 +799,9 @@ export interface ArcjetRequestDetails {
 }
 
 export type ArcjetRule<Props extends {} = {}> = {
-  // TODO(@wooorm-arcjet): investigate how to do type augmentation so we can ditch `string`
-  // and instead let types be strong.
+  // TODO(@wooorm-arcjet):
+  // if it is intentional that people can extend rules,
+  // then we need to allow that in the types.
   type: "RATE_LIMIT" | "BOT" | "EMAIL" | "SHIELD" | "SENSITIVE_INFO" | string;
   mode: ArcjetMode;
   priority: number;

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -288,12 +288,10 @@ export class ArcjetBotReason extends ArcjetReason {
     this.spoofed = init.spoofed;
   }
 
-  // TODO(@wooorm-arcjet): uncovered.
   isVerified(): boolean {
     return this.verified;
   }
 
-  // TODO(@wooorm-arcjet): uncovered.
   isSpoofed(): boolean {
     return this.spoofed;
   }
@@ -311,7 +309,6 @@ export class ArcjetShieldReason extends ArcjetReason {
   constructor(init: { shieldTriggered?: boolean }) {
     super();
 
-    // TODO(@wooorm-arcjet): uncovered.
     this.shieldTriggered = init.shieldTriggered ?? false;
   }
 }
@@ -323,11 +320,11 @@ export class ArcjetEmailReason extends ArcjetReason {
 
   constructor(init: { emailTypes?: ArcjetEmailType[] }) {
     super();
+
+    // TODO(@wooorm-arcjet): this is impossible per the types.
     if (typeof init === "undefined") {
-      // TODO(@wooorm-arcjet): uncovered.
       this.emailTypes = [];
     } else {
-      // TODO(@wooorm-arcjet): uncovered.
       this.emailTypes = init.emailTypes ?? [];
     }
   }
@@ -353,7 +350,6 @@ export class ArcjetErrorReason extends ArcjetReason {
 
     // TODO: Get rid of instanceof check
     if (error instanceof Error) {
-      // TODO(@wooorm-arcjet): uncovered.
       this.message = error.message;
       return;
     }
@@ -404,7 +400,6 @@ export class ArcjetRuleResult {
   }
 
   isDenied() {
-    // TODO(@wooorm-arcjet): uncovered.
     return this.conclusion === "DENY";
   }
 }
@@ -565,12 +560,10 @@ export class ArcjetIpDetails {
   }
 
   hasLatitude(): this is RequiredProps<this, "latitude" | "accuracyRadius"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.latitude !== "undefined";
   }
 
   hasLongitude(): this is RequiredProps<this, "longitude" | "accuracyRadius"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.longitude !== "undefined";
   }
 
@@ -578,42 +571,35 @@ export class ArcjetIpDetails {
     this,
     "latitude" | "longitude" | "accuracyRadius"
   > {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.accuracyRadius !== "undefined";
   }
 
   hasTimezone(): this is RequiredProps<this, "timezone"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.timezone !== "undefined";
   }
 
   hasPostalCode(): this is RequiredProps<this, "postalCode"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.postalCode !== "undefined";
   }
 
   // TODO: If we have city, what other data are we sure to have?
   hasCity(): this is RequiredProps<this, "city"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.city !== "undefined";
   }
 
   // TODO: If we have region, what other data are we sure to have?
   hasRegion(): this is RequiredProps<this, "region"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.region !== "undefined";
   }
 
   // If we have country, we should have country name
   // TODO: If we have country, should we also have continent?
   hasCountry(): this is RequiredProps<this, "country" | "countryName"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.country !== "undefined";
   }
 
   // If we have continent, we should have continent name
   hasContintent(): this is RequiredProps<this, "continent" | "continentName"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.continent !== "undefined";
   }
 
@@ -622,12 +608,10 @@ export class ArcjetIpDetails {
     this,
     "asn" | "asnName" | "asnDomain" | "asnType" | "asnCountry"
   > {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.asn !== "undefined";
   }
 
   hasService(): this is RequiredProps<this, "service"> {
-    // TODO(@wooorm-arcjet): uncovered.
     return typeof this.service !== "undefined";
   }
 
@@ -635,7 +619,6 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a hosting provider.
    */
   isHosting(): boolean {
-    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isHosting;
   }
@@ -644,7 +627,6 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a VPN provider.
    */
   isVpn(): boolean {
-    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isVpn;
   }
@@ -653,7 +635,6 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a proxy provider.
    */
   isProxy(): boolean {
-    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isProxy;
   }
@@ -662,7 +643,6 @@ export class ArcjetIpDetails {
    * @returns `true` if the IP address belongs to a Tor node.
    */
   isTor(): boolean {
-    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isTor;
   }
@@ -671,7 +651,6 @@ export class ArcjetIpDetails {
    * @returns `true` if the the IP address belongs to a relay service.
    */
   isRelay(): boolean {
-    // TODO(@wooorm-arcjet): uncovered.
     // @ts-expect-error because we attach this with Object.defineProperties
     return this._isRelay;
   }

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -826,6 +826,8 @@ export interface ArcjetRequestDetails {
 }
 
 export type ArcjetRule<Props extends {} = {}> = {
+  // TODO(@wooorm-arcjet): investigate how to do type augmentation so we can ditch `string`
+  // and instead let types be strong.
   type: "RATE_LIMIT" | "BOT" | "EMAIL" | "SHIELD" | "SENSITIVE_INFO" | string;
   mode: ArcjetMode;
   priority: number;

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -34,7 +34,10 @@ class ArcjetInvalidDecision extends ArcjetDecision {
 
   constructor() {
     super({ results: [], ttl: 0 });
-    // @ts-expect-error: TODO(@wooorm-arcjet): add support for registering custom conclusions.
+    // @ts-expect-error: TODO(@wooorm-arcjet):
+    // if it is intentional that people can extend decisions with such things as `INVALID`
+    // decisions,
+    // then we need to allow that in the types.
     this.conclusion = "INVALID";
     this.reason = new ArcjetReason();
   }
@@ -111,7 +114,6 @@ test("createClient", async (t) => {
       ...exampleClientOptions,
       timeout: 9876,
       transport: createRouterTransport(function ({ service }) {
-        // TODO(@wooorm-arcjet): there is no type error if this `implementation` object passed to `service` is an empty object?
         service(DecideService, {
           decide(_, handlerContext) {
             assert.equal(calls, 0);

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, mock, test } from "node:test";
+import { mock, test } from "node:test";
 import type { Cache } from "@arcjet/cache";
 import { createClient } from "../client.js";
 import { createRouterTransport } from "@connectrpc/connect";
@@ -61,7 +61,7 @@ class TestCache implements Cache {
   set() {}
 }
 
-describe("createClient", () => {
+test("createClient", async (t) => {
   const log = {
     debug() {},
     info() {},
@@ -76,7 +76,7 @@ describe("createClient", () => {
     sdkVersion: "__ARCJET_SDK_VERSION__",
   };
 
-  test("can be called with only a transport", () => {
+  await t.test("can be called with only a transport", () => {
     const client = createClient({
       ...defaultRemoteClientOptions,
       transport: createRouterTransport(() => {}),
@@ -85,7 +85,7 @@ describe("createClient", () => {
     assert.equal(typeof client.report, "function");
   });
 
-  test("allows overriding the default timeout", async () => {
+  await t.test("allows overriding the default timeout", async () => {
     // TODO(#32): createRouterTransport doesn't seem to handle timeouts/promises correctly
     const client = createClient({
       ...defaultRemoteClientOptions,
@@ -98,7 +98,7 @@ describe("createClient", () => {
     assert.equal(typeof client.report, "function");
   });
 
-  test("allows overriding the sdkStack", async () => {
+  await t.test("allows overriding the sdkStack", async () => {
     const key = "test-key";
     const fingerprint =
       "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
@@ -157,7 +157,7 @@ describe("createClient", () => {
     );
   });
 
-  test("sets the sdkStack as UNSPECIFIED if invalid", async () => {
+  await t.test("sets the sdkStack as UNSPECIFIED if invalid", async () => {
     const key = "test-key";
     const fingerprint =
       "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
@@ -217,980 +217,1028 @@ describe("createClient", () => {
     );
   });
 
-  test("calling `decide` will make RPC call with correct message", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.ALLOW,
-          },
-        });
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const _ = await client.decide(context, details, []);
-
-    assert.equal(router.decide.mock.callCount(), 1);
-    assert.deepEqual(
-      router.decide.mock.calls[0].arguments.at(0),
-      new DecideRequest({
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
+  await t.test(
+    "calling `decide` will make RPC call with correct message",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
         },
-        rules: [],
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-      }),
-    );
-  });
+      };
 
-  test("calling `decide` will make RPC with email included", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "abc@example.com",
-    };
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ALLOW,
+            },
+          });
+        }),
+      };
 
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.ALLOW,
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const _ = await client.decide(context, details, []);
+
+      assert.equal(router.decide.mock.callCount(), 1);
+      assert.deepEqual(
+        router.decide.mock.calls[0].arguments.at(0),
+        new DecideRequest({
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
           },
-        });
-      }),
-    };
+          rules: [],
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+        }),
+      );
+    },
+  );
 
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const _ = await client.decide(context, details, []);
-
-    assert.equal(router.decide.mock.callCount(), 1);
-    assert.deepEqual(
-      router.decide.mock.calls[0].arguments.at(0),
-      new DecideRequest({
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
+  await t.test(
+    "calling `decide` will make RPC with email included",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
         },
-        rules: [],
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-      }),
-    );
-  });
+        email: "abc@example.com",
+      };
 
-  test("calling `decide` will make RPC with rules included", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "abc@example.com",
-    };
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ALLOW,
+            },
+          });
+        }),
+      };
 
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.ALLOW,
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const _ = await client.decide(context, details, []);
+
+      assert.equal(router.decide.mock.callCount(), 1);
+      assert.deepEqual(
+        router.decide.mock.calls[0].arguments.at(0),
+        new DecideRequest({
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
           },
-        });
-      }),
-    };
+          rules: [],
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+        }),
+      );
+    },
+  );
 
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const rule: ArcjetRule = {
-      version: 0,
-      type: "TEST_RULE",
-      mode: "DRY_RUN",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-    const _ = await client.decide(context, details, [rule]);
-
-    assert.equal(router.decide.mock.callCount(), 1);
-    assert.deepEqual(
-      router.decide.mock.calls[0].arguments.at(0),
-      new DecideRequest({
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
+  await t.test(
+    "calling `decide` will make RPC with rules included",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
         },
-        rules: [new Rule()],
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-      }),
-    );
-  });
+        email: "abc@example.com",
+      };
 
-  test("calling `decide` creates an ALLOW ArcjetDecision if DecideResponse is allowed", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ALLOW,
+            },
+          });
+        }),
+      };
 
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.ALLOW,
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const rule: ArcjetRule = {
+        version: 0,
+        type: "TEST_RULE",
+        mode: "DRY_RUN",
+        priority: 1,
+        validate: mock.fn(),
+        protect: mock.fn(),
+      };
+      const _ = await client.decide(context, details, [rule]);
+
+      assert.equal(router.decide.mock.callCount(), 1);
+      assert.deepEqual(
+        router.decide.mock.calls[0].arguments.at(0),
+        new DecideRequest({
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
           },
-        });
-      }),
-    };
+          rules: [new Rule()],
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+        }),
+      );
+    },
+  );
 
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = await client.decide(context, details, []);
+  await t.test(
+    "calling `decide` creates an ALLOW ArcjetDecision if DecideResponse is allowed",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
 
-    assert.equal(decision.isErrored(), false);
-    assert.equal(decision.isAllowed(), true);
-  });
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ALLOW,
+            },
+          });
+        }),
+      };
 
-  test("calling `decide` creates a DENY ArcjetDecision if DecideResponse is denied", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = await client.decide(context, details, []);
 
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
+      assert.equal(decision.isErrored(), false);
+      assert.equal(decision.isAllowed(), true);
+    },
+  );
+
+  await t.test(
+    "calling `decide` creates a DENY ArcjetDecision if DecideResponse is denied",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.DENY,
+            },
+          });
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = await client.decide(context, details, []);
+
+      assert.equal(decision.isDenied(), true);
+    },
+  );
+
+  await t.test(
+    "calling `decide` creates a CHALLENGE ArcjetDecision if DecideResponse is challenged",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.CHALLENGE,
+            },
+          });
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = await client.decide(context, details, []);
+
+      assert.equal(decision.isChallenged(), true);
+    },
+  );
+
+  await t.test(
+    "calling `decide` creates an ERROR ArcjetDecision with default message if DecideResponse is error and no reason",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ERROR,
+            },
+          });
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = await client.decide(context, details, []);
+
+      assert.equal(decision.isErrored(), true);
+      // @ts-expect-error: TODO(#4452): union, or allow `String(reason)`.
+      assert.equal(decision.reason.message, "Unknown error occurred");
+    },
+  );
+
+  await t.test(
+    "calling `decide` creates an ERROR ArcjetDecision with message if DecideResponse if error and reason available",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ERROR,
+              reason: {
+                reason: {
+                  case: "error",
+                  value: { message: "Boom!" },
+                },
+              },
+            },
+          });
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = await client.decide(context, details, []);
+
+      assert.equal(decision.isErrored(), true);
+      // @ts-expect-error: TODO(#4452): union, or allow `String(reason)`.
+      assert.equal(decision.reason.message, "Boom!");
+    },
+  );
+
+  await t.test(
+    "calling `decide` creates an ERROR ArcjetDecision if DecideResponse is unspecified",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.UNSPECIFIED,
+            },
+          });
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = await client.decide(context, details, []);
+
+      assert.equal(decision.isErrored(), true);
+      assert.equal(decision.isAllowed(), true);
+    },
+  );
+
+  await t.test(
+    "calling `report` will use `waitUntil` if available",
+    async () => {
+      const [promise, resolve] = deferred();
+
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+        waitUntil: mock.fn((promise: Promise<unknown>) => {
+          promise.then(() => resolve());
+        }),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+        email: "test@example.com",
+      };
+
+      const router = {
+        report: () => {
+          return new ReportResponse({});
+        },
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(context.waitUntil.mock.callCount(), 1);
+    },
+  );
+
+  await t.test(
+    "calling `report` will make RPC call with ALLOW decision",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+        email: "test@example.com",
+      };
+
+      const [promise, resolve] = deferred();
+
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
           decision: {
+            id: decision.id,
+            conclusion: Conclusion.ALLOW,
+            reason: new Reason(),
+            ruleResults: [],
+          },
+        }),
+      );
+    },
+  );
+
+  await t.test(
+    "calling `report` will make RPC call with DENY decision",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const [promise, resolve] = deferred();
+
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = new ArcjetDenyDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
+          decision: {
+            id: decision.id,
             conclusion: Conclusion.DENY,
+            reason: new Reason(),
+            ruleResults: [],
           },
-        });
-      }),
-    };
+        }),
+      );
+    },
+  );
 
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = await client.decide(context, details, []);
+  await t.test(
+    "calling `report` will make RPC call with ERROR decision",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
 
-    assert.equal(decision.isDenied(), true);
-  });
+      const [promise, resolve] = deferred();
 
-  test("calling `decide` creates a CHALLENGE ArcjetDecision if DecideResponse is challenged", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
 
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.CHALLENGE,
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = new ArcjetErrorDecision({
+        ttl: 0,
+        reason: new ArcjetErrorReason("Failure"),
+        results: [],
+      });
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
           },
-        });
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = await client.decide(context, details, []);
-
-    assert.equal(decision.isChallenged(), true);
-  });
-
-  test("calling `decide` creates an ERROR ArcjetDecision with default message if DecideResponse is error and no reason", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
           decision: {
+            id: decision.id,
             conclusion: Conclusion.ERROR,
-          },
-        });
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = await client.decide(context, details, []);
-
-    assert.equal(decision.isErrored(), true);
-    // @ts-expect-error: TODO(#4452): union, or allow `String(reason)`.
-    assert.equal(decision.reason.message, "Unknown error occurred");
-  });
-
-  test("calling `decide` creates an ERROR ArcjetDecision with message if DecideResponse if error and reason available", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.ERROR,
-            reason: {
+            reason: new Reason({
               reason: {
                 case: "error",
-                value: { message: "Boom!" },
+                value: {
+                  message: "Failure",
+                },
               },
-            },
-          },
-        });
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = await client.decide(context, details, []);
-
-    assert.equal(decision.isErrored(), true);
-    // @ts-expect-error: TODO(#4452): union, or allow `String(reason)`.
-    assert.equal(decision.reason.message, "Boom!");
-  });
-
-  test("calling `decide` creates an ERROR ArcjetDecision if DecideResponse is unspecified", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.UNSPECIFIED,
-          },
-        });
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = await client.decide(context, details, []);
-
-    assert.equal(decision.isErrored(), true);
-    assert.equal(decision.isAllowed(), true);
-  });
-
-  test("calling `report` will use `waitUntil` if available", async () => {
-    const [promise, resolve] = deferred();
-
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-      waitUntil: mock.fn((promise: Promise<unknown>) => {
-        promise.then(() => resolve());
-      }),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "test@example.com",
-    };
-
-    const router = {
-      report: () => {
-        return new ReportResponse({});
-      },
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = new ArcjetAllowDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    client.report(context, details, decision, []);
-
-    await promise;
-
-    assert.equal(context.waitUntil.mock.callCount(), 1);
-  });
-
-  test("calling `report` will make RPC call with ALLOW decision", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "test@example.com",
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = new ArcjetAllowDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    client.report(context, details, decision, []);
-
-    await promise;
-
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.ALLOW,
-          reason: new Reason(),
-          ruleResults: [],
-        },
-      }),
-    );
-  });
-
-  test("calling `report` will make RPC call with DENY decision", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = new ArcjetDenyDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    client.report(context, details, decision, []);
-
-    await promise;
-
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.DENY,
-          reason: new Reason(),
-          ruleResults: [],
-        },
-      }),
-    );
-  });
-
-  test("calling `report` will make RPC call with ERROR decision", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason("Failure"),
-      results: [],
-    });
-    client.report(context, details, decision, []);
-
-    await promise;
-
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.ERROR,
-          reason: new Reason({
-            reason: {
-              case: "error",
-              value: {
-                message: "Failure",
-              },
-            },
-          }),
-          ruleResults: [],
-        },
-      }),
-    );
-  });
-
-  test("calling `report` will make RPC call with CHALLENGE decision", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = new ArcjetChallengeDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    client.report(context, details, decision, []);
-
-    await promise;
-
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.CHALLENGE,
-          reason: new Reason(),
-          ruleResults: [],
-        },
-      }),
-    );
-  });
-
-  test("calling `report` will make RPC call with UNSPECIFIED decision if invalid", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const decision = new ArcjetInvalidDecision();
-    client.report(context, details, decision, []);
-
-    await promise;
-
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.UNSPECIFIED,
-          reason: new Reason(),
-          ruleResults: [],
-        },
-      }),
-    );
-  });
-
-  test("calling `report` will make RPC with rules included", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "abc@example.com",
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-
-    const decision = new ArcjetDenyDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [
-        new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 0,
-          state: "RUN",
-          conclusion: "DENY",
-          reason: new ArcjetReason(),
-        }),
-      ],
-    });
-    const rule: ArcjetRule = {
-      version: 0,
-      type: "TEST_RULE",
-      mode: "LIVE",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-    client.report(context, details, decision, [rule]);
-
-    await promise;
-
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.DENY,
-          reason: new Reason(),
-          ruleResults: [
-            new RuleResult({
-              ruleId: "test-rule-id",
-              fingerprint: "test-fingerprint",
-              state: RuleState.RUN,
-              conclusion: Conclusion.DENY,
-              reason: new Reason(),
             }),
-          ],
-        },
-        rules: [new Rule()],
-      }),
-    );
-  });
+            ruleResults: [],
+          },
+        }),
+      );
+    },
+  );
 
-  test("calling `report` only logs if it fails", async () => {
+  await t.test(
+    "calling `report` will make RPC call with CHALLENGE decision",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const [promise, resolve] = deferred();
+
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = new ArcjetChallengeDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
+          decision: {
+            id: decision.id,
+            conclusion: Conclusion.CHALLENGE,
+            reason: new Reason(),
+            ruleResults: [],
+          },
+        }),
+      );
+    },
+  );
+
+  await t.test(
+    "calling `report` will make RPC call with UNSPECIFIED decision if invalid",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+      };
+
+      const [promise, resolve] = deferred();
+
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const decision = new ArcjetInvalidDecision();
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
+          decision: {
+            id: decision.id,
+            conclusion: Conclusion.UNSPECIFIED,
+            reason: new Reason(),
+            ruleResults: [],
+          },
+        }),
+      );
+    },
+  );
+
+  await t.test(
+    "calling `report` will make RPC with rules included",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
+        characteristics: [],
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+        email: "abc@example.com",
+      };
+
+      const [promise, resolve] = deferred();
+
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+
+      const decision = new ArcjetDenyDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [
+          new ArcjetRuleResult({
+            ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
+            ttl: 0,
+            state: "RUN",
+            conclusion: "DENY",
+            reason: new ArcjetReason(),
+          }),
+        ],
+      });
+      const rule: ArcjetRule = {
+        version: 0,
+        type: "TEST_RULE",
+        mode: "LIVE",
+        priority: 1,
+        validate: mock.fn(),
+        protect: mock.fn(),
+      };
+      client.report(context, details, decision, [rule]);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
+          decision: {
+            id: decision.id,
+            conclusion: Conclusion.DENY,
+            reason: new Reason(),
+            ruleResults: [
+              new RuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                state: RuleState.RUN,
+                conclusion: Conclusion.DENY,
+                reason: new Reason(),
+              }),
+            ],
+          },
+          rules: [new Rule()],
+        }),
+      );
+    },
+  );
+
+  await t.test("calling `report` only logs if it fails", async () => {
     const key = "test-key";
     const fingerprint =
       "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
@@ -1239,153 +1287,159 @@ describe("createClient", () => {
     assert.equal(logSpy.mock.callCount(), 1);
   });
 
-  test("calling `decide` will make RPC with top level characteristics included", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: ["src.ip"],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "abc@example.com",
-    };
-
-    const router = {
-      decide: mock.fn((args) => {
-        return new DecideResponse({
-          decision: {
-            conclusion: Conclusion.ALLOW,
-          },
-        });
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-    const _ = await client.decide(context, details, []);
-
-    assert.equal(router.decide.mock.callCount(), 1);
-    assert.deepEqual(
-      router.decide.mock.calls[0].arguments.at(0),
-      new DecideRequest({
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
+  await t.test(
+    "calling `decide` will make RPC with top level characteristics included",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
         characteristics: ["src.ip"],
-        rules: [],
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-      }),
-    );
-  });
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+        email: "abc@example.com",
+      };
 
-  test("calling `report` will make RPC with top level characteristics included", async () => {
-    const key = "test-key";
-    const fingerprint =
-      "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
-    const context = {
-      key,
-      fingerprint,
-      runtime: "test",
-      log,
-      characteristics: ["ip.src"],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "abc@example.com",
-    };
-
-    const [promise, resolve] = deferred();
-
-    const router = {
-      report: mock.fn((args) => {
-        resolve();
-        return new ReportResponse({});
-      }),
-    };
-
-    const client = createClient({
-      ...defaultRemoteClientOptions,
-      transport: createRouterTransport(({ service }) => {
-        service(DecideService, router);
-      }),
-    });
-
-    const decision = new ArcjetDenyDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [
-        new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 0,
-          state: "RUN",
-          conclusion: "DENY",
-          reason: new ArcjetReason(),
+      const router = {
+        decide: mock.fn((args) => {
+          return new DecideResponse({
+            decision: {
+              conclusion: Conclusion.ALLOW,
+            },
+          });
         }),
-      ],
-    });
-    client.report(context, details, decision, []);
+      };
 
-    await promise;
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+      const _ = await client.decide(context, details, []);
 
-    assert.equal(router.report.mock.callCount(), 1);
-    assert.deepEqual(
-      router.report.mock.calls[0].arguments.at(0),
-      new ReportRequest({
-        sdkStack: SDKStack.SDK_STACK_NODEJS,
-        sdkVersion: "__ARCJET_SDK_VERSION__",
-        details: {
-          ...details,
-          headers: { "user-agent": "curl/8.1.2" },
-        },
-        decision: {
-          id: decision.id,
-          conclusion: Conclusion.DENY,
-          reason: new Reason(),
-          ruleResults: [
-            new RuleResult({
-              ruleId: "test-rule-id",
-              fingerprint: "test-fingerprint",
-              state: RuleState.RUN,
-              conclusion: Conclusion.DENY,
-              reason: new Reason(),
-            }),
-          ],
-        },
-        rules: [],
+      assert.equal(router.decide.mock.callCount(), 1);
+      assert.deepEqual(
+        router.decide.mock.calls[0].arguments.at(0),
+        new DecideRequest({
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
+          characteristics: ["src.ip"],
+          rules: [],
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+        }),
+      );
+    },
+  );
+
+  await t.test(
+    "calling `report` will make RPC with top level characteristics included",
+    async () => {
+      const key = "test-key";
+      const fingerprint =
+        "fp_1_ac8547705f1f45c5050f1424700dfa3f6f2f681b550ca4f3c19571585aea7a2c";
+      const context = {
+        key,
+        fingerprint,
+        runtime: "test",
+        log,
         characteristics: ["ip.src"],
-      }),
-    );
-  });
+        cache: new TestCache(),
+        getBody: () => Promise.resolve(undefined),
+      };
+      const details = {
+        ip: "172.100.1.1",
+        method: "GET",
+        protocol: "http",
+        host: "example.com",
+        path: "/",
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+        extra: {
+          "extra-test": "extra-test-value",
+        },
+        email: "abc@example.com",
+      };
+
+      const [promise, resolve] = deferred();
+
+      const router = {
+        report: mock.fn((args) => {
+          resolve();
+          return new ReportResponse({});
+        }),
+      };
+
+      const client = createClient({
+        ...defaultRemoteClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, router);
+        }),
+      });
+
+      const decision = new ArcjetDenyDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [
+          new ArcjetRuleResult({
+            ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
+            ttl: 0,
+            state: "RUN",
+            conclusion: "DENY",
+            reason: new ArcjetReason(),
+          }),
+        ],
+      });
+      client.report(context, details, decision, []);
+
+      await promise;
+
+      assert.equal(router.report.mock.callCount(), 1);
+      assert.deepEqual(
+        router.report.mock.calls[0].arguments.at(0),
+        new ReportRequest({
+          sdkStack: SDKStack.SDK_STACK_NODEJS,
+          sdkVersion: "__ARCJET_SDK_VERSION__",
+          details: {
+            ...details,
+            headers: { "user-agent": "curl/8.1.2" },
+          },
+          decision: {
+            id: decision.id,
+            conclusion: Conclusion.DENY,
+            reason: new Reason(),
+            ruleResults: [
+              new RuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                state: RuleState.RUN,
+                conclusion: Conclusion.DENY,
+                reason: new Reason(),
+              }),
+            ],
+          },
+          rules: [],
+          characteristics: ["ip.src"],
+        }),
+      );
+    },
+  );
 });

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mock, test } from "node:test";
+import test from "node:test";
 import {
   ArcjetModeToProtocol,
   ArcjetEmailTypeToProtocol,
@@ -58,757 +58,1060 @@ import {
 import { Timestamp } from "@bufbuild/protobuf";
 
 test("convert", async (t) => {
-  await t.test("ArcjetModeToProtocol", () => {
-    assert.equal(ArcjetModeToProtocol("LIVE"), Mode.LIVE);
-    assert.equal(ArcjetModeToProtocol("DRY_RUN"), Mode.DRY_RUN);
-    assert.equal(
-      ArcjetModeToProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
-      ),
-      Mode.UNSPECIFIED,
+  await t.test("ArcjetModeToProtocol", async (t) => {
+    await t.test("should turn `DRY_RUN` into a mode", () => {
+      assert.equal(ArcjetModeToProtocol("DRY_RUN"), Mode.DRY_RUN);
+    });
+
+    await t.test("should turn `LIVE` into a mode", () => {
+      assert.equal(ArcjetModeToProtocol("LIVE"), Mode.LIVE);
+    });
+
+    await t.test(
+      "should turn unknown values into the `UNSPECIFIED` mode",
+      () => {
+        assert.equal(
+          ArcjetModeToProtocol(
+            // @ts-expect-error: test runtime behavior.
+            "NOT_VALID",
+          ),
+          Mode.UNSPECIFIED,
+        );
+      },
     );
   });
 
-  await t.test("ArcjetEmailTypeToProtocol", () => {
-    assert.equal(ArcjetEmailTypeToProtocol("DISPOSABLE"), EmailType.DISPOSABLE);
-    assert.equal(ArcjetEmailTypeToProtocol("FREE"), EmailType.FREE);
-    assert.equal(ArcjetEmailTypeToProtocol("INVALID"), EmailType.INVALID);
-    assert.equal(
-      ArcjetEmailTypeToProtocol("NO_GRAVATAR"),
-      EmailType.NO_GRAVATAR,
-    );
-    assert.equal(
-      ArcjetEmailTypeToProtocol("NO_MX_RECORDS"),
-      EmailType.NO_MX_RECORDS,
-    );
-    assert.equal(
-      ArcjetEmailTypeToProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
-      ),
-      EmailType.UNSPECIFIED,
-    );
-  });
-
-  await t.test("ArcjetEmailTypeFromProtocol", () => {
-    assert.equal(
-      ArcjetEmailTypeFromProtocol(EmailType.DISPOSABLE),
-      "DISPOSABLE",
-    );
-    assert.equal(ArcjetEmailTypeFromProtocol(EmailType.FREE), "FREE");
-    assert.equal(ArcjetEmailTypeFromProtocol(EmailType.INVALID), "INVALID");
-    assert.equal(
-      ArcjetEmailTypeFromProtocol(EmailType.NO_GRAVATAR),
-      "NO_GRAVATAR",
-    );
-    assert.equal(
-      ArcjetEmailTypeFromProtocol(EmailType.NO_MX_RECORDS),
-      "NO_MX_RECORDS",
-    );
-    assert.throws(() => {
-      ArcjetEmailTypeFromProtocol(EmailType.UNSPECIFIED);
-    }, /Invalid EmailType/);
-    assert.throws(() => {
-      ArcjetEmailTypeFromProtocol(
-        // @ts-expect-error
-        99,
+  await t.test("ArcjetEmailTypeToProtocol", async (t) => {
+    await t.test("should turn `DISPOSABLE` into an email type", () => {
+      assert.equal(
+        ArcjetEmailTypeToProtocol("DISPOSABLE"),
+        EmailType.DISPOSABLE,
       );
-    }, /Invalid EmailType/);
-  });
+    });
 
-  await t.test("ArcjetStackToProtocol", () => {
-    assert.equal(ArcjetStackToProtocol("NODEJS"), SDKStack.SDK_STACK_NODEJS);
-    assert.equal(ArcjetStackToProtocol("NEXTJS"), SDKStack.SDK_STACK_NEXTJS);
-    assert.equal(ArcjetStackToProtocol("BUN"), SDKStack.SDK_STACK_BUN);
-    assert.equal(
-      ArcjetStackToProtocol("SVELTEKIT"),
-      SDKStack.SDK_STACK_SVELTEKIT,
-    );
-    assert.equal(ArcjetStackToProtocol("DENO"), SDKStack.SDK_STACK_DENO);
-    assert.equal(ArcjetStackToProtocol("NESTJS"), SDKStack.SDK_STACK_NESTJS);
-    assert.equal(ArcjetStackToProtocol("REMIX"), SDKStack.SDK_STACK_REMIX);
-    assert.equal(ArcjetStackToProtocol("ASTRO"), SDKStack.SDK_STACK_ASTRO);
-    assert.equal(
-      ArcjetStackToProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
-      ),
-      SDKStack.SDK_STACK_UNSPECIFIED,
-    );
-  });
+    await t.test("should turn `FREE` into an email type", () => {
+      assert.equal(ArcjetEmailTypeToProtocol("FREE"), EmailType.FREE);
+    });
 
-  await t.test("ArcjetRuleStateToProtocol", () => {
-    assert.equal(ArcjetRuleStateToProtocol("CACHED"), RuleState.CACHED);
-    assert.equal(ArcjetRuleStateToProtocol("DRY_RUN"), RuleState.DRY_RUN);
-    assert.equal(ArcjetRuleStateToProtocol("NOT_RUN"), RuleState.NOT_RUN);
-    assert.equal(ArcjetRuleStateToProtocol("RUN"), RuleState.RUN);
-    assert.equal(
-      ArcjetRuleStateToProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
-      ),
-      RuleState.UNSPECIFIED,
-    );
-  });
+    await t.test("should turn `INVALID` into an email type", () => {
+      assert.equal(ArcjetEmailTypeToProtocol("INVALID"), EmailType.INVALID);
+    });
 
-  await t.test("ArcjetRuleStateFromProtocol", () => {
-    assert.equal(ArcjetRuleStateFromProtocol(RuleState.CACHED), "CACHED");
-    assert.equal(ArcjetRuleStateFromProtocol(RuleState.DRY_RUN), "DRY_RUN");
-    assert.equal(ArcjetRuleStateFromProtocol(RuleState.NOT_RUN), "NOT_RUN");
-    assert.equal(ArcjetRuleStateFromProtocol(RuleState.RUN), "RUN");
-    assert.throws(() => {
-      ArcjetRuleStateFromProtocol(RuleState.UNSPECIFIED);
-    }, /Invalid RuleState/);
-    assert.throws(() => {
-      ArcjetRuleStateFromProtocol(
-        // @ts-expect-error
-        99,
+    await t.test("should turn `NO_GRAVATAR` into an email type", () => {
+      assert.equal(
+        ArcjetEmailTypeToProtocol("NO_GRAVATAR"),
+        EmailType.NO_GRAVATAR,
       );
-    }, /Invalid RuleState/);
-  });
+    });
 
-  await t.test("ArcjetConclusionToProtocol", () => {
-    assert.equal(ArcjetConclusionToProtocol("ALLOW"), Conclusion.ALLOW);
-    assert.equal(ArcjetConclusionToProtocol("CHALLENGE"), Conclusion.CHALLENGE);
-    assert.equal(ArcjetConclusionToProtocol("DENY"), Conclusion.DENY);
-    assert.equal(ArcjetConclusionToProtocol("ERROR"), Conclusion.ERROR);
-    assert.equal(
-      ArcjetConclusionToProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
-      ),
-      Conclusion.UNSPECIFIED,
-    );
-  });
-
-  await t.test("ArcjetConclusionFromProtocol", () => {
-    assert.equal(ArcjetConclusionFromProtocol(Conclusion.ALLOW), "ALLOW");
-    assert.equal(
-      ArcjetConclusionFromProtocol(Conclusion.CHALLENGE),
-      "CHALLENGE",
-    );
-    assert.equal(ArcjetConclusionFromProtocol(Conclusion.DENY), "DENY");
-    assert.equal(ArcjetConclusionFromProtocol(Conclusion.ERROR), "ERROR");
-    assert.throws(() => {
-      ArcjetConclusionFromProtocol(Conclusion.UNSPECIFIED);
-    }, /Invalid Conclusion/);
-    assert.throws(() => {
-      ArcjetConclusionFromProtocol(
-        // @ts-expect-error
-        99,
+    await t.test("should turn `NO_MX_RECORDS` into an email type", () => {
+      assert.equal(
+        ArcjetEmailTypeToProtocol("NO_MX_RECORDS"),
+        EmailType.NO_MX_RECORDS,
       );
-    }, /Invalid Conclusion/);
+    });
+
+    await t.test(
+      "should turn unknown values into the `UNSPECIFIED` email type",
+      () => {
+        assert.equal(
+          ArcjetEmailTypeToProtocol(
+            // @ts-expect-error
+            "NOT_VALID",
+          ),
+          EmailType.UNSPECIFIED,
+        );
+      },
+    );
   });
 
-  await t.test("ArcjetReasonFromProtocol", () => {
-    assert.ok(ArcjetReasonFromProtocol() instanceof ArcjetReason);
-    assert.ok(
-      ArcjetReasonFromProtocol(
+  await t.test("ArcjetEmailTypeFromProtocol", async (t) => {
+    await t.test("should turn a `DISPOSABLE` email type into a string", () => {
+      assert.equal(
+        ArcjetEmailTypeFromProtocol(EmailType.DISPOSABLE),
+        "DISPOSABLE",
+      );
+    });
+
+    await t.test("should turn a `FREE` email type into a string", () => {
+      assert.equal(ArcjetEmailTypeFromProtocol(EmailType.FREE), "FREE");
+    });
+
+    await t.test("should turn an `INVALID` email type into a string", () => {
+      assert.equal(ArcjetEmailTypeFromProtocol(EmailType.INVALID), "INVALID");
+    });
+
+    await t.test("should turn a `NO_GRAVATAR` email type into a string", () => {
+      assert.equal(
+        ArcjetEmailTypeFromProtocol(EmailType.NO_GRAVATAR),
+        "NO_GRAVATAR",
+      );
+    });
+
+    await t.test(
+      "should turn a `NO_MX_RECORDS` email type into a string",
+      () => {
+        assert.equal(
+          ArcjetEmailTypeFromProtocol(EmailType.NO_MX_RECORDS),
+          "NO_MX_RECORDS",
+        );
+      },
+    );
+
+    await t.test("should fail on an `UNSPECIFIED` email type", () => {
+      assert.throws(() => {
+        ArcjetEmailTypeFromProtocol(EmailType.UNSPECIFIED);
+      }, /Invalid EmailType/);
+    });
+
+    await t.test("should fail on an unknown email type", () => {
+      assert.throws(() => {
+        ArcjetEmailTypeFromProtocol(
+          // @ts-expect-error
+          99,
+        );
+      }, /Invalid EmailType/);
+    });
+  });
+
+  await t.test("ArcjetStackToProtocol", async (t) => {
+    await t.test("should turn a `ASTRO` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("ASTRO"), SDKStack.SDK_STACK_ASTRO);
+    });
+
+    await t.test("should turn a `BUN` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("BUN"), SDKStack.SDK_STACK_BUN);
+    });
+
+    await t.test("should turn a `DENO` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("DENO"), SDKStack.SDK_STACK_DENO);
+    });
+
+    await t.test("should turn a `NESTJS` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("NESTJS"), SDKStack.SDK_STACK_NESTJS);
+    });
+
+    await t.test("should turn a `NEXTJS` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("NEXTJS"), SDKStack.SDK_STACK_NEXTJS);
+    });
+
+    await t.test("should turn a `NODEJS` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("NODEJS"), SDKStack.SDK_STACK_NODEJS);
+    });
+
+    await t.test("should turn a `REMIX` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("REMIX"), SDKStack.SDK_STACK_REMIX);
+    });
+
+    await t.test("should turn a `SVELTEKIT` stack into an SDK stack", () => {
+      assert.equal(
+        ArcjetStackToProtocol("SVELTEKIT"),
+        SDKStack.SDK_STACK_SVELTEKIT,
+      );
+    });
+
+    await t.test("should fail on an unknown stack", () => {
+      assert.equal(
+        ArcjetStackToProtocol(
+          // @ts-expect-error
+          "NOT_VALID",
+        ),
+        SDKStack.SDK_STACK_UNSPECIFIED,
+      );
+    });
+  });
+
+  await t.test("ArcjetRuleStateToProtocol", async (t) => {
+    await t.test("should turn a `CACHED` value into a rule state", () => {
+      assert.equal(ArcjetRuleStateToProtocol("CACHED"), RuleState.CACHED);
+    });
+
+    await t.test("should turn a `DRY_RUN` value into a rule state", () => {
+      assert.equal(ArcjetRuleStateToProtocol("DRY_RUN"), RuleState.DRY_RUN);
+    });
+
+    await t.test("should turn a `NOT_RUN` value into a rule state", () => {
+      assert.equal(ArcjetRuleStateToProtocol("NOT_RUN"), RuleState.NOT_RUN);
+    });
+
+    await t.test("should turn a `RUN` value into a rule state", () => {
+      assert.equal(ArcjetRuleStateToProtocol("RUN"), RuleState.RUN);
+    });
+
+    await t.test("should fail on an unknown rule state", () => {
+      assert.equal(
+        ArcjetRuleStateToProtocol(
+          // @ts-expect-error
+          "NOT_VALID",
+        ),
+        RuleState.UNSPECIFIED,
+      );
+    });
+  });
+
+  await t.test("ArcjetRuleStateFromProtocol", async (t) => {
+    await t.test("should turn a `CACHED` state into a string", () => {
+      assert.equal(ArcjetRuleStateFromProtocol(RuleState.CACHED), "CACHED");
+    });
+
+    await t.test("should turn a `DRY_RUN` state into a string", () => {
+      assert.equal(ArcjetRuleStateFromProtocol(RuleState.DRY_RUN), "DRY_RUN");
+    });
+
+    await t.test("should turn a `NOT_RUN` state into a string", () => {
+      assert.equal(ArcjetRuleStateFromProtocol(RuleState.NOT_RUN), "NOT_RUN");
+    });
+
+    await t.test("should turn a `RUN` state into a string", () => {
+      assert.equal(ArcjetRuleStateFromProtocol(RuleState.RUN), "RUN");
+    });
+
+    await t.test("should fail on an `UNSPECIFIED` state", () => {
+      assert.throws(() => {
+        ArcjetRuleStateFromProtocol(RuleState.UNSPECIFIED);
+      }, /Invalid RuleState/);
+    });
+
+    await t.test("should fail on an unknown state", () => {
+      assert.throws(() => {
+        ArcjetRuleStateFromProtocol(
+          // @ts-expect-error
+          99,
+        );
+      }, /Invalid RuleState/);
+    });
+  });
+
+  await t.test("ArcjetConclusionToProtocol", async (t) => {
+    await t.test("should turn an `ALLOW` value into a conclusion", () => {
+      assert.equal(ArcjetConclusionToProtocol("ALLOW"), Conclusion.ALLOW);
+    });
+
+    await t.test("should turn a `CHALLENGE` value into a conclusion", () => {
+      assert.equal(
+        ArcjetConclusionToProtocol("CHALLENGE"),
+        Conclusion.CHALLENGE,
+      );
+    });
+
+    await t.test("should turn a `DENY` value into a conclusion", () => {
+      assert.equal(ArcjetConclusionToProtocol("DENY"), Conclusion.DENY);
+    });
+
+    await t.test("should turn an `ERROR` value into a conclusion", () => {
+      assert.equal(ArcjetConclusionToProtocol("ERROR"), Conclusion.ERROR);
+    });
+
+    await t.test("should fail on a `NOT_VALID` value", () => {
+      assert.equal(
+        ArcjetConclusionToProtocol(
+          // @ts-expect-error
+          "NOT_VALID",
+        ),
+        Conclusion.UNSPECIFIED,
+      );
+    });
+  });
+
+  await t.test("ArcjetConclusionFromProtocol", async (t) => {
+    await t.test("should turn an `ALLOW` conclusion into a string", () => {
+      assert.equal(ArcjetConclusionFromProtocol(Conclusion.ALLOW), "ALLOW");
+    });
+
+    await t.test("should turn a `CHALLENGE` conclusion into a string", () => {
+      assert.equal(
+        ArcjetConclusionFromProtocol(Conclusion.CHALLENGE),
+        "CHALLENGE",
+      );
+    });
+
+    await t.test("should turn a `DENY` conclusion into a string", () => {
+      assert.equal(ArcjetConclusionFromProtocol(Conclusion.DENY), "DENY");
+    });
+
+    await t.test("should turn an `ERROR` conclusion into a string", () => {
+      assert.equal(ArcjetConclusionFromProtocol(Conclusion.ERROR), "ERROR");
+    });
+
+    await t.test("should fail on an `UNSPECIFIED` conclusion", () => {
+      assert.throws(() => {
+        ArcjetConclusionFromProtocol(Conclusion.UNSPECIFIED);
+      }, /Invalid Conclusion/);
+    });
+
+    await t.test("should fail on an unknown conclusion", () => {
+      assert.throws(() => {
+        ArcjetConclusionFromProtocol(
+          // @ts-expect-error
+          99,
+        );
+      }, /Invalid Conclusion/);
+    });
+  });
+
+  await t.test("ArcjetReasonFromProtocol", async (t) => {
+    await t.test("should create an anonymous reason w/o proto", () => {
+      const reason = ArcjetReasonFromProtocol();
+
+      assert.ok(reason instanceof ArcjetReason);
+      assert.equal(reason.type, undefined);
+    });
+
+    await t.test("should create an anonymous reason w/ an empty proto", () => {
+      const reason = ArcjetReasonFromProtocol(new Reason());
+
+      assert.ok(reason instanceof ArcjetReason);
+      assert.equal(reason.type, undefined);
+    });
+
+    await t.test("should create a bot reason", () => {
+      const reason = ArcjetReasonFromProtocol(
         new Reason({
-          reason: {
-            case: "botV2",
-            value: {
-              allowed: [],
-              denied: [],
-            },
-          },
+          reason: { case: "botV2", value: { allowed: [], denied: [] } },
         }),
-      ) instanceof ArcjetBotReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
-        new Reason({
-          reason: {
-            case: "edgeRule",
-            value: {},
-          },
-        }),
-      ) instanceof ArcjetEdgeRuleReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
+      );
+
+      assert.ok(reason instanceof ArcjetBotReason);
+      assert.equal(reason.type, "BOT");
+    });
+
+    await t.test("should create an edge rule reason", () => {
+      const reason = ArcjetReasonFromProtocol(
+        new Reason({ reason: { case: "edgeRule", value: {} } }),
+      );
+
+      assert.ok(reason instanceof ArcjetEdgeRuleReason);
+      assert.equal(reason.type, "EDGE_RULE");
+    });
+
+    await t.test("should create an email reason", () => {
+      const reason = ArcjetReasonFromProtocol(
         new Reason({
           reason: {
             case: "email",
-            value: {
-              emailTypes: [EmailType.DISPOSABLE],
-            },
+            value: { emailTypes: [EmailType.DISPOSABLE] },
           },
         }),
-      ) instanceof ArcjetEmailReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
+      );
+
+      assert.ok(reason instanceof ArcjetEmailReason);
+      assert.equal(reason.type, "EMAIL");
+    });
+
+    await t.test("should create an error reason", () => {
+      const reason = ArcjetReasonFromProtocol(
         new Reason({
           reason: {
             case: "error",
-            value: {
-              message: "Test error",
-            },
+            value: { message: "Test error" },
           },
         }),
-      ) instanceof ArcjetErrorReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
+      );
+
+      assert.ok(reason instanceof ArcjetErrorReason);
+      assert.equal(reason.type, "ERROR");
+    });
+
+    await t.test("should create a rate limit reason", () => {
+      const reason = ArcjetReasonFromProtocol(
         new Reason({
           reason: {
             case: "rateLimit",
             value: {
-              max: 1,
               count: 2,
+              max: 1,
               remaining: -1,
               resetInSeconds: 1000,
-              windowInSeconds: 1000,
               resetTime: undefined,
+              windowInSeconds: 1000,
             },
           },
         }),
-      ) instanceof ArcjetRateLimitReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
+      );
+
+      assert.ok(reason instanceof ArcjetRateLimitReason);
+      assert.equal(reason.type, "RATE_LIMIT");
+    });
+
+    await t.test("should create another rate limit reason", () => {
+      const reason = ArcjetReasonFromProtocol(
         new Reason({
           reason: {
             case: "rateLimit",
             value: {
-              max: 1,
               count: 2,
+              max: 1,
               remaining: -1,
               resetInSeconds: 1000,
-              windowInSeconds: 1000,
               resetTime: Timestamp.now(),
+              windowInSeconds: 1000,
             },
           },
         }),
-      ) instanceof ArcjetRateLimitReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
+      );
+
+      assert.ok(reason instanceof ArcjetRateLimitReason);
+      assert.equal(reason.type, "RATE_LIMIT");
+    });
+
+    await t.test("should create a sensitive info reason", () => {
+      const reason = ArcjetReasonFromProtocol(
         new Reason({
           reason: {
             case: "sensitiveInfo",
             value: {
               denied: [
-                {
-                  start: 0,
-                  end: 16,
-                  identifiedType: "credit-card-number",
-                },
+                { end: 16, identifiedType: "credit-card-number", start: 0 },
               ],
             },
           },
         }),
-      ) instanceof ArcjetSensitiveInfoReason,
-    );
-    assert.ok(
-      ArcjetReasonFromProtocol(
-        new Reason({
-          reason: {
-            case: "shield",
-            value: {
-              shieldTriggered: true,
-            },
-          },
-        }),
-      ) instanceof ArcjetShieldReason,
-    );
-    assert.ok(ArcjetReasonFromProtocol(new Reason()) instanceof ArcjetReason);
-    assert.ok(
-      ArcjetReasonFromProtocol(
-        new Reason({
-          reason: {
-            // @ts-expect-error
-            case: "NOT_VALID",
-          },
-        }),
-      ) instanceof ArcjetReason,
-    );
-    assert.throws(() => {
-      ArcjetReasonFromProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
       );
-    }, /Invalid Reason/);
-    assert.throws(() => {
-      ArcjetReasonFromProtocol({
-        // @ts-expect-error
-        reason: "NOT_VALID",
-      });
-    }, /Invalid Reason/);
-  });
 
-  await t.test("ArcjetReasonToProtocol", () => {
-    assert.ok(ArcjetReasonToProtocol(new ArcjetReason()) instanceof Reason);
-    assert.deepEqual(
-      ArcjetReasonToProtocol(
-        new ArcjetRateLimitReason({
-          max: 1,
-          remaining: -1,
-          reset: 100,
-          window: 100,
+      assert.ok(reason instanceof ArcjetSensitiveInfoReason);
+      assert.equal(reason.type, "SENSITIVE_INFO");
+    });
+
+    await t.test("should create a shield reason", () => {
+      const reason = ArcjetReasonFromProtocol(
+        new Reason({
+          reason: { case: "shield", value: { shieldTriggered: true } },
         }),
-      ),
-      new Reason({
-        reason: {
-          case: "rateLimit",
-          value: {
-            max: 1,
-            remaining: -1,
-            resetInSeconds: 100,
-            windowInSeconds: 100,
-          },
-        },
-      }),
-    );
+      );
 
-    const resetTime = new Date();
-    assert.deepEqual(
-      ArcjetReasonToProtocol(
-        new ArcjetRateLimitReason({
-          max: 1,
-          remaining: -1,
-          reset: 100,
-          window: 100,
-          resetTime,
-        }),
-      ),
-      new Reason({
-        reason: {
-          case: "rateLimit",
-          value: {
-            max: 1,
-            remaining: -1,
-            resetInSeconds: 100,
-            windowInSeconds: 100,
-            resetTime: Timestamp.fromDate(resetTime),
-          },
-        },
-      }),
-    );
+      assert.ok(reason instanceof ArcjetShieldReason);
+      assert.equal(reason.type, "SHIELD");
+    });
 
-    assert.deepEqual(
-      ArcjetReasonToProtocol(
-        new ArcjetBotReason({
-          allowed: ["GOOGLE_CRAWLER"],
-          denied: [],
-          verified: true,
-          spoofed: false,
-        }),
-      ),
-      new Reason({
-        reason: {
-          case: "botV2",
-          value: {
-            allowed: ["GOOGLE_CRAWLER"],
-            denied: [],
-            verified: true,
-            spoofed: false,
-          },
-        },
-      }),
-    );
-
-    assert.deepEqual(
-      ArcjetReasonToProtocol(
-        new ArcjetSensitiveInfoReason({
-          denied: [
-            {
-              start: 0,
-              end: 16,
-              identifiedType: "credit-card-number",
+    await t.test(
+      "should create an anonymous reason w/ an unknown `case` proto",
+      () => {
+        const reason = ArcjetReasonFromProtocol(
+          new Reason({
+            reason: {
+              // @ts-expect-error: test runtime behavior.
+              case: "NOT_VALID",
             },
-          ],
-          allowed: [],
-        }),
-      ),
-      new Reason({
-        reason: {
-          case: "sensitiveInfo",
-          value: {
-            denied: [
-              {
-                start: 0,
-                end: 16,
-                identifiedType: "credit-card-number",
+          }),
+        );
+
+        assert.ok(reason instanceof ArcjetReason);
+        assert.equal(reason.type, undefined);
+      },
+    );
+
+    await t.test("should fail on an invalid reason (string)", () => {
+      assert.throws(() => {
+        ArcjetReasonFromProtocol(
+          // @ts-expect-error: test runtime behavior.
+          "NOT_VALID",
+        );
+      }, /Invalid Reason/);
+    });
+
+    await t.test("should fail on an invalid reason (object)", () => {
+      assert.throws(() => {
+        ArcjetReasonFromProtocol({
+          // @ts-expect-error: test runtime behavior.
+          reason: "NOT_VALID",
+        });
+      }, /Invalid Reason/);
+    });
+  });
+
+  await t.test("ArcjetReasonToProtocol", async (t) => {
+    await t.test("should create an anonymous reason w/ an empty proto", () => {
+      const reason = ArcjetReasonToProtocol(new ArcjetReason());
+
+      assert.ok(reason instanceof Reason);
+      assert.equal(reason.reason.case, undefined);
+    });
+
+    await t.test(
+      "should create a protocol reason from an arcjet rate limit reason",
+      () => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(
+            new ArcjetRateLimitReason({
+              max: 1,
+              remaining: -1,
+              reset: 100,
+              window: 100,
+            }),
+          ),
+          new Reason({
+            reason: {
+              case: "rateLimit",
+              value: {
+                max: 1,
+                remaining: -1,
+                resetInSeconds: 100,
+                windowInSeconds: 100,
               },
-            ],
-          },
-        },
-      }),
+            },
+          }),
+        );
+      },
     );
 
-    assert.deepEqual(
-      ArcjetReasonToProtocol(new ArcjetEdgeRuleReason()),
-      new Reason({
-        reason: {
-          case: "edgeRule",
-          value: {},
-        },
-      }),
+    await t.test(
+      "should create a protocol reason from an arcjet rate limit reason w/ `resetTime`",
+      () => {
+        const resetTime = new Date();
+
+        assert.deepEqual(
+          ArcjetReasonToProtocol(
+            new ArcjetRateLimitReason({
+              max: 1,
+              remaining: -1,
+              resetTime,
+              reset: 100,
+              window: 100,
+            }),
+          ),
+          new Reason({
+            reason: {
+              case: "rateLimit",
+              value: {
+                max: 1,
+                remaining: -1,
+                resetInSeconds: 100,
+                resetTime: Timestamp.fromDate(resetTime),
+                windowInSeconds: 100,
+              },
+            },
+          }),
+        );
+      },
     );
 
-    assert.deepEqual(
-      ArcjetReasonToProtocol(new ArcjetShieldReason({ shieldTriggered: true })),
-      new Reason({
-        reason: {
-          case: "shield",
-          value: {
-            shieldTriggered: true,
-          },
-        },
-      }),
+    await t.test(
+      "should create a protocol reason from an arcjet bot reason",
+      () => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(
+            new ArcjetBotReason({
+              allowed: ["GOOGLE_CRAWLER"],
+              denied: [],
+              spoofed: false,
+              verified: true,
+            }),
+          ),
+          new Reason({
+            reason: {
+              case: "botV2",
+              value: {
+                allowed: ["GOOGLE_CRAWLER"],
+                denied: [],
+                spoofed: false,
+                verified: true,
+              },
+            },
+          }),
+        );
+      },
     );
 
-    assert.deepEqual(
-      ArcjetReasonToProtocol(
-        new ArcjetEmailReason({
-          emailTypes: ["DISPOSABLE"],
-        }),
-      ),
-      new Reason({
-        reason: {
-          case: "email",
-          value: {
-            emailTypes: [EmailType.DISPOSABLE],
-          },
-        },
-      }),
+    await t.test(
+      "should create a protocol reason from an arcjet sensitive info reason",
+      () => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(
+            new ArcjetSensitiveInfoReason({
+              allowed: [],
+              denied: [
+                { end: 16, identifiedType: "credit-card-number", start: 0 },
+              ],
+            }),
+          ),
+          new Reason({
+            reason: {
+              case: "sensitiveInfo",
+              value: {
+                denied: [
+                  { end: 16, identifiedType: "credit-card-number", start: 0 },
+                ],
+              },
+            },
+          }),
+        );
+      },
     );
 
-    assert.deepEqual(
-      ArcjetReasonToProtocol(new ArcjetErrorReason("Test error")),
-      new Reason({
-        reason: {
-          case: "error",
-          value: {
-            message: "Test error",
-          },
-        },
-      }),
+    await t.test(
+      "should create a protocol reason from an arcjet edge rule reason",
+      () => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(new ArcjetEdgeRuleReason()),
+          new Reason({ reason: { case: "edgeRule", value: {} } }),
+        );
+      },
+    );
+
+    await t.test(
+      "should create a protocol reason from an arcjet shield reason",
+      (t) => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(
+            new ArcjetShieldReason({ shieldTriggered: true }),
+          ),
+          new Reason({
+            reason: { case: "shield", value: { shieldTriggered: true } },
+          }),
+        );
+      },
+    );
+
+    await t.test(
+      "should create a protocol reason from an arcjet email reason",
+      () => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(
+            new ArcjetEmailReason({ emailTypes: ["DISPOSABLE"] }),
+          ),
+          new Reason({
+            reason: {
+              case: "email",
+              value: { emailTypes: [EmailType.DISPOSABLE] },
+            },
+          }),
+        );
+      },
+    );
+
+    await t.test(
+      "should create a protocol reason from an arcjet error reason",
+      () => {
+        assert.deepEqual(
+          ArcjetReasonToProtocol(new ArcjetErrorReason("Test error")),
+          new Reason({
+            reason: { case: "error", value: { message: "Test error" } },
+          }),
+        );
+      },
     );
   });
 
-  await t.test("ArcjetRuleResultToProtocol", () => {
-    assert.deepEqual(
-      ArcjetRuleResultToProtocol(
-        new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 0,
-          state: "RUN",
-          conclusion: "ALLOW",
-          reason: new ArcjetReason(),
-        }),
-      ),
-      new RuleResult({
-        ruleId: "test-rule-id",
-        fingerprint: "test-fingerprint",
-        state: RuleState.RUN,
-        conclusion: Conclusion.ALLOW,
-        reason: new Reason(),
-      }),
+  await t.test("ArcjetRuleResultToProtocol", async (t) => {
+    await t.test(
+      "should create a protocol rule result from an arcjet rule result",
+      () => {
+        assert.deepEqual(
+          ArcjetRuleResultToProtocol(
+            new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "test-fingerprint",
+              reason: new ArcjetReason(),
+              ruleId: "test-rule-id",
+              state: "RUN",
+              ttl: 0,
+            }),
+          ),
+          new RuleResult({
+            conclusion: Conclusion.ALLOW,
+            fingerprint: "test-fingerprint",
+            reason: new Reason(),
+            ruleId: "test-rule-id",
+            state: RuleState.RUN,
+          }),
+        );
+      },
     );
   });
 
-  await t.test("ArcjetRuleResultFromProtocol", () => {
-    assert.deepEqual(
-      ArcjetRuleResultFromProtocol(
-        new RuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          state: RuleState.RUN,
-          conclusion: Conclusion.ALLOW,
-          reason: new Reason(),
-        }),
-      ),
-      new ArcjetRuleResult({
-        ruleId: "test-rule-id",
-        fingerprint: "test-fingerprint",
-        ttl: 0,
-        state: "RUN",
-        conclusion: "ALLOW",
-        reason: new ArcjetReason(),
-      }),
+  await t.test("ArcjetRuleResultFromProtocol", async (t) => {
+    await t.test(
+      "should create an arcjet rule result from a protocol rule result",
+      () => {
+        assert.deepEqual(
+          ArcjetRuleResultFromProtocol(
+            new RuleResult({
+              conclusion: Conclusion.ALLOW,
+              fingerprint: "test-fingerprint",
+              reason: new Reason(),
+              ruleId: "test-rule-id",
+              state: RuleState.RUN,
+            }),
+          ),
+          new ArcjetRuleResult({
+            conclusion: "ALLOW",
+            fingerprint: "test-fingerprint",
+            reason: new ArcjetReason(),
+            ruleId: "test-rule-id",
+            state: "RUN",
+            ttl: 0,
+          }),
+        );
+      },
     );
   });
 
-  await t.test("ArcjetDecisionToProtocol", () => {
-    assert.deepEqual(
-      ArcjetDecisionToProtocol(
-        new ArcjetAllowDecision({
-          id: "abc123",
-          ttl: 0,
-          results: [],
-          reason: new ArcjetReason(),
-          ip: new ArcjetIpDetails(),
-        }),
-      ),
-      new Decision({
-        id: "abc123",
-        conclusion: Conclusion.ALLOW,
-        ruleResults: [],
-        reason: new Reason(),
-      }),
+  await t.test("ArcjetDecisionToProtocol", async (t) => {
+    await t.test(
+      "should create a protocol decision from an arcjet decision",
+      () => {
+        assert.deepEqual(
+          ArcjetDecisionToProtocol(
+            new ArcjetAllowDecision({
+              id: "abc123",
+              ip: new ArcjetIpDetails(),
+              reason: new ArcjetReason(),
+              results: [],
+              ttl: 0,
+            }),
+          ),
+          new Decision({
+            conclusion: Conclusion.ALLOW,
+            id: "abc123",
+            reason: new Reason(),
+            ruleResults: [],
+          }),
+        );
+      },
     );
   });
 
-  await t.test("ArcjetDecisionFromProtocol", () => {
-    assert.ok(ArcjetDecisionFromProtocol() instanceof ArcjetErrorDecision);
-    assert.ok(
-      ArcjetDecisionFromProtocol(new Decision()) instanceof ArcjetErrorDecision,
+  await t.test("ArcjetDecisionFromProtocol", async (t) => {
+    await t.test("should create an arcjet error decision w/o proto", () => {
+      const decision = ArcjetDecisionFromProtocol();
+
+      assert.ok(decision instanceof ArcjetErrorDecision);
+      assert.equal(decision.conclusion, "ERROR");
+    });
+
+    await t.test(
+      "should create an arcjet error decision w/ empty proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(new Decision());
+
+        assert.ok(decision instanceof ArcjetErrorDecision);
+        assert.equal(decision.conclusion, "ERROR");
+      },
     );
 
-    assert.ok(
-      ArcjetDecisionFromProtocol(
-        new Decision({
-          conclusion: Conclusion.ALLOW,
-        }),
-      ) instanceof ArcjetAllowDecision,
+    await t.test(
+      "should create an arcjet allow decision w/ an allow conclusion proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(
+          new Decision({ conclusion: Conclusion.ALLOW }),
+        );
+
+        assert.ok(decision instanceof ArcjetAllowDecision);
+        assert.equal(decision.conclusion, "ALLOW");
+      },
     );
 
-    assert.ok(
-      ArcjetDecisionFromProtocol(
-        new Decision({
-          conclusion: Conclusion.DENY,
-        }),
-      ) instanceof ArcjetDenyDecision,
+    await t.test(
+      "should create an arcjet deny decision w/ a deny conclusion proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(
+          new Decision({ conclusion: Conclusion.DENY }),
+        );
+
+        assert.ok(decision instanceof ArcjetDenyDecision);
+        assert.equal(decision.conclusion, "DENY");
+      },
     );
 
-    assert.ok(
-      ArcjetDecisionFromProtocol(
-        new Decision({
-          conclusion: Conclusion.CHALLENGE,
-        }),
-      ) instanceof ArcjetChallengeDecision,
+    await t.test(
+      "should create an arcjet challenge decision w/ a challenge conclusion proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(
+          new Decision({ conclusion: Conclusion.CHALLENGE }),
+        );
+
+        assert.ok(decision instanceof ArcjetChallengeDecision);
+        assert.equal(decision.conclusion, "CHALLENGE");
+      },
     );
 
-    assert.ok(
-      ArcjetDecisionFromProtocol(
-        new Decision({
-          conclusion: Conclusion.ERROR,
-        }),
-      ) instanceof ArcjetErrorDecision,
+    await t.test(
+      "should create an arcjet error decision w/ an error conclusion proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(
+          new Decision({ conclusion: Conclusion.ERROR }),
+        );
+
+        assert.ok(decision instanceof ArcjetErrorDecision);
+        assert.equal(decision.conclusion, "ERROR");
+      },
     );
 
-    assert.ok(
-      ArcjetDecisionFromProtocol({
-        // @ts-expect-error
-        conclusion: "NOT_VALID",
-      }) instanceof ArcjetErrorDecision,
+    await t.test(
+      "should create an arcjet error decision w/ an invalid conclusion proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol({
+          // @ts-expect-error: test runtime behavior.
+          conclusion: "NOT_VALID",
+        });
+
+        assert.ok(decision instanceof ArcjetErrorDecision);
+        assert.equal(decision.conclusion, "ERROR");
+      },
     );
 
-    assert.ok(
-      ArcjetDecisionFromProtocol(
-        // @ts-expect-error
-        "NOT_VALID",
-      ) instanceof ArcjetErrorDecision,
+    await t.test(
+      "should create an arcjet error decision w/ an invalid proto",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(
+          // @ts-expect-error: test runtime behavior.
+          "NOT_VALID",
+        );
+
+        assert.ok(decision instanceof ArcjetErrorDecision);
+        assert.equal(decision.conclusion, "ERROR");
+      },
     );
   });
 
-  await t.test("ArcjetRuleToProtocol", () => {
-    const unknownRule: ArcjetRule = {
-      version: 0,
-      type: "UNKNOWN",
-      mode: "DRY_RUN",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-
-    assert.deepEqual(ArcjetRuleToProtocol(unknownRule), new Rule({}));
-
-    const tokenBucketRule: ArcjetTokenBucketRateLimitRule<{}> = {
-      version: 0,
-      type: "RATE_LIMIT",
-      mode: "DRY_RUN",
-      priority: 1,
-      algorithm: "TOKEN_BUCKET",
-      refillRate: 1,
-      interval: 1,
-      capacity: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-
-    assert.deepEqual(
-      ArcjetRuleToProtocol(tokenBucketRule),
-      new Rule({
-        rule: {
-          case: "rateLimit",
-          value: {
-            mode: Mode.DRY_RUN,
-            algorithm: RateLimitAlgorithm.TOKEN_BUCKET,
-            refillRate: 1,
-            interval: 1,
-            capacity: 1,
-          },
+  await t.test("ArcjetRuleToProtocol", async (t) => {
+    await t.test("should create an anonymous protocol rule", () => {
+      const rule = ArcjetRuleToProtocol({
+        mode: "DRY_RUN",
+        priority: 1,
+        protect() {
+          assert.fail("should not call `protect`");
         },
-      }),
-    );
-
-    const fixedWindowRule: ArcjetFixedWindowRateLimitRule<{}> = {
-      version: 0,
-      type: "RATE_LIMIT",
-      mode: "DRY_RUN",
-      priority: 1,
-      algorithm: "FIXED_WINDOW",
-      max: 1,
-      window: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-
-    assert.deepEqual(
-      ArcjetRuleToProtocol(fixedWindowRule),
-      new Rule({
-        rule: {
-          case: "rateLimit",
-          value: {
-            mode: Mode.DRY_RUN,
-            algorithm: RateLimitAlgorithm.FIXED_WINDOW,
-            max: 1,
-            windowInSeconds: 1,
-          },
+        type: "UNKNOWN",
+        validate() {
+          assert.fail("should not call `validate`");
         },
-      }),
-    );
+        version: 0,
+      });
 
-    const slidingWindowRule: ArcjetSlidingWindowRateLimitRule<{}> = {
-      version: 0,
-      type: "RATE_LIMIT",
-      mode: "DRY_RUN",
-      priority: 1,
-      algorithm: "SLIDING_WINDOW",
-      max: 1,
-      interval: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
+      assert.deepEqual(rule, new Rule({}));
+      assert.equal(rule.rule.case, undefined);
+    });
 
-    assert.deepEqual(
-      ArcjetRuleToProtocol(slidingWindowRule),
-      new Rule({
-        rule: {
-          case: "rateLimit",
-          value: {
-            mode: Mode.DRY_RUN,
-            algorithm: RateLimitAlgorithm.SLIDING_WINDOW,
-            max: 1,
-            interval: 1,
+    await t.test(
+      "should create a rate limit protocol rule (token bucket)",
+      () => {
+        const rule = ArcjetRuleToProtocol({
+          algorithm: "TOKEN_BUCKET",
+          capacity: 1,
+          interval: 1,
+          mode: "DRY_RUN",
+          priority: 1,
+          protect() {
+            assert.fail("should not call `protect`");
           },
-        },
-      }),
-    );
+          refillRate: 1,
+          type: "RATE_LIMIT",
+          validate() {
+            assert.fail("should not call `validate`");
+          },
+          version: 0,
+          // TODO: `{}` is confusing in TypeScript, and likely points to a bug.
+        } as ArcjetTokenBucketRateLimitRule<{}>);
 
-    const emailRule: ArcjetEmailRule<{ email: string }> = {
-      version: 0,
-      type: "EMAIL",
-      mode: "DRY_RUN",
-      priority: 1,
-      allow: [],
-      deny: ["INVALID"],
-      requireTopLevelDomain: false,
-      allowDomainLiteral: false,
-      validate() {
-        throw new Error("should not be called");
+        assert.deepEqual(
+          rule,
+          new Rule({
+            rule: {
+              case: "rateLimit",
+              value: {
+                algorithm: RateLimitAlgorithm.TOKEN_BUCKET,
+                capacity: 1,
+                interval: 1,
+                mode: Mode.DRY_RUN,
+                refillRate: 1,
+              },
+            },
+          }),
+        );
+        assert.equal(rule.rule.case, "rateLimit");
       },
-      protect() {
-        throw new Error("should not be called");
-      },
-    };
-
-    assert.deepEqual(
-      ArcjetRuleToProtocol(emailRule),
-      new Rule({
-        rule: {
-          case: "email",
-          value: {
-            mode: Mode.DRY_RUN,
-            allow: [],
-            deny: [EmailType.INVALID],
-          },
-        },
-      }),
     );
 
-    const botRule: ArcjetBotRule<{}> = {
-      version: 0,
-      type: "BOT",
-      mode: "DRY_RUN",
-      priority: 1,
-      allow: [],
-      deny: [],
-      validate() {
-        throw new Error("should not be called");
-      },
-      protect() {
-        throw new Error("should not be called");
-      },
-    };
-    assert.deepEqual(
-      ArcjetRuleToProtocol(botRule),
-      new Rule({
-        rule: {
-          case: "botV2",
-          value: {
-            mode: Mode.DRY_RUN,
-            allow: [],
-            deny: [],
+    await t.test(
+      "should create a rate limit protocol rule (fixed window)",
+      () => {
+        const rule = ArcjetRuleToProtocol({
+          algorithm: "FIXED_WINDOW",
+          max: 1,
+          mode: "DRY_RUN",
+          type: "RATE_LIMIT",
+          validate() {
+            assert.fail("should not call `validate`");
           },
-        },
-      }),
+          version: 0,
+          priority: 1,
+          protect() {
+            assert.fail("should not call `protect`");
+          },
+          window: 1,
+          // TODO: `{}` is confusing in TypeScript, and likely points to a bug.
+        } as ArcjetFixedWindowRateLimitRule<{}>);
+
+        assert.deepEqual(
+          rule,
+          new Rule({
+            rule: {
+              case: "rateLimit",
+              value: {
+                algorithm: RateLimitAlgorithm.FIXED_WINDOW,
+                max: 1,
+                mode: Mode.DRY_RUN,
+                windowInSeconds: 1,
+              },
+            },
+          }),
+        );
+        assert.equal(rule.rule.case, "rateLimit");
+      },
     );
 
-    const shieldRule: ArcjetShieldRule<{}> = {
-      version: 0,
-      type: "SHIELD",
-      mode: "DRY_RUN",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-    assert.deepEqual(
-      ArcjetRuleToProtocol(shieldRule),
-      new Rule({
-        rule: {
-          case: "shield",
-          value: {
-            mode: Mode.DRY_RUN,
-            autoAdded: false,
+    await t.test(
+      "should create a rate limit protocol rule (sliding window)",
+      () => {
+        const rule = ArcjetRuleToProtocol({
+          algorithm: "SLIDING_WINDOW",
+          interval: 1,
+          max: 1,
+          mode: "DRY_RUN",
+          priority: 1,
+          protect() {
+            assert.fail("should not call `protect`");
           },
-        },
-      }),
+          type: "RATE_LIMIT",
+          validate() {
+            assert.fail("should not call `validate`");
+          },
+          version: 0,
+          // TODO: `{}` is confusing in TypeScript, and likely points to a bug.
+        } as ArcjetSlidingWindowRateLimitRule<{}>);
+
+        assert.deepEqual(
+          rule,
+          new Rule({
+            rule: {
+              case: "rateLimit",
+              value: {
+                algorithm: RateLimitAlgorithm.SLIDING_WINDOW,
+                interval: 1,
+                max: 1,
+                mode: Mode.DRY_RUN,
+              },
+            },
+          }),
+        );
+        assert.equal(rule.rule.case, "rateLimit");
+      },
     );
 
-    const sensitiveInfoRule: ArcjetSensitiveInfoRule<{}> = {
-      version: 0,
-      type: "SENSITIVE_INFO",
-      mode: "DRY_RUN",
-      priority: 1,
-      allow: [],
-      deny: [],
-      validate() {
-        throw new Error("should not be called");
-      },
-      protect() {
-        throw new Error("should not be called");
-      },
-    };
-
-    assert.deepEqual(
-      ArcjetRuleToProtocol(sensitiveInfoRule),
-      new Rule({
-        rule: {
-          case: "sensitiveInfo",
-          value: {
-            mode: Mode.DRY_RUN,
-            allow: [],
-            deny: [],
-          },
+    await t.test("should create an email protocol rule", () => {
+      const rule = ArcjetRuleToProtocol({
+        allowDomainLiteral: false,
+        allow: [],
+        deny: ["INVALID"],
+        mode: "DRY_RUN",
+        priority: 1,
+        protect() {
+          assert.fail("should not call `protect`");
         },
-      }),
-    );
+        requireTopLevelDomain: false,
+        type: "EMAIL",
+        validate() {
+          assert.fail("should not call `validate`");
+        },
+        version: 0,
+      } as ArcjetEmailRule<{ email: string }>);
+
+      assert.deepEqual(
+        rule,
+        new Rule({
+          rule: {
+            case: "email",
+            value: { allow: [], deny: [EmailType.INVALID], mode: Mode.DRY_RUN },
+          },
+        }),
+      );
+      assert.equal(rule.rule.case, "email");
+    });
+
+    await t.test("should create a bot protocol rule", () => {
+      const rule = ArcjetRuleToProtocol({
+        allow: [],
+        deny: [],
+        mode: "DRY_RUN",
+        type: "BOT",
+        priority: 1,
+        protect() {
+          assert.fail("should not call `protect`");
+        },
+        validate() {
+          assert.fail("should not call `validate`");
+        },
+        version: 0,
+        // TODO: `{}` is confusing in TypeScript, and likely points to a bug.
+      } as ArcjetBotRule<{}>);
+
+      assert.deepEqual(
+        rule,
+        new Rule({
+          rule: {
+            case: "botV2",
+            value: { allow: [], mode: Mode.DRY_RUN, deny: [] },
+          },
+        }),
+      );
+      assert.equal(rule.rule.case, "botV2");
+    });
+
+    await t.test("should create a shield protocol rule", () => {
+      const rule = ArcjetRuleToProtocol({
+        mode: "DRY_RUN",
+        priority: 1,
+        protect() {
+          assert.fail("should not call `protect`");
+        },
+        type: "SHIELD",
+        validate() {
+          assert.fail("should not call `validate`");
+        },
+        version: 0,
+        // TODO: `{}` is confusing in TypeScript, and likely points to a bug.
+      } as ArcjetShieldRule<{}>);
+
+      assert.deepEqual(
+        rule,
+        new Rule({
+          rule: {
+            case: "shield",
+            value: { autoAdded: false, mode: Mode.DRY_RUN },
+          },
+        }),
+      );
+      assert.equal(rule.rule.case, "shield");
+    });
+
+    await t.test("should create a sensitive info protocol rule", () => {
+      const rule = ArcjetRuleToProtocol({
+        allow: [],
+        deny: [],
+        mode: "DRY_RUN",
+        priority: 1,
+        protect() {
+          assert.fail("should not call `protect`");
+        },
+        type: "SENSITIVE_INFO",
+        validate() {
+          assert.fail("should not call `validate`");
+        },
+        version: 0,
+        // TODO: `{}` is confusing in TypeScript, and likely points to a bug.
+      } as ArcjetSensitiveInfoRule<{}>);
+
+      assert.deepEqual(
+        rule,
+        new Rule({
+          rule: {
+            case: "sensitiveInfo",
+            value: { allow: [], deny: [], mode: Mode.DRY_RUN },
+          },
+        }),
+      );
+      assert.equal(rule.rule.case, "sensitiveInfo");
+    });
   });
 });

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -765,18 +765,18 @@ test("convert", async (t) => {
           ArcjetRuleResultToProtocol(
             new ArcjetRuleResult({
               conclusion: "ALLOW",
-              fingerprint: "test-fingerprint",
+              fingerprint: "fingerprint",
               reason: new ArcjetReason(),
-              ruleId: "test-rule-id",
+              ruleId: "rule-id",
               state: "RUN",
               ttl: 0,
             }),
           ),
           new RuleResult({
             conclusion: Conclusion.ALLOW,
-            fingerprint: "test-fingerprint",
+            fingerprint: "fingerprint",
             reason: new Reason(),
-            ruleId: "test-rule-id",
+            ruleId: "rule-id",
             state: RuleState.RUN,
           }),
         );
@@ -792,17 +792,17 @@ test("convert", async (t) => {
           ArcjetRuleResultFromProtocol(
             new RuleResult({
               conclusion: Conclusion.ALLOW,
-              fingerprint: "test-fingerprint",
+              fingerprint: "fingerprint",
               reason: new Reason(),
-              ruleId: "test-rule-id",
+              ruleId: "rule-id",
               state: RuleState.RUN,
             }),
           ),
           new ArcjetRuleResult({
             conclusion: "ALLOW",
-            fingerprint: "test-fingerprint",
+            fingerprint: "fingerprint",
             reason: new ArcjetReason(),
-            ruleId: "test-rule-id",
+            ruleId: "rule-id",
             state: "RUN",
             ttl: 0,
           }),
@@ -815,9 +815,9 @@ test("convert", async (t) => {
     await t.test("ArcjetRuleResult#isDenied", () => {
       const result = new ArcjetRuleResult({
         conclusion: "ALLOW",
-        fingerprint: "test-fingerprint",
+        fingerprint: "fingerprint",
         reason: new ArcjetReason(),
-        ruleId: "test-rule-id",
+        ruleId: "rule-id",
         state: "RUN",
         ttl: 0,
       });

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, mock, test } from "node:test";
+import { mock, test } from "node:test";
 import {
   ArcjetModeToProtocol,
   ArcjetEmailTypeToProtocol,
@@ -57,8 +57,8 @@ import {
 } from "../index.js";
 import { Timestamp } from "@bufbuild/protobuf";
 
-describe("convert", () => {
-  test("ArcjetModeToProtocol", () => {
+test("convert", async (t) => {
+  await t.test("ArcjetModeToProtocol", () => {
     assert.equal(ArcjetModeToProtocol("LIVE"), Mode.LIVE);
     assert.equal(ArcjetModeToProtocol("DRY_RUN"), Mode.DRY_RUN);
     assert.equal(
@@ -70,7 +70,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetEmailTypeToProtocol", () => {
+  await t.test("ArcjetEmailTypeToProtocol", () => {
     assert.equal(ArcjetEmailTypeToProtocol("DISPOSABLE"), EmailType.DISPOSABLE);
     assert.equal(ArcjetEmailTypeToProtocol("FREE"), EmailType.FREE);
     assert.equal(ArcjetEmailTypeToProtocol("INVALID"), EmailType.INVALID);
@@ -91,7 +91,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetEmailTypeFromProtocol", () => {
+  await t.test("ArcjetEmailTypeFromProtocol", () => {
     assert.equal(
       ArcjetEmailTypeFromProtocol(EmailType.DISPOSABLE),
       "DISPOSABLE",
@@ -117,7 +117,7 @@ describe("convert", () => {
     }, /Invalid EmailType/);
   });
 
-  test("ArcjetStackToProtocol", () => {
+  await t.test("ArcjetStackToProtocol", () => {
     assert.equal(ArcjetStackToProtocol("NODEJS"), SDKStack.SDK_STACK_NODEJS);
     assert.equal(ArcjetStackToProtocol("NEXTJS"), SDKStack.SDK_STACK_NEXTJS);
     assert.equal(ArcjetStackToProtocol("BUN"), SDKStack.SDK_STACK_BUN);
@@ -138,7 +138,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetRuleStateToProtocol", () => {
+  await t.test("ArcjetRuleStateToProtocol", () => {
     assert.equal(ArcjetRuleStateToProtocol("CACHED"), RuleState.CACHED);
     assert.equal(ArcjetRuleStateToProtocol("DRY_RUN"), RuleState.DRY_RUN);
     assert.equal(ArcjetRuleStateToProtocol("NOT_RUN"), RuleState.NOT_RUN);
@@ -152,7 +152,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetRuleStateFromProtocol", () => {
+  await t.test("ArcjetRuleStateFromProtocol", () => {
     assert.equal(ArcjetRuleStateFromProtocol(RuleState.CACHED), "CACHED");
     assert.equal(ArcjetRuleStateFromProtocol(RuleState.DRY_RUN), "DRY_RUN");
     assert.equal(ArcjetRuleStateFromProtocol(RuleState.NOT_RUN), "NOT_RUN");
@@ -168,7 +168,7 @@ describe("convert", () => {
     }, /Invalid RuleState/);
   });
 
-  test("ArcjetConclusionToProtocol", () => {
+  await t.test("ArcjetConclusionToProtocol", () => {
     assert.equal(ArcjetConclusionToProtocol("ALLOW"), Conclusion.ALLOW);
     assert.equal(ArcjetConclusionToProtocol("CHALLENGE"), Conclusion.CHALLENGE);
     assert.equal(ArcjetConclusionToProtocol("DENY"), Conclusion.DENY);
@@ -182,7 +182,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetConclusionFromProtocol", () => {
+  await t.test("ArcjetConclusionFromProtocol", () => {
     assert.equal(ArcjetConclusionFromProtocol(Conclusion.ALLOW), "ALLOW");
     assert.equal(
       ArcjetConclusionFromProtocol(Conclusion.CHALLENGE),
@@ -201,7 +201,7 @@ describe("convert", () => {
     }, /Invalid Conclusion/);
   });
 
-  test("ArcjetReasonFromProtocol", () => {
+  await t.test("ArcjetReasonFromProtocol", () => {
     assert.ok(ArcjetReasonFromProtocol() instanceof ArcjetReason);
     assert.ok(
       ArcjetReasonFromProtocol(
@@ -339,7 +339,7 @@ describe("convert", () => {
     }, /Invalid Reason/);
   });
 
-  test("ArcjetReasonToProtocol", () => {
+  await t.test("ArcjetReasonToProtocol", () => {
     assert.ok(ArcjetReasonToProtocol(new ArcjetReason()) instanceof Reason);
     assert.deepEqual(
       ArcjetReasonToProtocol(
@@ -490,7 +490,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetRuleResultToProtocol", () => {
+  await t.test("ArcjetRuleResultToProtocol", () => {
     assert.deepEqual(
       ArcjetRuleResultToProtocol(
         new ArcjetRuleResult({
@@ -512,7 +512,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetRuleResultFromProtocol", () => {
+  await t.test("ArcjetRuleResultFromProtocol", () => {
     assert.deepEqual(
       ArcjetRuleResultFromProtocol(
         new RuleResult({
@@ -534,7 +534,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetDecisionToProtocol", () => {
+  await t.test("ArcjetDecisionToProtocol", () => {
     assert.deepEqual(
       ArcjetDecisionToProtocol(
         new ArcjetAllowDecision({
@@ -554,7 +554,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetDecisionFromProtocol", () => {
+  await t.test("ArcjetDecisionFromProtocol", () => {
     assert.ok(ArcjetDecisionFromProtocol() instanceof ArcjetErrorDecision);
     assert.ok(
       ArcjetDecisionFromProtocol(new Decision()) instanceof ArcjetErrorDecision,
@@ -607,7 +607,7 @@ describe("convert", () => {
     );
   });
 
-  test("ArcjetRuleToProtocol", () => {
+  await t.test("ArcjetRuleToProtocol", () => {
     const unknownRule: ArcjetRule = {
       version: 0,
       type: "UNKNOWN",

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -472,6 +472,17 @@ test("convert", async (t) => {
       assert.equal(reason.type, "SENSITIVE_INFO");
     });
 
+    await t.test("should create an error reason on a bot reason", () => {
+      const reason = ArcjetReasonFromProtocol(
+        new Reason({
+          reason: { case: "bot", value: {} },
+        }),
+      );
+
+      assert.ok(reason instanceof ArcjetErrorReason);
+      assert.equal(reason.type, "ERROR");
+    });
+
     await t.test("should create a shield reason", () => {
       const reason = ArcjetReasonFromProtocol(
         new Reason({

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -21,6 +21,7 @@ import {
   Conclusion,
   Decision,
   EmailType,
+  IpDetails,
   Mode,
   RateLimitAlgorithm,
   Reason,
@@ -871,6 +872,67 @@ test("convert", async (t) => {
 
         assert.ok(decision instanceof ArcjetErrorDecision);
         assert.equal(decision.conclusion, "ERROR");
+      },
+    );
+
+    await t.test(
+      "should create an arcjet decision w/ an IP detail proto (full)",
+      () => {
+        const latitude = 40.7127;
+        const longitude = 74.0059;
+        const decision = ArcjetDecisionFromProtocol(
+          new Decision({
+            ipDetails: new IpDetails({
+              asnCountry: "a",
+              asnDomain: "b",
+              asnName: "c",
+              asnType: "d",
+              asn: "e",
+              city: "f",
+              continentName: "g",
+              continent: "h",
+              countryName: "i",
+              country: "j",
+              latitude,
+              longitude,
+              postalCode: "k",
+              region: "l",
+              service: "m",
+              timezone: "America/New_York",
+            }),
+          }),
+        );
+
+        assert.deepEqual(JSON.parse(JSON.stringify(decision.ip)), {
+          accuracyRadius: 0,
+          asnCountry: "a",
+          asnDomain: "b",
+          asnName: "c",
+          asnType: "d",
+          asn: "e",
+          city: "f",
+          continentName: "g",
+          continent: "h",
+          countryName: "i",
+          country: "j",
+          latitude,
+          longitude,
+          postalCode: "k",
+          region: "l",
+          service: "m",
+          timezone: "America/New_York",
+        });
+      },
+    );
+
+    await t.test(
+      "should create an arcjet decision w/ an IP detail proto (empty)",
+      () => {
+        const decision = ArcjetDecisionFromProtocol(
+          new Decision({ ipDetails: new IpDetails() }),
+        );
+
+        assert.deepEqual(JSON.parse(JSON.stringify(decision.ip)), {});
       },
     );
   });


### PR DESCRIPTION
In GH-4415 and GH-4472 I noticed that in particular the protocol tests could use some cleaning up.
I had some extra time to work on a big PR due to holiday in US.

Test cases were often testing equality of big objects as a sort of “fixture” testing. This made it difficult to see *what* was different between test cases. And, if a property would be added to such objects, all tests would need changing.

After cleaning (the first 2 commits), I went through the uncovered lines and added tests cases for them.

Importantly, there are barely any changes to `protocol/*` and `index.ts`. Only because their behavior was not tested, and not allowed by the types, I removed the dead code.

***Please open the files that GH collapses, and tip: go through commits one by one***