### PR TITLE
test: clean core tests

### DIFF
--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -1842,7 +1842,7 @@ test("shield", async (t) => {
   });
 
   await t.test("should set `mode: DRY_RUN` w/o `mode`", async () => {
-    // TODO(@wooorm-arcjet): if `{}` is allowed than so should ``? But types do not allow it?
+    // TODO(#4560): if `{}` is allowed then so could/should ``.
     const [rule] = shield({});
     assert.equal(rule.mode, "DRY_RUN");
   });

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2466,7 +2466,7 @@ test("SDK", async (t) => {
       const testRule: ArcjetRule<{ abc: number }> = {
         version: 0,
         mode: "LIVE",
-        type: "test",
+        type: "example",
         priority: 10000,
         validate() {},
         protect() {
@@ -2533,7 +2533,7 @@ test("SDK", async (t) => {
     const testRule: ArcjetRule<{ abc: number }> = {
       version: 0,
       mode: "LIVE",
-      type: "test",
+      type: "example",
       priority: 10000,
       validate() {},
       protect() {
@@ -2570,70 +2570,7 @@ test("SDK", async (t) => {
     }, /Log is required/);
   });
 
-  await t.test("should support local-only rules", async () => {
-    let calls = 0;
-
-    const aj = arcjet({
-      ...exampleOptions,
-      rules: [
-        [
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_ALLOWED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 0);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 1);
-              calls++;
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 0,
-                state: "RUN",
-                conclusion: "ALLOW",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-        ],
-        [
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_DENIED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 2);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 3);
-              calls++;
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 5000,
-                state: "RUN",
-                conclusion: "DENY",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-        ],
-      ],
-    });
-
-    const decision = await aj.protect(exampleContext, exampleDetails);
-    assert.equal(decision.conclusion, "DENY");
-    assert.equal(calls, 4);
-  });
-
-  await t.test("should support only remote rules", async () => {
-    // TODO(@wooorm-arcjet): how is this testing remote rules?
+  await t.test("should support a rule that allows", async () => {
     let calls = 0;
 
     const client = {
@@ -2658,7 +2595,7 @@ test("SDK", async (t) => {
           {
             version: 0,
             mode: "LIVE",
-            type: "TEST_RULE_REMOTE",
+            type: "example-allow",
             priority: 1,
             validate() {
               assert.equal(calls, 0);
@@ -2687,144 +2624,8 @@ test("SDK", async (t) => {
     assert.equal(calls, 3);
   });
 
-  await t.test("should create an SDK with local and remote rules", async () => {
-    // TODO(@wooorm-arcjet): how is this testing remote rules?
-    let calls = 0;
-
-    const aj = arcjet({
-      ...exampleOptions,
-      rules: [
-        [
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_ALLOWED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 0);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 1);
-              calls++;
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 0,
-                state: "RUN",
-                conclusion: "ALLOW",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_DENIED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 2);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 3);
-              calls++;
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 5000,
-                state: "RUN",
-                conclusion: "DENY",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_REMOTE",
-            priority: 1,
-            validate() {
-              assert.fail();
-            },
-            protect() {
-              assert.fail();
-            },
-          } as const,
-        ],
-      ],
-    });
-
-    const decision = await aj.protect(exampleContext, exampleDetails);
-    assert.equal(decision.conclusion, "DENY");
-    assert.equal(calls, 4);
-  });
-
-  await t.test("should call rules until one yields `DENY` (1)", async () => {
-    // TODO(@wooorm-arcjet): the above things were testing that too.
-    let calls = 0;
-
-    const aj = arcjet({
-      ...exampleOptions,
-      rules: [
-        [
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_ALLOWED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 0);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 1);
-              calls++;
-
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 0,
-                state: "RUN",
-                conclusion: "ALLOW",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_DENIED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 2);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 3);
-              calls++;
-
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 5000,
-                state: "RUN",
-                conclusion: "DENY",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-        ],
-      ],
-    });
-
-    const decision = await aj.protect(exampleContext, exampleDetails);
-    assert.equal(decision.conclusion, "DENY");
-    assert.equal(calls, 4);
-  });
-
   await t.test(
-    "should see a rule w/o result from `validate` as an `ALLOW`",
+    "should support a rule that allows and one that denies",
     async () => {
       let calls = 0;
 
@@ -2835,15 +2636,152 @@ test("SDK", async (t) => {
             {
               version: 0,
               mode: "LIVE",
-              type: "TEST_RULE_LOCAL_INCORRECT",
+              type: "example-allow",
               priority: 1,
               validate() {
                 assert.equal(calls, 0);
                 calls++;
               },
-              // @ts-expect-error: test runtime behavior of no return value.
               async protect() {
                 assert.equal(calls, 1);
+                calls++;
+                return new ArcjetRuleResult({
+                  ruleId: "test-rule-id",
+                  fingerprint: "test-fingerprint",
+                  ttl: 0,
+                  state: "RUN",
+                  conclusion: "ALLOW",
+                  reason: new ArcjetTestReason(),
+                });
+              },
+            } as const,
+          ],
+          [
+            {
+              version: 0,
+              mode: "LIVE",
+              type: "example-deny",
+              priority: 1,
+              validate() {
+                assert.equal(calls, 2);
+                calls++;
+              },
+              async protect() {
+                assert.equal(calls, 3);
+                calls++;
+                return new ArcjetRuleResult({
+                  ruleId: "test-rule-id",
+                  fingerprint: "test-fingerprint",
+                  ttl: 5000,
+                  state: "RUN",
+                  conclusion: "DENY",
+                  reason: new ArcjetTestReason(),
+                });
+              },
+            } as const,
+          ],
+        ],
+      });
+
+      const decision = await aj.protect(exampleContext, exampleDetails);
+      assert.equal(decision.conclusion, "DENY");
+      assert.equal(calls, 4);
+    },
+  );
+
+  await t.test(
+    "should support a rule that allows, one that denies, and one that is never called",
+    async () => {
+      let calls = 0;
+
+      const aj = arcjet({
+        ...exampleOptions,
+        rules: [
+          [
+            {
+              version: 0,
+              mode: "LIVE",
+              type: "example-allow",
+              priority: 1,
+              validate() {
+                assert.equal(calls, 0);
+                calls++;
+              },
+              async protect() {
+                assert.equal(calls, 1);
+                calls++;
+                return new ArcjetRuleResult({
+                  ruleId: "test-rule-id",
+                  fingerprint: "test-fingerprint",
+                  ttl: 0,
+                  state: "RUN",
+                  conclusion: "ALLOW",
+                  reason: new ArcjetTestReason(),
+                });
+              },
+            } as const,
+            {
+              version: 0,
+              mode: "LIVE",
+              type: "example-deny",
+              priority: 1,
+              validate() {
+                assert.equal(calls, 2);
+                calls++;
+              },
+              async protect() {
+                assert.equal(calls, 3);
+                calls++;
+                return new ArcjetRuleResult({
+                  ruleId: "test-rule-id",
+                  fingerprint: "test-fingerprint",
+                  ttl: 5000,
+                  state: "RUN",
+                  conclusion: "DENY",
+                  reason: new ArcjetTestReason(),
+                });
+              },
+            } as const,
+            {
+              version: 0,
+              mode: "LIVE",
+              type: "example-never-called",
+              priority: 1,
+              validate() {
+                assert.fail();
+              },
+              protect() {
+                assert.fail();
+              },
+            } as const,
+          ],
+        ],
+      });
+
+      const decision = await aj.protect(exampleContext, exampleDetails);
+      assert.equal(decision.conclusion, "DENY");
+      assert.equal(calls, 4);
+    },
+  );
+
+  await t.test(
+    "should see a rule w/o result from `protect` as an `ALLOW`",
+    async () => {
+      let calls = 0;
+
+      const aj = arcjet({
+        ...exampleOptions,
+        rules: [
+          [
+            {
+              version: 0,
+              mode: "LIVE",
+              type: "example-no-result",
+              priority: 1,
+              validate() {},
+              // @ts-expect-error: test runtime behavior of no return value.
+              async protect() {
+                assert.equal(calls, 0);
                 calls++;
               },
             } as const,
@@ -2852,10 +2790,8 @@ test("SDK", async (t) => {
       });
 
       const decision = await aj.protect(exampleContext, exampleDetails);
-      // TODO(@wooorm-arcjet): I don’t think this comment is correct.
-      // ALLOW because the remote rule was called and it returned ALLOW.
       assert.equal(decision.conclusion, "ALLOW");
-      assert.equal(calls, 2);
+      assert.equal(calls, 1);
     },
   );
 
@@ -2870,7 +2806,7 @@ test("SDK", async (t) => {
           {
             version: 0,
             mode: "LIVE",
-            type: "TEST_RULE_LOCAL_INCORRECT",
+            type: "example-no-validate",
             priority: 1,
             protect() {
               assert.fail();
@@ -2879,7 +2815,7 @@ test("SDK", async (t) => {
           {
             version: 0,
             mode: "LIVE",
-            type: "TEST_RULE_LOCAL_DENIED",
+            type: "example-deny",
             priority: 1,
             validate() {
               assert.equal(calls, 0);
@@ -2926,7 +2862,7 @@ test("SDK", async (t) => {
           {
             version: 0,
             mode: "LIVE",
-            type: "TEST_RULE_LOCAL_INCORRECT",
+            type: "example-no-protect",
             priority: 1,
             validate() {
               assert.equal(calls, 0);
@@ -2936,7 +2872,7 @@ test("SDK", async (t) => {
           {
             version: 0,
             mode: "LIVE",
-            type: "TEST_RULE_LOCAL_DENIED",
+            type: "example-deny",
             priority: 1,
             validate() {
               assert.equal(calls, 1);
@@ -2995,11 +2931,11 @@ test("SDK", async (t) => {
   await t.test("should allow `10` rules", async () => {
     const rules = Array.from(
       { length: 10 },
-      (): Array<ArcjetRule> => [
+      (index): Array<ArcjetRule> => [
         {
           version: 0,
           mode: "LIVE",
-          type: "TEST_RULE_MULTIPLE",
+          type: "example-" + index,
           priority: 1,
           validate() {},
           protect() {
@@ -3019,11 +2955,11 @@ test("SDK", async (t) => {
   await t.test("should conclude error on `11` rules", async () => {
     const rules = Array.from(
       { length: 11 },
-      (): Array<ArcjetRule> => [
+      (index): Array<ArcjetRule> => [
         {
           version: 0,
           mode: "LIVE",
-          type: "TEST_RULE_MULTIPLE",
+          type: "example-" + index,
           priority: 1,
           validate() {},
           protect() {
@@ -3033,62 +2969,220 @@ test("SDK", async (t) => {
       ],
     );
 
+    await t.test(
+      "should call `decide` if all rules decide `ALLOW`",
+      async () => {
+        let parameters: unknown;
+
+        const client: Client = {
+          async decide(a, b, ...rest) {
+            parameters = rest;
+            return new ArcjetErrorDecision({
+              ttl: 0,
+              reason: new ArcjetErrorReason("reason"),
+              results: [],
+            });
+          },
+          report() {
+            assert.fail();
+          },
+        };
+
+        const rule: ArcjetRule = {
+          version: 0,
+          mode: "LIVE",
+          type: "example-allow",
+          priority: 1,
+          validate() {},
+          async protect() {
+            return new ArcjetRuleResult({
+              ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetTestReason(),
+            });
+          },
+        };
+
+        await arcjet({
+          ...exampleOptions,
+          client,
+          rules: [[rule]],
+        }).protect(exampleContext, exampleDetails);
+
+        assert.deepEqual(parameters, [[rule]]);
+      },
+    );
+
+    await t.test(
+      "should not call `decide` if a rule decides `DENY",
+      async () => {
+        // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
+        // or even as an `as const` object.
+        const rule: ArcjetRule = {
+          version: 0,
+          mode: "LIVE",
+          type: "example-deny",
+          priority: 1,
+          validate() {},
+          async protect() {
+            return new ArcjetRuleResult({
+              ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
+              ttl: 5000,
+              state: "RUN",
+              conclusion: "DENY",
+              reason: new ArcjetTestReason(),
+            });
+          },
+        };
+
+        let called = 0;
+
+        await arcjet({
+          ...exampleOptions,
+          client: {
+            async decide() {
+              // Should not be called.
+              called++;
+              assert.fail();
+            },
+            report() {
+              assert.equal(called, 0);
+              called++;
+            },
+          },
+          rules: [[rule]],
+        }).protect(exampleContext, exampleDetails);
+
+        assert.equal(called, 1);
+      },
+    );
+
+    await t.test("should call `decide` w/o rules", async () => {
+      let calls = 0;
+
+      const client = {
+        async decide() {
+          assert.equal(calls, 0);
+          calls++;
+          return new ArcjetAllowDecision({
+            ttl: 0,
+            reason: new ArcjetTestReason(),
+            results: [],
+          });
+        },
+        report() {
+          assert.fail();
+        },
+      };
+
+      await arcjet({ ...exampleOptions, client }).protect(
+        exampleContext,
+        exampleDetails,
+      );
+      assert.equal(calls, 1);
+    });
+
+    await t.test(
+      "should not call `report` if all rules decide `ALLOW`",
+      async () => {
+        let parameters: unknown;
+
+        const client: Client = {
+          async decide(a, b, ...rest) {
+            parameters = rest;
+            return new ArcjetErrorDecision({
+              ttl: 0,
+              reason: new ArcjetErrorReason("reason"),
+              results: [],
+            });
+          },
+          report() {
+            assert.fail();
+          },
+        };
+
+        const rule: ArcjetRule = {
+          version: 0,
+          mode: "LIVE",
+          type: "example-allow",
+          priority: 1,
+          validate() {},
+          async protect() {
+            return new ArcjetRuleResult({
+              ruleId: "test-rule-id",
+              fingerprint: "test-fingerprint",
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetTestReason(),
+            });
+          },
+        };
+
+        await arcjet({ ...exampleOptions, client, rules: [[rule]] }).protect(
+          exampleContext,
+          exampleDetails,
+        );
+
+        assert.deepEqual(parameters, [[rule]]);
+      },
+    );
+
+    await t.test("should call `report` if a rule decides `DENY`", async () => {
+      let calls = 0;
+
+      const client: Client = {
+        async decide() {
+          return new ArcjetErrorDecision({
+            ttl: 0,
+            reason: new ArcjetErrorReason("reason"),
+            results: [],
+          });
+        },
+        report(context, request, decision, rules) {
+          assert.equal(calls, 0);
+          calls++;
+          assert.equal(decision.conclusion, "DENY");
+          assert.equal(rules.length, 1);
+        },
+      };
+
+      const rule: ArcjetRule = {
+        version: 0,
+        mode: "LIVE",
+        type: "example-deny",
+        priority: 1,
+        validate() {},
+        async protect() {
+          return new ArcjetRuleResult({
+            ruleId: "test-rule-id",
+            fingerprint: "test-fingerprint",
+            ttl: 5000,
+            state: "RUN",
+            conclusion: "DENY",
+            reason: new ArcjetTestReason(),
+          });
+        },
+      };
+
+      await arcjet({
+        ...exampleOptions,
+        client,
+        rules: [[rule]],
+      }).protect(exampleContext, exampleDetails);
+
+      assert.equal(calls, 1);
+    });
+
     const decision = await arcjet({ ...exampleOptions, rules }).protect(
       exampleContext,
       exampleDetails,
     );
     assert.equal(decision.conclusion, "ERROR");
-  });
-
-  await t.test("should call rules until one yields `DENY` (2)", async () => {
-    // TODO(@wooorm-arcjet): seems the same as “should call rules until one yields `DENY`” above.
-    let calls = 0;
-
-    const aj = arcjet({
-      ...exampleOptions,
-      rules: [
-        [
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_DENIED",
-            priority: 1,
-            validate() {
-              assert.equal(calls, 0);
-              calls++;
-            },
-            async protect() {
-              assert.equal(calls, 1);
-              calls++;
-              return new ArcjetRuleResult({
-                ruleId: "test-rule-id",
-                fingerprint: "test-fingerprint",
-                ttl: 5000,
-                state: "RUN",
-                conclusion: "DENY",
-                reason: new ArcjetTestReason(),
-              });
-            },
-          } as const,
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_LOCAL_ALLOWED",
-            priority: 1,
-            validate() {
-              assert.fail();
-            },
-            async protect() {
-              assert.fail();
-            },
-          } as const,
-        ],
-      ],
-    });
-
-    const decision = await aj.protect(exampleContext, exampleDetails);
-    assert.equal(decision.conclusion, "DENY");
-    assert.equal(calls, 2);
   });
 
   await t.test("should support headers as a regular object", async () => {
@@ -3156,6 +3250,40 @@ test("SDK", async (t) => {
     },
   );
 
+  await t.test(
+    "should generate fingerprints w/ header characteristics",
+    async () => {
+      let fingerprint: unknown;
+      const client: Client = {
+        async decide(context) {
+          fingerprint = context.fingerprint;
+          return new ArcjetAllowDecision({
+            ttl: 0,
+            reason: new ArcjetTestReason(),
+            results: [],
+          });
+        },
+        report() {
+          assert.fail();
+        },
+      };
+
+      await arcjet({
+        ...exampleOptions,
+        characteristics: ['http.request.headers["abcxyz"]'],
+        client,
+      }).protect(
+        { getBody: exampleContext.getBody },
+        { ...exampleDetails, headers: new Headers([["abcxyz", "test1234"]]) },
+      );
+
+      assert.equal(
+        fingerprint,
+        "fp::2::6f3a3854134fe3d20fe56387bdcb594f18b182683424757b88da75e8f13b92bd",
+      );
+    },
+  );
+
   await t.test("should support extra details", async () => {
     let calls = 0;
 
@@ -3197,209 +3325,6 @@ test("SDK", async (t) => {
     assert.equal(calls, 1);
   });
 
-  await t.test("should call `decide` if all rules decide `ALLOW`", async () => {
-    let parameters: unknown;
-
-    const client: Client = {
-      async decide(a, b, ...rest) {
-        parameters = rest;
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("reason"),
-          results: [],
-        });
-      },
-      report() {
-        assert.fail();
-      },
-    };
-
-    const rule: ArcjetRule = {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_ALLOWED",
-      priority: 1,
-      validate() {},
-      async protect() {
-        return new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 0,
-          state: "RUN",
-          conclusion: "ALLOW",
-          reason: new ArcjetTestReason(),
-        });
-      },
-    };
-
-    await arcjet({
-      ...exampleOptions,
-      client,
-      rules: [[rule]],
-    }).protect(exampleContext, exampleDetails);
-
-    assert.deepEqual(parameters, [[rule]]);
-  });
-
-  await t.test("should not call `decide` if a rule decides `DENY", async () => {
-    // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
-    // or even as an `as const` object.
-    const rule: ArcjetRule = {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_DENIED",
-      priority: 1,
-      validate() {},
-      async protect() {
-        return new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 5000,
-          state: "RUN",
-          conclusion: "DENY",
-          reason: new ArcjetTestReason(),
-        });
-      },
-    };
-
-    let called = 0;
-
-    await arcjet({
-      ...exampleOptions,
-      client: {
-        async decide() {
-          // Should not be called.
-          called++;
-          assert.fail();
-        },
-        report() {
-          assert.equal(called, 0);
-          called++;
-        },
-      },
-      rules: [[rule]],
-    }).protect(exampleContext, exampleDetails);
-
-    assert.equal(called, 1);
-  });
-
-  await t.test("should call `decide` w/o rules", async () => {
-    let calls = 0;
-
-    const client = {
-      async decide() {
-        assert.equal(calls, 0);
-        calls++;
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      },
-      report() {
-        assert.fail();
-      },
-    };
-
-    await arcjet({ ...exampleOptions, client }).protect(
-      exampleContext,
-      exampleDetails,
-    );
-    assert.equal(calls, 1);
-  });
-
-  await t.test(
-    "should not call `report` if all rules decide `ALLOW`",
-    async () => {
-      let parameters: unknown;
-
-      const client: Client = {
-        async decide(a, b, ...rest) {
-          parameters = rest;
-          return new ArcjetErrorDecision({
-            ttl: 0,
-            reason: new ArcjetErrorReason("reason"),
-            results: [],
-          });
-        },
-        report() {
-          assert.fail();
-        },
-      };
-
-      const rule: ArcjetRule = {
-        version: 0,
-        mode: "LIVE",
-        type: "TEST_RULE_LOCAL_ALLOWED",
-        priority: 1,
-        validate() {},
-        async protect() {
-          return new ArcjetRuleResult({
-            ruleId: "test-rule-id",
-            fingerprint: "test-fingerprint",
-            ttl: 0,
-            state: "RUN",
-            conclusion: "ALLOW",
-            reason: new ArcjetTestReason(),
-          });
-        },
-      };
-
-      await arcjet({ ...exampleOptions, client, rules: [[rule]] }).protect(
-        exampleContext,
-        exampleDetails,
-      );
-
-      assert.deepEqual(parameters, [[rule]]);
-    },
-  );
-
-  await t.test("should call `report` if a rule decides `DENY`", async () => {
-    let calls = 0;
-
-    const client: Client = {
-      async decide() {
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("reason"),
-          results: [],
-        });
-      },
-      report(context, request, decision, rules) {
-        assert.equal(calls, 0);
-        calls++;
-        assert.equal(decision.conclusion, "DENY");
-        assert.equal(rules.length, 1);
-      },
-    };
-
-    const rule: ArcjetRule = {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_DENIED",
-      priority: 1,
-      validate() {},
-      async protect() {
-        return new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 5000,
-          state: "RUN",
-          conclusion: "DENY",
-          reason: new ArcjetTestReason(),
-        });
-      },
-    };
-
-    await arcjet({
-      ...exampleOptions,
-      client,
-      rules: [[rule]],
-    }).protect(exampleContext, exampleDetails);
-
-    assert.equal(calls, 1);
-  });
-
   await t.test(
     "should detect `@vercel/request-context` and provide it to `report`",
     async () => {
@@ -3422,7 +3347,7 @@ test("SDK", async (t) => {
       const rule: ArcjetRule = {
         version: 0,
         mode: "LIVE",
-        type: "TEST_RULE_LOCAL_DENIED",
+        type: "example-deny",
         priority: 1,
         validate() {},
         async protect() {
@@ -3497,7 +3422,7 @@ test("SDK", async (t) => {
       const rule: ArcjetRule = {
         version: 0,
         mode: "LIVE",
-        type: "TEST_RULE_LOCAL_CACHED",
+        type: "example-cache",
         priority: 1,
         validate() {},
         async protect(context) {
@@ -3545,45 +3470,12 @@ test("SDK", async (t) => {
     },
   );
 
-  await t.test("should not throw if unknown rule type is passed", () => {
-    // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
-    // or even as an `as const` object.
-    const rule: ArcjetRule = {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_INVALID_TYPE",
-      priority: 1,
-      validate() {},
-      protect() {
-        assert.fail();
-      },
-    } as const;
-
-    // TODO(@wooorm-arcjet): where would that `Unknown Rule type` be thrown?
-    // What is this really testing: the above object is an `ArcjetRule`,
-    // what would be invalid about it?
-
-    // Specifically should not throw `Unknown Rule type`.
-    arcjet({
-      ...exampleOptions,
-      client: {
-        decide() {
-          assert.fail();
-        },
-        report() {
-          assert.fail();
-        },
-      },
-      rules: [[rule]],
-    });
-  });
-
-  await t.test("should not call `report` if local rules throw", async () => {
+  await t.test("should not call `report` if `validate` throws", async () => {
     let calls = 0;
     const rule: ArcjetRule = {
       version: 0,
       mode: "LIVE",
-      type: "TEST_RULE_LOCAL_THROW",
+      type: "example-throw",
       priority: 1,
       validate() {
         assert.equal(calls, 0);
@@ -3622,15 +3514,14 @@ test("SDK", async (t) => {
     assert.equal(calls, 2);
   });
 
-  await t.test("should handle `string` being thrown by a rule", async () => {
+  await t.test("should handle `validate` throwing `string`", async () => {
     let calls = 0;
-
     // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
     // or even as an `as const` object.
     const rule = {
       version: 0,
       mode: "LIVE",
-      type: "TEST_RULE_LOCAL_THROW_STRING",
+      type: "example-throw-string",
       priority: 1,
       validate() {},
       async protect() {
@@ -3650,7 +3541,7 @@ test("SDK", async (t) => {
           calls++;
           assert.deepEqual(parameters, [
             "Failure running rule: %s due to %s",
-            "TEST_RULE_LOCAL_THROW_STRING",
+            "example-throw-string",
             "Local rule protect failed",
           ]);
         },
@@ -3660,7 +3551,7 @@ test("SDK", async (t) => {
     assert.equal(calls, 2);
   });
 
-  await t.test("should handle `null` being thrown by a rule", async () => {
+  await t.test("should handle `validate` throwing `null`", async () => {
     let calls = 0;
 
     // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
@@ -3668,7 +3559,7 @@ test("SDK", async (t) => {
     const rule = {
       version: 0,
       mode: "LIVE",
-      type: "TEST_RULE_LOCAL_THROW_NULL",
+      type: "example-throw-null",
       priority: 1,
       validate() {},
       async protect() {
@@ -3688,7 +3579,7 @@ test("SDK", async (t) => {
           calls++;
           assert.deepEqual(parameters, [
             "Failure running rule: %s due to %s",
-            "TEST_RULE_LOCAL_THROW_NULL",
+            "example-throw-null",
             "Unknown problem",
           ]);
         },
@@ -3723,7 +3614,7 @@ test("SDK", async (t) => {
             {
               version: 0,
               mode: "DRY_RUN",
-              type: "TEST_RULE_LOCAL_DRY_RUN",
+              type: "example-deny-dry-run",
               priority: 1,
               validate() {},
               async protect() {
@@ -3752,43 +3643,6 @@ test("SDK", async (t) => {
     },
   );
 
-  await t.test("should process a remote rule", async () => {
-    // TODO(@wooorm-arcjet): what is this really testing? What is remote about it?
-    let calls = 0;
-    const rule = {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_REMOTE",
-      priority: 1,
-      validate() {},
-      protect() {
-        assert.fail();
-      },
-    } as const;
-    const client: Client = {
-      async decide(context, details, rules) {
-        assert.equal(calls, 0);
-        calls++;
-        assert.deepEqual(rules, [rule]);
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      },
-      report() {
-        assert.fail();
-      },
-    };
-    const decision = await arcjet({
-      ...exampleOptions,
-      client,
-      rules: [[rule]],
-    }).protect(exampleContext, exampleDetails);
-    assert.equal(decision.isErrored(), false);
-    assert.equal(calls, 1);
-  });
-
   await t.test("should pass a `key` through to `decide`", async () => {
     let calls = 0;
     const client: Client = {
@@ -3809,20 +3663,7 @@ test("SDK", async (t) => {
     const decision = await arcjet({
       ...exampleOptions,
       client,
-      rules: [
-        [
-          {
-            version: 0,
-            mode: "LIVE",
-            type: "TEST_RULE_REMOTE",
-            priority: 1,
-            validate() {},
-            protect() {
-              assert.fail();
-            },
-          } as const,
-        ],
-      ],
+      rules: [],
     }).protect({ ...exampleContext, key: "overridden-key" }, exampleDetails);
     assert.equal(decision.isErrored(), false);
     assert.equal(calls, 1);
@@ -3850,38 +3691,4 @@ test("SDK", async (t) => {
     assert.equal(decision.isErrored(), true);
     assert.equal(calls, 2);
   });
-
-  await t.test(
-    "should generate fingerprints w/ header characteristics",
-    async () => {
-      let fingerprint: unknown;
-      const client: Client = {
-        async decide(context) {
-          fingerprint = context.fingerprint;
-          return new ArcjetAllowDecision({
-            ttl: 0,
-            reason: new ArcjetTestReason(),
-            results: [],
-          });
-        },
-        report() {
-          assert.fail();
-        },
-      };
-
-      await arcjet({
-        ...exampleOptions,
-        characteristics: ['http.request.headers["abcxyz"]'],
-        client,
-      }).protect(
-        { getBody: exampleContext.getBody },
-        { ...exampleDetails, headers: new Headers([["abcxyz", "test1234"]]) },
-      );
-
-      assert.equal(
-        fingerprint,
-        "fp::2::6f3a3854134fe3d20fe56387bdcb594f18b182683424757b88da75e8f13b92bd",
-      );
-    },
-  );
 });

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2175,7 +2175,7 @@ test("sensitiveInfo", async (t) => {
   );
 
   await t.test("should support a custom `detect` function", async () => {
-    function detect(tokens: string[]): Array<"CUSTOM" | undefined> {
+    function detect(tokens: string[]) {
       return tokens.map((token) => {
         if (token === "bad") {
           return "CUSTOM";

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -3017,7 +3017,7 @@ test("SDK", async (t) => {
     );
 
     await t.test(
-      "should not call `decide` if a rule decides `DENY",
+      "should call `report` instead of `decide` if a rule decides `DENY`",
       async () => {
         // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
         // or even as an `as const` object.

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -3315,8 +3315,6 @@ test("SDK", async (t) => {
     const aj = arcjet({ ...exampleOptions, client });
     await aj.protect(exampleContext, {
       ...details,
-      // To do: should we drop values of `null`, `undefined`, etc?
-      // Now they result in `<unsupported value>`.
       "extra-number": 123,
       "extra-false": false,
       "extra-true": true,

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2208,7 +2208,7 @@ test("sensitiveInfo", async (t) => {
   });
 
   await t.test(
-    "should fail id custom `detect` returns non-string",
+    "should fail if custom `detect` returns non-string",
     async () => {
       function detect(tokens: string[]) {
         return tokens.map((token) => {

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2429,9 +2429,9 @@ test("SDK", async (t) => {
     async () => {
       let parameters: unknown;
 
-      const client = {
-        async decide() {
-          parameters = [...arguments].slice(2);
+      const client: Client = {
+        async decide(a, b, ...rest) {
+          parameters = rest;
           return new ArcjetAllowDecision({
             ttl: 0,
             reason: new ArcjetTestReason(),
@@ -2496,9 +2496,9 @@ test("SDK", async (t) => {
   await t.test("should not add rules to the parent client", async () => {
     let parameters: unknown;
 
-    const client = {
-      async decide() {
-        parameters = [...arguments].slice(2);
+    const client: Client = {
+      async decide(a, b, ...rest) {
+        parameters = rest;
         return new ArcjetAllowDecision({
           ttl: 0,
           reason: new ArcjetTestReason(),
@@ -3200,9 +3200,9 @@ test("SDK", async (t) => {
   await t.test("should call `decide` if all rules decide `ALLOW`", async () => {
     let parameters: unknown;
 
-    const client = {
-      async decide() {
-        parameters = [...arguments].slice(2);
+    const client: Client = {
+      async decide(a, b, ...rest) {
+        parameters = rest;
         return new ArcjetErrorDecision({
           ttl: 0,
           reason: new ArcjetErrorReason("reason"),
@@ -3313,9 +3313,9 @@ test("SDK", async (t) => {
     async () => {
       let parameters: unknown;
 
-      const client = {
-        async decide() {
-          parameters = [...arguments].slice(2);
+      const client: Client = {
+        async decide(a, b, ...rest) {
+          parameters = rest;
           return new ArcjetErrorDecision({
             ttl: 0,
             reason: new ArcjetErrorReason("reason"),
@@ -3645,17 +3645,14 @@ test("SDK", async (t) => {
       rules: [[rule]],
       log: {
         ...exampleLogger,
-        error() {
+        error(...parameters) {
           assert.equal(calls, 1);
           calls++;
-          assert.deepEqual(
-            [...arguments],
-            [
-              "Failure running rule: %s due to %s",
-              "TEST_RULE_LOCAL_THROW_STRING",
-              "Local rule protect failed",
-            ],
-          );
+          assert.deepEqual(parameters, [
+            "Failure running rule: %s due to %s",
+            "TEST_RULE_LOCAL_THROW_STRING",
+            "Local rule protect failed",
+          ]);
         },
       },
     }).protect(exampleContext, exampleDetails);
@@ -3686,17 +3683,14 @@ test("SDK", async (t) => {
       rules: [[rule]],
       log: {
         ...exampleLogger,
-        error() {
+        error(...parameters) {
           assert.equal(calls, 1);
           calls++;
-          assert.deepEqual(
-            [...arguments],
-            [
-              "Failure running rule: %s due to %s",
-              "TEST_RULE_LOCAL_THROW_NULL",
-              "Unknown problem",
-            ],
-          );
+          assert.deepEqual(parameters, [
+            "Failure running rule: %s due to %s",
+            "TEST_RULE_LOCAL_THROW_NULL",
+            "Unknown problem",
+          ]);
         },
       },
     }).protect(exampleContext, exampleDetails);

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -3087,7 +3087,7 @@ test("SDK", async (t) => {
     });
 
     await t.test(
-      "should not call `report` if all rules decide `ALLOW`",
+      "should call `decide` instead of `report` if all rules decide `ALLOW`",
       async () => {
         let parameters: unknown;
 

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -3324,7 +3324,7 @@ test("SDK", async (t) => {
   });
 
   await t.test(
-    "should detect `@vercel/request-context` and provide it to `report`",
+    "should detect `@vercel/request-context` and provide `waitUntil` to `report`",
     async () => {
       let calls = 0;
       const client: Client = {

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
-import { describe, test, mock } from "node:test";
-
-import type { ArcjetRule, Primitive, Arcjet } from "../index.js";
+import test from "node:test";
+import type { Client } from "@arcjet/protocol/client.js";
 import arcjet, {
+  type ArcjetContext,
+  type ArcjetLogger,
+  type ArcjetOptions,
+  type ArcjetRule,
+  type Arcjet,
+  type Primitive,
   detectBot,
   validateEmail,
   protectSignup,
@@ -62,516 +67,428 @@ type Props<P extends Primitive> =
 type RuleProps<P extends Primitive, E> = IsEqual<Props<P>, E>;
 type SDKProps<SDK, E> = IsEqual<SDK extends Arcjet<infer P> ? P : never, E>;
 
-// In Node 18,
-// instances of `Headers` contain symbols that may be different depending on if
-// they have been iterated or not,
-// here we turn them into a regular object for easier comparison.
-// The rest of the request is just plain json.
-function requestAsJson(value: unknown): object {
-  assert(value);
-  assert(typeof value === "object");
-  assert("headers" in value);
-  assert(value.headers);
-  assert(value.headers instanceof Headers);
-  return { ...value, headers: Object.fromEntries(value.headers) };
-}
-
 class ArcjetTestReason extends ArcjetReason {}
 
-class TestCache {
-  get = mock.fn<() => Promise<[unknown, number]>>(async () => [undefined, 0]);
-  set = mock.fn();
+/**
+ * Empty cache.
+ */
+class ExampleCache {
+  async get(): Promise<[unknown, number]> {
+    return [undefined, 0];
+  }
+  set() {}
 }
 
-function mockLogger() {
-  return {
-    time: mock.fn(),
-    timeEnd: mock.fn(),
-    debug: mock.fn(),
-    info: mock.fn(),
-    warn: mock.fn(),
-    error: mock.fn(),
-  };
-}
+/**
+ * Arcjet logger that does nothing.
+ */
+const exampleLogger: ArcjetLogger = {
+  debug() {},
+  error() {},
+  info() {},
+  warn() {},
+};
 
-describe("ArcjetDecision", () => {
-  test("will default the `id` property if not specified", () => {
-    const decision = new ArcjetAllowDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
+/**
+ * Empty values for context.
+ */
+const exampleContext: ArcjetContext = {
+  characteristics: [],
+  cache: new ExampleCache(),
+  fingerprint: "b",
+  getBody() {
+    return Promise.resolve(undefined);
+  },
+  key: "a",
+  log: exampleLogger,
+  runtime: "c",
+};
+
+/**
+ * Empty values for options.
+ */
+const exampleOptions: ArcjetOptions<Array<Array<ArcjetRule>>, []> = {
+  client: {
+    async decide() {
+      return new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+    },
+    report() {},
+  },
+  key: "a",
+  log: exampleLogger,
+  rules: [],
+};
+
+/**
+ * Empty values for details.
+ */
+const exampleDetails = {
+  cookies: "",
+  extra: {},
+  headers: new Headers(),
+  host: "example.com",
+  ip: "172.100.1.1",
+  method: "GET",
+  path: "/",
+  protocol: "http",
+  query: "",
+};
+
+test("ArcjetDecision", async (t) => {
+  await t.test("id", async (t) => {
+    await t.test("should generate an `id` field if not given", () => {
+      const decision = new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+
+      assert.match(decision.id, /^lreq_/);
     });
-    assert.match(decision.id, /^lreq_/);
+
+    await t.test("should support a given `id` field", () => {
+      const decision = new ArcjetAllowDecision({
+        id: "abc_123",
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.id, "abc_123");
+    });
   });
 
-  test("the `id` property if to be specified to the constructor", () => {
-    const decision = new ArcjetAllowDecision({
-      id: "abc_123",
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
+  await t.test("error reason", async (t) => {
+    // TODO: This test doesn't make sense anymore
+    await t.test("should support an error given to an error reason", () => {
+      const decision = new ArcjetErrorDecision({
+        ttl: 0,
+        reason: new ArcjetErrorReason(new Error("Foo bar baz")),
+        results: [],
+      });
+      assert.ok(decision.reason instanceof ArcjetErrorReason);
+      assert.equal(decision.reason.message, "Foo bar baz");
     });
-    assert.equal(decision.id, "abc_123");
+
+    // TODO: This test doesn't make sense anymore
+    await t.test("should support a string given to an error reason", () => {
+      const decision = new ArcjetErrorDecision({
+        ttl: 0,
+        reason: new ArcjetErrorReason("Boom!"),
+        results: [],
+      });
+      assert.ok(decision.reason instanceof ArcjetErrorReason);
+      assert.equal(decision.reason.message, "Boom!");
+    });
+
+    // TODO: This test doesn't make sense anymore
+    await t.test(
+      "should support an unknown value given to an error reason",
+      () => {
+        const decision = new ArcjetErrorDecision({
+          ttl: 0,
+          reason: new ArcjetErrorReason(["not", "valid", "error"]),
+          results: [],
+        });
+        assert.ok(decision.reason instanceof ArcjetErrorReason);
+        assert.equal(decision.reason.message, "Unknown error occurred");
+      },
+    );
   });
 
-  // TODO: This test doesn't make sense anymore
-  test("an ERROR decision can be constructed with an Error object", () => {
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason(new Error("Foo bar baz")),
-      results: [],
+  await t.test("isAllowed", async (t) => {
+    await t.test("should return `true` on an allow decision", () => {
+      const decision = new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isAllowed(), true);
     });
-    assert.ok(decision.reason instanceof ArcjetErrorReason);
-    assert.equal(decision.reason.message, "Foo bar baz");
+
+    await t.test("should return `true` on an error decision", () => {
+      const decision = new ArcjetErrorDecision({
+        ttl: 0,
+        reason: new ArcjetErrorReason("Something"),
+        results: [],
+      });
+      assert.equal(decision.isAllowed(), true);
+    });
+
+    await t.test("should return `false` on a deny decision", () => {
+      const decision = new ArcjetDenyDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isAllowed(), false);
+    });
   });
 
-  // TODO: This test doesn't make sense anymore
-  test("an ERROR decision can be constructed with a string message", () => {
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason("Boom!"),
-      results: [],
+  await t.test("isDenied", async (t) => {
+    await t.test("should return `false` on an allow decision", () => {
+      const decision = new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isDenied(), false);
     });
-    assert.ok(decision.reason instanceof ArcjetErrorReason);
-    assert.equal(decision.reason.message, "Boom!");
+
+    await t.test("should return `false` on an error decision", () => {
+      const decision = new ArcjetErrorDecision({
+        ttl: 0,
+        reason: new ArcjetErrorReason("Something"),
+        results: [],
+      });
+      assert.equal(decision.isDenied(), false);
+    });
+
+    await t.test("should return `true` on a deny decision", () => {
+      const decision = new ArcjetDenyDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isDenied(), true);
+    });
   });
 
-  // TODO: This test doesn't make sense anymore
-  test("use an unknown error for an ERROR decision constructed with other types", () => {
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason(["not", "valid", "error"]),
-      results: [],
+  await t.test("isChallenged", async (t) => {
+    await t.test("should return `true` on a challenge decision", () => {
+      const decision = new ArcjetChallengeDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isChallenged(), true);
     });
-    assert.ok(decision.reason instanceof ArcjetErrorReason);
-    assert.equal(decision.reason.message, "Unknown error occurred");
   });
 
-  test("`isAllowed()` returns true when type is ALLOW", () => {
-    const decision = new ArcjetAllowDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
+  await t.test("isErrored", async (t) => {
+    await t.test("should return `false` on an allow decision", () => {
+      const decision = new ArcjetAllowDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isErrored(), false);
     });
-    assert.equal(decision.isAllowed(), true);
-  });
 
-  test("`isAllowed()` returns true when type is ERROR (fail open)", () => {
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason("Something"),
-      results: [],
+    await t.test("should return `true` on an error decision", () => {
+      const decision = new ArcjetErrorDecision({
+        ttl: 0,
+        reason: new ArcjetErrorReason("Something"),
+        results: [],
+      });
+      assert.equal(decision.isErrored(), true);
     });
-    assert.equal(decision.isAllowed(), true);
-  });
 
-  test("`isAllowed()` returns false when type is DENY", () => {
-    const decision = new ArcjetDenyDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
+    await t.test("should return `false` on a deny decision", () => {
+      const decision = new ArcjetDenyDecision({
+        ttl: 0,
+        reason: new ArcjetTestReason(),
+        results: [],
+      });
+      assert.equal(decision.isErrored(), false);
     });
-    assert.equal(decision.isAllowed(), false);
-  });
-
-  test("`isDenied()` returns false when type is ALLOW", () => {
-    const decision = new ArcjetAllowDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    assert.equal(decision.isDenied(), false);
-  });
-
-  test("`isDenied()` returns false when type is ERROR (fail open)", () => {
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason("Something"),
-      results: [],
-    });
-    assert.equal(decision.isDenied(), false);
-  });
-
-  test("`isDenied()` returns true when type is DENY", () => {
-    const decision = new ArcjetDenyDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    assert.equal(decision.isDenied(), true);
-  });
-
-  test("`isChallenged()` returns true when type is CHALLENGE", () => {
-    const decision = new ArcjetChallengeDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    assert.equal(decision.isChallenged(), true);
-  });
-
-  test("`isErrored()` returns false when type is ALLOW", () => {
-    const decision = new ArcjetAllowDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    assert.equal(decision.isErrored(), false);
-  });
-
-  test("`isErrored()` returns false when type is ERROR", () => {
-    const decision = new ArcjetErrorDecision({
-      ttl: 0,
-      reason: new ArcjetErrorReason("Something"),
-      results: [],
-    });
-    assert.equal(decision.isErrored(), true);
-  });
-
-  test("`isErrored()` returns false when type is DENY", () => {
-    const decision = new ArcjetDenyDecision({
-      ttl: 0,
-      reason: new ArcjetTestReason(),
-      results: [],
-    });
-    assert.equal(decision.isErrored(), false);
-  });
-
-  test("`isRateLimit()` returns true when reason is RATE_LIMIT", () => {
-    const reason = new ArcjetRateLimitReason({
-      max: 0,
-      remaining: 0,
-      reset: 100,
-      window: 100,
-    });
-    assert.equal(reason.isRateLimit(), true);
-  });
-
-  test("`isRateLimit()` returns true when reason is not RATE_LIMIT", () => {
-    const reason = new ArcjetTestReason();
-    assert.equal(reason.isRateLimit(), false);
-  });
-
-  test("`isBot()` returns true when reason is BOT", () => {
-    const reason = new ArcjetBotReason({
-      allowed: [],
-      denied: [],
-      verified: false,
-      spoofed: false,
-    });
-    assert.equal(reason.isBot(), true);
-  });
-
-  test("isVerified() returns the correct value", () => {
-    const reasonTrue = new ArcjetBotReason({
-      allowed: [],
-      denied: [],
-      verified: true,
-      spoofed: false,
-    });
-    assert.equal(reasonTrue.isVerified(), true);
-    const reasonFalse = new ArcjetBotReason({
-      allowed: [],
-      denied: [],
-      verified: false,
-      spoofed: false,
-    });
-    assert.equal(reasonFalse.isVerified(), false);
-  });
-
-  test("isSpoofed() returns the correct value", () => {
-    const reasonTrue = new ArcjetBotReason({
-      allowed: [],
-      denied: [],
-      verified: false,
-      spoofed: true,
-    });
-    assert.equal(reasonTrue.isSpoofed(), true);
-    const reasonFalse = new ArcjetBotReason({
-      allowed: [],
-      denied: [],
-      verified: false,
-      spoofed: false,
-    });
-    assert.equal(reasonFalse.isSpoofed(), false);
-  });
-
-  test("`isBot()` returns false when reason is not BOT", () => {
-    const reason = new ArcjetTestReason();
-    assert.equal(reason.isBot(), false);
   });
 });
 
-describe("Primitive > detectBot", () => {
-  test("validates `mode` option if it is set", async () => {
+test("Arcjet*Reason", async (t) => {
+  await t.test("isRateLimit", async (t) => {
+    await t.test("should return `true` on a rate limit reason", () => {
+      const reason = new ArcjetRateLimitReason({
+        max: 0,
+        remaining: 0,
+        reset: 100,
+        window: 100,
+      });
+      assert.equal(reason.isRateLimit(), true);
+    });
+
+    await t.test("should return `false` on a test reason", () => {
+      const reason = new ArcjetTestReason();
+      assert.equal(reason.isRateLimit(), false);
+    });
+  });
+
+  await t.test("isBot", async (t) => {
+    await t.test("should return `true` on a bot reason", () => {
+      const reason = new ArcjetBotReason({
+        allowed: [],
+        denied: [],
+        verified: false,
+        spoofed: false,
+      });
+      assert.equal(reason.isBot(), true);
+    });
+
+    await t.test("should return `false` on a test reason", () => {
+      const reason = new ArcjetTestReason();
+      assert.equal(reason.isBot(), false);
+    });
+  });
+
+  await t.test("isVerified", async (t) => {
+    await t.test("should return `true` if passed", () => {
+      const reason = new ArcjetBotReason({
+        allowed: [],
+        denied: [],
+        verified: true,
+        spoofed: false,
+      });
+      assert.equal(reason.isVerified(), true);
+    });
+
+    await t.test("should return `false` if passed", () => {
+      const reason = new ArcjetBotReason({
+        allowed: [],
+        denied: [],
+        verified: false,
+        spoofed: false,
+      });
+      assert.equal(reason.isVerified(), false);
+    });
+  });
+
+  await t.test("isSpoofed", async (t) => {
+    await t.test("should return `true` if passed", () => {
+      const reason = new ArcjetBotReason({
+        allowed: [],
+        denied: [],
+        verified: false,
+        spoofed: true,
+      });
+      assert.equal(reason.isSpoofed(), true);
+    });
+
+    await t.test("should return `false` if passed", () => {
+      const reason = new ArcjetBotReason({
+        allowed: [],
+        denied: [],
+        verified: false,
+        spoofed: false,
+      });
+      assert.equal(reason.isSpoofed(), false);
+    });
+  });
+});
+
+test("detectBot", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       detectBot({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of unknown `mode`.
         mode: "INVALID",
         allow: [],
       });
     }, /`detectBot` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("validates `allow` option is array if set", async () => {
+  await t.test("should fail if `allow` is invalid", async () => {
     assert.throws(() => {
-      const _ = detectBot({
-        // @ts-expect-error
+      detectBot({
+        // @ts-expect-error: test runtime behavior of invalid `allow` value.
         allow: "abc",
       });
     }, /detectBot` options error: invalid type for `allow` - expected an array/);
   });
 
-  test("validates `allow` option only contains strings", async () => {
+  await t.test("should fail if items in `allow` are invalid", async () => {
     assert.throws(() => {
-      const _ = detectBot({
-        // @ts-expect-error
+      detectBot({
+        // @ts-expect-error: test runtime behavior of invalid `allow[]` value.
         allow: [/abc/],
       });
     }, /detectBot` options error: invalid type for `allow\[0]` - expected string/);
   });
 
-  test("validates `deny` option is an array if set", async () => {
+  await t.test("should fail if `deny` is invalid", async () => {
     assert.throws(() => {
-      const _ = detectBot({
-        // @ts-expect-error
+      detectBot({
+        // @ts-expect-error: test runtime behavior of invalid `deny` value.
         deny: "abc",
       });
     }, /detectBot` options error: invalid type for `deny` - expected an array/);
   });
 
-  test("validates `deny` option only contains strings", async () => {
+  await t.test("should fail if `deny` is invalid", async () => {
     assert.throws(() => {
-      const _ = detectBot({
-        // @ts-expect-error
+      detectBot({
+        // @ts-expect-error: test runtime behavior of invalid `deny[]` value.
         deny: [/abc/],
       });
     }, /detectBot` options error: invalid type for `deny\[0]` - expected string/);
   });
 
-  test("validates `allow` and `deny` options are not specified together", async () => {
+  await t.test("should fail if `allow` and `deny` are both given", async () => {
     assert.throws(() => {
-      const _ = detectBot(
-        // @ts-expect-error
-        {
-          allow: ["CURL"],
-          deny: ["GOOGLE_ADSBOT"],
-        },
+      detectBot(
+        // @ts-expect-error: test runtime behavior of invalid combination of both fields.
+        { allow: ["CURL"], deny: ["GOOGLE_ADSBOT"] },
       );
     }, /`detectBot` options error: `allow` and `deny` cannot be provided together/);
   });
 
-  test("validates either `allow` or `deny` option is specified", async () => {
+  await t.test(
+    "should fail if neither `allow` nor `deny` are given",
+    async () => {
+      assert.throws(() => {
+        detectBot(
+          // @ts-expect-error: test runtime behavior of neither `allow` nor `deny`.
+          {},
+        );
+      }, /`detectBot` options error: either `allow` or `deny` must be specified/);
+    },
+  );
+
+  await t.test("should fail when calling `validate` w/o headers", () => {
+    const [rule] = detectBot({ allow: [], mode: "LIVE" });
+
     assert.throws(() => {
-      const _ = detectBot(
-        // @ts-expect-error
-        {},
-      );
-    }, /`detectBot` options error: either `allow` or `deny` must be specified/);
+      const _ = rule.validate(exampleContext, {
+        ...exampleDetails,
+        headers: undefined,
+      });
+    }, /bot detection requires `headers` to be set/);
   });
 
-  test("throws via `validate()` if headers is undefined", () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      headers: undefined,
-    };
+  await t.test("should fail when calling `validate` w/ invalid headers", () => {
+    const [rule] = detectBot({ allow: [], mode: "LIVE" });
 
-    const [rule] = detectBot({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "BOT");
     assert.throws(() => {
-      const _ = rule.validate(context, details);
-    });
+      const _ = rule.validate(exampleContext, {
+        ...exampleDetails,
+        // @ts-expect-error: test runtime behavior of invalid `headers`.
+        headers: {},
+      });
+    }, /bot detection requires `headers` to extend `Headers`/);
   });
 
-  test("throws via `validate()` if headers does not extend Headers", () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      headers: {},
-    };
+  await t.test(
+    "should fail when calling `validate` w/o `User-Agent` header",
+    async () => {
+      const [rule] = detectBot({ allow: [], mode: "LIVE" });
 
-    const [rule] = detectBot({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "BOT");
-    assert.throws(() => {
-      const _ = rule.validate(
-        context,
-        //@ts-expect-error
-        details,
-      );
-    });
-  });
+      assert.throws(() => {
+        const _ = rule.validate(exampleContext, {
+          ...exampleDetails,
+          headers: new Headers(),
+        });
+      }, /bot detection requires user-agent header/);
+    },
+  );
 
-  test("throws via `validate()` if user-agent header is missing", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = detectBot({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "BOT");
-    assert.throws(() => {
-      const _ = rule.validate(context, details);
-    });
-  });
-
-  test("uses cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
-      {
-        conclusion: "DENY",
-        reason: new ArcjetBotReason({
-          allowed: [],
-          denied: ["CURL"],
-          verified: false,
-          spoofed: false,
-        }),
-      },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
+  await t.test("should support `mode: DRY_RUN`", async () => {
+    const [rule] = detectBot({ allow: [], mode: "DRY_RUN" });
+    const result = await rule.protect(exampleContext, {
+      ...exampleDetails,
       headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = detectBot({
-      mode: "LIVE",
-      allow: [],
     });
-    assert.equal(rule.type, "BOT");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 1);
-    assert.deepEqual(cache.get.mock.calls[0].arguments, [
-      "84d7c3e132098fafcd8076e0d70154224336f5de91e23c1e538f203e5e46735f",
-      "test-fingerprint",
-    ]);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetBotReason);
-    assert.deepEqual(result.reason.allowed, []);
-    assert.deepEqual(result.reason.denied, ["CURL"]);
-    assert.equal(result.reason.spoofed, false);
-    assert.equal(result.reason.verified, false);
-    assert.equal(result.state, "CACHED");
-    assert.equal(result.ttl, 10);
-  });
-
-  test("denies curl", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = detectBot({
-      mode: "LIVE",
-      allow: [],
-    });
-    assert.equal(rule.type, "BOT");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetBotReason);
-    assert.deepEqual(result.reason.allowed, []);
-    assert.deepEqual(result.reason.denied, ["CURL"]);
-    assert.equal(result.reason.spoofed, false);
-    assert.equal(result.reason.verified, false);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("produces a dry run result in DRY_RUN mode", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = detectBot({
-      mode: "DRY_RUN",
-      allow: [],
-    });
-    assert.equal(rule.type, "BOT");
-    const result = await rule.protect(context, details);
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetBotReason);
     assert.deepEqual(result.reason.allowed, []);
@@ -581,234 +498,238 @@ describe("Primitive > detectBot", () => {
     assert.equal(result.state, "DRY_RUN");
   });
 
-  test("only denies CURL if configured", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const curlDetails = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
+  await t.test("should deny a well-known bot w/ empty `allow`", async () => {
+    const [rule] = detectBot({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(exampleContext, {
+      ...exampleDetails,
       headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-    const googlebotDetails = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Googlebot/2.0"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = detectBot({
-      mode: "LIVE",
-      deny: ["CURL"],
     });
-    assert.equal(rule.type, "BOT");
-    const curlResult = await rule.protect(context, curlDetails);
-    assert.equal(curlResult.conclusion, "DENY");
-    assert.ok(curlResult.reason instanceof ArcjetBotReason);
-    assert.deepEqual(curlResult.reason.allowed, []);
-    assert.deepEqual(curlResult.reason.denied, ["CURL"]);
-    assert.equal(curlResult.reason.spoofed, false);
-    assert.equal(curlResult.reason.verified, false);
-    assert.equal(curlResult.state, "RUN");
-    const googlebotResults = await rule.protect(context, googlebotDetails);
-    assert.equal(googlebotResults.conclusion, "ALLOW");
-    assert.ok(googlebotResults.reason instanceof ArcjetBotReason);
-    assert.deepEqual(googlebotResults.reason.allowed, ["GOOGLE_CRAWLER"]);
-    assert.deepEqual(googlebotResults.reason.denied, []);
-    assert.equal(googlebotResults.reason.spoofed, false);
-    assert.equal(googlebotResults.reason.verified, false);
-    assert.equal(googlebotResults.state, "RUN");
-  });
-
-  test("can be configured to allow curl", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = detectBot({
-      mode: "LIVE",
-      allow: ["CURL"],
-    });
-    assert.equal(rule.type, "BOT");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "ALLOW");
+    assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetBotReason);
-    assert.deepEqual(result.reason.allowed, ["CURL"]);
-    assert.deepEqual(result.reason.denied, []);
+    assert.deepEqual(result.reason.allowed, []);
+    assert.deepEqual(result.reason.denied, ["CURL"]);
     assert.equal(result.reason.spoofed, false);
     assert.equal(result.reason.verified, false);
     assert.equal(result.state, "RUN");
   });
+
+  await t.test(
+    "should allow a well-known bot if listed in `allow`",
+    async () => {
+      const [rule] = detectBot({ allow: ["CURL"], mode: "LIVE" });
+      const result = await rule.protect(exampleContext, {
+        ...exampleDetails,
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+      });
+      assert.equal(result.conclusion, "ALLOW");
+      assert.ok(result.reason instanceof ArcjetBotReason);
+      assert.deepEqual(result.reason.allowed, ["CURL"]);
+      assert.deepEqual(result.reason.denied, []);
+      assert.equal(result.reason.spoofed, false);
+      assert.equal(result.reason.verified, false);
+      assert.equal(result.state, "RUN");
+    },
+  );
+
+  await t.test(
+    "should deny a well-known both if listed in `deny`",
+    async () => {
+      const [rule] = detectBot({ deny: ["CURL"], mode: "LIVE" });
+      const result = await rule.protect(exampleContext, {
+        ...exampleDetails,
+        headers: new Headers([["User-Agent", "curl/8.1.2"]]),
+      });
+      assert.equal(result.conclusion, "DENY");
+      assert.ok(result.reason instanceof ArcjetBotReason);
+      assert.deepEqual(result.reason.allowed, []);
+      assert.deepEqual(result.reason.denied, ["CURL"]);
+      assert.equal(result.reason.spoofed, false);
+      assert.equal(result.reason.verified, false);
+      assert.equal(result.state, "RUN");
+    },
+  );
+
+  await t.test("should use the cache", async () => {
+    let calls = 0;
+    const [rule] = detectBot({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          async get(namespace, key) {
+            calls++;
+            assert.equal(
+              namespace,
+              "84d7c3e132098fafcd8076e0d70154224336f5de91e23c1e538f203e5e46735f",
+            );
+            assert.equal(key, "b");
+            return [
+              {
+                conclusion: "DENY",
+                reason: new ArcjetBotReason({
+                  allowed: [],
+                  denied: ["CURL"],
+                  spoofed: false,
+                  verified: false,
+                }),
+              },
+              10,
+            ];
+          },
+          set() {},
+        },
+      },
+      exampleDetails,
+    );
+
+    assert.equal(calls, 1);
+    assert.equal(result.conclusion, "DENY");
+    assert.ok(result.reason instanceof ArcjetBotReason);
+    assert.deepEqual(result.reason.allowed, []);
+    assert.deepEqual(result.reason.denied, ["CURL"]);
+    assert.equal(result.reason.spoofed, false);
+    assert.equal(result.reason.verified, false);
+    assert.equal(result.state, "CACHED");
+    assert.equal(result.ttl, 10);
+  });
 });
 
-describe("Primitive > tokenBucket", () => {
-  test("validates `mode` option if it is set", async () => {
+test("tokenBucket", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       tokenBucket({
-        // @ts-expect-error
+        capacity: 1,
+        interval: 1,
+        // @ts-expect-error: test runtime behavior of `mode`.
         mode: "INVALID",
         refillRate: 1,
-        interval: 1,
-        capacity: 1,
       });
     }, /`tokenBucket` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("validates `characteristics` items are strings if it is set", async () => {
+  await t.test("should fail if `characteristics` is invalid", async () => {
     assert.throws(() => {
       tokenBucket({
-        // @ts-expect-error
-        characteristics: [/foobar/],
-        refillRate: 1,
-        interval: 1,
         capacity: 1,
-      });
-    }, /`tokenBucket` options error: invalid type for `characteristics\[0]` - expected string/);
-  });
-
-  test("validates `characteristics` option is an array if set", async () => {
-    assert.throws(() => {
-      tokenBucket({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of `characteristics`.
         characteristics: 12345,
-        refillRate: 1,
         interval: 1,
-        capacity: 1,
+        refillRate: 1,
       });
     }, /`tokenBucket` options error: invalid type for `characteristics` - expected an array/);
   });
 
-  test("validates `refillRate` option is required", async () => {
+  await t.test(
+    "should fail if items in `characteristics` are invalid",
+    async () => {
+      assert.throws(() => {
+        tokenBucket({
+          capacity: 1,
+          // @ts-expect-error: test runtime behavior of `characteristics[]`.
+          characteristics: [/foobar/],
+          interval: 1,
+          refillRate: 1,
+        });
+      }, /`tokenBucket` options error: invalid type for `characteristics\[0]` - expected string/);
+    },
+  );
+
+  await t.test("should fail if `refillRate` is missing", async () => {
     assert.throws(() => {
       tokenBucket(
-        // @ts-expect-error
-        {
-          interval: 1,
-          capacity: 1,
-        },
+        // @ts-expect-error: test runtime behavior of `options`.
+        { capacity: 1, interval: 1 },
       );
     }, /`tokenBucket` options error: `refillRate` is required/);
   });
 
-  test("validates `refillRate` option is a number", async () => {
+  await t.test("should fail if `refillRate` is invalid", async () => {
     assert.throws(() => {
       tokenBucket({
-        // @ts-expect-error
-        refillRate: "abc",
-        interval: 1,
         capacity: 1,
+        interval: 1,
+        // @ts-expect-error: test runtime behavior of invalid `refillRate`.
+        refillRate: "abc",
       });
     }, /`tokenBucket` options error: invalid type for `refillRate` - expected number/);
   });
 
-  test("validates `interval` option is required", async () => {
+  await t.test("should fail if `interval` is missing", async () => {
     assert.throws(() => {
       tokenBucket(
-        // @ts-expect-error
-        {
-          refillRate: 1,
-          capacity: 1,
-        },
+        // @ts-expect-error: test runtime behavior of missing `interval`.
+        { capacity: 1, refillRate: 1 },
       );
     }, /`tokenBucket` options error: `interval` is required/);
   });
 
-  test("validates `interval` option is a number or string", async () => {
+  await t.test("should fail if `interval` is invalid", async () => {
     assert.throws(() => {
       tokenBucket({
-        refillRate: 1,
-        // @ts-expect-error
-        interval: /foobar/,
         capacity: 1,
+        // @ts-expect-error: test runtime behavior of invalid `interval`.
+        interval: /foobar/,
+        refillRate: 1,
       });
     }, /`tokenBucket` options error: invalid type for `interval` - expected one of string, number/);
   });
 
-  test("validates `capacity` option is required", async () => {
+  await t.test("should fail if `capacity` is missing", async () => {
     assert.throws(() => {
       tokenBucket(
-        // @ts-expect-error
-        {
-          refillRate: 1,
-          interval: 1,
-        },
+        // @ts-expect-error: test runtime behavior of missing `capacity`.
+        { interval: 1, refillRate: 1 },
       );
     }, /`tokenBucket` options error: `capacity` is required/);
   });
 
-  test("validates `capacity` option is a number", async () => {
+  await t.test("should fail if `capacity` is invalid", async () => {
     assert.throws(() => {
       tokenBucket({
-        refillRate: 1,
-        interval: 1,
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `capacity`.
         capacity: "abc",
+        interval: 1,
+        refillRate: 1,
       });
     }, /`tokenBucket` options error: invalid type for `capacity` - expected number/);
   });
 
-  test("sets mode as `LIVE` if specified", async () => {
+  await t.test("should set `mode: LIVE` if passed", async () => {
     const [rule] = tokenBucket({
-      mode: "LIVE",
-      characteristics: ["ip.src"],
-      refillRate: 1,
-      interval: 1,
       capacity: 1,
+      characteristics: ["ip.src"],
+      interval: 1,
+      mode: "LIVE",
+      refillRate: 1,
     });
-    assert.equal(rule.type, "RATE_LIMIT");
     assert.equal(rule.mode, "LIVE");
   });
 
-  test("can specify interval as a string duration", async () => {
-    const options = {
-      refillRate: 60,
-      interval: "60s",
-      capacity: 120,
-    };
+  await t.test(
+    "should support `string` duration notation for `interval`",
+    async () => {
+      const [rule] = tokenBucket({
+        capacity: 120,
+        interval: "60s",
+        refillRate: 60,
+      });
 
-    const rules = tokenBucket(options);
-    assert.equal(rules.length, 1);
-    const rule = rules[0];
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.refillRate, 60);
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.interval, 60);
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.capacity, 120);
+    },
+  );
+
+  await t.test("should support `number`s for `interval`", async () => {
+    const [rule] = tokenBucket({
+      capacity: 120,
+      interval: 60,
+      refillRate: 60,
+    });
+
     assert.equal(rule.type, "RATE_LIMIT");
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
     assert.equal(rule.refillRate, 60);
@@ -818,145 +739,115 @@ describe("Primitive > tokenBucket", () => {
     assert.equal(rule.capacity, 120);
   });
 
-  test("can specify interval as an integer duration", async () => {
-    const options = {
-      refillRate: 60,
-      interval: 60,
-      capacity: 120,
-    };
-
-    const rules = tokenBucket(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].refillRate, 60);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].interval, 60);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].capacity, 120);
-  });
-
-  test("can specify user-defined characteristics which are reflected in required props", async () => {
-    const rules = tokenBucket({
-      characteristics: ["userId"],
-      refillRate: 60,
-      interval: 60,
-      capacity: 120,
-    });
-    type Test = Assert<
-      RuleProps<
-        typeof rules,
-        { requested: number; userId: string | number | boolean }
-      >
-    >;
-  });
-
-  test("well-known characteristics don't affect the required props", async () => {
-    const rules = tokenBucket({
-      characteristics: [
-        "ip.src",
-        "http.host",
-        "http.method",
-        "http.request.uri.path",
-        `http.request.headers["abc"]`,
-        `http.request.cookie["xyz"]`,
-        `http.request.uri.args["foobar"]`,
-      ],
-      refillRate: 60,
-      interval: 60,
-      capacity: 120,
-    });
-    type Test = Assert<RuleProps<typeof rules, { requested: number }>>;
-  });
-
-  test("produces a rules based on configuration specified", async () => {
-    const options = {
-      characteristics: ["ip.src"],
-      refillRate: 1,
-      interval: 1,
-      capacity: 1,
-    };
-
-    const rules = tokenBucket(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    assert.equal(rules[0].mode, "DRY_RUN");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.deepEqual(rules[0].characteristics, ["ip.src"]);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].algorithm, "TOKEN_BUCKET");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].refillRate, 1);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].interval, 1);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].capacity, 1);
-  });
-
-  test("does not default `characteristics` if not specified", async () => {
-    const options = {
-      refillRate: 1,
-      interval: 1,
-      capacity: 1,
-    };
-
-    const [rule] = tokenBucket(options);
-    assert.equal(rule.type, "RATE_LIMIT");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rule.characteristics, undefined);
-  });
-
-  test("uses cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
-      {
-        conclusion: "DENY",
-        reason: new ArcjetRateLimitReason({
-          max: 0,
-          remaining: 0,
-          // This will be updated by the rule based on TTL
-          reset: 100,
-          window: 1,
-        }),
-      },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      requested: 1,
-    };
-
+  await t.test("should support options", async () => {
     const [rule] = tokenBucket({
-      refillRate: 1,
-      interval: 1,
       capacity: 1,
+      characteristics: ["ip.src"],
+      interval: 1,
+      refillRate: 1,
     });
+
     assert.equal(rule.type, "RATE_LIMIT");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 1);
-    assert.deepEqual(cache.get.mock.calls[0].arguments, [
-      "da610f3767d3b939fe2769b489fba4a91da2ab7413184dbbbe6d12519abc1e7b",
-      "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-    ]);
+    assert.equal(rule.mode, "DRY_RUN");
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.deepEqual(rule.characteristics, ["ip.src"]);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.algorithm, "TOKEN_BUCKET");
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.refillRate, 1);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.interval, 1);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.capacity, 1);
+  });
+
+  await t.test(
+    "should not default to some value if w/o `characteristics`",
+    async () => {
+      const [rule] = tokenBucket({ capacity: 1, interval: 1, refillRate: 1 });
+      assert.equal(rule.type, "RATE_LIMIT");
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.characteristics, undefined);
+    },
+  );
+
+  await t.test(
+    "should reflect user-defined `characteristics` in required props",
+    async () => {
+      const rules = tokenBucket({
+        capacity: 120,
+        characteristics: ["userId"],
+        interval: 60,
+        refillRate: 60,
+      });
+      type Test = Assert<
+        RuleProps<
+          typeof rules,
+          { requested: number; userId: string | number | boolean }
+        >
+      >;
+    },
+  );
+
+  await t.test(
+    "should ignore well-known `characteristics` in props",
+    async () => {
+      const rules = tokenBucket({
+        capacity: 120,
+        characteristics: [
+          "ip.src",
+          "http.host",
+          "http.method",
+          "http.request.uri.path",
+          `http.request.headers["abc"]`,
+          `http.request.cookie["xyz"]`,
+          `http.request.uri.args["foobar"]`,
+        ],
+        interval: 60,
+        refillRate: 60,
+      });
+      type Test = Assert<RuleProps<typeof rules, { requested: number }>>;
+    },
+  );
+
+  await t.test("should use the cache", async () => {
+    let calls = 0;
+    const [rule] = tokenBucket({ capacity: 1, interval: 1, refillRate: 1 });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          async get(namespace, key) {
+            calls++;
+            assert.equal(
+              namespace,
+              "da610f3767d3b939fe2769b489fba4a91da2ab7413184dbbbe6d12519abc1e7b",
+            );
+            assert.equal(
+              key,
+              "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
+            );
+            return [
+              {
+                conclusion: "DENY",
+                reason: new ArcjetRateLimitReason({
+                  max: 0,
+                  remaining: 0,
+                  // This will be updated by the rule based on TTL
+                  reset: 100,
+                  window: 1,
+                }),
+              },
+              10,
+            ];
+          },
+          set() {},
+        },
+      },
+      { ...exampleDetails, requested: 1 },
+    );
+
+    assert.equal(calls, 1);
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetRateLimitReason);
     assert.equal(result.reason.max, 0);
@@ -967,213 +858,291 @@ describe("Primitive > tokenBucket", () => {
     assert.equal(result.state, "CACHED");
     assert.equal(result.ttl, 10);
   });
+
+  await t.test("should pass global characteristics", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.equal(rules.length, 1);
+        const item = rules.at(0);
+        assert.ok(item);
+        assert.ok("characteristics" in item);
+        assert.deepEqual(item.characteristics, ["someGlobalCharacteristic"]);
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      characteristics: ["someGlobalCharacteristic"],
+      rules: [
+        tokenBucket({
+          capacity: 10,
+          interval: "1h",
+          mode: "LIVE",
+          refillRate: 1,
+        }),
+      ],
+      client,
+    });
+
+    await aj.protect(exampleContext, {
+      ...exampleDetails,
+      requested: 1,
+      someGlobalCharacteristic: "test",
+    });
+    assert.equal(calls, 1);
+  });
+
+  await t.test("should prefer local characteristics", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.equal(rules.length, 1);
+        const item = rules.at(0);
+        assert.ok(item);
+        assert.ok("characteristics" in item);
+        assert.deepEqual(item.characteristics, ["someLocalCharacteristic"]);
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      characteristics: ["someGlobalCharacteristic"],
+      rules: [
+        tokenBucket({
+          capacity: 10,
+          characteristics: ["someLocalCharacteristic"],
+          interval: "1h",
+          mode: "LIVE",
+          refillRate: 1,
+        }),
+      ],
+      client,
+    });
+
+    await aj.protect(exampleContext, {
+      ...exampleDetails,
+      requested: 1,
+      someGlobalCharacteristic: "test",
+      someLocalCharacteristic: "test",
+    });
+    assert.equal(calls, 1);
+  });
 });
 
-describe("Primitive > fixedWindow", () => {
-  test("validates `mode` option if it is set", async () => {
+test("fixedWindow", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       fixedWindow({
-        // @ts-expect-error
+        max: 1,
+        // @ts-expect-error: test runtime behavior of invalid `mode`.
         mode: "INVALID",
         window: "1h",
-        max: 1,
       });
     }, /`fixedWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("validates `window` option is required", async () => {
+  await t.test("should fail if `window` is missing", async () => {
     assert.throws(() => {
       fixedWindow(
-        // @ts-expect-error
-        {
-          max: 1,
-        },
+        // @ts-expect-error: test runtime behavior of missing `window`.
+        { max: 1 },
       );
     }, /`fixedWindow` options error: `window` is required/);
   });
 
-  test("validates `window` option is string or number", async () => {
+  await t.test("should fail if `window` is invalid", async () => {
     assert.throws(() => {
       fixedWindow({
-        // @ts-expect-error
-        window: /foobar/,
         max: 1,
+        // @ts-expect-error: test runtime behavior of invalid `window`.
+        window: /foobar/,
       });
     }, /`fixedWindow` options error: invalid type for `window` - expected one of string, number/);
   });
 
-  test("validates `max` option is required", async () => {
+  await t.test("should fail if `max` is missing", async () => {
     assert.throws(() => {
       fixedWindow(
-        // @ts-expect-error
-        {
-          window: 1,
-        },
+        // @ts-expect-error: test runtime behavior of missing `max`.
+        { window: 1 },
       );
     }, /`fixedWindow` options error: `max` is required/);
   });
 
-  test("validates `max` option is number", async () => {
+  await t.test("should fail if `max` is invalid", async () => {
     assert.throws(() => {
       fixedWindow({
-        window: 1,
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `max`.
         max: "abc",
+        window: 1,
       });
     }, /`fixedWindow` options error: invalid type for `max` - expected number/);
   });
 
-  test("sets mode as `LIVE` if specified", async () => {
+  await t.test("should set `mode: LIVE` if passed", async () => {
     const [rule] = fixedWindow({
-      mode: "LIVE",
       characteristics: ["ip.src"],
-      window: "1h",
       max: 1,
+      mode: "LIVE",
+      window: "1h",
     });
     assert.equal(rule.type, "RATE_LIMIT");
     assert.equal(rule.mode, "LIVE");
   });
 
-  test("can specify window as a string duration", async () => {
-    const options = {
-      window: "60s",
-      max: 1,
-    };
+  await t.test(
+    "should support `string` duration notation for `window`",
+    async () => {
+      const [rule] = fixedWindow({ max: 1, window: "60s" });
 
-    const rules = fixedWindow(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].window, 60);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].max, 1);
-  });
+      assert.equal(rule.type, "RATE_LIMIT");
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.window, 60);
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.max, 1);
+    },
+  );
 
-  test("can specify window as an integer duration", async () => {
-    const options = {
-      window: 60,
-      max: 1,
-    };
+  await t.test("should support `number`s for `window`", async () => {
+    const [rule] = fixedWindow({ max: 1, window: 60 });
 
-    const rules = fixedWindow(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].window, 60);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].max, 1);
-  });
-
-  test("can specify user-defined characteristics which are reflected in required props", async () => {
-    const rules = fixedWindow({
-      characteristics: ["userId"],
-      window: "1h",
-      max: 1,
-    });
-    type Test = Assert<
-      RuleProps<typeof rules, { userId: string | number | boolean }>
-    >;
-  });
-
-  test("well-known characteristics don't affect the required props", async () => {
-    const rules = fixedWindow({
-      characteristics: [
-        "ip.src",
-        "http.host",
-        "http.method",
-        "http.request.uri.path",
-        `http.request.headers["abc"]`,
-        `http.request.cookie["xyz"]`,
-        `http.request.uri.args["foobar"]`,
-      ],
-      window: "1h",
-      max: 1,
-    });
-    type Test = Assert<RuleProps<typeof rules, {}>>;
-  });
-
-  test("produces a rules based on configuration specified", async () => {
-    const options = {
-      characteristics: ["ip.src"],
-      window: "1h",
-      max: 1,
-    };
-
-    const rules = fixedWindow(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    assert.equal(rules[0].mode, "DRY_RUN");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.deepEqual(rules[0].characteristics, ["ip.src"]);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].algorithm, "FIXED_WINDOW");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].window, 3600);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].max, 1);
-  });
-
-  test("does not default `characteristics` if not specified", async () => {
-    const options = {
-      window: "1h",
-      max: 1,
-    };
-
-    const [rule] = fixedWindow(options);
     assert.equal(rule.type, "RATE_LIMIT");
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rule.characteristics, undefined);
+    assert.equal(rule.window, 60);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.max, 1);
   });
 
-  test("uses cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
-      {
-        conclusion: "DENY",
-        reason: new ArcjetRateLimitReason({
-          max: 0,
-          remaining: 0,
-          // This will be updated by the rule based on TTL
-          reset: 100,
-          window: 1,
-        }),
-      },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
+  await t.test("should support options", async () => {
     const [rule] = fixedWindow({
+      characteristics: ["ip.src"],
       max: 1,
-      window: 1,
+      window: "1h",
     });
+
     assert.equal(rule.type, "RATE_LIMIT");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 1);
-    assert.deepEqual(cache.get.mock.calls[0].arguments, [
-      "c60466a160b56b4cc129995377ef6fbbcacc67f90218920416ae8431a6fd499c",
-      "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-    ]);
+    assert.equal(rule.mode, "DRY_RUN");
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.deepEqual(rule.characteristics, ["ip.src"]);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.algorithm, "FIXED_WINDOW");
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.window, 3600);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.max, 1);
+  });
+
+  await t.test(
+    "should not default to some value if w/o `characteristics`",
+    async () => {
+      const [rule] = fixedWindow({ max: 1, window: "1h" });
+      assert.equal(rule.type, "RATE_LIMIT");
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.characteristics, undefined);
+    },
+  );
+
+  await t.test(
+    "should reflect user-defined `characteristics` in required props",
+    async () => {
+      const rules = fixedWindow({
+        characteristics: ["userId"],
+        max: 1,
+        window: "1h",
+      });
+
+      type Test = Assert<
+        RuleProps<typeof rules, { userId: string | number | boolean }>
+      >;
+    },
+  );
+
+  await t.test(
+    "should ignore well-known `characteristics` in props",
+    async () => {
+      const rules = fixedWindow({
+        characteristics: [
+          "ip.src",
+          "http.host",
+          "http.method",
+          "http.request.uri.path",
+          `http.request.headers["abc"]`,
+          `http.request.cookie["xyz"]`,
+          `http.request.uri.args["foobar"]`,
+        ],
+        max: 1,
+        window: "1h",
+      });
+
+      type Test = Assert<RuleProps<typeof rules, {}>>;
+    },
+  );
+
+  await t.test("should use the cache", async () => {
+    let calls = 0;
+    const [rule] = fixedWindow({ max: 1, window: 1 });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          async get(namespace, key) {
+            calls++;
+            assert.equal(
+              namespace,
+              "c60466a160b56b4cc129995377ef6fbbcacc67f90218920416ae8431a6fd499c",
+            );
+            assert.equal(
+              key,
+              "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
+            );
+            return [
+              {
+                conclusion: "DENY",
+                reason: new ArcjetRateLimitReason({
+                  max: 0,
+                  remaining: 0,
+                  // This will be updated by the rule based on TTL
+                  reset: 100,
+                  window: 1,
+                }),
+              },
+              10,
+            ];
+          },
+          set() {},
+        },
+      },
+      exampleDetails,
+    );
+
+    assert.equal(calls, 1);
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetRateLimitReason);
     assert.equal(result.reason.max, 0);
@@ -1184,213 +1153,280 @@ describe("Primitive > fixedWindow", () => {
     assert.equal(result.state, "CACHED");
     assert.equal(result.ttl, 10);
   });
+
+  await t.test("should pass global characteristics", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.equal(rules.length, 1);
+        const item = rules.at(0);
+        assert.ok(item);
+        assert.ok("characteristics" in item);
+        assert.deepEqual(item.characteristics, ["someGlobalCharacteristic"]);
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      characteristics: ["someGlobalCharacteristic"],
+      rules: [fixedWindow({ max: 60, mode: "LIVE", window: "1h" })],
+      client,
+    });
+
+    await aj.protect(exampleContext, {
+      ...exampleDetails,
+      someGlobalCharacteristic: "test",
+    });
+    assert.equal(calls, 1);
+  });
+
+  await t.test("should prefer local characteristics", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.equal(rules.length, 1);
+        const item = rules.at(0);
+        assert.ok(item);
+        assert.ok("characteristics" in item);
+        assert.deepEqual(item.characteristics, ["someLocalCharacteristic"]);
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      characteristics: ["someGlobalCharacteristic"],
+      rules: [
+        fixedWindow({
+          characteristics: ["someLocalCharacteristic"],
+          max: 60,
+          mode: "LIVE",
+          window: "1h",
+        }),
+      ],
+      client,
+    });
+
+    await aj.protect(exampleContext, {
+      ...exampleDetails,
+      someGlobalCharacteristic: "test",
+      someLocalCharacteristic: "test",
+    });
+    assert.equal(calls, 1);
+  });
 });
 
-describe("Primitive > slidingWindow", () => {
-  test("validates `mode` option if it is set", async () => {
+test("slidingWindow", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       slidingWindow({
-        // @ts-expect-error
-        mode: "INVALID",
         interval: 3600,
         max: 1,
+        // @ts-expect-error: test runtime behavior of invalid `mode`.
+        mode: "INVALID",
       });
     }, /`slidingWindow` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("validates `interval` option is required", async () => {
+  await t.test("should fail if `interval` is missing", async () => {
     assert.throws(() => {
       slidingWindow(
-        // @ts-expect-error
-        {
-          max: 1,
-        },
+        // @ts-expect-error: test runtime behavior of missing `interval`.
+        { max: 1 },
       );
     }, /`slidingWindow` options error: `interval` is required/);
   });
 
-  test("validates `interval` option is string or number", async () => {
+  await t.test("should fail if `interval` is invalid", async () => {
     assert.throws(() => {
       slidingWindow({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `interval`.
         interval: /foobar/,
         max: 1,
       });
     }, /`slidingWindow` options error: invalid type for `interval` - expected one of string, number/);
   });
 
-  test("validates `max` option is required", async () => {
+  await t.test("should fail if `max` is missing", async () => {
     assert.throws(() => {
       slidingWindow(
-        // @ts-expect-error
-        {
-          interval: 1,
-        },
+        // @ts-expect-error: test runtime behavior of missing `max`.
+        { interval: 1 },
       );
     }, /`slidingWindow` options error: `max` is required/);
   });
 
-  test("validates `max` option is number", async () => {
+  await t.test("should fail if `max` is invalid", async () => {
     assert.throws(() => {
       slidingWindow({
         interval: 1,
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `max`.
         max: "abc",
       });
     }, /`slidingWindow` options error: invalid type for `max` - expected number/);
   });
 
-  test("sets mode as `LIVE` if specified", async () => {
+  await t.test("should set `mode: LIVE` if passed", async () => {
     const [rule] = slidingWindow({
-      mode: "LIVE",
       characteristics: ["ip.src"],
       interval: 3600,
       max: 1,
+      mode: "LIVE",
     });
     assert.equal(rule.type, "RATE_LIMIT");
     assert.equal(rule.mode, "LIVE");
   });
 
-  test("can specify interval as a string duration", async () => {
-    const options = {
-      interval: "60s",
-      max: 1,
-    };
+  await t.test(
+    "should support `string` duration notation for `interval`",
+    async () => {
+      const [rule] = slidingWindow({ interval: "60s", max: 1 });
 
-    const rules = slidingWindow(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
+      assert.equal(rule.type, "RATE_LIMIT");
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.interval, 60);
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.max, 1);
+    },
+  );
+
+  await t.test("should support `number`s for `interval`", async () => {
+    const [rule] = slidingWindow({ interval: 60, max: 1 });
+
+    assert.equal(rule.type, "RATE_LIMIT");
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].interval, 60);
+    assert.equal(rule.interval, 60);
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].max, 1);
+    assert.equal(rule.max, 1);
   });
 
-  test("can specify interval as an integer duration", async () => {
-    const options = {
-      interval: 60,
-      max: 1,
-    };
-
-    const rules = slidingWindow(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].interval, 60);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].max, 1);
-  });
-
-  test("can specify user-defined characteristics which are reflected in required props", async () => {
-    const rules = slidingWindow({
-      characteristics: ["userId"],
-      interval: "1h",
-      max: 1,
-    });
-    type Test = Assert<
-      RuleProps<typeof rules, { userId: string | number | boolean }>
-    >;
-  });
-
-  test("well-known characteristics don't affect the required props", async () => {
-    const rules = slidingWindow({
-      characteristics: [
-        "ip.src",
-        "http.host",
-        "http.method",
-        "http.request.uri.path",
-        `http.request.headers["abc"]`,
-        `http.request.cookie["xyz"]`,
-        `http.request.uri.args["foobar"]`,
-      ],
-      interval: "1h",
-      max: 1,
-    });
-    type Test = Assert<RuleProps<typeof rules, {}>>;
-  });
-
-  test("produces a rules based on configuration specified", async () => {
-    const options = {
+  await t.test("should support options", async () => {
+    const [rule] = slidingWindow({
       characteristics: ["ip.src"],
       interval: 3600,
       max: 1,
-    };
-
-    const rules = slidingWindow(options);
-    assert.equal(rules.length, 1);
-    assert.equal(rules[0].type, "RATE_LIMIT");
-    assert.equal(rules[0].mode, "DRY_RUN");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.deepEqual(rules[0].characteristics, ["ip.src"]);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].algorithm, "SLIDING_WINDOW");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].interval, 3600);
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rules[0].max, 1);
-  });
-
-  test("does not default `characteristics` if not specified", async () => {
-    const options = {
-      interval: 3600,
-      max: 1,
-    };
-
-    const [rule] = slidingWindow(options);
-    assert.equal(rule.type, "RATE_LIMIT");
-    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
-    assert.equal(rule.characteristics, undefined);
-  });
-
-  test("uses cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
-      {
-        conclusion: "DENY",
-        reason: new ArcjetRateLimitReason({
-          max: 0,
-          remaining: 0,
-          // This will be updated by the rule based on TTL
-          reset: 100,
-          window: 1,
-        }),
-      },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = slidingWindow({
-      max: 1,
-      interval: 1,
     });
+
     assert.equal(rule.type, "RATE_LIMIT");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 1);
-    assert.deepEqual(cache.get.mock.calls[0].arguments, [
-      "64653030723222b3227a642239fbfae3bc53369d858b5ed1a31a2bb0438dacb1",
-      "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-    ]);
+    assert.equal(rule.mode, "DRY_RUN");
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.deepEqual(rule.characteristics, ["ip.src"]);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.algorithm, "SLIDING_WINDOW");
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.interval, 3600);
+    // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+    assert.equal(rule.max, 1);
+  });
+
+  await t.test(
+    "should not default to some value if w/o `characteristics`",
+    async () => {
+      const [rule] = slidingWindow({ interval: 3600, max: 1 });
+      assert.equal(rule.type, "RATE_LIMIT");
+      // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
+      assert.equal(rule.characteristics, undefined);
+    },
+  );
+
+  await t.test(
+    "should reflect user-defined `characteristics` in required props",
+    async () => {
+      const rules = slidingWindow({
+        characteristics: ["userId"],
+        interval: "1h",
+        max: 1,
+      });
+
+      type Test = Assert<
+        RuleProps<typeof rules, { userId: string | number | boolean }>
+      >;
+    },
+  );
+
+  await t.test(
+    "should ignore well-known `characteristics` in props",
+    async () => {
+      const rules = slidingWindow({
+        characteristics: [
+          "ip.src",
+          "http.host",
+          "http.method",
+          "http.request.uri.path",
+          `http.request.headers["abc"]`,
+          `http.request.cookie["xyz"]`,
+          `http.request.uri.args["foobar"]`,
+        ],
+        interval: "1h",
+        max: 1,
+      });
+
+      type Test = Assert<RuleProps<typeof rules, {}>>;
+    },
+  );
+
+  await t.test("should use the cache", async () => {
+    let calls = 0;
+    const [rule] = slidingWindow({ interval: 1, max: 1 });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          async get(namespace, key) {
+            calls++;
+            assert.equal(
+              namespace,
+              "64653030723222b3227a642239fbfae3bc53369d858b5ed1a31a2bb0438dacb1",
+            );
+            assert.equal(
+              key,
+              "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
+            );
+            return [
+              {
+                conclusion: "DENY",
+                reason: new ArcjetRateLimitReason({
+                  max: 0,
+                  remaining: 0,
+                  // This will be updated by the rule based on TTL
+                  reset: 100,
+                  window: 1,
+                }),
+              },
+              10,
+            ];
+          },
+          set() {},
+        },
+      },
+      exampleDetails,
+    );
+    assert.equal(calls, 1);
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetRateLimitReason);
     assert.equal(result.reason.max, 0);
@@ -1401,548 +1437,393 @@ describe("Primitive > slidingWindow", () => {
     assert.equal(result.state, "CACHED");
     assert.equal(result.ttl, 10);
   });
+
+  await t.test("should pass global characteristics", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.equal(rules.length, 1);
+        const item = rules.at(0);
+        assert.ok(item);
+        assert.ok("characteristics" in item);
+        assert.deepEqual(item.characteristics, ["someGlobalCharacteristic"]);
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      characteristics: ["someGlobalCharacteristic"],
+      rules: [slidingWindow({ interval: "1h", max: 60, mode: "LIVE" })],
+      client,
+    });
+
+    await aj.protect(exampleContext, {
+      ...exampleDetails,
+      someGlobalCharacteristic: "test",
+    });
+    assert.equal(calls, 1);
+  });
+
+  await t.test("should prefer local characteristics", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.equal(rules.length, 1);
+        const item = rules.at(0);
+        assert.ok(item);
+        assert.ok("characteristics" in item);
+        assert.deepEqual(item.characteristics, ["someLocalCharacteristic"]);
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      characteristics: ["someGlobalCharacteristic"],
+      rules: [
+        slidingWindow({
+          characteristics: ["someLocalCharacteristic"],
+          interval: "1h",
+          max: 60,
+          mode: "LIVE",
+        }),
+      ],
+      client,
+    });
+
+    await aj.protect(exampleContext, {
+      ...exampleDetails,
+      someGlobalCharacteristic: "test",
+      someLocalCharacteristic: "test",
+    });
+    assert.equal(calls, 1);
+  });
 });
 
-describe("Primitive > validateEmail", () => {
-  test("validates `mode` option if it is set", async () => {
+test("validateEmail", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       validateEmail({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `mode`.
         mode: "INVALID",
       });
     }, /`validateEmail` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("validates `block` option is array if it is set", async () => {
+  await t.test("should fail if `allow` is invalid", async () => {
     assert.throws(() => {
       validateEmail({
-        // @ts-expect-error
-        block: 1234,
-      });
-    }, /`validateEmail` options error: invalid type for `block` - expected an array/);
-  });
-
-  test("validates `deny` option is array if it is set", async () => {
-    assert.throws(() => {
-      validateEmail({
-        // @ts-expect-error
-        deny: 1234,
-      });
-    }, /`validateEmail` options error: invalid type for `deny` - expected an array/);
-  });
-
-  test("validates `allow` option is array if it is set", async () => {
-    assert.throws(() => {
-      validateEmail({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `allow`.
         allow: 1234,
       });
     }, /`validateEmail` options error: invalid type for `allow` - expected an array/);
   });
 
-  test("validates `block` option only contains specific values", async () => {
+  await t.test("should fail if `block` is invalid", async () => {
     assert.throws(() => {
       validateEmail({
-        // @ts-expect-error
-        block: ["FOOBAR"],
+        // @ts-expect-error: test runtime behavior of invalid `block`.
+        block: 1234,
       });
-    }, /`validateEmail` options error: invalid value for `block\[0]` - expected one of 'DISPOSABLE', 'FREE', 'NO_MX_RECORDS', 'NO_GRAVATAR', 'INVALID'/);
+    }, /`validateEmail` options error: invalid type for `block` - expected an array/);
   });
 
-  test("validates `deny` option only contains specific values", async () => {
+  await t.test("should fail if `deny` is invalid", async () => {
     assert.throws(() => {
       validateEmail({
-        // @ts-expect-error
-        deny: ["FOOBAR"],
+        // @ts-expect-error: test runtime behavior of invalid `deny`.
+        deny: 1234,
       });
-    }, /`validateEmail` options error: invalid value for `deny\[0]` - expected one of 'DISPOSABLE', 'FREE', 'NO_MX_RECORDS', 'NO_GRAVATAR', 'INVALID'/);
+    }, /`validateEmail` options error: invalid type for `deny` - expected an array/);
   });
 
-  test("validates `allow` option only contains specific values", async () => {
+  await t.test("should fail if items in `allow` are invalid", async () => {
     assert.throws(() => {
       validateEmail({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `allow[]`.
         allow: ["FOOBAR"],
       });
     }, /`validateEmail` options error: invalid value for `allow\[0]` - expected one of 'DISPOSABLE', 'FREE', 'NO_MX_RECORDS', 'NO_GRAVATAR', 'INVALID'/);
   });
 
-  test("validates `deny` and `block` cannot be set at the same time", async () => {
+  await t.test("should fail if items in `block` are invalid", async () => {
     assert.throws(() => {
-      // @ts-expect-error
       validateEmail({
-        deny: ["INVALID"],
-        block: ["INVALID"],
+        // @ts-expect-error: test runtime behavior of invalid `block`.
+        block: ["FOOBAR"],
       });
-    }, /`validateEmail` options error: `deny` and `block` cannot be provided together, `block` is now deprecated so `deny` should be preferred./);
+    }, /`validateEmail` options error: invalid value for `block\[0]` - expected one of 'DISPOSABLE', 'FREE', 'NO_MX_RECORDS', 'NO_GRAVATAR', 'INVALID'/);
   });
 
-  test("validates `allow` and `deny` cannot be set at the same time", async () => {
+  await t.test("should fail if items in `deny` are invalid", async () => {
     assert.throws(() => {
-      // @ts-expect-error
       validateEmail({
-        allow: ["INVALID"],
-        deny: ["INVALID"],
+        // @ts-expect-error: test runtime behavior of invalid `deny[]`.
+        deny: ["FOOBAR"],
       });
+    }, /`validateEmail` options error: invalid value for `deny\[0]` - expected one of 'DISPOSABLE', 'FREE', 'NO_MX_RECORDS', 'NO_GRAVATAR', 'INVALID'/);
+  });
+
+  await t.test("should fail if `allow` and `deny` are both given", async () => {
+    assert.throws(() => {
+      validateEmail(
+        // @ts-expect-error: test runtime behavior of invalid combination of both fields.
+        { allow: ["INVALID"], deny: ["INVALID"] },
+      );
     }, /`validateEmail` options error: `allow` and `deny` cannot be provided together/);
   });
 
-  test("validates `block` and `deny` cannot be set at the same time", async () => {
+  await t.test("should fail if `block` and `deny` are both given", async () => {
     assert.throws(() => {
-      // @ts-expect-error
-      validateEmail({
-        allow: ["INVALID"],
-        block: ["INVALID"],
-      });
-    }, /`validateEmail` options error: `allow` and `block` cannot be provided together/);
+      validateEmail(
+        // @ts-expect-error: test runtime behavior of invalid combination of both fields.
+        { block: ["INVALID"], deny: ["INVALID"] },
+      );
+    }, /`validateEmail` options error: `deny` and `block` cannot be provided together, `block` is now deprecated so `deny` should be preferred./);
   });
 
-  test("validates `requireTopLevelDomain` option if it is set", async () => {
-    assert.throws(() => {
-      validateEmail({
-        // @ts-expect-error
-        requireTopLevelDomain: "abc",
-      });
-    }, /`validateEmail` options error: invalid type for `requireTopLevelDomain` - expected boolean/);
-  });
+  await t.test(
+    "should fail if `allow` and `block` are both given",
+    async () => {
+      assert.throws(() => {
+        validateEmail(
+          // @ts-expect-error: test runtime behavior of invalid combination of both fields.
+          { allow: ["INVALID"], block: ["INVALID"] },
+        );
+      }, /`validateEmail` options error: `allow` and `block` cannot be provided together/);
+    },
+  );
 
-  test("validates `allowDomainLiteral` option if it is set", async () => {
+  await t.test(
+    "should fail if `requireTopLevelDomain` is invalid",
+    async () => {
+      assert.throws(() => {
+        validateEmail({
+          // @ts-expect-error: test runtime behavior of invalid `requireTopLevelDomain`.
+          requireTopLevelDomain: "abc",
+        });
+      }, /`validateEmail` options error: invalid type for `requireTopLevelDomain` - expected boolean/);
+    },
+  );
+
+  await t.test("should fail if `allowDomainLiteral` is invalid", async () => {
     assert.throws(() => {
       validateEmail({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `allowDomainLiteral`.
         allowDomainLiteral: "abc",
       });
     }, /`validateEmail` options error: invalid type for `allowDomainLiteral` - expected boolean/);
   });
 
-  test("allows specifying EmailTypes to deny", async () => {
+  await t.test("should support known values in `deny`", async () => {
     const [rule] = validateEmail({
-      deny: ["DISPOSABLE", "FREE", "NO_GRAVATAR", "NO_MX_RECORDS", "INVALID"],
+      deny: ["DISPOSABLE", "FREE", "INVALID", "NO_GRAVATAR", "NO_MX_RECORDS"],
     });
-    assert.equal(rule.type, "EMAIL");
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
     assert.deepEqual(rule.deny, [
       "DISPOSABLE",
       "FREE",
+      "INVALID",
       "NO_GRAVATAR",
       "NO_MX_RECORDS",
-      "INVALID",
     ]);
   });
 
-  test("allows specifying EmailTypes to block and maps these to deny", async () => {
+  await t.test("should support known values in `block` as `deny`", async () => {
     const [rule] = validateEmail({
-      block: ["DISPOSABLE", "FREE", "NO_GRAVATAR", "NO_MX_RECORDS", "INVALID"],
+      block: ["DISPOSABLE", "FREE", "INVALID", "NO_GRAVATAR", "NO_MX_RECORDS"],
     });
-    assert.equal(rule.type, "EMAIL");
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
     assert.deepEqual(rule.deny, [
       "DISPOSABLE",
       "FREE",
+      "INVALID",
       "NO_GRAVATAR",
       "NO_MX_RECORDS",
-      "INVALID",
     ]);
   });
 
-  test("allows specifying EmailTypes to allow", async () => {
+  await t.test("should support known values in `allow`", async () => {
     const [rule] = validateEmail({
-      allow: ["DISPOSABLE", "FREE", "NO_GRAVATAR", "NO_MX_RECORDS", "INVALID"],
+      allow: ["DISPOSABLE", "FREE", "INVALID", "NO_GRAVATAR", "NO_MX_RECORDS"],
     });
-    assert.equal(rule.type, "EMAIL");
     // @ts-expect-error: TODO(#4452): fix types to allow access of properties.
     assert.deepEqual(rule.allow, [
       "DISPOSABLE",
       "FREE",
+      "INVALID",
       "NO_GRAVATAR",
       "NO_MX_RECORDS",
-      "INVALID",
     ]);
   });
 
-  test("validates that email is defined", () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      email: "abc@example.com",
-    };
+  await t.test("should fail when calling `validate` w/o `email` field", () => {
+    const [rule] = validateEmail({ deny: [], mode: "LIVE" });
 
-    const [rule] = validateEmail({ mode: "LIVE", deny: [] });
-    assert.equal(rule.type, "EMAIL");
-    assert.doesNotThrow(() => {
-      const _ = rule.validate(context, details);
-    });
-  });
-
-  test("throws via `validate()` if email is undefined", () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      email: undefined,
-    };
-
-    const [rule] = validateEmail({ mode: "LIVE", deny: [] });
-    assert.equal(rule.type, "EMAIL");
     assert.throws(() => {
-      const _ = rule.validate(context, details);
+      const _ = rule.validate(exampleContext, {
+        ...exampleDetails,
+        email: undefined,
+      });
     });
   });
 
-  test("produces a dry run result in DRY_RUN mode", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      email: "foobarbaz",
-      extra: {},
-    };
+  await t.test("should pass when calling `validate` w/ `email` field", () => {
+    const [rule] = validateEmail({ deny: [], mode: "LIVE" });
 
-    const [rule] = validateEmail({ mode: "DRY_RUN", allow: [] });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetEmailReason);
-    assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
-    assert.equal(result.state, "DRY_RUN");
+    assert.doesNotThrow(() => {
+      const _ = rule.validate(exampleContext, {
+        ...exampleDetails,
+        email: "abc@example.com",
+      });
+    });
   });
 
-  test("allows a valid email", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
+  await t.test(
+    "should support calling `protect` w/ `mode: DRY_RUN`",
+    async () => {
+      const [rule] = validateEmail({ allow: [], mode: "DRY_RUN" });
+
+      const result = await rule.protect(exampleContext, {
+        ...exampleDetails,
+        email: "foobarbaz",
+      });
+      assert.equal(result.conclusion, "DENY");
+      assert.ok(result.reason instanceof ArcjetEmailReason);
+      assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
+      assert.equal(result.state, "DRY_RUN");
+    },
+  );
+
+  await t.test("should allow a valid email", async () => {
+    const [rule] = validateEmail({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(exampleContext, {
+      ...exampleDetails,
       email: "foobarbaz@example.com",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
+    });
     assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetEmailReason);
     assert.deepEqual(result.reason.emailTypes, []);
     assert.equal(result.state, "RUN");
   });
 
-  test("denies email with no domain segment", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
+  await t.test("should deny an email w/o domain segment", async () => {
+    const [rule] = validateEmail({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(exampleContext, {
+      ...exampleDetails,
       email: "foobarbaz",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetEmailReason);
-    assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("denies email with no TLD", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      email: "foobarbaz@localhost",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetEmailReason);
-    assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("denies email with no TLD even if some options are specified", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      email: "foobarbaz@localhost",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({
-      mode: "LIVE",
-      allow: [],
     });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetEmailReason);
     assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
     assert.equal(result.state, "RUN");
   });
 
-  test("denies email with empty name segment", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      email: "@example.com",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
+  await t.test("should deny an email w/o TLD", async () => {
+    const [rule] = validateEmail({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(exampleContext, {
+      ...exampleDetails,
+      email: "foobarbaz@localhost",
+    });
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetEmailReason);
     assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
     assert.equal(result.state, "RUN");
   });
 
-  test("denies email with domain literal", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
+  await t.test(
+    "should allow an email w/o TLD w/ `requireTopLevelDomain: false`",
+    async () => {
+      const [rule] = validateEmail({
+        allow: [],
+        mode: "LIVE",
+        requireTopLevelDomain: false,
+      });
+      assert.equal(rule.type, "EMAIL");
+      const result = await rule.protect(exampleContext, {
+        ...exampleDetails,
+        email: "foobarbaz@localhost",
+      });
+      assert.equal(result.conclusion, "ALLOW");
+      assert.ok(result.reason instanceof ArcjetEmailReason);
+      assert.deepEqual(result.reason.emailTypes, []);
+    },
+  );
+
+  await t.test("should deny an email w/ domain literal", async () => {
+    const [rule] = validateEmail({ allow: [], mode: "LIVE" });
+    assert.equal(rule.type, "EMAIL");
+    const result = await rule.protect(exampleContext, {
+      ...exampleDetails,
       email: "foobarbaz@[127.0.0.1]",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
+    });
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetEmailReason);
     assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
     assert.equal(result.state, "RUN");
   });
 
-  test("can be configured to allow no TLD", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      email: "foobarbaz@localhost",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({
-      requireTopLevelDomain: false,
-      mode: "LIVE",
-      allow: [],
-    });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "ALLOW");
-    assert.ok(result.reason instanceof ArcjetEmailReason);
-    assert.deepEqual(result.reason.emailTypes, []);
-  });
-
-  test("can be configured to allow domain literals", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      email: "foobarbaz@[127.0.0.1]",
-      extra: {},
-    };
-
-    const [rule] = validateEmail({
-      allowDomainLiteral: true,
-      mode: "LIVE",
-      allow: [],
-    });
-    assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "ALLOW");
-    assert.ok(result.reason instanceof ArcjetEmailReason);
-    assert.deepEqual(result.reason.emailTypes, []);
-    assert.equal(result.state, "RUN");
-  });
+  await t.test(
+    "should allow an email w/ domain literal w/ `allowDomainLiteral: true`",
+    async () => {
+      const [rule] = validateEmail({
+        allowDomainLiteral: true,
+        mode: "LIVE",
+        allow: [],
+      });
+      assert.equal(rule.type, "EMAIL");
+      const result = await rule.protect(exampleContext, {
+        ...exampleDetails,
+        email: "foobarbaz@[127.0.0.1]",
+      });
+      assert.equal(result.conclusion, "ALLOW");
+      assert.ok(result.reason instanceof ArcjetEmailReason);
+      assert.deepEqual(result.reason.emailTypes, []);
+      assert.equal(result.state, "RUN");
+    },
+  );
 
   // Email validation is dynamic so all TTL are zero
-  test("does not use cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
-      {
-        conclusion: "DENY",
-        reason: new ArcjetEmailReason({
-          emailTypes: ["INVALID"],
-        }),
-      },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      email: "test@example.com",
-    };
-
-    const [rule] = validateEmail({
-      mode: "LIVE",
-      allow: [],
-    });
+  await t.test("should not use the cache", async () => {
+    const [rule] = validateEmail({ allow: [], mode: "LIVE" });
     assert.equal(rule.type, "EMAIL");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 0);
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          get() {
+            assert.fail();
+          },
+          set() {},
+        },
+      },
+      { ...exampleDetails, email: "test@example.com" },
+    );
     assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetEmailReason);
     assert.deepEqual(result.reason.emailTypes, []);
@@ -1950,74 +1831,58 @@ describe("Primitive > validateEmail", () => {
   });
 });
 
-describe("Primitive > shield", () => {
-  test("validates `mode` option if it is set", async () => {
+test("shield", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       shield({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `mode`.
         mode: "INVALID",
       });
     }, /`shield` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("sets mode as `LIVE` if specified", async () => {
-    const [rule] = shield({
-      mode: "LIVE",
-    });
-    assert.equal(rule.type, "SHIELD");
-    assert.equal(rule.mode, "LIVE");
-  });
-
-  test("sets mode as `DRY_RUN` if not specified", async () => {
+  await t.test("should set `mode: DRY_RUN` w/o `mode`", async () => {
+    // TODO(@wooorm-arcjet): if `{}` is allowed than so should ``? But types do not allow it?
     const [rule] = shield({});
-    assert.equal(rule.type, "SHIELD");
     assert.equal(rule.mode, "DRY_RUN");
   });
 
-  test("uses cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
-      {
-        conclusion: "DENY",
-        reason: new ArcjetShieldReason({
-          shieldTriggered: true,
-        }),
-      },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
+  await t.test("should set `mode: LIVE` if passed", async () => {
+    const [rule] = shield({ mode: "LIVE" });
+    assert.equal(rule.mode, "LIVE");
+  });
 
-    const [rule] = shield({
-      mode: "LIVE",
-    });
-    assert.equal(rule.type, "SHIELD");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 1);
-    assert.deepEqual(cache.get.mock.calls[0].arguments, [
-      "1a506ff95a8c2017894fcb6cc3be55053b144bd15666631945a5c453c477bd16",
-      "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-    ]);
+  await t.test("should use the cache", async () => {
+    let calls = 0;
+    const [rule] = shield({ mode: "LIVE" });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          async get(namespace, key) {
+            calls++;
+            assert.equal(
+              namespace,
+              "1a506ff95a8c2017894fcb6cc3be55053b144bd15666631945a5c453c477bd16",
+            );
+            assert.equal(
+              key,
+              "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
+            );
+            return [
+              {
+                conclusion: "DENY",
+                reason: new ArcjetShieldReason({ shieldTriggered: true }),
+              },
+              10,
+            ];
+          },
+          set() {},
+        },
+      },
+      exampleDetails,
+    );
+    assert.equal(calls, 1);
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetShieldReason);
     assert.equal(result.reason.shieldTriggered, true);
@@ -2025,36 +1890,9 @@ describe("Primitive > shield", () => {
     assert.equal(result.ttl, 10);
   });
 
-  test("does not run rule locally", async () => {
-    const cache = new TestCache();
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
-
-    const [rule] = shield({
-      mode: "LIVE",
-    });
-    assert.equal(rule.type, "SHIELD");
-    const result = await rule.protect(context, details);
+  await t.test("should not run locally", async () => {
+    const [rule] = shield({ mode: "LIVE" });
+    const result = await rule.protect(exampleContext, exampleDetails);
     assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetShieldReason);
     assert.equal(result.reason.shieldTriggered, false);
@@ -2063,740 +1901,460 @@ describe("Primitive > shield", () => {
   });
 });
 
-describe("Primitive > sensitiveInfo", () => {
-  test("validates `mode` option if it is set", async () => {
+test("sensitiveInfo", async (t) => {
+  await t.test("should fail if `mode` is invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `mode`.
         mode: "INVALID",
-        allow: [],
       });
     }, /`sensitiveInfo` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  test("validates `allow` option is an array if set", async () => {
+  await t.test("should fail if `allow` is invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `allow`.
         allow: "abc",
       });
     }, /`sensitiveInfo` options error: invalid type for `allow` - expected an array/);
   });
 
-  test("validates `allow` option only contains strings", async () => {
+  await t.test("should fail if items in `allow` are invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `allow[]`.
         allow: [/foo/],
       });
     }, /`sensitiveInfo` options error: invalid type for `allow\[0]` - expected string/);
   });
 
-  test("validates `deny` option is an array if set", async () => {
+  await t.test("should fail if `deny` is invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `deny`.
         deny: "abc",
       });
     }, /`sensitiveInfo` options error: invalid type for `deny` - expected an array/);
   });
 
-  test("validates `deny` option only contains strings", async () => {
+  await t.test("should fail if items in `deny` are invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `deny[]`.
         deny: [/foo/],
       });
     }, /`sensitiveInfo` options error: invalid type for `deny\[0]` - expected string/);
   });
 
-  test("validates `contextWindowSize` option if set", async () => {
+  await t.test("should fail if `contextWindowSize` is invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        allow: [],
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `contextWindowSize`.
         contextWindowSize: "abc",
       });
     }, /`sensitiveInfo` options error: invalid type for `contextWindowSize` - expected number/);
   });
 
-  test("validates `detect` option if set", async () => {
+  await t.test("should fail if `detect` is invalid", async () => {
     assert.throws(() => {
       sensitiveInfo({
-        allow: [],
-        // @ts-expect-error
+        // @ts-expect-error: test runtime behavior of invalid `detect`.
         detect: "abc",
       });
     }, /`sensitiveInfo` options error: invalid type for `detect` - expected function/);
   });
 
-  test("validates `allow` and `deny` options are not specified together", async () => {
+  await t.test("should fail if `allow` and `deny` are both given", async () => {
     assert.throws(() => {
-      const _ = sensitiveInfo(
-        // @ts-expect-error
-        {
-          allow: [],
-          deny: [],
-        },
+      sensitiveInfo(
+        // @ts-expect-error: test runtime behavior of invalid combination of both fields.
+        { allow: [], deny: [] },
       );
     }, /`sensitiveInfo` options error: `allow` and `deny` cannot be provided together/);
   });
 
-  test("validates either `allow` or `deny` option is specified", async () => {
-    assert.throws(() => {
-      const _ = sensitiveInfo(
-        // @ts-expect-error
-        {},
-      );
-    }, /`sensitiveInfo` options error: either `allow` or `deny` must be specified/);
+  await t.test(
+    "should fail if neither `allow` nor `deny` are given",
+    async () => {
+      assert.throws(() => {
+        sensitiveInfo(
+          // @ts-expect-error: test runtime behavior of neither `allow` nor `deny`.
+          {},
+        );
+      }, /`sensitiveInfo` options error: either `allow` or `deny` must be specified/);
+    },
+  );
+
+  await t.test("should work w/ `allow`", async () => {
+    const [rule] = sensitiveInfo({ allow: ["CREDIT_CARD_NUMBER", "EMAIL"] });
+    assert.equal(rule.type, "SENSITIVE_INFO");
   });
 
-  test("does not throw via `validate()`", () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      email: undefined,
-    };
-
-    const [rule] = sensitiveInfo({ mode: "LIVE", allow: [] });
-    assert.equal(rule.type, "SENSITIVE_INFO");
+  await t.test("should not fail when calling `validate`", () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "LIVE" });
     assert.doesNotThrow(() => {
-      const _ = rule.validate(context, details);
+      const _ = rule.validate(exampleContext, exampleDetails);
     });
   });
 
-  test("allows specifying sensitive info entities to allow", async () => {
-    const [rule] = sensitiveInfo({
-      allow: ["EMAIL", "CREDIT_CARD_NUMBER"],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
+  await t.test("should protect a body w/ normal info (live)", async () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        async getBody() {
+          return "none of this is sensitive";
+        },
+      },
+      exampleDetails,
+    );
+    assert.equal(result.conclusion, "ALLOW");
+    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
+    assert.deepEqual(result.reason.allowed, []);
+    assert.deepEqual(result.reason.denied, []);
+    assert.equal(result.state, "RUN");
   });
 
-  test("produces a dry run result in DRY_RUN mode", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () =>
-        Promise.resolve(
-          "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
-        ),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "DRY_RUN",
-      allow: [],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
+  await t.test("should detect sensitive info (dry run)", async () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "DRY_RUN" });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        async getBody() {
+          return "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567";
+        },
+      },
+      exampleDetails,
+    );
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
     assert.deepEqual(result.reason.allowed, []);
     assert.deepEqual(result.reason.denied, [
-      {
-        start: 0,
-        end: 9,
-        identifiedType: "IP_ADDRESS",
-      },
-      {
-        start: 10,
-        end: 26,
-        identifiedType: "EMAIL",
-      },
-      {
-        start: 27,
-        end: 43,
-        identifiedType: "CREDIT_CARD_NUMBER",
-      },
-      {
-        start: 44,
-        end: 60,
-        identifiedType: "PHONE_NUMBER",
-      },
+      { end: 9, identifiedType: "IP_ADDRESS", start: 0 },
+      { end: 26, identifiedType: "EMAIL", start: 10 },
+      { end: 43, identifiedType: "CREDIT_CARD_NUMBER", start: 27 },
+      { end: 60, identifiedType: "PHONE_NUMBER", start: 44 },
     ]);
     assert.equal(result.state, "DRY_RUN");
   });
 
-  test("it doesnt detect any entities in a non sensitive body", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("none of this is sensitive"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: [],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "ALLOW");
-    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
-    assert.deepEqual(result.reason.allowed, []);
-    assert.deepEqual(result.reason.denied, []);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("it identifies built-in entities", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () =>
-        Promise.resolve(
-          "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
-        ),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: [],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
+  await t.test("should detect sensitive info (live)", async () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        async getBody() {
+          return "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567";
+        },
+      },
+      exampleDetails,
+    );
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
     assert.deepEqual(result.reason.allowed, []);
     assert.deepEqual(result.reason.denied, [
-      {
-        start: 0,
-        end: 9,
-        identifiedType: "IP_ADDRESS",
-      },
-      {
-        start: 10,
-        end: 26,
-        identifiedType: "EMAIL",
-      },
-      {
-        start: 27,
-        end: 43,
-        identifiedType: "CREDIT_CARD_NUMBER",
-      },
-      {
-        start: 44,
-        end: 60,
-        identifiedType: "PHONE_NUMBER",
-      },
+      { end: 9, identifiedType: "IP_ADDRESS", start: 0 },
+      { end: 26, identifiedType: "EMAIL", start: 10 },
+      { end: 43, identifiedType: "CREDIT_CARD_NUMBER", start: 27 },
+      { end: 60, identifiedType: "PHONE_NUMBER", start: 44 },
     ]);
     assert.equal(result.state, "RUN");
   });
 
-  test("it allows entities on the allow list", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () =>
-        Promise.resolve(
-          "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567",
-        ),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
+  await t.test(
+    "should detect sensitive info, some of which in `allow`",
+    async () => {
+      const [rule] = sensitiveInfo({
+        allow: ["EMAIL", "PHONE_NUMBER"],
+        mode: "LIVE",
+      });
+      const result = await rule.protect(
+        {
+          ...exampleContext,
+          async getBody() {
+            return "127.0.0.1 test@example.com 4242424242424242 +353 87 123 4567";
+          },
+        },
+        exampleDetails,
+      );
+      assert.equal(result.conclusion, "DENY");
+      assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
+      assert.deepEqual(result.reason.allowed, [
+        { end: 26, identifiedType: "EMAIL", start: 10 },
+        { end: 60, identifiedType: "PHONE_NUMBER", start: 44 },
+      ]);
+      assert.deepEqual(result.reason.denied, [
+        { end: 9, identifiedType: "IP_ADDRESS", start: 0 },
+        { end: 43, identifiedType: "CREDIT_CARD_NUMBER", start: 27 },
+      ]);
+      assert.equal(result.state, "RUN");
+    },
+  );
 
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: ["EMAIL", "PHONE_NUMBER"],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
-    assert.deepEqual(result.reason.allowed, [
-      {
-        start: 10,
-        end: 26,
-        identifiedType: "EMAIL",
-      },
-      {
-        start: 44,
-        end: 60,
-        identifiedType: "PHONE_NUMBER",
-      },
-    ]);
-    assert.deepEqual(result.reason.denied, [
-      {
-        start: 0,
-        end: 9,
-        identifiedType: "IP_ADDRESS",
-      },
-      {
-        start: 27,
-        end: 43,
-        identifiedType: "CREDIT_CARD_NUMBER",
-      },
-    ]);
-    assert.equal(result.state, "RUN");
-  });
+  await t.test(
+    "should detect sensitive info, all of which in `allow`",
+    async () => {
+      const [rule] = sensitiveInfo({
+        allow: ["EMAIL", "PHONE_NUMBER"],
+        mode: "LIVE",
+      });
+      const result = await rule.protect(
+        {
+          ...exampleContext,
+          async getBody() {
+            return "test@example.com +353 87 123 4567";
+          },
+        },
+        exampleDetails,
+      );
+      assert.equal(result.conclusion, "ALLOW");
+      assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
+      assert.deepEqual(result.reason.allowed, [
+        { end: 16, identifiedType: "EMAIL", start: 0 },
+        { end: 33, identifiedType: "PHONE_NUMBER", start: 17 },
+      ]);
+      assert.deepEqual(result.reason.denied, []);
+      assert.equal(result.state, "RUN");
+    },
+  );
 
-  test("it returns an allow decision when all identified types are allowed", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
+  await t.test(
+    "should detect sensitive info, some of which in `deny` (1)",
+    async () => {
+      const [rule] = sensitiveInfo({
+        deny: ["CREDIT_CARD_NUMBER", "IP_ADDRESS"],
+        mode: "LIVE",
+      });
+      const result = await rule.protect(
+        {
+          ...exampleContext,
+          async getBody() {
+            return "127.0.0.1 test@example.com +353 87 123 4567";
+          },
+        },
+        exampleDetails,
+      );
+      assert.equal(result.conclusion, "DENY");
+      assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
+      assert.deepEqual(result.reason.allowed, [
+        { end: 26, identifiedType: "EMAIL", start: 10 },
+        { end: 43, identifiedType: "PHONE_NUMBER", start: 27 },
+      ]);
+      assert.deepEqual(result.reason.denied, [
+        { end: 9, identifiedType: "IP_ADDRESS", start: 0 },
+      ]);
+      assert.equal(result.state, "RUN");
+    },
+  );
 
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: ["EMAIL", "PHONE_NUMBER"],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "ALLOW");
-    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
-    assert.deepEqual(result.reason.allowed, [
-      {
-        start: 0,
-        end: 16,
-        identifiedType: "EMAIL",
-      },
-      {
-        start: 17,
-        end: 33,
-        identifiedType: "PHONE_NUMBER",
-      },
-    ]);
-    assert.deepEqual(result.reason.denied, []);
-    assert.equal(result.state, "RUN");
-  });
+  await t.test(
+    "should detect sensitive info, some of which is in `deny` (2)",
+    async () => {
+      const [rule] = sensitiveInfo({ deny: ["EMAIL"], mode: "LIVE" });
+      const result = await rule.protect(
+        {
+          ...exampleContext,
+          async getBody() {
+            return "test@example.com +353 87 123 4567";
+          },
+        },
+        exampleDetails,
+      );
+      assert.equal(result.conclusion, "DENY");
+      assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
+      assert.deepEqual(result.reason.allowed, [
+        { end: 33, identifiedType: "PHONE_NUMBER", start: 17 },
+      ]);
+      assert.deepEqual(result.reason.denied, [
+        { end: 16, identifiedType: "EMAIL", start: 0 },
+      ]);
+      assert.equal(result.state, "RUN");
+    },
+  );
 
-  test("it only denies listed entities when deny mode is set", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () =>
-        Promise.resolve("127.0.0.1 test@example.com +353 87 123 4567"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      deny: ["CREDIT_CARD_NUMBER", "IP_ADDRESS"],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
-    assert.deepEqual(result.reason.allowed, [
-      {
-        start: 10,
-        end: 26,
-        identifiedType: "EMAIL",
-      },
-      {
-        start: 27,
-        end: 43,
-        identifiedType: "PHONE_NUMBER",
-      },
-    ]);
-    assert.deepEqual(result.reason.denied, [
-      {
-        start: 0,
-        end: 9,
-        identifiedType: "IP_ADDRESS",
-      },
-    ]);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("it returns a deny decision in deny mode when an entity is matched", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("test@example.com +353 87 123 4567"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      deny: ["EMAIL"],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
-    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
-    assert.deepEqual(result.reason.allowed, [
-      {
-        start: 17,
-        end: 33,
-        identifiedType: "PHONE_NUMBER",
-      },
-    ]);
-    assert.deepEqual(result.reason.denied, [
-      {
-        start: 0,
-        end: 16,
-        identifiedType: "EMAIL",
-      },
-    ]);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("it blocks entities identified by a custom function", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("this is bad"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const customDetect = (tokens: string[]) => {
+  await t.test("should support a custom `detect` function", async () => {
+    function detect(tokens: string[]): Array<"CUSTOM" | undefined> {
       return tokens.map((token) => {
         if (token === "bad") {
           return "CUSTOM";
         }
       });
-    };
+    }
 
     const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      deny: ["CUSTOM"],
       contextWindowSize: 1,
-      detect: customDetect,
+      deny: ["CUSTOM"],
+      detect,
+      mode: "LIVE",
     });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        async getBody() {
+          return "this is bad";
+        },
+      },
+      exampleDetails,
+    );
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
     assert.deepEqual(result.reason.allowed, []);
     assert.deepEqual(result.reason.denied, [
-      {
-        start: 8,
-        end: 11,
-        identifiedType: "CUSTOM",
-      },
+      { end: 11, identifiedType: "CUSTOM", start: 8 },
     ]);
     assert.equal(result.state, "RUN");
   });
 
-  test("it throws when custom function returns non-string", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("this is bad"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
+  await t.test(
+    "should fail id custom `detect` returns non-string",
+    async () => {
+      function detect(tokens: string[]) {
+        return tokens.map((token) => {
+          if (token === "bad") {
+            return 12345;
+          }
+        });
+      }
 
-    const customDetect = (tokens: string[]) => {
-      return tokens.map((token) => {
-        if (token === "bad") {
-          return 12345;
-        }
+      const [rule] = sensitiveInfo({
+        allow: [],
+        contextWindowSize: 1,
+        // @ts-expect-error: test runtime behavior of invalid `detect`.
+        detect,
+        mode: "LIVE",
       });
-    };
+      await assert.rejects(async () => {
+        await rule.protect(
+          {
+            ...exampleContext,
+            async getBody() {
+              return "this is bad";
+            },
+          },
+          exampleDetails,
+        );
+      }, /invalid entity type/);
+    },
+  );
 
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: [],
-      contextWindowSize: 1,
-      // @ts-expect-error
-      detect: customDetect,
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    await assert.rejects(async () => {
-      const _ = await rule.protect(context, details);
-    }, new Error("invalid entity type"));
-  });
+  await t.test(
+    "should support a custom `detect` matching default values, and allowing them",
+    async () => {
+      function detect(tokens: string[]) {
+        return tokens.map((token) => {
+          if (token === "test@example.com") {
+            return "custom";
+          }
+        });
+      }
 
-  test("it allows custom entities identified by a function that would have otherwise been blocked", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("my email is test@example.com"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const customDetect = (tokens: string[]) => {
-      return tokens.map((token) => {
-        if (token === "test@example.com") {
-          return "custom";
-        }
+      const [rule] = sensitiveInfo({
+        allow: ["custom"],
+        contextWindowSize: 1,
+        detect,
+        mode: "LIVE",
       });
-    };
+      const result = await rule.protect(
+        {
+          ...exampleContext,
+          async getBody() {
+            return "my email is test@example.com";
+          },
+        },
+        exampleDetails,
+      );
+      assert.equal(result.conclusion, "ALLOW");
+      assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
+      assert.deepEqual(result.reason.allowed, [
+        { end: 28, identifiedType: "custom", start: 12 },
+      ]);
+      assert.deepEqual(result.reason.denied, []);
+      assert.equal(result.state, "RUN");
+    },
+  );
 
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: ["custom"],
-      detect: customDetect,
-      contextWindowSize: 1,
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "ALLOW");
-    assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
-    assert.deepEqual(result.reason.allowed, [
+  await t.test(
+    "should pass n-grams the size of `contextWindowSize`",
+    async () => {
+      let called = false;
+
+      function detect(tokens: string[]) {
+        called = true;
+        assert.equal(tokens.length, 3);
+        return tokens.map(() => undefined);
+      }
+
+      const [rule] = sensitiveInfo({
+        allow: [],
+        contextWindowSize: 3,
+        detect,
+        mode: "LIVE",
+      });
+      await rule.protect(
+        {
+          ...exampleContext,
+          async getBody() {
+            return "my email is test@example.com";
+          },
+        },
+        exampleDetails,
+      );
+
+      assert.ok(called);
+    },
+  );
+
+  await t.test("should error if w/o body (`undefined`)", async () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "LIVE" });
+    const decision = await rule.protect(
       {
-        start: 12,
-        end: 28,
-        identifiedType: "custom",
+        ...exampleContext,
+        getBody() {
+          return Promise.resolve(undefined);
+        },
       },
-    ]);
-    assert.deepEqual(result.reason.denied, []);
-    assert.equal(result.state, "RUN");
-  });
-
-  test("it provides the right size context window", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve("my email is test@example.com"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const customDetect = (tokens: string[]) => {
-      assert.equal(tokens.length, 3);
-      return tokens.map(() => undefined);
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: [],
-      detect: customDetect,
-      contextWindowSize: 3,
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    await rule.protect(context, details);
-  });
-
-  test("it returns an error decision when body is not available", async () => {
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache: new TestCache(),
-      getBody: () => Promise.resolve(undefined),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      cookies: "",
-      query: "",
-      extra: {},
-    };
-
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: [],
-      contextWindowSize: 1,
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const decision = await rule.protect(context, details);
+      exampleDetails,
+    );
     assert.equal(decision.ttl, 0);
     assert.equal(decision.state, "NOT_RUN");
     assert.equal(decision.conclusion, "ERROR");
   });
 
-  // Sensitive info detection is dynamic so all TTL are zero
-  test("does not use cache", async () => {
-    const cache = new TestCache();
-    mock.method(cache, "get", async () => [
+  await t.test("should allow if w/ empty body (`''`)", async () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "LIVE" });
+    const decision = await rule.protect(
       {
-        conclusion: "DENY",
-        reason: new ArcjetSensitiveInfoReason({
-          allowed: [],
-          denied: [],
-        }),
+        ...exampleContext,
+        getBody() {
+          return Promise.resolve("");
+        },
       },
-      10,
-    ]);
-    const context = {
-      key: "test-key",
-      fingerprint: "test-fingerprint",
-      runtime: "test",
-      log: mockLogger(),
-      characteristics: [],
-      cache,
-      getBody: () => Promise.resolve("nothing to detect"),
-    };
-    const details = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      cookies: "",
-      query: "",
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-    };
+      exampleDetails,
+    );
+    assert.equal(decision.ttl, 0);
+    assert.equal(decision.state, "RUN");
+    assert.equal(decision.conclusion, "ALLOW");
+  });
 
-    const [rule] = sensitiveInfo({
-      mode: "LIVE",
-      allow: [],
-    });
-    assert.equal(rule.type, "SENSITIVE_INFO");
-    const result = await rule.protect(context, details);
-    assert.equal(cache.get.mock.callCount(), 0);
+  // Sensitive info detection is dynamic so all TTL are zero
+  await t.test("should not use the cache", async () => {
+    const [rule] = sensitiveInfo({ allow: [], mode: "LIVE" });
+    const result = await rule.protect(
+      {
+        ...exampleContext,
+        cache: {
+          get() {
+            assert.fail();
+          },
+          set() {},
+        },
+        async getBody() {
+          return "nothing to detect";
+        },
+      },
+      exampleDetails,
+    );
     assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
     assert.deepEqual(result.reason.allowed, []);
@@ -2805,2197 +2363,1531 @@ describe("Primitive > sensitiveInfo", () => {
   });
 });
 
-describe("Products > protectSignup", () => {
-  test("allows configuration of rateLimit, bot, and email", () => {
+test("protectSignup", async (t) => {
+  await t.test("should work", () => {
     const rules = protectSignup({
+      bots: { allow: [], mode: "DRY_RUN" },
+      email: { allow: [], mode: "LIVE" },
       rateLimit: {
-        mode: "DRY_RUN",
         characteristics: ["ip.src"],
         interval: 60 /* minutes */ * 60 /* seconds */,
         max: 1,
-      },
-      bots: {
         mode: "DRY_RUN",
-        allow: [],
-      },
-      email: {
-        allow: [],
-        mode: "LIVE",
       },
     });
     assert.equal(rules.length, 3);
   });
 });
 
-describe("SDK", () => {
-  function testRuleLocalAllowed() {
-    return {
+test("SDK", async (t) => {
+  await t.test("should work w/o rules", () => {
+    const aj = arcjet(exampleOptions);
+    assert.equal(typeof aj.protect, "function");
+  });
+
+  await t.test("should add more rules w/ `withRule`", async () => {
+    const rule = tokenBucket({
+      characteristics: ["userId"],
+      refillRate: 60,
+      interval: 60,
+      capacity: 120,
+    });
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.deepEqual(rules, rule);
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({ ...exampleOptions, client });
+    type WithoutRuleTest = Assert<SDKProps<typeof aj, {}>>;
+
+    const ajOther = aj.withRule(rule);
+    type WithRuleTest = Assert<
+      SDKProps<
+        typeof ajOther,
+        { requested: number; userId: string | number | boolean }
+      >
+    >;
+
+    await ajOther.protect(exampleContext, {
+      ...exampleDetails,
+      userId: "abc123",
+      requested: 1,
+    });
+  });
+
+  await t.test(
+    "should add more rules w/ repeated `withRule` calls",
+    async () => {
+      let parameters: unknown;
+
+      const client = {
+        async decide() {
+          parameters = [...arguments].slice(2);
+          return new ArcjetAllowDecision({
+            ttl: 0,
+            reason: new ArcjetTestReason(),
+            results: [],
+          });
+        },
+        report() {
+          assert.fail();
+        },
+      };
+
+      const aj = arcjet({ ...exampleOptions, client });
+      type WithoutRuleTest = Assert<SDKProps<typeof aj, {}>>;
+
+      const rule = tokenBucket({
+        characteristics: ["userId"],
+        refillRate: 60,
+        interval: 60,
+        capacity: 120,
+      });
+
+      const ajOther = aj.withRule(rule);
+      type WithRuleTestOne = Assert<
+        SDKProps<
+          typeof ajOther,
+          { requested: number; userId: string | number | boolean }
+        >
+      >;
+
+      // TODO(@wooorm-arcjet): the types do not relate to reality,
+      // this rule has nothing to do with some field `abc`.
+      const testRule: ArcjetRule<{ abc: number }> = {
+        version: 0,
+        mode: "LIVE",
+        type: "test",
+        priority: 10000,
+        validate() {},
+        protect() {
+          assert.fail();
+        },
+      } as const;
+
+      // Note that this extends from `ajOther`.
+      const ajYetAnother = ajOther.withRule([testRule]);
+      type WithRuleTestTwo = Assert<
+        SDKProps<
+          typeof ajYetAnother,
+          { abc: number; requested: number; userId: string | number | boolean }
+        >
+      >;
+
+      await ajYetAnother.protect(exampleContext, {
+        ...exampleDetails,
+        userId: "abc123",
+        requested: 1,
+        abc: 123,
+      });
+      assert.deepEqual(parameters, [[...rule, testRule]]);
+    },
+  );
+
+  await t.test("should not add rules to the parent client", async () => {
+    let parameters: unknown;
+
+    const client = {
+      async decide() {
+        parameters = [...arguments].slice(2);
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({ ...exampleOptions, client });
+    type WithoutRuleTest = Assert<SDKProps<typeof aj, {}>>;
+
+    const tokenBucketRule = tokenBucket({
+      characteristics: ["userId"],
+      refillRate: 60,
+      interval: 60,
+      capacity: 120,
+    });
+
+    const ajOther = aj.withRule(tokenBucketRule);
+    type WithRuleTestOne = Assert<
+      SDKProps<
+        typeof ajOther,
+        { requested: number; userId: string | number | boolean }
+      >
+    >;
+
+    // TODO(@wooorm-arcjet): the types do not relate to reality,
+    // this rule has nothing to do with some field `abc`.
+    const testRule: ArcjetRule<{ abc: number }> = {
+      version: 0,
+      mode: "LIVE",
+      type: "test",
+      priority: 10000,
+      validate() {},
+      protect() {
+        assert.fail();
+      },
+    } as const;
+
+    // Note that this **does not** extend from `ajOther`.
+    const ajYetAnother = aj.withRule([testRule]);
+    type WithRuleTestTwo = Assert<
+      SDKProps<typeof ajYetAnother, { abc: number }>
+    >;
+
+    await ajYetAnother.protect(exampleContext, {
+      ...exampleDetails,
+      userId: "abc123",
+      requested: 1,
+      abc: 123,
+    });
+    assert.deepEqual(parameters, [[testRule]]);
+  });
+
+  // TODO(#207): Remove this once we default the client in the main SDK
+  await t.test("should fail if `client` is missing", () => {
+    assert.throws(() => {
+      arcjet({ ...exampleOptions, client: undefined });
+    }, /Client is required/);
+  });
+
+  // TODO(@wooorm-arcjet): `log` sounds like something we can allow and provide by default.
+  await t.test("should fail if `log` is missing", () => {
+    assert.throws(() => {
+      arcjet({ ...exampleOptions, log: undefined });
+    }, /Log is required/);
+  });
+
+  await t.test("should support local-only rules", async () => {
+    let calls = 0;
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_ALLOWED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 1);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 0,
+                state: "RUN",
+                conclusion: "ALLOW",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+        ],
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_DENIED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 2);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 3);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 5000,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+        ],
+      ],
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(decision.conclusion, "DENY");
+    assert.equal(calls, 4);
+  });
+
+  await t.test("should support only remote rules", async () => {
+    // TODO(@wooorm-arcjet): how is this testing remote rules?
+    let calls = 0;
+
+    const client = {
+      async decide() {
+        assert.equal(calls, 2);
+        calls++;
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_REMOTE",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 1);
+              calls++;
+              return new ArcjetRuleResult({
+                conclusion: "ALLOW",
+                fingerprint: "test-fingerprint",
+                reason: new ArcjetTestReason(),
+                ruleId: "test-rule-id",
+                state: "RUN",
+                ttl: 0,
+              });
+            },
+          } as const,
+        ],
+      ],
+      client,
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(decision.conclusion, "ALLOW");
+    assert.equal(calls, 3);
+  });
+
+  await t.test("should create an SDK with local and remote rules", async () => {
+    // TODO(@wooorm-arcjet): how is this testing remote rules?
+    let calls = 0;
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_ALLOWED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 1);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 0,
+                state: "RUN",
+                conclusion: "ALLOW",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_DENIED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 2);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 3);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 5000,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_REMOTE",
+            priority: 1,
+            validate() {
+              assert.fail();
+            },
+            protect() {
+              assert.fail();
+            },
+          } as const,
+        ],
+      ],
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(decision.conclusion, "DENY");
+    assert.equal(calls, 4);
+  });
+
+  await t.test("should call rules until one yields `DENY` (1)", async () => {
+    // TODO(@wooorm-arcjet): the above things were testing that too.
+    let calls = 0;
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_ALLOWED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 1);
+              calls++;
+
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 0,
+                state: "RUN",
+                conclusion: "ALLOW",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_DENIED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 2);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 3);
+              calls++;
+
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 5000,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+        ],
+      ],
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(decision.conclusion, "DENY");
+    assert.equal(calls, 4);
+  });
+
+  await t.test(
+    "should see a rule w/o result from `validate` as an `ALLOW`",
+    async () => {
+      let calls = 0;
+
+      const aj = arcjet({
+        ...exampleOptions,
+        rules: [
+          [
+            {
+              version: 0,
+              mode: "LIVE",
+              type: "TEST_RULE_LOCAL_INCORRECT",
+              priority: 1,
+              validate() {
+                assert.equal(calls, 0);
+                calls++;
+              },
+              // @ts-expect-error: test runtime behavior of no return value.
+              async protect() {
+                assert.equal(calls, 1);
+                calls++;
+              },
+            } as const,
+          ],
+        ],
+      });
+
+      const decision = await aj.protect(exampleContext, exampleDetails);
+      // TODO(@wooorm-arcjet): I don’t think this comment is correct.
+      // ALLOW because the remote rule was called and it returned ALLOW.
+      assert.equal(decision.conclusion, "ALLOW");
+      assert.equal(calls, 2);
+    },
+  );
+
+  await t.test("should ignore a rule w/o `validate`", async () => {
+    let calls = 0;
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          // @ts-expect-error: test runtime behavior of no `validate`.
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_INCORRECT",
+            priority: 1,
+            protect() {
+              assert.fail();
+            },
+          } as const,
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_DENIED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 1);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 5000,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+        ],
+      ],
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(calls, 2);
+    assert.equal(decision.conclusion, "DENY");
+    const result = decision.results.find((d) => d.ruleId === "");
+    assert.ok(result);
+    assert.equal(result.reason.type, "ERROR");
+    assert.equal(
+      // @ts-expect-error: TODO(#4452): `message` should be accessible.
+      result.reason.message,
+      "rule must have a `validate` function",
+    );
+  });
+
+  await t.test("should ignore a rule w/o `protect`", async () => {
+    let calls = 0;
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          // @ts-expect-error: test runtime behavior of missing `protect`.
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_INCORRECT",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+          } as const,
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_DENIED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 1);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 2);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 5000,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+        ],
+      ],
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(calls, 3);
+    assert.equal(decision.conclusion, "DENY");
+    const result = decision.results.find((d) => d.ruleId === "");
+    assert.ok(result);
+    assert.equal(result.reason.type, "ERROR");
+    assert.equal(
+      // @ts-expect-error: TODO(#4452): `message` should be accessible.
+      result.reason.message,
+      "rule must have a `protect` function",
+    );
+  });
+
+  await t.test(
+    "should conclude an error if fingerprint cannot be generated (no request)",
+    async () => {
+      const aj = arcjet(exampleOptions);
+      // @ts-expect-error: test runtime behavior of no request object.
+      const decision = await aj.protect(exampleContext);
+      assert.equal(decision.conclusion, "ERROR");
+    },
+  );
+
+  await t.test(
+    "should conclude an error if fingerprint cannot be generated (empty request)",
+    async () => {
+      const aj = arcjet(exampleOptions);
+      // TODO(@wooorm-arcjet): if this so clearly throws, then why is an empty object allowed by the types?
+      const decision = await aj.protect(exampleContext, {});
+      assert.equal(decision.conclusion, "ERROR");
+    },
+  );
+
+  await t.test("should allow `10` rules", async () => {
+    const rules = Array.from(
+      { length: 10 },
+      (): Array<ArcjetRule> => [
+        {
+          version: 0,
+          mode: "LIVE",
+          type: "TEST_RULE_MULTIPLE",
+          priority: 1,
+          validate() {},
+          protect() {
+            assert.fail();
+          },
+        },
+      ],
+    );
+
+    const decision = await arcjet({ ...exampleOptions, rules }).protect(
+      exampleContext,
+      exampleDetails,
+    );
+    assert.equal(decision.conclusion, "ALLOW");
+  });
+
+  await t.test("should conclude error on `11` rules", async () => {
+    const rules = Array.from(
+      { length: 11 },
+      (): Array<ArcjetRule> => [
+        {
+          version: 0,
+          mode: "LIVE",
+          type: "TEST_RULE_MULTIPLE",
+          priority: 1,
+          validate() {},
+          protect() {
+            assert.fail();
+          },
+        },
+      ],
+    );
+
+    const decision = await arcjet({ ...exampleOptions, rules }).protect(
+      exampleContext,
+      exampleDetails,
+    );
+    assert.equal(decision.conclusion, "ERROR");
+  });
+
+  await t.test("should call rules until one yields `DENY` (2)", async () => {
+    // TODO(@wooorm-arcjet): seems the same as “should call rules until one yields `DENY`” above.
+    let calls = 0;
+
+    const aj = arcjet({
+      ...exampleOptions,
+      rules: [
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_DENIED",
+            priority: 1,
+            validate() {
+              assert.equal(calls, 0);
+              calls++;
+            },
+            async protect() {
+              assert.equal(calls, 1);
+              calls++;
+              return new ArcjetRuleResult({
+                ruleId: "test-rule-id",
+                fingerprint: "test-fingerprint",
+                ttl: 5000,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              });
+            },
+          } as const,
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_LOCAL_ALLOWED",
+            priority: 1,
+            validate() {
+              assert.fail();
+            },
+            async protect() {
+              assert.fail();
+            },
+          } as const,
+        ],
+      ],
+    });
+
+    const decision = await aj.protect(exampleContext, exampleDetails);
+    assert.equal(decision.conclusion, "DENY");
+    assert.equal(calls, 2);
+  });
+
+  await t.test("should support headers as a regular object", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details) {
+        assert.equal(calls, 0);
+        calls++;
+        assert.ok(details.headers);
+        assert.deepEqual(Object.fromEntries(details.headers), {
+          "user-agent": "curl/8.1.2",
+        });
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    await arcjet({ ...exampleOptions, client }).protect(exampleContext, {
+      ...exampleDetails,
+      headers: { "user-agent": "curl/8.1.2" },
+    });
+    assert.equal(calls, 1);
+  });
+
+  await t.test(
+    "should support headers as a regular object (array values)",
+    async () => {
+      let calls = 0;
+
+      const client: Client = {
+        async decide(context, details) {
+          assert.equal(calls, 0);
+          calls++;
+
+          assert.ok(details.headers);
+          assert.deepEqual(Object.fromEntries(details.headers), {
+            // Note: array is serialized.
+            "user-agent": "curl/8.1.2, something",
+          });
+
+          return new ArcjetAllowDecision({
+            ttl: 0,
+            reason: new ArcjetTestReason(),
+            results: [],
+          });
+        },
+        report() {
+          assert.fail();
+        },
+      };
+
+      const aj = arcjet({ ...exampleOptions, client });
+      await aj.protect(exampleContext, {
+        ...exampleDetails,
+        headers: { "User-Agent": ["curl/8.1.2", "something"] },
+      });
+      assert.equal(calls, 1);
+    },
+  );
+
+  await t.test("should support extra details", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide(context, details) {
+        assert.equal(calls, 0);
+        calls++;
+
+        assert.deepEqual(details.extra, {
+          "extra-number": "123",
+          "extra-false": "false",
+          "extra-true": "true",
+          "extra-unsupported": "<unsupported value>",
+        });
+
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const { extra, ...details } = exampleDetails;
+
+    const aj = arcjet({ ...exampleOptions, client });
+    await aj.protect(exampleContext, {
+      ...details,
+      // To do: should we drop values of `null`, `undefined`, etc?
+      // Now they result in `<unsupported value>`.
+      "extra-number": 123,
+      "extra-false": false,
+      "extra-true": true,
+      "extra-unsupported": new Date(),
+    });
+    assert.equal(calls, 1);
+  });
+
+  await t.test("should call `decide` if all rules decide `ALLOW`", async () => {
+    let parameters: unknown;
+
+    const client = {
+      async decide() {
+        parameters = [...arguments].slice(2);
+        return new ArcjetErrorDecision({
+          ttl: 0,
+          reason: new ArcjetErrorReason("reason"),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    const rule: ArcjetRule = {
       version: 0,
       mode: "LIVE",
       type: "TEST_RULE_LOCAL_ALLOWED",
       priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(
-        async () =>
-          new ArcjetRuleResult({
+      validate() {},
+      async protect() {
+        return new ArcjetRuleResult({
+          ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
+          ttl: 0,
+          state: "RUN",
+          conclusion: "ALLOW",
+          reason: new ArcjetTestReason(),
+        });
+      },
+    };
+
+    await arcjet({
+      ...exampleOptions,
+      client,
+      rules: [[rule]],
+    }).protect(exampleContext, exampleDetails);
+
+    assert.deepEqual(parameters, [[rule]]);
+  });
+
+  await t.test("should not call `decide` if a rule decides `DENY", async () => {
+    // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
+    // or even as an `as const` object.
+    const rule: ArcjetRule = {
+      version: 0,
+      mode: "LIVE",
+      type: "TEST_RULE_LOCAL_DENIED",
+      priority: 1,
+      validate() {},
+      async protect() {
+        return new ArcjetRuleResult({
+          ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
+          ttl: 5000,
+          state: "RUN",
+          conclusion: "DENY",
+          reason: new ArcjetTestReason(),
+        });
+      },
+    };
+
+    let called = 0;
+
+    await arcjet({
+      ...exampleOptions,
+      client: {
+        async decide() {
+          // Should not be called.
+          called++;
+          assert.fail();
+        },
+        report() {
+          assert.equal(called, 0);
+          called++;
+        },
+      },
+      rules: [[rule]],
+    }).protect(exampleContext, exampleDetails);
+
+    assert.equal(called, 1);
+  });
+
+  await t.test("should call `decide` w/o rules", async () => {
+    let calls = 0;
+
+    const client = {
+      async decide() {
+        assert.equal(calls, 0);
+        calls++;
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+
+    await arcjet({ ...exampleOptions, client }).protect(
+      exampleContext,
+      exampleDetails,
+    );
+    assert.equal(calls, 1);
+  });
+
+  await t.test(
+    "should not call `report` if all rules decide `ALLOW`",
+    async () => {
+      let parameters: unknown;
+
+      const client = {
+        async decide() {
+          parameters = [...arguments].slice(2);
+          return new ArcjetErrorDecision({
+            ttl: 0,
+            reason: new ArcjetErrorReason("reason"),
+            results: [],
+          });
+        },
+        report() {
+          assert.fail();
+        },
+      };
+
+      const rule: ArcjetRule = {
+        version: 0,
+        mode: "LIVE",
+        type: "TEST_RULE_LOCAL_ALLOWED",
+        priority: 1,
+        validate() {},
+        async protect() {
+          return new ArcjetRuleResult({
             ruleId: "test-rule-id",
             fingerprint: "test-fingerprint",
             ttl: 0,
             state: "RUN",
             conclusion: "ALLOW",
             reason: new ArcjetTestReason(),
-          }),
-      ),
-    } as const;
-  }
-  function testRuleLocalDenied() {
-    return {
+          });
+        },
+      };
+
+      await arcjet({ ...exampleOptions, client, rules: [[rule]] }).protect(
+        exampleContext,
+        exampleDetails,
+      );
+
+      assert.deepEqual(parameters, [[rule]]);
+    },
+  );
+
+  await t.test("should call `report` if a rule decides `DENY`", async () => {
+    let calls = 0;
+
+    const client: Client = {
+      async decide() {
+        return new ArcjetErrorDecision({
+          ttl: 0,
+          reason: new ArcjetErrorReason("reason"),
+          results: [],
+        });
+      },
+      report(context, request, decision, rules) {
+        assert.equal(calls, 0);
+        calls++;
+        assert.equal(decision.conclusion, "DENY");
+        assert.equal(rules.length, 1);
+      },
+    };
+
+    const rule: ArcjetRule = {
       version: 0,
       mode: "LIVE",
       type: "TEST_RULE_LOCAL_DENIED",
       priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(
-        async () =>
-          new ArcjetRuleResult({
+      validate() {},
+      async protect() {
+        return new ArcjetRuleResult({
+          ruleId: "test-rule-id",
+          fingerprint: "test-fingerprint",
+          ttl: 5000,
+          state: "RUN",
+          conclusion: "DENY",
+          reason: new ArcjetTestReason(),
+        });
+      },
+    };
+
+    await arcjet({
+      ...exampleOptions,
+      client,
+      rules: [[rule]],
+    }).protect(exampleContext, exampleDetails);
+
+    assert.equal(calls, 1);
+  });
+
+  await t.test(
+    "should detect `@vercel/request-context` and provide it to `report`",
+    async () => {
+      let calls = 0;
+      const client: Client = {
+        async decide() {
+          return new ArcjetErrorDecision({
+            ttl: 0,
+            reason: new ArcjetErrorReason("reason"),
+            results: [],
+          });
+        },
+        report(context) {
+          assert.equal(calls, 0);
+          calls++;
+          assert.ok(context);
+          assert.equal(context.waitUntil, waitUntil);
+        },
+      };
+      const rule: ArcjetRule = {
+        version: 0,
+        mode: "LIVE",
+        type: "TEST_RULE_LOCAL_DENIED",
+        priority: 1,
+        validate() {},
+        async protect() {
+          return new ArcjetRuleResult({
             ruleId: "test-rule-id",
             fingerprint: "test-fingerprint",
             ttl: 5000,
             state: "RUN",
             conclusion: "DENY",
             reason: new ArcjetTestReason(),
-          }),
-      ),
-    } as const;
-  }
-  function testRuleLocalCached() {
-    const ruleId = "test-rule-id";
-    const fingerprint =
-      "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e";
-    return {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_CACHED",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(async (ctx) => {
-        const [result, ttl] = await ctx.cache.get(ruleId, ctx.fingerprint);
-        if (result) {
-          return new ArcjetRuleResult({
-            ruleId,
-            fingerprint,
-            ttl,
-            state: "CACHED",
-            conclusion: "DENY",
-            reason: new ArcjetTestReason(),
           });
-        } else {
-          return new ArcjetRuleResult({
-            ruleId,
-            fingerprint,
-            ttl: 0,
-            state: "RUN",
-            conclusion: "ALLOW",
+        },
+      };
+
+      const SYMBOL_FOR_REQ_CONTEXT = Symbol.for("@vercel/request-context");
+
+      // @ts-expect-error: TODO(@wooorm-arcjet): investigate if this can be typed.
+      globalThis[SYMBOL_FOR_REQ_CONTEXT] = {
+        get() {
+          return { waitUntil };
+        },
+      };
+
+      await arcjet({
+        ...exampleOptions,
+        client,
+        rules: [[rule]],
+      }).protect(exampleContext, exampleDetails);
+      assert.equal(calls, 1);
+
+      // @ts-expect-error: TODO(@wooorm-arcjet): investigate if this can be typed.
+      delete globalThis[SYMBOL_FOR_REQ_CONTEXT];
+
+      function waitUntil() {
+        assert.fail();
+      }
+    },
+  );
+
+  await t.test(
+    "should cache a `DENY` from `decide`, and `report` when a cached decision is used",
+    async () => {
+      let calls = 0;
+      const ruleId = "test-rule-id";
+      const fingerprint =
+        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e";
+      const client: Client = {
+        async decide() {
+          assert.equal(calls, 1);
+          calls++;
+          return new ArcjetDenyDecision({
+            ttl: 10,
             reason: new ArcjetTestReason(),
+            results: [
+              // The important part is that this result is cached.
+              new ArcjetRuleResult({
+                ruleId,
+                fingerprint,
+                ttl: 10,
+                state: "RUN",
+                conclusion: "DENY",
+                reason: new ArcjetTestReason(),
+              }),
+            ],
           });
-        }
-      }),
-    } as const;
-  }
-  function testRuleLocalIncorrect() {
-    return {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_INCORRECT",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(async () => undefined),
-    } as const;
-  }
-  function testRuleLocalNoValidate() {
-    return {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_INCORRECT",
-      priority: 1,
-      protect: mock.fn(),
-    } as const;
-  }
-  function testRuleLocalNoProtect() {
-    return {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_LOCAL_INCORRECT",
-      priority: 1,
-      validate: mock.fn(),
-    } as const;
-  }
-
-  function testRuleRemote(): ArcjetRule {
-    return {
-      version: 0,
-      mode: "LIVE",
-      type: "TEST_RULE_REMOTE",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-  }
-
-  function testRuleMultiple(): ArcjetRule[] {
-    return [
-      {
+        },
+        report() {
+          assert.equal(calls, 3);
+          calls++;
+        },
+      };
+      const rule: ArcjetRule = {
         version: 0,
         mode: "LIVE",
-        type: "TEST_RULE_MULTIPLE",
+        type: "TEST_RULE_LOCAL_CACHED",
         priority: 1,
-        validate: mock.fn(),
-        protect: mock.fn(),
-      },
-      {
-        version: 0,
-        mode: "LIVE",
-        type: "TEST_RULE_MULTIPLE",
-        priority: 1,
-        validate: mock.fn(),
-        protect: mock.fn(),
-      },
-      {
-        version: 0,
-        mode: "LIVE",
-        type: "TEST_RULE_MULTIPLE",
-        priority: 1,
-        validate: mock.fn(),
-        protect: mock.fn(),
-      },
-    ];
-  }
+        validate() {},
+        async protect(context) {
+          const [result, ttl] = await context.cache.get(
+            ruleId,
+            context.fingerprint,
+          );
 
-  function testRuleInvalidType(): ArcjetRule {
-    return {
+          if (result) {
+            assert.equal(calls, 2);
+            calls++;
+            return new ArcjetRuleResult({
+              ruleId,
+              fingerprint,
+              ttl,
+              state: "CACHED",
+              conclusion: "DENY",
+              reason: new ArcjetTestReason(),
+            });
+          } else {
+            assert.equal(calls, 0);
+            calls++;
+            return new ArcjetRuleResult({
+              ruleId,
+              fingerprint,
+              ttl: 0,
+              state: "RUN",
+              conclusion: "ALLOW",
+              reason: new ArcjetTestReason(),
+            });
+          }
+        },
+      };
+
+      const aj = arcjet({ ...exampleOptions, client, rules: [[rule]] });
+      const decision = await aj.protect(exampleContext, exampleDetails);
+      assert.equal(decision.isErrored(), false);
+      assert.equal(decision.conclusion, "DENY");
+      assert.equal(calls, 2);
+
+      const decision2 = await aj.protect(exampleContext, exampleDetails);
+      assert.equal(decision2.isErrored(), false);
+      assert.equal(decision2.conclusion, "DENY");
+      assert.equal(calls, 4);
+    },
+  );
+
+  await t.test("should not throw if unknown rule type is passed", () => {
+    // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
+    // or even as an `as const` object.
+    const rule: ArcjetRule = {
       version: 0,
       mode: "LIVE",
       type: "TEST_RULE_INVALID_TYPE",
       priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(),
-    };
-  }
+      validate() {},
+      protect() {
+        assert.fail();
+      },
+    } as const;
 
-  function testRuleLocalThrow() {
-    return {
+    // TODO(@wooorm-arcjet): where would that `Unknown Rule type` be thrown?
+    // What is this really testing: the above object is an `ArcjetRule`,
+    // what would be invalid about it?
+
+    // Specifically should not throw `Unknown Rule type`.
+    arcjet({
+      ...exampleOptions,
+      client: {
+        decide() {
+          assert.fail();
+        },
+        report() {
+          assert.fail();
+        },
+      },
+      rules: [[rule]],
+    });
+  });
+
+  await t.test("should not call `report` if local rules throw", async () => {
+    let calls = 0;
+    const rule: ArcjetRule = {
       version: 0,
       mode: "LIVE",
       type: "TEST_RULE_LOCAL_THROW",
       priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(async () => {
-        throw new Error("Local rule protect failed");
-      }),
-    } as const;
-  }
-
-  function testRuleLocalDryRun() {
-    return {
-      version: 0,
-      mode: "DRY_RUN",
-      type: "TEST_RULE_LOCAL_DRY_RUN",
-      priority: 1,
-      validate: mock.fn(),
-      protect: mock.fn(async () => {
-        return new ArcjetRuleResult({
-          ruleId: "test-rule-id",
-          fingerprint: "test-fingerprint",
-          ttl: 0,
-          state: "DRY_RUN",
-          conclusion: "DENY",
-          reason: new ArcjetTestReason(),
-        });
-      }),
-    } as const;
-  }
-
-  function testRuleProps(): Primitive<{ abc: number }> {
-    return [
-      {
-        version: 0,
-        mode: "LIVE",
-        type: "test",
-        priority: 10000,
-        validate: mock.fn(),
-        protect: mock.fn(),
+      validate() {
+        assert.equal(calls, 0);
+        calls++;
+        throw new Error("Some error");
       },
-    ];
-  }
-
-  test("creates a new Arcjet SDK with no rules", () => {
-    const client = {
-      decide: mock.fn(async () => {
+      protect() {
+        // Make sure this is never called.
+        calls++;
+        assert.fail();
+      },
+    };
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 1);
+        calls++;
+        assert.deepEqual(rules, [rule]);
         return new ArcjetAllowDecision({
           ttl: 0,
           reason: new ArcjetTestReason(),
           results: [],
         });
-      }),
-      report: mock.fn(),
+      },
+      report() {
+        // Make sure this is never called.
+        calls++;
+        assert.fail();
+      },
     };
 
-    const aj = arcjet({
-      key: "test-key",
-      rules: [],
+    await arcjet({
+      ...exampleOptions,
+      rules: [[rule]],
       client,
-      log: mockLogger(),
-    });
-    assert.ok("protect" in aj);
-    assert.equal(typeof aj.protect, "function");
+    }).protect(exampleContext, exampleDetails);
+    assert.equal(calls, 2);
   });
 
-  test("can augment rules via `withRule` API", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
+  await t.test("should handle `string` being thrown by a rule", async () => {
+    let calls = 0;
 
-    const key = "test-key";
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: { "User-Agent": "curl/8.1.2" },
-      "extra-test": "extra-test-value",
-      userId: "abc123",
-      requested: 1,
-    };
+    // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
+    // or even as an `as const` object.
+    const rule = {
+      version: 0,
+      mode: "LIVE",
+      type: "TEST_RULE_LOCAL_THROW_STRING",
+      priority: 1,
+      validate() {},
+      async protect() {
+        assert.equal(calls, 0);
+        calls++;
+        throw "Local rule protect failed";
+      },
+    } as const;
 
-    const aj = arcjet({
-      key,
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-    type WithoutRuleTest = Assert<SDKProps<typeof aj, {}>>;
+    await arcjet({
+      ...exampleOptions,
+      rules: [[rule]],
+      log: {
+        ...exampleLogger,
+        error() {
+          assert.equal(calls, 1);
+          calls++;
+          assert.deepEqual(
+            [...arguments],
+            [
+              "Failure running rule: %s due to %s",
+              "TEST_RULE_LOCAL_THROW_STRING",
+              "Local rule protect failed",
+            ],
+          );
+        },
+      },
+    }).protect(exampleContext, exampleDetails);
 
-    const tokenBucketRule = tokenBucket({
-      characteristics: ["userId"],
-      refillRate: 60,
-      interval: 60,
-      capacity: 120,
-    });
-
-    const aj2 = aj.withRule(tokenBucketRule);
-    type WithRuleTest = Assert<
-      SDKProps<
-        typeof aj2,
-        { requested: number; userId: string | number | boolean }
-      >
-    >;
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj2.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const call = client.decide.mock.calls[0];
-    assert.ok(call);
-    assert.deepEqual(call.arguments.slice(2), [tokenBucketRule]);
+    assert.equal(calls, 2);
   });
 
-  test("can chain new rules via multiple `withRule` calls", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
+  await t.test("should handle `null` being thrown by a rule", async () => {
+    let calls = 0;
 
-    const key = "test-key";
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: { "User-Agent": "curl/8.1.2" },
-      "extra-test": "extra-test-value",
-      userId: "abc123",
-      requested: 1,
-      abc: 123,
-    };
+    // TODO(@wooorm-arcjet): investigate why typescript does not allow this object to be passed as a regular object
+    // or even as an `as const` object.
+    const rule = {
+      version: 0,
+      mode: "LIVE",
+      type: "TEST_RULE_LOCAL_THROW_NULL",
+      priority: 1,
+      validate() {},
+      async protect() {
+        assert.equal(calls, 0);
+        calls++;
+        throw null;
+      },
+    } as const;
 
-    const aj = arcjet({
-      key,
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-    type WithoutRuleTest = Assert<SDKProps<typeof aj, {}>>;
-
-    const tokenBucketRule = tokenBucket({
-      characteristics: ["userId"],
-      refillRate: 60,
-      interval: 60,
-      capacity: 120,
-    });
-
-    const aj2 = aj.withRule(tokenBucketRule);
-    type WithRuleTestOne = Assert<
-      SDKProps<
-        typeof aj2,
-        { requested: number; userId: string | number | boolean }
-      >
-    >;
-
-    const testRule = testRuleProps();
-
-    const aj3 = aj2.withRule(testRule);
-    type WithRuleTestTwo = Assert<
-      SDKProps<
-        typeof aj3,
-        { requested: number; userId: string | number | boolean; abc: number }
-      >
-    >;
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj3.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const call = client.decide.mock.calls[0];
-    assert.ok(call);
-    assert.deepEqual(call.arguments.slice(2), [
-      [...tokenBucketRule, ...testRule],
-    ]);
+    await arcjet({
+      ...exampleOptions,
+      rules: [[rule]],
+      log: {
+        ...exampleLogger,
+        error() {
+          assert.equal(calls, 1);
+          calls++;
+          assert.deepEqual(
+            [...arguments],
+            [
+              "Failure running rule: %s due to %s",
+              "TEST_RULE_LOCAL_THROW_NULL",
+              "Unknown problem",
+            ],
+          );
+        },
+      },
+    }).protect(exampleContext, exampleDetails);
+    assert.equal(calls, 2);
   });
 
-  test("creates different augmented clients when `withRule` not chained", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
+  await t.test(
+    "should not deny a `DRY_RUN` result nor cache a deny decision",
+    async () => {
+      let calls = 0;
 
-    const key = "test-key";
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: { "User-Agent": "curl/8.1.2" },
-      "extra-test": "extra-test-value",
-      userId: "abc123",
-      requested: 1,
-      abc: 123,
-    };
-
-    const aj = arcjet({
-      key,
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-    type WithoutRuleTest = Assert<SDKProps<typeof aj, {}>>;
-
-    const tokenBucketRule = tokenBucket({
-      characteristics: ["userId"],
-      refillRate: 60,
-      interval: 60,
-      capacity: 120,
-    });
-
-    const aj2 = aj.withRule(tokenBucketRule);
-    type WithRuleTestOne = Assert<
-      SDKProps<
-        typeof aj2,
-        { requested: number; userId: string | number | boolean }
-      >
-    >;
-
-    const testRule = testRuleProps();
-
-    const aj3 = aj.withRule(testRule);
-    type WithRuleTestTwo = Assert<SDKProps<typeof aj3, { abc: number }>>;
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj3.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const call = client.decide.mock.calls[0];
-    assert.ok(call);
-    assert.deepEqual(call.arguments.slice(2), [testRule]);
-  });
-
-  test("creates a new Arcjet SDK with only local rules", () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleLocalAllowed(), testRuleLocalDenied()]],
-      client,
-      log: mockLogger(),
-    });
-    assert.ok("protect" in aj);
-    assert.equal(typeof aj.protect, "function");
-  });
-
-  test("creates a new Arcjet SDK with only remote rules", () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleRemote()]],
-      client,
-      log: mockLogger(),
-    });
-    assert.ok("protect" in aj);
-    assert.equal(typeof aj.protect, "function");
-  });
-
-  test("creates a new Arcjet SDK with both local and remote rules", () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [
-        [testRuleLocalAllowed(), testRuleLocalDenied(), testRuleRemote()],
-      ],
-      client,
-      log: mockLogger(),
-    });
-    assert.ok("protect" in aj);
-    assert.equal(typeof aj.protect, "function");
-  });
-
-  // TODO(#207): Remove this once we default the client in the main SDK
-  test("throws if no client is specified", () => {
-    assert.throws(() => {
-      const aj = arcjet({
-        key: "test-key",
-        rules: [],
-        log: mockLogger(),
-      });
-    });
-  });
-
-  test("throws if no log is specified", () => {
-    assert.throws(() => {
       const client = {
-        decide: mock.fn(async () => {
+        async decide() {
+          calls++;
           return new ArcjetAllowDecision({
             ttl: 0,
             reason: new ArcjetTestReason(),
             results: [],
           });
-        }),
-        report: mock.fn(),
+        },
+        report() {
+          assert.fail();
+        },
       };
 
       const aj = arcjet({
-        key: "test-key",
-        rules: [],
-        client,
-      });
-    });
-  });
-
-  test("calls each local rule until a DENY decision is encountered", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const allowed = testRuleLocalAllowed();
-    const denied = testRuleLocalDenied();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[allowed, denied]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    assert.equal(decision.conclusion, "DENY");
-
-    assert.equal(allowed.validate.mock.callCount(), 1);
-    assert.equal(allowed.protect.mock.callCount(), 1);
-    assert.equal(denied.validate.mock.callCount(), 1);
-    assert.equal(denied.protect.mock.callCount(), 1);
-  });
-
-  test("does not crash if a local rule does not return a result", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const rule = testRuleLocalIncorrect();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [
-        [
-          // @ts-expect-error because the rule is written wrong
-          rule,
-        ],
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    // ALLOW because the remote rule was called and it returned ALLOW
-    assert.equal(decision.conclusion, "ALLOW");
-
-    assert.equal(rule.validate.mock.callCount(), 1);
-    assert.equal(rule.protect.mock.callCount(), 1);
-  });
-
-  test("does not crash if a rule does not define `validate` function", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const rule = testRuleLocalNoValidate();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [
-        [
-          // @ts-expect-error because the rule is written wrong
-          rule,
-          testRuleLocalDenied(),
-        ],
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    // DENY because one local rule errored and the other denied
-    assert.equal(decision.conclusion, "DENY");
-    const anonymousResult = decision.results.find((d) => d.ruleId === "");
-    assert.ok(anonymousResult);
-    assert.equal(anonymousResult.reason.type, "ERROR");
-    assert.equal(
-      // @ts-expect-error: TODO(#4452): `message` should be accessible.
-      anonymousResult.reason.message,
-      "rule must have a `validate` function",
-    );
-  });
-
-  test("does not crash if a rule does not define `protect` function", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const rule = testRuleLocalNoProtect();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [
-        [
-          // @ts-expect-error because the rule is written wrong
-          rule,
-          testRuleLocalDenied(),
-        ],
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    // DENY because one local rule errored and the other denied
-    assert.equal(decision.conclusion, "DENY");
-    const anonymousResult = decision.results.find((d) => d.ruleId === "");
-    assert.ok(anonymousResult);
-    assert.equal(anonymousResult.reason.type, "ERROR");
-    assert.equal(
-      // @ts-expect-error: TODO(#4452): `message` should be accessible.
-      anonymousResult.reason.message,
-      "rule must have a `protect` function",
-    );
-  });
-
-  test("returns an ERROR decision if fingerprint cannot be generated", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {};
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    assert.equal(decision.conclusion, "ERROR");
-  });
-
-  test("returns an ERROR decision with no request object", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    // @ts-expect-error
-    const decision = await aj.protect();
-    assert.equal(decision.conclusion, "ERROR");
-  });
-
-  test("returns an ERROR decision when more than 10 rules are generated", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "100.100.100.100",
-    };
-
-    const rules: ArcjetRule[][] = [];
-    // We only iterate 4 times because `testRuleMultiple` generates 3 rules
-    for (let idx = 0; idx < 4; idx++) {
-      rules.push(testRuleMultiple());
-    }
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: rules,
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    assert.equal(decision.conclusion, "ERROR");
-  });
-
-  test("won't run a later local rule if a DENY decision is encountered", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const allowed = testRuleLocalAllowed();
-    const denied = testRuleLocalDenied();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[denied, allowed]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-    assert.equal(decision.conclusion, "DENY");
-
-    assert.equal(denied.validate.mock.callCount(), 1);
-    assert.equal(denied.protect.mock.callCount(), 1);
-    assert.equal(allowed.validate.mock.callCount(), 0);
-    assert.equal(allowed.protect.mock.callCount(), 0);
-  });
-
-  test("accepts plain object of headers", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: { "user-agent": "curl/8.1.2" },
-      "extra-test": "extra-test-value",
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args = client.decide.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      headers: request.headers,
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-  });
-
-  test("accepts plain object of `raw` headers", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: { "User-Agent": ["curl/8.1.2", "something"] },
-      "extra-test": "extra-test-value",
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args = client.decide.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      // Note that the headers are serialized.
-      headers: { "user-agent": "curl/8.1.2, something" },
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-  });
-
-  test("converts extra keys with non-string values to string values", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: { "user-agent": "curl/8.1.2" },
-      "extra-number": 123,
-      "extra-false": false,
-      "extra-true": true,
-      "extra-unsupported": new Date(),
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args = client.decide.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-number": "123",
-        "extra-false": "false",
-        "extra-true": "true",
-        "extra-unsupported": "<unsupported value>",
-      },
-      headers: request.headers,
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-  });
-
-  test("does not call `client.report()` if the local decision is ALLOW", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("This decision not under test"),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const allowed = testRuleLocalAllowed();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[allowed]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-    assert.equal(client.report.mock.callCount(), 0);
-    assert.equal(client.decide.mock.callCount(), 1);
-    // TODO: Validate correct `ruleResults` are sent with `decide` when available
-  });
-
-  test("calls `client.decide()` if the local decision is ALLOW", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("This decision not under test"),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const rule = testRuleLocalAllowed();
-
-    const aj = arcjet({
-      key,
-      rules: [[rule]],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      headers: { "user-agent": "curl/8.1.2" },
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-    assert.deepEqual(args.at(2), [rule]);
-  });
-
-  test("calls `client.report()` if the local decision is DENY", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("This decision not under test"),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const rule = testRuleLocalDenied();
-
-    const aj = arcjet({
-      key,
-      rules: [[rule]],
-      client,
-      log: mockLogger(),
-    });
-
-    const _ = await aj.protect(context, request);
-    assert.equal(client.report.mock.callCount(), 1);
-    const args: unknown[] = client.report.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      headers: { "user-agent": "curl/8.1.2" },
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-    const two = args.at(2);
-    assert.ok(two);
-    assert.ok(typeof two === "object");
-    assert.ok("conclusion" in two);
-    assert.equal(two.conclusion, "DENY");
-    assert.deepEqual(args.at(3), [rule]);
-  });
-
-  test("provides `waitUntil` in context to  `client.report()` if available", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("This decision not under test"),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const waitUntil = mock.fn();
-
-    const SYMBOL_FOR_REQ_CONTEXT = Symbol.for("@vercel/request-context");
-    // @ts-ignore
-    globalThis[SYMBOL_FOR_REQ_CONTEXT] = {
-      get() {
-        return { waitUntil };
-      },
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const rule = testRuleLocalDenied();
-
-    const aj = arcjet({
-      key,
-      rules: [[rule]],
-      client,
-      log: mockLogger(),
-    });
-
-    const _ = await aj.protect(context, request);
-    assert.equal(client.report.mock.callCount(), 1);
-
-    const args: unknown[] = client.report.mock.calls[0].arguments;
-    const head = args.at(0);
-    assert.ok(head);
-    assert.ok(typeof head === "object");
-    assert.ok("waitUntil" in head);
-    assert.equal(head.waitUntil, waitUntil);
-    // @ts-ignore
-    delete globalThis[SYMBOL_FOR_REQ_CONTEXT];
-  });
-
-  test("does not call `client.decide()` if the local decision is DENY", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetErrorDecision({
-          ttl: 0,
-          reason: new ArcjetErrorReason("This decision not under test"),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "curl/8.1.2"]]),
-      "extra-test": "extra-test-value",
-    };
-    const denied = testRuleLocalDenied();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[denied]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-    assert.equal(client.decide.mock.callCount(), 0);
-  });
-
-  test("calls `client.decide()` even with no rules", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    const aj = arcjet({
-      key,
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.report.mock.callCount(), 0);
-    assert.equal(client.decide.mock.callCount(), 1);
-
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-test": "extra-test-value",
-      },
-      headers: { "user-agent": "Mozilla/5.0" },
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-  });
-
-  test("caches a DENY decision locally and reports when a cached decision is used", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetDenyDecision({
-          ttl: 10,
-          reason: new ArcjetTestReason(),
-          results: [
-            new ArcjetRuleResult({
-              ruleId: "test-rule-id",
-              fingerprint:
-                "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-              ttl: 10,
-              state: "RUN",
-              conclusion: "DENY",
-              reason: new ArcjetTestReason(),
-            }),
+        ...exampleOptions,
+        rules: [
+          [
+            {
+              version: 0,
+              mode: "DRY_RUN",
+              type: "TEST_RULE_LOCAL_DRY_RUN",
+              priority: 1,
+              validate() {},
+              async protect() {
+                return new ArcjetRuleResult({
+                  ruleId: "test-rule-id",
+                  fingerprint: "test-fingerprint",
+                  ttl: 0,
+                  state: "DRY_RUN",
+                  conclusion: "DENY",
+                  reason: new ArcjetTestReason(),
+                });
+              },
+            } as const,
           ],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleLocalCached()]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-
-    assert.equal(decision.isErrored(), false);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    assert.equal(client.report.mock.callCount(), 0);
-
-    assert.equal(decision.conclusion, "DENY");
-
-    const decision2 = await aj.protect(context, request);
-
-    assert.equal(decision2.isErrored(), false);
-    assert.equal(client.decide.mock.callCount(), 1);
-    assert.equal(client.report.mock.callCount(), 1);
-
-    assert.equal(decision2.conclusion, "DENY");
-  });
-
-  test("does not throw if unknown rule type is passed", () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    // Specifically should not throw `Unknown Rule type`.
-    assert.doesNotThrow(() => {
-      const aj = arcjet({
-        key: "test-key",
-        rules: [[testRuleInvalidType()]],
+        ],
         client,
-        log: mockLogger(),
       });
-    });
-  });
 
-  test("does not call `client.report()` if a local rule throws", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
+      const decision = await aj.protect(exampleContext, exampleDetails);
+      assert.equal(decision.isDenied(), false);
+      assert.equal(calls, 1);
 
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
+      const decision2 = await aj.protect(exampleContext, exampleDetails);
+      assert.equal(decision2.isDenied(), false);
+      assert.equal(calls, 2);
+    },
+  );
 
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleLocalThrow()]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.report.mock.callCount(), 0);
-    assert.equal(client.decide.mock.callCount(), 1);
-    // TODO: Validate correct `ruleResults` are sent with `decide` when available
-  });
-
-  test("correctly logs an error message if a local rule throws a string", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    function testRuleLocalThrowString(): ArcjetRule {
-      return {
-        version: 0,
-        mode: "LIVE",
-        type: "TEST_RULE_LOCAL_THROW_STRING",
-        priority: 1,
-        validate: mock.fn(),
-        async protect(context, details) {
-          throw "Local rule protect failed";
-        },
-      };
-    }
-
-    const log = mockLogger();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleLocalThrowString()]],
-      client,
-      log,
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(log.error.mock.callCount(), 1);
-    assert.deepEqual(log.error.mock.calls[0].arguments, [
-      "Failure running rule: %s due to %s",
-      "TEST_RULE_LOCAL_THROW_STRING",
-      "Local rule protect failed",
-    ]);
-  });
-
-  test("correctly logs an error message if a local rule throws a non-error", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    function testRuleLocalThrowNull(): ArcjetRule {
-      return {
-        version: 0,
-        mode: "LIVE",
-        type: "TEST_RULE_LOCAL_THROW_NULL",
-        priority: 1,
-        validate: mock.fn(),
-        async protect(context, details) {
-          throw null;
-        },
-      };
-    }
-
-    const log = mockLogger();
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleLocalThrowNull()]],
-      client,
-      log,
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(log.error.mock.callCount(), 1);
-    assert.deepEqual(log.error.mock.calls[0].arguments, [
-      "Failure running rule: %s due to %s",
-      "TEST_RULE_LOCAL_THROW_NULL",
-      "Unknown problem",
-    ]);
-  });
-
-  test("does not return nor cache a deny decision if DENY decision in a dry run local rule", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      rules: [[testRuleLocalDryRun()]],
-      client,
-      log: mockLogger(),
-    });
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const decision = await aj.protect(context, request);
-
-    assert.equal(decision.isDenied(), false);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    assert.equal(client.report.mock.callCount(), 0);
-
-    const decision2 = await aj.protect(context, request);
-
-    assert.equal(decision2.isDenied(), false);
-
-    assert.equal(client.decide.mock.callCount(), 2);
-    assert.equal(client.report.mock.callCount(), 0);
-  });
-
-  test("processes a single rule from a REMOTE ArcjetRule", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    const rule = testRuleRemote();
-
-    const aj = arcjet({
-      key,
-      rules: [[rule]],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(context, request);
-
-    assert.equal(decision.isErrored(), false);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    assert.deepEqual(requestAsJson(args.at(1)), {
-      cookies: undefined,
-      email: undefined,
-      extra: {
-        "extra-test": "extra-test-value",
+  await t.test("should process a remote rule", async () => {
+    // TODO(@wooorm-arcjet): what is this really testing? What is remote about it?
+    let calls = 0;
+    const rule = {
+      version: 0,
+      mode: "LIVE",
+      type: "TEST_RULE_REMOTE",
+      priority: 1,
+      validate() {},
+      protect() {
+        assert.fail();
       },
-      headers: { "user-agent": "Mozilla/5.0" },
-      host: request.host,
-      ip: request.ip,
-      method: request.method,
-      path: request.path,
-      protocol: request.protocol,
-      query: undefined,
-    });
-    assert.deepEqual(args.at(2), [rule]);
-  });
-
-  test("overrides `key` with custom context", async () => {
-    const client = {
-      decide: mock.fn(async () => {
+    } as const;
+    const client: Client = {
+      async decide(context, details, rules) {
+        assert.equal(calls, 0);
+        calls++;
+        assert.deepEqual(rules, [rule]);
         return new ArcjetAllowDecision({
           ttl: 0,
           reason: new ArcjetTestReason(),
           results: [],
         });
-      }),
-      report: mock.fn(),
+      },
+      report() {
+        assert.fail();
+      },
     };
-
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    const rule = testRuleRemote();
-
-    const aj = arcjet({
-      key,
+    const decision = await arcjet({
+      ...exampleOptions,
+      client,
       rules: [[rule]],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(
-      { ...context, key: "overridden-key" },
-      request,
-    );
-
+    }).protect(exampleContext, exampleDetails);
     assert.equal(decision.isErrored(), false);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const head = args.at(0);
-    assert.ok(head);
-    assert.ok(typeof head === "object");
-    assert.ok("key" in head);
-    assert.equal(head.key, "overridden-key");
+    assert.equal(calls, 1);
   });
 
-  test("reports and returns an ERROR decision if a `client.decide()` fails", async () => {
-    const client = {
-      decide: mock.fn(async () => {
+  await t.test("should pass a `key` through to `decide`", async () => {
+    let calls = 0;
+    const client: Client = {
+      async decide(context) {
+        assert.equal(calls, 0);
+        calls++;
+        assert.equal(context.key, "overridden-key");
+        return new ArcjetAllowDecision({
+          ttl: 0,
+          reason: new ArcjetTestReason(),
+          results: [],
+        });
+      },
+      report() {
+        assert.fail();
+      },
+    };
+    const decision = await arcjet({
+      ...exampleOptions,
+      client,
+      rules: [
+        [
+          {
+            version: 0,
+            mode: "LIVE",
+            type: "TEST_RULE_REMOTE",
+            priority: 1,
+            validate() {},
+            protect() {
+              assert.fail();
+            },
+          } as const,
+        ],
+      ],
+    }).protect({ ...exampleContext, key: "overridden-key" }, exampleDetails);
+    assert.equal(decision.isErrored(), false);
+    assert.equal(calls, 1);
+  });
+
+  await t.test("should handle an error being thrown by `decide`", async () => {
+    let calls = 0;
+    const client: Client = {
+      async decide() {
+        assert.equal(calls, 0);
+        calls++;
         throw new Error("Decide function failed");
-      }),
-      report: mock.fn(),
+      },
+      report(context, request, decision) {
+        assert.equal(calls, 1);
+        calls++;
+        assert.equal(decision.conclusion, "ERROR");
+      },
     };
 
-    const key = "test-key";
-    const context = {
-      key,
-      fingerprint:
-        "fp::2::516289fae7993d35ffb6e76883e09b475bbc7a622a378f3b430f35e8c657687e",
-      getBody: () => Promise.resolve(undefined),
-    };
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["User-Agent", "Mozilla/5.0"]]),
-      "extra-test": "extra-test-value",
-    };
-
-    const aj = arcjet({
-      key,
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const decision = await aj.protect(context, request);
-
-    assert.equal(decision.isErrored(), true);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    assert.equal(client.report.mock.callCount(), 1);
-    const args: unknown[] = client.report.mock.calls[0].arguments;
-    const item = args.at(2);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("conclusion" in item);
-    assert.equal(item.conclusion, "ERROR");
-  });
-
-  test("header characteristics are used to generate fingerprints", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: ['http.request.headers["abcxyz"]'],
-      rules: [],
-      client,
-      log: mockLogger(),
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers([["abcxyz", "test1234"]]),
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const head = args.at(0);
-    assert.ok(head);
-    assert.ok(typeof head === "object");
-    assert.ok("fingerprint" in head);
-    assert.equal(
-      head.fingerprint,
-      "fp::2::6f3a3854134fe3d20fe56387bdcb594f18b182683424757b88da75e8f13b92bd",
+    const decision = await arcjet({ ...exampleOptions, client }).protect(
+      exampleContext,
+      exampleDetails,
     );
+    assert.equal(decision.isErrored(), true);
+    assert.equal(calls, 2);
   });
 
-  test("global characteristics are propagated if they aren't separately specified in fixedWindow", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
+  await t.test(
+    "should generate fingerprints w/ header characteristics",
+    async () => {
+      let fingerprint: unknown;
+      const client: Client = {
+        async decide(context) {
+          fingerprint = context.fingerprint;
+          return new ArcjetAllowDecision({
+            ttl: 0,
+            reason: new ArcjetTestReason(),
+            results: [],
+          });
+        },
+        report() {
+          assert.fail();
+        },
+      };
 
-    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: globalCharacteristics,
-      rules: [
-        fixedWindow({
-          mode: "LIVE",
-          window: "1h",
-          max: 60,
-        }),
-      ],
-      client,
-      log: mockLogger(),
-    });
+      await arcjet({
+        ...exampleOptions,
+        characteristics: ['http.request.headers["abcxyz"]'],
+        client,
+      }).protect(
+        { getBody: exampleContext.getBody },
+        { ...exampleDetails, headers: new Headers([["abcxyz", "test1234"]]) },
+      );
 
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      someGlobalCharacteristic: "test",
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const list = args.at(2);
-    assert.ok(Array.isArray(list));
-    const item = list.at(0);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("characteristics" in item);
-    assert.deepEqual(item.characteristics, globalCharacteristics);
-  });
-
-  test("local characteristics are prefered on fixedWindow over global characteristics", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
-    const localCharacteristics = ["someLocalCharacteristic"] as const;
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: globalCharacteristics,
-      rules: [
-        fixedWindow({
-          mode: "LIVE",
-          window: "1h",
-          max: 60,
-          characteristics: localCharacteristics,
-        }),
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      someGlobalCharacteristic: "test",
-      someLocalCharacteristic: "test",
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const list = args.at(2);
-    assert.ok(Array.isArray(list));
-    const item = list.at(0);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("characteristics" in item);
-    assert.deepEqual(item.characteristics, localCharacteristics);
-  });
-
-  test("global characteristics are propagated if they aren't separately specified in slidingWindow", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: globalCharacteristics,
-      rules: [
-        slidingWindow({
-          mode: "LIVE",
-          interval: "1h",
-          max: 60,
-        }),
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      someGlobalCharacteristic: "test",
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const list = args.at(2);
-    assert.ok(Array.isArray(list));
-    const item = list.at(0);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("characteristics" in item);
-    assert.deepEqual(item.characteristics, globalCharacteristics);
-  });
-
-  test("local characteristics are prefered on slidingWindow over global characteristics", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
-    const localCharacteristics = ["someLocalCharacteristic"] as const;
-
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: globalCharacteristics,
-      rules: [
-        slidingWindow({
-          mode: "LIVE",
-          interval: "1h",
-          max: 60,
-          characteristics: localCharacteristics,
-        }),
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      someGlobalCharacteristic: "test",
-      someLocalCharacteristic: "test",
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const list = args.at(2);
-    assert.ok(Array.isArray(list));
-    const item = list.at(0);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("characteristics" in item);
-    assert.deepEqual(item.characteristics, localCharacteristics);
-  });
-
-  test("global characteristics are propagated if they aren't separately specified in tokenBucket", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: globalCharacteristics,
-      rules: [
-        tokenBucket({
-          mode: "LIVE",
-          interval: "1h",
-          refillRate: 1,
-          capacity: 10,
-        }),
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      requested: 1,
-      someGlobalCharacteristic: "test",
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const list = args.at(2);
-    assert.ok(Array.isArray(list));
-    const item = list.at(0);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("characteristics" in item);
-    assert.deepEqual(item.characteristics, globalCharacteristics);
-  });
-
-  test("local characteristics are prefered on tokenBucket over global characteristics", async () => {
-    const client = {
-      decide: mock.fn(async () => {
-        return new ArcjetAllowDecision({
-          ttl: 0,
-          reason: new ArcjetTestReason(),
-          results: [],
-        });
-      }),
-      report: mock.fn(),
-    };
-
-    const globalCharacteristics = ["someGlobalCharacteristic"] as const;
-    const localCharacteristics = ["someLocalCharacteristic"] as const;
-
-    const aj = arcjet({
-      key: "test-key",
-      characteristics: globalCharacteristics,
-      rules: [
-        tokenBucket({
-          mode: "LIVE",
-          interval: "1h",
-          refillRate: 1,
-          capacity: 10,
-          characteristics: localCharacteristics,
-        }),
-      ],
-      client,
-      log: mockLogger(),
-    });
-
-    const request = {
-      ip: "172.100.1.1",
-      method: "GET",
-      protocol: "http",
-      host: "example.com",
-      path: "/",
-      headers: new Headers(),
-      requested: 1,
-      someGlobalCharacteristic: "test",
-      someLocalCharacteristic: "test",
-    };
-
-    const context = {
-      getBody: () => Promise.resolve(undefined),
-    };
-
-    const _ = await aj.protect(context, request);
-
-    assert.equal(client.decide.mock.callCount(), 1);
-    const args: unknown[] = client.decide.mock.calls[0].arguments;
-    const list = args.at(2);
-    assert.ok(Array.isArray(list));
-    const item = list.at(0);
-    assert.ok(item);
-    assert.ok(typeof item === "object");
-    assert.ok("characteristics" in item);
-    assert.deepEqual(item.characteristics, localCharacteristics);
-  });
+      assert.equal(
+        fingerprint,
+        "fp::2::6f3a3854134fe3d20fe56387bdcb594f18b182683424757b88da75e8f13b92bd",
+      );
+    },
+  );
 });

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -138,7 +138,7 @@ const exampleDetails = {
   query: "",
 };
 
-test("ArcjetDecision", async (t) => {
+test("Arcjet*Decision", async (t) => {
   await t.test("id", async (t) => {
     await t.test("should generate an `id` field if not given", () => {
       const decision = new ArcjetAllowDecision({

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2027,6 +2027,7 @@ test("sensitiveInfo", async (t) => {
       },
       exampleDetails,
     );
+    // TODO(#4561): should be `ALLOW` in dry run mode.
     assert.equal(result.conclusion, "DENY");
     assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
     assert.deepEqual(result.reason.allowed, []);

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -2923,7 +2923,6 @@ test("SDK", async (t) => {
     "should conclude an error if fingerprint cannot be generated (empty request)",
     async () => {
       const aj = arcjet(exampleOptions);
-      // TODO(@wooorm-arcjet): if this so clearly throws, then why is an empty object allowed by the types?
       const decision = await aj.protect(exampleContext, {});
       assert.equal(decision.conclusion, "ERROR");
     },


### PR DESCRIPTION
This is similar to c67d5179.

It’s big, best to compare side-by-side.

Like that commit, this removes `assert`s that are not really related to what is being tested.
That helps when in the future we add another property somewhere, which could in some cases result in many tests failing.

The main tests were giant. 5k lines.
This commit removes a lot of repetition. Cutting it down to 3.9k lines. A follow-up PR could split things up into different files. Another follow-up PR could improve the coverage by adding more tests.

Some test cases for particular rules were in the general “SDK” group. This commit moves them into the sections for those rules.

Some test cases tested different things.
This commit splits those into different cases.

Another example is a test case that tested that 10+ rules fail by passing 12 rules.
To illustrate, I took that intent and made a test case that asserted `10` rules pass and another that `11` rules fail.

Some names of test cases were a bit confusing compared to what they tested. And labels were a bit different from each other as they were added at various points in time.
This commit reworks labels for clarity and consistency.

I also labelled `@ts-expect-error`s to explain whether they were testing runtime behavior or are up for improvement.

There were already some `TODO`s inline about improving the tests, which I solved.

I found different things that seem like bugs or could otherwise be improved and noted them inline as `TODO`s.