### PR TITLE
perf: remove latency logging except on `debug`

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -176,10 +176,13 @@ class Performance {
     this.log = logger;
   }
 
-  // TODO(#2020): We should no-op this if loglevel is not `debug` to do less work
   measure(label: string) {
+    if (this.log.level !== "debug") {
+      return Function.prototype;
+    }
+
     const start = performance.now();
-    return () => {
+    return (): undefined => {
       const end = performance.now();
       const diff = end - start;
       this.log.debug("LATENCY %s: %sms", label, diff.toFixed(3));

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -85,8 +85,7 @@ class TestCache {
 
 function mockLogger() {
   return {
-    time: mock.fn(),
-    timeEnd: mock.fn(),
+    level: "error" as const,
     debug: mock.fn(),
     info: mock.fn(),
     warn: mock.fn(),

--- a/logger/index.ts
+++ b/logger/index.ts
@@ -64,7 +64,9 @@ function getOutput(obj: unknown, msg: unknown, args: unknown[]) {
 }
 
 export class Logger {
-  #logLevel: number;
+  #logLevel: 0 | 1 | 2 | 3;
+
+  level: "debug" | "error" | "info" | "warn";
 
   constructor(opts: LoggerOptions) {
     if (typeof opts.level !== "string") {
@@ -88,6 +90,8 @@ export class Logger {
         throw new Error(`Unknown log level: ${opts.level}`);
       }
     }
+
+    this.level = opts.level;
   }
 
   debug(msg: string, ...args: unknown[]): void;

--- a/logger/index.ts
+++ b/logger/index.ts
@@ -66,7 +66,18 @@ function getOutput(obj: unknown, msg: unknown, args: unknown[]) {
 export class Logger {
   #logLevel: 0 | 1 | 2 | 3;
 
-  level: string;
+  get level(): string {
+    switch (this.#logLevel) {
+      case 0:
+        return "debug";
+      case 1:
+        return "info";
+      case 2:
+        return "info";
+      case 3:
+        return "error";
+    }
+  }
 
   constructor(opts: LoggerOptions) {
     if (typeof opts.level !== "string") {
@@ -90,8 +101,6 @@ export class Logger {
         throw new Error(`Unknown log level: ${opts.level}`);
       }
     }
-
-    this.level = opts.level;
   }
 
   debug(msg: string, ...args: unknown[]): void;

--- a/logger/index.ts
+++ b/logger/index.ts
@@ -66,7 +66,7 @@ function getOutput(obj: unknown, msg: unknown, args: unknown[]) {
 export class Logger {
   #logLevel: 0 | 1 | 2 | 3;
 
-  level: "debug" | "error" | "info" | "warn";
+  level: string;
 
   constructor(opts: LoggerOptions) {
     if (typeof opts.level !== "string") {

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -883,7 +883,7 @@ export interface ArcjetShieldRule<Props extends {}> extends ArcjetRule<Props> {
 }
 
 export interface ArcjetLogger {
-  level: "debug" | "error" | "info" | "warn";
+  level: string;
   // Pino-compatible logging functions are required.
   debug(msg: string, ...args: unknown[]): void;
   debug(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -883,6 +883,7 @@ export interface ArcjetShieldRule<Props extends {}> extends ArcjetRule<Props> {
 }
 
 export interface ArcjetLogger {
+  level: "debug" | "error" | "info" | "warn";
   // Pino-compatible logging functions are required.
   debug(msg: string, ...args: unknown[]): void;
   debug(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -53,7 +53,8 @@ class TestCache implements Cache {
 /**
  * Arcjet logger that does nothing.
  */
-const exampleLogger: ArcjetLogger = {
+const exampleLogger = {
+  level: "error" as const,
   debug() {},
   error() {},
   info() {},


### PR DESCRIPTION
Closes GH-2020.

Pino allows any string as a level. Here we are more strict.