### PR TITLE
fix(bun): Rely on connect-web to communicate from Bun runtime

### DIFF
--- a/transport/bun.ts
+++ b/transport/bun.ts
@@ -1,9 +1,8 @@
-import { createConnectTransport } from "@connectrpc/connect-node";
+// Bun doesn't properly support connect-node so we need to use connect-web
+import { createConnectTransport } from "@connectrpc/connect-web";
 
 export function createTransport(baseUrl: string) {
   return createConnectTransport({
     baseUrl,
-    // Bun doesn't properly support HTTP/2 so we need to force HTTP/1.1
-    httpVersion: "1.1",
   });
 }


### PR DESCRIPTION
Closes #4522 

It seems that Bun broke protobuf messages when submitted through their `node:https` compatibility layer. I've switched the dependency to use `@connectrpc/connect-web` which just uses fetch behind the scenes. I don't remember why this used the compatibility layer previously, but I tested this on Bun v1.1.45, v1.2.10, and v1.2.17.