### PR TITLE
types: add union of arcjet reasons

### DIFF
--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -117,12 +117,12 @@ export async function GET(req: Request) {
   console.log("Arcjet decision", decision);
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json(
         { error: "Too Many Requests", reason: decision.reason },
         { status: 429 },
       );
-    } else if (decision.reason.isBot()) {
+    } else if (decision.reason.type === "BOT") {
       return NextResponse.json(
         { error: "No bots allowed", reason: decision.reason },
         { status: 403 },
@@ -189,7 +189,7 @@ and results.
 ```ts
 for (const result of decision.results) {
   // Check the rate limit rule results
-  if (result.reason.isRateLimit()) {
+  if (result.reason.type === "RATE_LIMIT") {
     if (result.isDenied()) {
       console.log("Rate limit rule returned deny conclusion", result);
     }
@@ -200,7 +200,7 @@ for (const result of decision.results) {
   }
 
   // Log the name of any denied bots
-  if (result.reason.isBot()) {
+  if (result.reason.type === "BOT") {
     if (result.isDenied()) {
       console.log("Detected bot", reason.denied);
     }

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -614,7 +614,7 @@ export function createMiddleware(
 
     if (decision.isDenied()) {
       // TODO(#222): Content type negotiation using `Accept` header
-      if (decision.reason.isRateLimit()) {
+      if (decision.reason.type === "RATE_LIMIT") {
         return NextResponse.json(
           { code: 429, message: "Too Many Requests" },
           { status: 429 },
@@ -680,7 +680,7 @@ export function withArcjet<Args extends [ArcjetNextRequest, ...unknown[]], Res>(
     if (decision.isDenied()) {
       if (isNextApiResponse(response)) {
         // TODO(#222): Content type negotiation using `Accept` header
-        if (decision.reason.isRateLimit()) {
+        if (decision.reason.type === "RATE_LIMIT") {
           return response
             .status(429)
             .json({ code: 429, message: "Too Many Requests" });
@@ -689,7 +689,7 @@ export function withArcjet<Args extends [ArcjetNextRequest, ...unknown[]], Res>(
         }
       } else {
         // TODO(#222): Content type negotiation using `Accept` header
-        if (decision.reason.isRateLimit()) {
+        if (decision.reason.type === "RATE_LIMIT") {
           return NextResponse.json(
             { code: 429, message: "Too Many Requests" },
             { status: 429 },

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -245,7 +245,7 @@ export interface ArcjetNext<Props extends PlainObject> {
    *   conclusion based on evaluating each of the configured rules. If you wish
    *   to accept Arcjet’s recommended action based on the configured rules then
    *   you can use this property.
-   * - `reason` (`ArcjetReason`) - An object containing more detailed
+   * - `reason` (`ArcjetReasons`) - An object containing more detailed
    *   information about the conclusion.
    * - `results` (`ArcjetRuleResult[]`) - An array of {@link ArcjetRuleResult} objects
    *   containing the results of each rule that was executed.

--- a/arcjet-remix/README.md
+++ b/arcjet-remix/README.md
@@ -71,7 +71,7 @@ export async function loader(args: LoaderFunctionArgs) {
   const decision = await aj.protect(args);
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       throw new Response(null, {
         status: 429,
         statusText: "Too Many Requests",

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -17,12 +17,12 @@ import type {
   ArcjetEmailType,
   ArcjetSensitiveInfoType,
   ArcjetRateLimitRule,
+  ArcjetReasons,
 } from "@arcjet/protocol";
 import {
   ArcjetBotReason,
   ArcjetEmailReason,
   ArcjetErrorReason,
-  ArcjetReason,
   ArcjetRuleResult,
   ArcjetSensitiveInfoReason,
   ArcjetDecision,
@@ -31,6 +31,7 @@ import {
   ArcjetShieldReason,
   ArcjetRateLimitReason,
   ArcjetConclusion,
+  ArcjetUnknownReason,
 } from "@arcjet/protocol";
 import type { Client } from "@arcjet/protocol/client.js";
 import * as analyze from "@arcjet/analyze";
@@ -659,7 +660,7 @@ export type ArcjetRequest<Props extends PlainObject> = Simplify<
 
 type CachedResult = {
   conclusion: ArcjetConclusion;
-  reason: ArcjetReason;
+  reason: ArcjetReasons;
 };
 
 function isRateLimitRule<Props extends PlainObject>(
@@ -2290,7 +2291,7 @@ export default function arcjet<
         ttl: 0,
         state: "NOT_RUN",
         conclusion: "ALLOW",
-        reason: new ArcjetReason(),
+        reason: new ArcjetUnknownReason(),
       });
 
       // Add top-level characteristics to all Rate Limit rules that don't already have

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -792,7 +792,7 @@ export function tokenBucket<
       );
 
       const [cached, ttl] = await context.cache.get(ruleId, fingerprint);
-      if (cached && cached.reason.isRateLimit()) {
+      if (cached && cached.reason.type === "RATE_LIMIT") {
         return new ArcjetRuleResult({
           ruleId,
           fingerprint,
@@ -939,7 +939,7 @@ export function fixedWindow<
       );
 
       const [cached, ttl] = await context.cache.get(ruleId, fingerprint);
-      if (cached && cached.reason.isRateLimit()) {
+      if (cached && cached.reason.type === "RATE_LIMIT") {
         return new ArcjetRuleResult({
           ruleId,
           fingerprint,
@@ -1080,7 +1080,7 @@ export function slidingWindow<
       );
 
       const [cached, ttl] = await context.cache.get(ruleId, fingerprint);
-      if (cached && cached.reason.isRateLimit()) {
+      if (cached && cached.reason.type === "RATE_LIMIT") {
         return new ArcjetRuleResult({
           ruleId,
           fingerprint,

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -10,7 +10,7 @@ import arcjet, {
   ArcjetDenyDecision,
   ArcjetErrorDecision,
   ArcjetChallengeDecision,
-  ArcjetReason,
+  ArcjetUnknownReason,
   ArcjetErrorReason,
   ArcjetRuleResult,
   ArcjetEmailReason,
@@ -76,8 +76,6 @@ function requestAsJson(value: unknown): object {
   return { ...value, headers: Object.fromEntries(value.headers) };
 }
 
-class ArcjetTestReason extends ArcjetReason {}
-
 class TestCache {
   get = mock.fn<() => Promise<[unknown, number]>>(async () => [undefined, 0]);
   set = mock.fn();
@@ -98,7 +96,7 @@ describe("ArcjetDecision", () => {
   test("will default the `id` property if not specified", () => {
     const decision = new ArcjetAllowDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.match(decision.id, /^lreq_/);
@@ -108,7 +106,7 @@ describe("ArcjetDecision", () => {
     const decision = new ArcjetAllowDecision({
       id: "abc_123",
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.id, "abc_123");
@@ -150,7 +148,7 @@ describe("ArcjetDecision", () => {
   test("`isAllowed()` returns true when type is ALLOW", () => {
     const decision = new ArcjetAllowDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isAllowed(), true);
@@ -168,7 +166,7 @@ describe("ArcjetDecision", () => {
   test("`isAllowed()` returns false when type is DENY", () => {
     const decision = new ArcjetDenyDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isAllowed(), false);
@@ -177,7 +175,7 @@ describe("ArcjetDecision", () => {
   test("`isDenied()` returns false when type is ALLOW", () => {
     const decision = new ArcjetAllowDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isDenied(), false);
@@ -195,7 +193,7 @@ describe("ArcjetDecision", () => {
   test("`isDenied()` returns true when type is DENY", () => {
     const decision = new ArcjetDenyDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isDenied(), true);
@@ -204,7 +202,7 @@ describe("ArcjetDecision", () => {
   test("`isChallenged()` returns true when type is CHALLENGE", () => {
     const decision = new ArcjetChallengeDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isChallenged(), true);
@@ -213,7 +211,7 @@ describe("ArcjetDecision", () => {
   test("`isErrored()` returns false when type is ALLOW", () => {
     const decision = new ArcjetAllowDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isErrored(), false);
@@ -231,7 +229,7 @@ describe("ArcjetDecision", () => {
   test("`isErrored()` returns false when type is DENY", () => {
     const decision = new ArcjetDenyDecision({
       ttl: 0,
-      reason: new ArcjetTestReason(),
+      reason: new ArcjetUnknownReason(),
       results: [],
     });
     assert.equal(decision.isErrored(), false);
@@ -248,7 +246,7 @@ describe("ArcjetDecision", () => {
   });
 
   test("`isRateLimit()` returns true when reason is not RATE_LIMIT", () => {
-    const reason = new ArcjetTestReason();
+    const reason = new ArcjetUnknownReason();
     assert.equal(reason.isRateLimit(), false);
   });
 
@@ -297,7 +295,7 @@ describe("ArcjetDecision", () => {
   });
 
   test("`isBot()` returns false when reason is not BOT", () => {
-    const reason = new ArcjetTestReason();
+    const reason = new ArcjetUnknownReason();
     assert.equal(reason.isBot(), false);
   });
 });
@@ -2843,7 +2841,7 @@ describe("SDK", () => {
             ttl: 0,
             state: "RUN",
             conclusion: "ALLOW",
-            reason: new ArcjetTestReason(),
+            reason: new ArcjetUnknownReason(),
           }),
       ),
     } as const;
@@ -2863,7 +2861,7 @@ describe("SDK", () => {
             ttl: 5000,
             state: "RUN",
             conclusion: "DENY",
-            reason: new ArcjetTestReason(),
+            reason: new ArcjetUnknownReason(),
           }),
       ),
     } as const;
@@ -2887,7 +2885,7 @@ describe("SDK", () => {
             ttl,
             state: "CACHED",
             conclusion: "DENY",
-            reason: new ArcjetTestReason(),
+            reason: new ArcjetUnknownReason(),
           });
         } else {
           return new ArcjetRuleResult({
@@ -2896,7 +2894,7 @@ describe("SDK", () => {
             ttl: 0,
             state: "RUN",
             conclusion: "ALLOW",
-            reason: new ArcjetTestReason(),
+            reason: new ArcjetUnknownReason(),
           });
         }
       }),
@@ -3009,7 +3007,7 @@ describe("SDK", () => {
           ttl: 0,
           state: "DRY_RUN",
           conclusion: "DENY",
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
         });
       }),
     } as const;
@@ -3033,7 +3031,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3055,7 +3053,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3114,7 +3112,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3186,7 +3184,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3251,7 +3249,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3273,7 +3271,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3295,7 +3293,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3331,7 +3329,7 @@ describe("SDK", () => {
         decide: mock.fn(async () => {
           return new ArcjetAllowDecision({
             ttl: 0,
-            reason: new ArcjetTestReason(),
+            reason: new ArcjetUnknownReason(),
             results: [],
           });
         }),
@@ -3351,7 +3349,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3395,7 +3393,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3442,7 +3440,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3484,7 +3482,6 @@ describe("SDK", () => {
     assert.ok(anonymousResult);
     assert.equal(anonymousResult.reason.type, "ERROR");
     assert.equal(
-      // @ts-expect-error: TODO(#4452): `message` should be accessible.
       anonymousResult.reason.message,
       "rule must have a `validate` function",
     );
@@ -3495,7 +3492,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3537,7 +3534,6 @@ describe("SDK", () => {
     assert.ok(anonymousResult);
     assert.equal(anonymousResult.reason.type, "ERROR");
     assert.equal(
-      // @ts-expect-error: TODO(#4452): `message` should be accessible.
       anonymousResult.reason.message,
       "rule must have a `protect` function",
     );
@@ -3548,7 +3544,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3577,7 +3573,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3601,7 +3597,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3638,7 +3634,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3682,7 +3678,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3737,7 +3733,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -3793,7 +3789,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4111,7 +4107,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4169,7 +4165,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetDenyDecision({
           ttl: 10,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [
             new ArcjetRuleResult({
               ruleId: "test-rule-id",
@@ -4178,7 +4174,7 @@ describe("SDK", () => {
               ttl: 10,
               state: "RUN",
               conclusion: "DENY",
-              reason: new ArcjetTestReason(),
+              reason: new ArcjetUnknownReason(),
             }),
           ],
         });
@@ -4230,7 +4226,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4253,7 +4249,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4293,7 +4289,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4351,7 +4347,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4409,7 +4405,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4457,7 +4453,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4518,7 +4514,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4618,7 +4614,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4665,7 +4661,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4719,7 +4715,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4776,7 +4772,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4830,7 +4826,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4888,7 +4884,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),
@@ -4944,7 +4940,7 @@ describe("SDK", () => {
       decide: mock.fn(async () => {
         return new ArcjetAllowDecision({
           ttl: 0,
-          reason: new ArcjetTestReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
         });
       }),

--- a/decorate/index.ts
+++ b/decorate/index.ts
@@ -1,10 +1,6 @@
 import format from "@arcjet/sprintf";
-import type { ArcjetDecision } from "@arcjet/protocol";
-import {
-  ArcjetRateLimitReason,
-  ArcjetReason,
-  ArcjetRuleResult,
-} from "@arcjet/protocol";
+import type { ArcjetDecision, ArcjetReasons } from "@arcjet/protocol";
+import { ArcjetRateLimitReason, ArcjetRuleResult } from "@arcjet/protocol";
 
 interface HeaderLike {
   has(name: string): boolean;
@@ -117,12 +113,12 @@ function toLimitString({
   return `limit=${max}, remaining=${remaining}, reset=${reset}`;
 }
 
-function extractReason(result: ArcjetRuleResult): ArcjetReason {
+function extractReason(result: ArcjetRuleResult): ArcjetReasons {
   return result.reason;
 }
 
 function isRateLimitReason(
-  reason: ArcjetReason,
+  reason: ArcjetReasons,
 ): reason is ArcjetRateLimitReason {
   return reason.isRateLimit();
 }

--- a/decorate/index.ts
+++ b/decorate/index.ts
@@ -120,7 +120,7 @@ function extractReason(result: ArcjetRuleResult): ArcjetReasons {
 function isRateLimitReason(
   reason: ArcjetReasons,
 ): reason is ArcjetRateLimitReason {
-  return reason.isRateLimit();
+  return reason.type === "RATE_LIMIT";
 }
 
 function nearestLimit(

--- a/decorate/test/decorate.test.ts
+++ b/decorate/test/decorate.test.ts
@@ -4,8 +4,8 @@ import { setRateLimitHeaders } from "../index.js";
 import {
   ArcjetAllowDecision,
   ArcjetRateLimitReason,
-  ArcjetReason,
   ArcjetRuleResult,
+  ArcjetUnknownReason,
 } from "@arcjet/protocol";
 import { OutgoingMessage } from "http";
 
@@ -20,7 +20,7 @@ describe("setRateLimitHeaders", () => {
         new ArcjetAllowDecision({
           results: [],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), false);
@@ -39,11 +39,11 @@ describe("setRateLimitHeaders", () => {
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
-              reason: new ArcjetReason(),
+              reason: new ArcjetUnknownReason(),
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), false);
@@ -75,7 +75,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.get.mock.callCount(), 0);
@@ -107,7 +107,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has.mock.callCount(), 0);
@@ -139,7 +139,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has.mock.callCount(), 0);
@@ -182,7 +182,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -215,7 +215,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -248,7 +248,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -281,7 +281,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -314,7 +314,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -461,7 +461,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -504,7 +504,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -547,7 +547,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -590,7 +590,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -636,7 +636,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -682,7 +682,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -728,7 +728,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(headers.has("RateLimit"), true);
@@ -764,7 +764,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(warnLogSpy.mock.callCount(), 1);
@@ -798,7 +798,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(warnLogSpy.mock.callCount(), 1);
@@ -817,7 +817,7 @@ describe("setRateLimitHeaders", () => {
         new ArcjetAllowDecision({
           results: [],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), false);
@@ -836,11 +836,11 @@ describe("setRateLimitHeaders", () => {
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
-              reason: new ArcjetReason(),
+              reason: new ArcjetUnknownReason(),
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), false);
@@ -868,7 +868,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.deepEqual(resp, {});
@@ -896,7 +896,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.deepEqual(resp, { headers: {} });
@@ -938,7 +938,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -971,7 +971,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1004,7 +1004,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1037,7 +1037,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1070,7 +1070,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1220,7 +1220,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1266,7 +1266,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1312,7 +1312,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1358,7 +1358,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1407,7 +1407,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1456,7 +1456,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1505,7 +1505,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.headers.has("RateLimit"), true);
@@ -1544,7 +1544,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(warnLogSpy.mock.callCount(), 1);
@@ -1581,7 +1581,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(warnLogSpy.mock.callCount(), 1);
@@ -1603,7 +1603,7 @@ describe("setRateLimitHeaders", () => {
         new ArcjetAllowDecision({
           results: [],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), false);
@@ -1622,11 +1622,11 @@ describe("setRateLimitHeaders", () => {
               ttl: 0,
               state: "RUN",
               conclusion: "ALLOW",
-              reason: new ArcjetReason(),
+              reason: new ArcjetUnknownReason(),
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), false);
@@ -1665,7 +1665,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(errorLogSpy.mock.callCount(), 1);
@@ -1699,7 +1699,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
     });
@@ -1732,7 +1732,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
     });
@@ -1767,7 +1767,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
     });
@@ -1808,7 +1808,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1841,7 +1841,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1874,7 +1874,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1907,7 +1907,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -1940,7 +1940,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
 
@@ -2090,7 +2090,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2136,7 +2136,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2182,7 +2182,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2228,7 +2228,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2277,7 +2277,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2326,7 +2326,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2375,7 +2375,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(resp.hasHeader("RateLimit"), true);
@@ -2414,7 +2414,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(warnLogSpy.mock.callCount(), 1);
@@ -2451,7 +2451,7 @@ describe("setRateLimitHeaders", () => {
             }),
           ],
           ttl: 0,
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
         }),
       );
       assert.equal(warnLogSpy.mock.callCount(), 1);

--- a/examples/astro-integration/src/actions/index.ts
+++ b/examples/astro-integration/src/actions/index.ts
@@ -13,7 +13,7 @@ export const server = {
         .withRule(sensitiveInfo({ mode: "LIVE", allow: [] }))
         .protect(request);
       if (decision.isDenied()) {
-        if (decision.reason.isSensitiveInfo()) {
+        if (decision.reason.type === 'SENSITIVE_INFO') {
           throw new ActionError({
             code: "BAD_REQUEST",
             message: `Your message contains sensitive information.`,
@@ -36,7 +36,7 @@ export const server = {
         .withRule(validateEmail({ mode: "LIVE", allow: [] }))
         .protect(request, { email });
       if (decision.isDenied()) {
-        if (decision.reason.isEmail()) {
+        if (decision.reason.type === "EMAIL") {
           throw new ActionError({
             code: "BAD_REQUEST",
             message: `Invalid email address provided.`,

--- a/examples/astro-integration/src/pages/randomizer.json.ts
+++ b/examples/astro-integration/src/pages/randomizer.json.ts
@@ -17,7 +17,7 @@ function random() {
 export const GET: APIRoute = async ({ request }) => {
   const decision = await ajWithRateLimit.protect(request);
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return new Response(null, {
         status: 429,
         statusText: "Too many requests",

--- a/examples/bun-rate-limit/index.ts
+++ b/examples/bun-rate-limit/index.ts
@@ -10,7 +10,7 @@ const aj = arcjet({
     shield({ mode: "LIVE" }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
-      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       refillRate: 5, // refill 5 tokens per interval
       interval: 10, // refill every 10 seconds
       capacity: 10, // bucket maximum capacity of 10 tokens
@@ -28,7 +28,7 @@ export default {
     console.log("Arcjet decision", decision.conclusion);
 
     if (decision.isDenied()) {
-      if (decision.reason.isRateLimit()) {
+      if (decision.reason.type === "RATE_LIMIT") {
         return new Response("Too many requests", { status: 429 });
       } else {
         return new Response("Forbidden", { status: 403 });
@@ -50,7 +50,7 @@ const server = Bun.serve({
     console.log("Arcjet decision", decision.conclusion);
 
     if (decision.isDenied()) {
-      if (decision.reason.isRateLimit()) {
+      if (decision.reason.type === "RATE_LIMIT") {
         return new Response("Too many requests", { status: 429 });
       } else {
         return new Response("Forbidden", { status: 403 });

--- a/examples/express-bots/index.js
+++ b/examples/express-bots/index.js
@@ -32,7 +32,7 @@ app.get('/', async (req, res) => {
     );
   }
 
-  if (decision.isBot()) {
+  if (decision.type === "BOT") {
     // We want to check for disallowed bots, or spoofed bots
     if (decision.isDenied() || decision.reason.isSpoofed()) {
       res.writeHead(400, { "Content-Type": "application/json" });

--- a/examples/express-sensitive-info/index.js
+++ b/examples/express-sensitive-info/index.js
@@ -27,7 +27,7 @@ app.use(express.text());
 app.post('/', async (req, res) => {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isSensitiveInfo()) {
+  if (decision.isDenied() && decision.reason.type === 'SENSITIVE_INFO') {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Sensitive Information Detected", denied: decision.reason.denied }));
   } else {

--- a/examples/gatsby-rate-limit/src/api/arcjet.ts
+++ b/examples/gatsby-rate-limit/src/api/arcjet.ts
@@ -25,7 +25,7 @@ export default async function handler(
     }
 
     if (decision.isDenied()) {
-        if (decision.reason.isRateLimit()) {
+        if (decision.reason.type === "RATE_LIMIT") {
             return res.status(429).json({ error: "Too many requests" });
         }
 

--- a/examples/nestjs-fastify/src/validate-email/validate-email.controller.ts
+++ b/examples/nestjs-fastify/src/validate-email/validate-email.controller.ts
@@ -36,7 +36,7 @@ export class ValidateEmailController {
       .protect(req, { email });
 
     if (decision.isDenied()) {
-      if (decision.reason.isEmail()) {
+      if (decision.reason.type === "EMAIL") {
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
       } else {
         throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);

--- a/examples/nestjs/src/validate-email/validate-email.controller.ts
+++ b/examples/nestjs/src/validate-email/validate-email.controller.ts
@@ -36,7 +36,7 @@ export class ValidateEmailController {
       .protect(req, { email });
 
     if (decision.isDenied()) {
-      if (decision.reason.isEmail()) {
+      if (decision.reason.type === "EMAIL") {
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
       } else {
         throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);

--- a/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
@@ -84,7 +84,7 @@ export async function GET(req: NextRequest, res: Response) {
   }
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json(
         {
           error: "Too Many Requests",

--- a/examples/nextjs-14-nextauth-4/app/api/auth/[...nextauth]/route.ts
+++ b/examples/nextjs-14-nextauth-4/app/api/auth/[...nextauth]/route.ts
@@ -42,7 +42,7 @@ const ajProtectedPOST = async (req: Request, res: Response) => {
   console.log("Arcjet decision", decision);
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json({ error: "Too Many Requests" }, { status: 429 });
     } else {
       return NextResponse.json({ error: "Unauthorized" }, { status: 403 });

--- a/examples/nextjs-authjs-5/app/auth/[...nextauth]/route.ts
+++ b/examples/nextjs-authjs-5/app/auth/[...nextauth]/route.ts
@@ -26,7 +26,7 @@ const ajProtectedPOST = async (req: NextRequest) => {
   console.log("Arcjet decision", decision);
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json({ error: "Too Many Requests" }, { status: 429 });
     } else {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/examples/nextjs-better-auth/app/api/auth/[...all]/route.ts
+++ b/examples/nextjs-better-auth/app/api/auth/[...all]/route.ts
@@ -107,9 +107,9 @@ export const POST = async (req: NextRequest) => {
   console.log("Arcjet Decision:", decision);
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return new Response(null, { status: 429 });
-    } else if (decision.reason.isEmail()) {
+    } else if (decision.reason.type === "EMAIL") {
       let message: string;
 
       if (decision.reason.emailTypes.includes("INVALID")) {

--- a/examples/nextjs-bot-categories/app/api/arcjet/route.ts
+++ b/examples/nextjs-bot-categories/app/api/arcjet/route.ts
@@ -34,7 +34,7 @@ export async function GET(req: Request) {
   }
 
   const headers = new Headers();
-  if (decision.reason.isBot()) {
+  if (decision.reason.type === "BOT") {
     // WARNING: This is illustrative! Don't share this metadata with users;
     // otherwise they may use it to subvert bot detection!
     headers.set("X-Arcjet-Bot-Allowed", decision.reason.allowed.join(", "))

--- a/examples/nextjs-clerk-rate-limit/app/api/arcjet/route.ts
+++ b/examples/nextjs-clerk-rate-limit/app/api/arcjet/route.ts
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest) {
   }
 
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json(
         {
           error: "Too Many Requests",
@@ -69,11 +69,11 @@ export async function GET(req: NextRequest) {
       );
     }
   }
-  
+
   let reset: Date | undefined;
   let remaining: number | undefined;
 
-  if (decision.reason.isRateLimit()) {
+  if (decision.reason.type === "RATE_LIMIT") {
     reset = decision.reason.resetTime;
     remaining = decision.reason.remaining;
   }

--- a/examples/nextjs-openai/app/api/chat/route.ts
+++ b/examples/nextjs-openai/app/api/chat/route.ts
@@ -31,7 +31,7 @@ const aj = arcjet({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
     }),
     tokenBucket({
-      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       refillRate: 2_000, // fill the bucket up by 2,000 tokens
       interval: "1h", // every hour
       capacity: 5_000, // up to 5,000 tokens
@@ -59,13 +59,13 @@ export async function POST(req: Request) {
   const decision = await aj.protect(req, { requested: estimate });
   console.log("Arcjet decision", decision.conclusion);
 
-  if (decision.reason.isRateLimit()) {
+  if (decision.reason.type === "RATE_LIMIT") {
     console.log("Requests remaining", decision.reason.remaining);
   }
 
   // If the request is denied, return a 429
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return new Response("Too Many Requests", {
         status: 429,
       });

--- a/examples/nextjs-openai/app/api/chat_userid/route.ts
+++ b/examples/nextjs-openai/app/api/chat_userid/route.ts
@@ -32,7 +32,7 @@ const aj = arcjet({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
     }),
     tokenBucket({
-      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       refillRate: 2_000, // fill the bucket up by 2,000 tokens
       interval: "1h", // every hour
       capacity: 5_000, // up to 5,000 tokens
@@ -64,13 +64,13 @@ export async function POST(req: Request) {
   const decision = await aj.protect(req, { requested: estimate, userId });
   console.log("Arcjet decision", decision.conclusion);
 
-  if (decision.reason.isRateLimit()) {
+  if (decision.reason.type === "RATE_LIMIT") {
     console.log("Requests remaining", decision.reason.remaining);
   }
 
   // If the request is denied, return a 429
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return new Response("Too Many Requests", {
         status: 429,
       });

--- a/examples/nextjs-permit/src/app/api/permissions/route.ts
+++ b/examples/nextjs-permit/src/app/api/permissions/route.ts
@@ -21,7 +21,7 @@ export async function GET(req: Request) {
 
   // If the decision is denied then return an error response
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json(
         { error: "Too Many Requests", reason: decision.reason },
         { status: 429 }

--- a/examples/nextjs-permit/src/app/api/stats/route.ts
+++ b/examples/nextjs-permit/src/app/api/stats/route.ts
@@ -50,7 +50,7 @@ export async function GET(req: NextRequest) {
 
   // If the decision is denied then return an error response
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return NextResponse.json(
         { error: "Too Many Requests", reason: decision.reason },
         { status: 429 }
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest) {
   let ratelimitData = null;
   for (const result of decision.results) {
     console.log("Results", ratelimitData);
-    if (result.reason.isRateLimit()) {
+    if (result.reason.type === "RATE_LIMIT") {
       ratelimitData = result.reason;
     }
   }

--- a/examples/nextjs-react-hook-form/app/api/submit/route.ts
+++ b/examples/nextjs-react-hook-form/app/api/submit/route.ts
@@ -54,7 +54,7 @@ export async function POST(req: Request) {
   console.log("Arcjet decision: ", decision);
 
   if (decision.isDenied()) {
-    if (decision.reason.isEmail()) {
+    if (decision.reason.type === "EMAIL") {
       let message: string;
 
       // These are specific errors to help the user, but will also reveal the
@@ -76,7 +76,7 @@ export async function POST(req: Request) {
         { message, reason: decision.reason },
         { status: 400 }
       );
-    } else if (decision.reason.isRateLimit()) {
+    } else if (decision.reason.type === "RATE_LIMIT") {
       const reset = decision.reason.resetTime;
 
       if (reset === undefined) {

--- a/examples/nodejs-express-launchdarkly/index.js
+++ b/examples/nodejs-express-launchdarkly/index.js
@@ -11,7 +11,7 @@ app.get("/", async (req, res) => {
 
   // If the decision is denied, return an appropriate status code
   if (decision.isDenied()) {
-    if (decision.reason.isRateLimit()) {
+    if (decision.reason.type === "RATE_LIMIT") {
       return res.status(429).send("Too many requests");
     } else {
       return res.status(403).send("Forbidden");

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -283,7 +283,7 @@ export function ArcjetReasonFromProtocol(proto?: Reason): ArcjetReasons {
 }
 
 export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
-  if (reason.isRateLimit()) {
+  if (reason.type === "RATE_LIMIT") {
     return new Reason({
       reason: {
         case: "rateLimit",
@@ -300,7 +300,7 @@ export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
     });
   }
 
-  if (reason.isBot()) {
+  if (reason.type === "BOT") {
     return new Reason({
       reason: {
         case: "botV2",
@@ -314,7 +314,7 @@ export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
     });
   }
 
-  if (reason.isEdgeRule()) {
+  if (reason.type === "EDGE_RULE") {
     return new Reason({
       reason: {
         case: "edgeRule",
@@ -323,7 +323,7 @@ export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
     });
   }
 
-  if (reason.isShield()) {
+  if (reason.type === "SHIELD") {
     return new Reason({
       reason: {
         case: "shield",
@@ -334,7 +334,7 @@ export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
     });
   }
 
-  if (reason.isEmail()) {
+  if (reason.type === "EMAIL") {
     return new Reason({
       reason: {
         case: "email",
@@ -345,7 +345,7 @@ export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
     });
   }
 
-  if (reason.isError()) {
+  if (reason.type === "ERROR") {
     return new Reason({
       reason: {
         case: "error",
@@ -356,7 +356,7 @@ export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
     });
   }
 
-  if (reason.isSensitiveInfo()) {
+  if (reason.type === "SENSITIVE_INFO") {
     return new Reason({
       reason: {
         case: "sensitiveInfo",

--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -1,5 +1,6 @@
 import { Timestamp } from "@bufbuild/protobuf";
 import type {
+  ArcjetReasons,
   ArcjetRule,
   ArcjetRateLimitRule,
   ArcjetBotRule,
@@ -16,6 +17,7 @@ import type {
   ArcjetSensitiveInfoRule,
 } from "./index.js";
 import {
+  ArcjetUnknownReason,
   ArcjetAllowDecision,
   ArcjetBotReason,
   ArcjetChallengeDecision,
@@ -28,7 +30,6 @@ import {
   ArcjetRuleResult,
   ArcjetShieldReason,
   ArcjetDecision,
-  ArcjetReason,
   ArcjetIpDetails,
   ArcjetSensitiveInfoReason,
 } from "./index.js";
@@ -213,9 +214,9 @@ export function ArcjetConclusionFromProtocol(
   }
 }
 
-export function ArcjetReasonFromProtocol(proto?: Reason) {
+export function ArcjetReasonFromProtocol(proto?: Reason): ArcjetReasons {
   if (typeof proto === "undefined") {
-    return new ArcjetReason();
+    return new ArcjetUnknownReason();
   }
 
   if (typeof proto !== "object" || typeof proto.reason !== "object") {
@@ -272,16 +273,16 @@ export function ArcjetReasonFromProtocol(proto?: Reason) {
       return new ArcjetErrorReason(reason.message);
     }
     case undefined: {
-      return new ArcjetReason();
+      return new ArcjetUnknownReason();
     }
     default: {
       const _exhaustive: never = proto.reason;
-      return new ArcjetReason();
+      return new ArcjetUnknownReason();
     }
   }
 }
 
-export function ArcjetReasonToProtocol(reason: ArcjetReason): Reason {
+export function ArcjetReasonToProtocol(reason: ArcjetReasons): Reason {
   if (reason.isRateLimit()) {
     return new Reason({
       reason: {

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -184,40 +184,81 @@ export const ArcjetSensitiveInfoType = Object.freeze({
   CREDIT_CARD_NUMBER: "CREDIT_CARD_NUMBER",
 });
 
-export class ArcjetReason {
-  type?:
-    | "RATE_LIMIT"
-    | "BOT"
-    | "EDGE_RULE"
-    | "SHIELD"
-    | "EMAIL"
-    | "ERROR"
-    | "SENSITIVE_INFO";
+/**
+ * Map of concrete Arcjet reasons.
+ */
+export interface ArcjetReasonMap {
+  BOT: ArcjetBotReason;
+  EDGE_RULE: ArcjetEdgeRuleReason;
+  EMAIL: ArcjetEmailReason;
+  ERROR: ArcjetErrorReason;
+  RATE_LIMIT: ArcjetRateLimitReason;
+  SENSITIVE_INFO: ArcjetSensitiveInfoReason;
+  SHIELD: ArcjetShieldReason;
+}
 
+/**
+ * Union of all concrete Arcjet reasons.
+ */
+export type ArcjetReasons =
+  | ArcjetReasonMap[keyof ArcjetReasonMap]
+  | ArcjetUnknownReason;
+
+export class ArcjetReason {
+  type: ArcjetReasons["type"];
+
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isSensitiveInfo(): this is ArcjetSensitiveInfoReason {
     return this.type === "SENSITIVE_INFO";
   }
 
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isRateLimit(): this is ArcjetRateLimitReason {
     return this.type === "RATE_LIMIT";
   }
 
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isBot(): this is ArcjetBotReason {
     return this.type === "BOT";
   }
 
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isEdgeRule(): this is ArcjetEdgeRuleReason {
     return this.type === "EDGE_RULE";
   }
 
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isShield(): this is ArcjetShieldReason {
     return this.type === "SHIELD";
   }
 
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isEmail(): this is ArcjetEmailReason {
     return this.type === "EMAIL";
   }
 
+  /**
+   * @deprecated
+   *   Use the `type` property instead.
+   */
   isError(): this is ArcjetErrorReason {
     return this.type === "ERROR";
   }
@@ -357,6 +398,10 @@ export class ArcjetErrorReason extends ArcjetReason {
   }
 }
 
+export class ArcjetUnknownReason extends ArcjetReason {
+  type = undefined;
+}
+
 export class ArcjetRuleResult {
   /**
    * The stable, deterministic, and unique identifier of the rule that generated
@@ -375,7 +420,7 @@ export class ArcjetRuleResult {
   ttl: number;
   state: ArcjetRuleState;
   conclusion: ArcjetConclusion;
-  reason: ArcjetReason;
+  reason: ArcjetReasons;
 
   constructor(init: {
     ruleId: string;
@@ -383,7 +428,7 @@ export class ArcjetRuleResult {
     ttl: number;
     state: ArcjetRuleState;
     conclusion: ArcjetConclusion;
-    reason: ArcjetReason;
+    reason: ArcjetReasons;
   }) {
     this.ruleId = init.ruleId;
     this.fingerprint = init.fingerprint;
@@ -681,7 +726,7 @@ export abstract class ArcjetDecision {
   ip: ArcjetIpDetails;
 
   abstract conclusion: ArcjetConclusion;
-  abstract reason: ArcjetReason;
+  abstract reason: ArcjetReasons;
 
   constructor(init: {
     id?: string;
@@ -719,13 +764,13 @@ export abstract class ArcjetDecision {
 
 export class ArcjetAllowDecision extends ArcjetDecision {
   conclusion = "ALLOW" as const;
-  reason: ArcjetReason;
+  reason: ArcjetReasons;
 
   constructor(init: {
     id?: string;
     results: ArcjetRuleResult[];
     ttl: number;
-    reason: ArcjetReason;
+    reason: ArcjetReasons;
     ip?: ArcjetIpDetails;
   }) {
     super(init);
@@ -736,13 +781,13 @@ export class ArcjetAllowDecision extends ArcjetDecision {
 
 export class ArcjetDenyDecision extends ArcjetDecision {
   conclusion = "DENY" as const;
-  reason: ArcjetReason;
+  reason: ArcjetReasons;
 
   constructor(init: {
     id?: string;
     results: ArcjetRuleResult[];
     ttl: number;
-    reason: ArcjetReason;
+    reason: ArcjetReasons;
     ip?: ArcjetIpDetails;
   }) {
     super(init);
@@ -752,13 +797,13 @@ export class ArcjetDenyDecision extends ArcjetDecision {
 }
 export class ArcjetChallengeDecision extends ArcjetDecision {
   conclusion = "CHALLENGE" as const;
-  reason: ArcjetReason;
+  reason: ArcjetReasons;
 
   constructor(init: {
     id?: string;
     results: ArcjetRuleResult[];
     ttl: number;
-    reason: ArcjetReason;
+    reason: ArcjetReasons;
     ip?: ArcjetIpDetails;
   }) {
     super(init);

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -15,6 +15,7 @@ import type {
   ArcjetConclusion,
   ArcjetContext,
   ArcjetLogger,
+  ArcjetReasons,
   ArcjetRequestDetails,
 } from "../index.js";
 import {
@@ -24,13 +25,13 @@ import {
   ArcjetDenyDecision,
   ArcjetErrorDecision,
   ArcjetErrorReason,
-  ArcjetReason,
   ArcjetRuleResult,
+  ArcjetUnknownReason,
 } from "../index.js";
 
 class ArcjetInvalidDecision extends ArcjetDecision {
   conclusion: ArcjetConclusion;
-  reason: ArcjetReason;
+  reason: ArcjetReasons;
 
   constructor() {
     super({ results: [], ttl: 0 });
@@ -39,7 +40,7 @@ class ArcjetInvalidDecision extends ArcjetDecision {
     // decisions,
     // then we need to allow that in the types.
     this.conclusion = "INVALID";
-    this.reason = new ArcjetReason();
+    this.reason = new ArcjetUnknownReason();
   }
 }
 
@@ -435,7 +436,7 @@ test("createClient", async (t) => {
         },
         exampleDetails,
         new ArcjetAllowDecision({
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
           ttl: 0,
         }),
@@ -479,7 +480,7 @@ test("createClient", async (t) => {
         exampleContext,
         exampleDetails,
         new ArcjetAllowDecision({
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
           ttl: 0,
         }),
@@ -524,7 +525,7 @@ test("createClient", async (t) => {
         exampleContext,
         exampleDetails,
         new ArcjetDenyDecision({
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
           ttl: 0,
         }),
@@ -614,7 +615,7 @@ test("createClient", async (t) => {
         exampleContext,
         exampleDetails,
         new ArcjetChallengeDecision({
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
           ttl: 0,
         }),
@@ -704,7 +705,7 @@ test("createClient", async (t) => {
         exampleContext,
         exampleDetails,
         new ArcjetDenyDecision({
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
           results: [],
           ttl: 0,
         }),
@@ -757,7 +758,7 @@ test("createClient", async (t) => {
           },
           exampleDetails,
           new ArcjetAllowDecision({
-            reason: new ArcjetReason(),
+            reason: new ArcjetUnknownReason(),
             results: [],
             ttl: 0,
           }),
@@ -830,12 +831,12 @@ test("createClient", async (t) => {
         { ...exampleContext, characteristics: ["src.ip"] },
         exampleDetails,
         new ArcjetDenyDecision({
-          reason: new ArcjetReason(),
+          reason: new ArcjetUnknownReason(),
           results: [
             new ArcjetRuleResult({
               conclusion: "DENY",
               fingerprint: "fingerprint",
-              reason: new ArcjetReason(),
+              reason: new ArcjetUnknownReason(),
               ruleId: "rule",
               state: "RUN",
               ttl: 0,

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -49,11 +49,11 @@ import {
   ArcjetErrorDecision,
   ArcjetErrorReason,
   ArcjetRateLimitReason,
-  ArcjetReason,
   ArcjetRuleResult,
   ArcjetShieldReason,
   ArcjetIpDetails,
   ArcjetSensitiveInfoReason,
+  ArcjetUnknownReason,
 } from "../index.js";
 import { Timestamp } from "@bufbuild/protobuf";
 
@@ -352,15 +352,11 @@ test("convert", async (t) => {
   await t.test("ArcjetReasonFromProtocol", async (t) => {
     await t.test("should create an anonymous reason w/o proto", () => {
       const reason = ArcjetReasonFromProtocol();
-
-      assert.ok(reason instanceof ArcjetReason);
       assert.equal(reason.type, undefined);
     });
 
     await t.test("should create an anonymous reason w/ an empty proto", () => {
       const reason = ArcjetReasonFromProtocol(new Reason());
-
-      assert.ok(reason instanceof ArcjetReason);
       assert.equal(reason.type, undefined);
     });
 
@@ -579,8 +575,6 @@ test("convert", async (t) => {
             },
           }),
         );
-
-        assert.ok(reason instanceof ArcjetReason);
         assert.equal(reason.type, undefined);
       },
     );
@@ -606,7 +600,7 @@ test("convert", async (t) => {
 
   await t.test("ArcjetReasonToProtocol", async (t) => {
     await t.test("should create an anonymous reason w/ an empty proto", () => {
-      const reason = ArcjetReasonToProtocol(new ArcjetReason());
+      const reason = ArcjetReasonToProtocol(new ArcjetUnknownReason());
 
       assert.ok(reason instanceof Reason);
       assert.equal(reason.reason.case, undefined);
@@ -793,7 +787,7 @@ test("convert", async (t) => {
             new ArcjetRuleResult({
               conclusion: "ALLOW",
               fingerprint: "fingerprint",
-              reason: new ArcjetReason(),
+              reason: new ArcjetUnknownReason(),
               ruleId: "rule-id",
               state: "RUN",
               ttl: 0,
@@ -828,7 +822,7 @@ test("convert", async (t) => {
           new ArcjetRuleResult({
             conclusion: "ALLOW",
             fingerprint: "fingerprint",
-            reason: new ArcjetReason(),
+            reason: new ArcjetUnknownReason(),
             ruleId: "rule-id",
             state: "RUN",
             ttl: 0,
@@ -847,7 +841,7 @@ test("convert", async (t) => {
             new ArcjetAllowDecision({
               id: "abc123",
               ip: new ArcjetIpDetails(),
-              reason: new ArcjetReason(),
+              reason: new ArcjetUnknownReason(),
               results: [],
               ttl: 0,
             }),

--- a/protocol/test/protocol.test.ts
+++ b/protocol/test/protocol.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ArcjetIpDetails, ArcjetReason, ArcjetRuleResult } from "../index.js";
+import {
+  ArcjetIpDetails,
+  ArcjetRuleResult,
+  ArcjetUnknownReason,
+} from "../index.js";
 import { IpDetails } from "../proto/decide/v1alpha1/decide_pb.js";
 
 test("protocol", async (t) => {
@@ -9,7 +13,7 @@ test("protocol", async (t) => {
       const result = new ArcjetRuleResult({
         conclusion: "ALLOW",
         fingerprint: "fingerprint",
-        reason: new ArcjetReason(),
+        reason: new ArcjetUnknownReason(),
         ruleId: "rule-id",
         state: "RUN",
         ttl: 0,


### PR DESCRIPTION
This is a PR that shows, as an example, how unions can be used, to let TypeScript differentiate based concrete things, such as a `type` field.
But also, a user can now check if a particular reason has an `allowed` field: after that check, TypeScript then can know that the reason is either an `ArcjetSensitiveInfoReason` or an `ArcjetBotReason`.
This prevents the need for `is*` functions, which internally use that `type` field.
While nice, such functions could lead to problems, as they are not really checked:

```
  // This passes, TypeScript accepts functions that yield booleans, and doesn’t check whether the assertion relates to reality.
  isRateLimit(): this is ArcjetRateLimitReason {
    return true;
  }
```