### PR TITLE
test: add tests for public interface

### DIFF
--- a/analyze-wasm/package.json
+++ b/analyze-wasm/package.json
@@ -54,7 +54,9 @@
     "build": "npm run build:jco && npm run build:rollup",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test-api": "node --test",
+    "test-coverage": "node --experimental-test-coverage --test",
+    "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},
   "devDependencies": {

--- a/analyze-wasm/test/index.test.ts
+++ b/analyze-wasm/test/index.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/analyze-wasm", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "initializeWasm",
+    ]);
+  });
+});

--- a/analyze/test/analyze.test.ts
+++ b/analyze/test/analyze.test.ts
@@ -14,6 +14,17 @@ const exampleEmailOptions = {
   requireTopLevelDomain: true,
 };
 
+test("@arcjet/analyze", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "detectBot",
+      "detectSensitiveInfo",
+      "generateFingerprint",
+      "isValidEmail",
+    ]);
+  });
+});
+
 test("detectBot", async function (t) {
   await t.test("should fail w/o user agent", async function () {
     await assert.rejects(

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -42,7 +42,6 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "pretest": "npm run build",
     "test-api": "node --test",
     "test-coverage": "node --experimental-test-coverage --test",
     "test": "npm run build && npm run lint && npm run test-coverage"

--- a/arcjet/test/index.test.ts
+++ b/arcjet/test/index.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("arcjet", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "ArcjetAllowDecision",
+      "ArcjetBotReason",
+      "ArcjetChallengeDecision",
+      "ArcjetConclusion",
+      "ArcjetDecision",
+      "ArcjetDenyDecision",
+      "ArcjetEdgeRuleReason",
+      "ArcjetEmailReason",
+      "ArcjetEmailType",
+      "ArcjetErrorDecision",
+      "ArcjetErrorReason",
+      "ArcjetIpDetails",
+      "ArcjetMode",
+      "ArcjetRateLimitAlgorithm",
+      "ArcjetRateLimitReason",
+      "ArcjetReason",
+      "ArcjetRuleResult",
+      "ArcjetRuleState",
+      "ArcjetSensitiveInfoReason",
+      "ArcjetSensitiveInfoType",
+      "ArcjetShieldReason",
+      "ArcjetStack",
+      "botCategories",
+      "default",
+      "detectBot",
+      "fixedWindow",
+      "protectSignup",
+      "sensitiveInfo",
+      "shield",
+      "slidingWindow",
+      "tokenBucket",
+      "validateEmail",
+    ]);
+  });
+});

--- a/body/test/body.test.ts
+++ b/body/test/body.test.ts
@@ -4,6 +4,14 @@ import * as http from "http";
 import { readBody } from "../index.js";
 import type { AddressInfo } from "net";
 
+test("@arcjet/body", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "readBody",
+    ]);
+  });
+});
+
 describe("reads the body from the readable stream", () => {
   test("should read normal body streams", (t, done) => {
     const server = http.createServer(async (req, res) => {

--- a/cache/test/index.test.ts
+++ b/cache/test/index.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("@arcjet/cache", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "MemoryCache",
+    ]);
+  });
+});

--- a/decorate/test/decorate.test.ts
+++ b/decorate/test/decorate.test.ts
@@ -11,6 +11,14 @@ import { OutgoingMessage } from "http";
 
 function noop() {}
 
+test("@arcjet/decorate", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "setRateLimitHeaders",
+    ]);
+  });
+});
+
 describe("setRateLimitHeaders", () => {
   describe("Header object", () => {
     test("empty results do not set headers", () => {

--- a/duration/test/index.test.ts
+++ b/duration/test/index.test.ts
@@ -2,6 +2,14 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { parse } from "../index.js";
 
+test("@arcjet/duration", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "parse",
+    ]);
+  });
+});
+
 describe("parse", () => {
   test("always returns 0 if the duration string is just 0", () => {
     assert.equal(parse("0"), 0);

--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -2,6 +2,18 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import * as env from "../index.ts";
 
+test("@arcjet/env", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "apiKey",
+      "baseUrl",
+      "isDevelopment",
+      "logLevel",
+      "platform",
+    ]);
+  });
+});
+
 describe("env", () => {
   test("platform", () => {
     assert.equal(env.platform({}), undefined);

--- a/headers/test/headers.test.ts
+++ b/headers/test/headers.test.ts
@@ -2,6 +2,15 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import ArcjetHeaders from "../index.js";
 
+test("@arcjet/headers", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      // TODO(@wooorm-arcjet): use named exports.
+      "default",
+    ]);
+  });
+});
+
 describe("ArcjetHeaders", () => {
   test("can be constructed with no initializer", () => {
     const headers = new ArcjetHeaders();

--- a/inspect/test/inspect.test.ts
+++ b/inspect/test/inspect.test.ts
@@ -8,6 +8,16 @@ import {
   ArcjetRuleState,
 } from "@arcjet/protocol";
 
+test("@arcjet/inspect", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "isMissingUserAgent",
+      "isSpoofedBot",
+      "isVerifiedBot",
+    ]);
+  });
+});
+
 describe("isSpoofedBot", () => {
   test("returns true for active bots that are spoofed", () => {
     const activeStates: Exclude<ArcjetRuleState[], "DRY_RUN"> = [

--- a/ip/test/index.test.ts
+++ b/ip/test/index.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/ip", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      // TODO(@wooorm-arcjet): use named exports.
+      "default",
+      "parseProxy",
+    ]);
+  });
+});

--- a/logger/test/index.test.ts
+++ b/logger/test/index.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/logger", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "Logger",
+    ]);
+  });
+});

--- a/nosecone-next/package.json
+++ b/nosecone-next/package.json
@@ -50,7 +50,9 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test-api": "node --test",
+    "test-coverage": "node --experimental-test-coverage --test",
+    "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {
     "nosecone": "1.0.0-beta.9"

--- a/nosecone-next/test/index.test.ts
+++ b/nosecone-next/test/index.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@nosecone/next", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "createMiddleware",
+      // TODO(@wooorm-arcjet): use named exports.
+      "default",
+      // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
+      "defaults",
+      "withVercelToolbar",
+    ]);
+  });
+});

--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -50,7 +50,9 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test-api": "node --test",
+    "test-coverage": "node --experimental-test-coverage --test",
+    "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {
     "nosecone": "1.0.0-beta.9"

--- a/nosecone-sveltekit/test/index.test.ts
+++ b/nosecone-sveltekit/test/index.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@nosecone/sveltekit", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "createHook",
+      "csp",
+      // TODO(@wooorm-arcjet): use named exports.
+      "default",
+      // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
+      "defaults",
+      "withVercelToolbar",
+    ]);
+  });
+});

--- a/nosecone/test/nosecone.test.ts
+++ b/nosecone/test/nosecone.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, test } from "node:test";
 
 import nosecone, {
   defaults,
@@ -19,6 +19,41 @@ import nosecone, {
   NoseconeValidationError,
   withVercelToolbar,
 } from "../index.js";
+
+test("nosecone", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      // TODO(@wooorm-arcjet): that’s a ton, perhaps make it smaller.
+      "CONTENT_SECURITY_POLICY_DIRECTIVES",
+      "CROSS_ORIGIN_EMBEDDER_POLICIES",
+      "CROSS_ORIGIN_OPENER_POLICIES",
+      "CROSS_ORIGIN_RESOURCE_POLICIES",
+      "NoseconeValidationError",
+      "PERMITTED_CROSS_DOMAIN_POLICIES",
+      "QUOTED",
+      "REFERRER_POLICIES",
+      "SANDBOX_DIRECTIVES",
+      "createContentSecurityPolicy",
+      "createContentTypeOptions",
+      "createCrossOriginEmbedderPolicy",
+      "createCrossOriginOpenerPolicy",
+      "createCrossOriginResourcePolicy",
+      "createDnsPrefetchControl",
+      "createDownloadOptions",
+      "createFrameOptions",
+      "createOriginAgentCluster",
+      "createPermittedCrossDomainPolicies",
+      "createReferrerPolicy",
+      "createStrictTransportSecurity",
+      "createXssProtection",
+      // TODO(@wooorm-arcjet): use named exports.
+      "default",
+      // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
+      "defaults",
+      "withVercelToolbar",
+    ]);
+  });
+});
 
 describe("nosecone", () => {
   describe("NoseconeValidationError", () => {

--- a/protocol/test/protocol.test.ts
+++ b/protocol/test/protocol.test.ts
@@ -3,6 +3,36 @@ import test from "node:test";
 import { ArcjetIpDetails, ArcjetReason, ArcjetRuleResult } from "../index.js";
 import { IpDetails } from "../proto/decide/v1alpha1/decide_pb.js";
 
+test("@arcjet/protocol", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "ArcjetAllowDecision",
+      "ArcjetBotReason",
+      "ArcjetChallengeDecision",
+      "ArcjetConclusion",
+      "ArcjetDecision",
+      "ArcjetDenyDecision",
+      "ArcjetEdgeRuleReason",
+      "ArcjetEmailReason",
+      "ArcjetEmailType",
+      "ArcjetErrorDecision",
+      "ArcjetErrorReason",
+      "ArcjetIpDetails",
+      "ArcjetMode",
+      "ArcjetRateLimitAlgorithm",
+      "ArcjetRateLimitReason",
+      "ArcjetReason",
+      "ArcjetRuleResult",
+      "ArcjetRuleState",
+      "ArcjetSensitiveInfoReason",
+      "ArcjetSensitiveInfoType",
+      "ArcjetShieldReason",
+      "ArcjetStack",
+      "botCategories",
+    ]);
+  });
+});
+
 test("protocol", async (t) => {
   await t.test("ArcjetRuleResult", async (t) => {
     await t.test("ArcjetRuleResult#isDenied", () => {

--- a/redact-wasm/package.json
+++ b/redact-wasm/package.json
@@ -52,7 +52,9 @@
     "build": "npm run build:jco && npm run build:rollup",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test-api": "node --test",
+    "test-coverage": "node --experimental-test-coverage --test",
+    "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},
   "devDependencies": {

--- a/redact-wasm/test/index.test.ts
+++ b/redact-wasm/test/index.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/redact-wasm", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "initializeWasm",
+    ]);
+  });
+});

--- a/redact/test/index.test.ts
+++ b/redact/test/index.test.ts
@@ -2,6 +2,14 @@ import assert from "node:assert/strict";
 import { describe, test, afterEach, mock } from "node:test";
 import { redact } from "../index.js";
 
+test("@arcjet/redact", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "redact",
+    ]);
+  });
+});
+
 describe("ArcjetRedact", () => {
   describe("redact()", () => {
     afterEach(() => {

--- a/runtime/test/index.test.ts
+++ b/runtime/test/index.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/runtime", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "runtime",
+    ]);
+  });
+});

--- a/sprintf/test/index.test.ts
+++ b/sprintf/test/index.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/sprintf", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      // TODO(@wooorm-arcjet): named exports.
+      "default",
+    ]);
+  });
+});

--- a/stable-hash/test/index.test.ts
+++ b/stable-hash/test/index.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/stable-hash", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "bool",
+      "hash",
+      "makeHasher",
+      "string",
+      "stringSliceOrdered",
+      "uint32",
+    ]);
+  });
+});

--- a/transport/package.json
+++ b/transport/package.json
@@ -47,7 +47,9 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test-api": "node --test",
+    "test-coverage": "node --experimental-test-coverage --test",
+    "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {
     "@bufbuild/protobuf": "1.10.1",

--- a/transport/test/index.test.ts
+++ b/transport/test/index.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@arcjet/transport", async function (t) {
+  await t.test("should expose the public api", async function () {
+    assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
+      "createTransport",
+    ]);
+  });
+});


### PR DESCRIPTION
This adds tests for what’s exposed from packages.
They make it visible when something is accidentally leaked.
Especially because of current `export *` use.
From https://github.com/arcjet/arcjet-js/pull/4538#discussion_r2185727579

In a future PR I’d like to add export maps everywhere. That prevents leaking entire files. Then these test cases can be updated to check the paths that are exposed too.