### PR TITLE
test: add tests for `analyze`

### DIFF
--- a/analyze-wasm/index.ts
+++ b/analyze-wasm/index.ts
@@ -34,6 +34,7 @@ async function moduleFromPath(path: string): Promise<WebAssembly.Module> {
     return componentCore3WasmPromise;
   }
 
+  // TODO(@wooorm-arcjet): figure out a test case that makes this throw.
   throw new Error(`Unknown path: ${path}`);
 }
 

--- a/analyze/README.md
+++ b/analyze/README.md
@@ -33,6 +33,12 @@ npm install -S @arcjet/analyze
 
 ## Example
 
+<!--
+  TODO(@wooorm-arcjet): I think this example is out of date?
+  Either remove it if we don’t want people to use this.
+  Or, change the API to allow simpler use?
+-->
+
 ```ts
 import { generateFingerprint, isValidEmail } from "@arcjet/analyze";
 

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -79,9 +79,11 @@ function createCoreImports(detect?: DetectSensitiveInfoFunction): ImportObject {
         return "unknown";
       },
     },
+    // TODO(@wooorm-arcjet): figure out a test case for this with the default `detect`.
     "arcjet:js-req/sensitive-information-identifier": {
       detect,
     },
+    // TODO(@wooorm-arcjet): figure out a test case for this that calls `verify`.
     "arcjet:js-req/verify-bot": {
       verify() {
         return "unverifiable";
@@ -90,6 +92,7 @@ function createCoreImports(detect?: DetectSensitiveInfoFunction): ImportObject {
   };
 }
 
+// TODO(@wooorm-arcjet): document what is used to fingerprint.
 /**
  * Generate a fingerprint for the client. This is used to identify the client
  * across multiple requests.
@@ -110,13 +113,15 @@ export async function generateFingerprint(
       JSON.stringify(request),
       context.characteristics,
     );
-  } else {
-    log.debug("WebAssembly is not supported in this runtime");
+    // Ignore the `else` branch as we test in places that have WebAssembly.
+    /* node:coverage ignore next 4 */
   }
 
+  log.debug("WebAssembly is not supported in this runtime");
   return "";
 }
 
+// TODO(@wooorm-arcjet): docs.
 export async function isValidEmail(
   context: AnalyzeContext,
   candidate: string,
@@ -128,16 +133,15 @@ export async function isValidEmail(
 
   if (typeof analyze !== "undefined") {
     return analyze.isValidEmail(candidate, options);
-  } else {
-    log.debug("WebAssembly is not supported in this runtime");
-    // Skip the local evaluation of the rule if WASM is not available
-    return {
-      validity: "valid",
-      blocked: [],
-    };
+    // Ignore the `else` branch as we test in places that have WebAssembly.
+    /* node:coverage ignore next 4 */
   }
+
+  log.debug("WebAssembly is not supported in this runtime");
+  return { blocked: [], validity: "valid" };
 }
 
+// TODO(@wooorm-arcjet): docs.
 export async function detectBot(
   context: AnalyzeContext,
   request: AnalyzeRequest,
@@ -149,18 +153,15 @@ export async function detectBot(
 
   if (typeof analyze !== "undefined") {
     return analyze.detectBot(JSON.stringify(request), options);
-  } else {
-    log.debug("WebAssembly is not supported in this runtime");
-    // Skip the local evaluation of the rule if Wasm is not available
-    return {
-      allowed: [],
-      denied: [],
-      spoofed: false,
-      verified: false,
-    };
+    // Ignore the `else` branch as we test in places that have WebAssembly.
+    /* node:coverage ignore next 4 */
   }
+
+  log.debug("WebAssembly is not supported in this runtime");
+  return { allowed: [], denied: [], spoofed: false, verified: false };
 }
 
+// TODO(@wooorm-arcjet): docs.
 export async function detectSensitiveInfo(
   context: AnalyzeContext,
   candidate: string,
@@ -179,10 +180,12 @@ export async function detectSensitiveInfo(
       contextWindowSize,
       skipCustomDetect,
     });
-  } else {
-    log.debug("WebAssembly is not supported in this runtime");
-    throw new Error(
-      "SENSITIVE_INFO rule failed to run because Wasm is not supported in this environment.",
-    );
+    // Ignore the `else` branch as we test in places that have WebAssembly.
+    /* node:coverage ignore next 4 */
   }
+
+  log.debug("WebAssembly is not supported in this runtime");
+  throw new Error(
+    "SENSITIVE_INFO rule failed to run because Wasm is not supported in this environment.",
+  );
 }

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -40,7 +40,9 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test-api": "node --test",
+    "test-coverage": "node --experimental-test-coverage --test",
+    "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {
     "@arcjet/analyze-wasm": "1.0.0-beta.8",

--- a/analyze/test/analyze.test.ts
+++ b/analyze/test/analyze.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectBot,
+  detectSensitiveInfo,
+  generateFingerprint,
+  isValidEmail,
+} from "../index.js";
+
+const exampleContext = { characteristics: [], log: console };
+const exampleEmailOptions = {
+  allowDomainLiteral: false,
+  allow: [],
+  requireTopLevelDomain: true,
+};
+
+test("detectBot", async function (t) {
+  await t.test("should fail w/o user agent", async function () {
+    await assert.rejects(
+      detectBot(
+        exampleContext,
+        { ip: "127.0.0.1" },
+        {
+          tag: "allowed-bot-config",
+          val: { entities: [], skipCustomDetect: false },
+        },
+      ),
+      /user-agent header is empty/,
+    );
+  });
+
+  await t.test("should allow a non-bot", async function () {
+    const result = await detectBot(
+      exampleContext,
+      { ip: "127.0.0.1", headers: { "user-agent": "Mozilla/5.0" } },
+      {
+        tag: "allowed-bot-config",
+        val: { entities: [], skipCustomDetect: false },
+      },
+    );
+
+    assert.deepEqual(result, {
+      allowed: [],
+      denied: [],
+      spoofed: false,
+      verified: false,
+    });
+  });
+
+  await t.test("should detect a bot (curl)", async function () {
+    const result = await detectBot(
+      exampleContext,
+      { ip: "127.0.0.1", headers: { "user-agent": "curl/8.1.2" } },
+      {
+        tag: "allowed-bot-config",
+        val: { entities: [], skipCustomDetect: false },
+      },
+    );
+
+    assert.deepEqual(result, {
+      allowed: [],
+      denied: ["CURL"],
+      spoofed: false,
+      verified: false,
+    });
+  });
+
+  await t.test("should detect a bot (googlebot)", async function () {
+    const result = await detectBot(
+      exampleContext,
+      { ip: "127.0.0.1", headers: { "user-agent": "Googlebot/2.0" } },
+      {
+        tag: "allowed-bot-config",
+        val: { entities: [], skipCustomDetect: false },
+      },
+    );
+
+    assert.deepEqual(result, {
+      allowed: [],
+      denied: ["GOOGLE_CRAWLER"],
+      spoofed: false,
+      verified: false,
+    });
+  });
+});
+
+test("detectSensitiveInfo", async function (t) {
+  await t.test("should detect sensitive info", async function () {
+    const result = await detectSensitiveInfo(
+      exampleContext,
+      "a b@c.d e",
+      { tag: "allow", val: [] },
+      1,
+    );
+
+    assert.deepEqual(result, {
+      allowed: [],
+      denied: [{ end: 7, identifiedType: { tag: "email" }, start: 2 }],
+    });
+  });
+
+  await t.test("should not detect regular stuff", async function () {
+    const result = await detectSensitiveInfo(
+      exampleContext,
+      "a b c d e",
+      { tag: "allow", val: [] },
+      1,
+    );
+
+    assert.deepEqual(result, { allowed: [], denied: [] });
+  });
+
+  await t.test("should detect w/ a custom detect function", async function () {
+    let calls = 0;
+
+    const result = await detectSensitiveInfo(
+      exampleContext,
+      "a b c d e",
+      { tag: "allow", val: [] },
+      1,
+      function (tokens) {
+        calls++;
+        assert.ok(Array.isArray(tokens));
+        assert.equal(tokens.length, 1);
+
+        if (tokens[0] === "c") {
+          return [{ tag: "custom", val: "c" }];
+        }
+
+        return [];
+      },
+    );
+
+    assert.deepEqual(calls, 5);
+    assert.deepEqual(result, {
+      allowed: [],
+      denied: [
+        { end: 5, identifiedType: { tag: "custom", val: "c" }, start: 4 },
+      ],
+    });
+  });
+});
+
+test("generateFingerprint", async function (t) {
+  await t.test("should generate a fingerprint", async function () {
+    const result = await generateFingerprint(exampleContext, {
+      ip: "127.0.0.1",
+    });
+
+    assert.equal(
+      result,
+      "fp::2::0d219da6100b99f95cf639b77e088c6df3c096aa5fd61dec5287c5cf94d5e545",
+    );
+  });
+
+  await t.test("should generate another fingerprint", async function () {
+    const result = await generateFingerprint(exampleContext, {
+      ip: "76.76.21.21",
+    });
+
+    assert.equal(
+      result,
+      "fp::2::30cc6b092efff7b35f658730073f40ceae0a724873e1ff175826fc57e1462149",
+    );
+    assert.ok(result);
+  });
+
+  await t.test("should fail", async function () {
+    await assert.rejects(
+      generateFingerprint(
+        exampleContext,
+        // Note: not sure why `cookies` existing should fail but it does.
+        { cookies: "test-cookie", ip: "127.0.0.1" },
+      ),
+      /Failed to generate fingerprint/,
+    );
+  });
+});
+
+test("isValidEmail", async function (t) {
+  await t.test("should allow a regular email", async function () {
+    const result = await isValidEmail(exampleContext, "a@b.c", {
+      tag: "allow-email-validation-config",
+      val: exampleEmailOptions,
+    });
+
+    assert.deepEqual(result, { blocked: [], validity: "valid" });
+  });
+
+  await t.test("should not allow something weird", async function () {
+    const result = await isValidEmail(exampleContext, "example", {
+      tag: "allow-email-validation-config",
+      val: exampleEmailOptions,
+    });
+
+    assert.deepEqual(result, { blocked: ["INVALID"], validity: "invalid" });
+  });
+
+  await t.test(
+    "should not allow a basic free email provider by default (gmail)",
+    async function () {
+      const result = await isValidEmail(exampleContext, "example@gmail.com", {
+        tag: "allow-email-validation-config",
+        val: exampleEmailOptions,
+      });
+
+      assert.deepEqual(result, { blocked: ["FREE"], validity: "invalid" });
+    },
+  );
+
+  await t.test("should not allow a missing TLD by default", async function () {
+    const result = await isValidEmail(exampleContext, "a@b", {
+      tag: "allow-email-validation-config",
+      val: exampleEmailOptions,
+    });
+
+    assert.deepEqual(result, { blocked: ["INVALID"], validity: "invalid" });
+  });
+
+  await t.test(
+    "should allow a missing TLD w/ `requireTopLevelDomain: false`",
+    async function () {
+      const result = await isValidEmail(exampleContext, "a@b", {
+        tag: "allow-email-validation-config",
+        val: { ...exampleEmailOptions, requireTopLevelDomain: false },
+      });
+
+      assert.deepEqual(result, { blocked: [], validity: "valid" });
+    },
+  );
+
+  await t.test(
+    "should not allow a domain literal by default",
+    async function () {
+      const result = await isValidEmail(exampleContext, "a@[127.0.0.1]", {
+        tag: "allow-email-validation-config",
+        val: exampleEmailOptions,
+      });
+
+      assert.deepEqual(result, { blocked: ["INVALID"], validity: "invalid" });
+    },
+  );
+
+  await t.test(
+    "should allow a domain literal w/ `allowDomainLiteral: true`",
+    async function () {
+      const result = await isValidEmail(exampleContext, "a@[127.0.0.1]", {
+        tag: "allow-email-validation-config",
+        val: { ...exampleEmailOptions, allowDomainLiteral: true },
+      });
+
+      assert.deepEqual(result, { blocked: [], validity: "valid" });
+    },
+  );
+
+  // TODO: test `allow` option.
+});


### PR DESCRIPTION
This tests basically everything in `analyze`. Left some comments for the uncovered lines. And other things I ran into.
There’s a lot of tests for sensitive info detection and other things in the core tests too. The interface here seems mostly for internal use. So I didn’t go too far with all the different options and results.