### PR TITLE
refactor: rename use of deprecated method name

### DIFF
--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -1,5 +1,5 @@
 import type { Transport } from "@connectrpc/connect";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient as createConnectRpcClient } from "@connectrpc/connect";
 import {
   ArcjetDecisionFromProtocol,
   ArcjetDecisionToProtocol,
@@ -68,7 +68,7 @@ export function createClient(options: ClientOptions): Client {
 
   const sdkStack = ArcjetStackToProtocol(options.sdkStack);
 
-  const client = createPromiseClient(DecideService, transport);
+  const client = createConnectRpcClient(DecideService, transport);
 
   return Object.freeze({
     async decide(


### PR DESCRIPTION
My IDE showed that `createPromiseClient` was deprecated. The JSDocs of it suggest replacing it with `createClient`. That name is already used by us here. Hence a clearer name.