### PR TITLE
chore: fix unused import in tests

### DIFF
--- a/inspect/test/inspect.test.ts
+++ b/inspect/test/inspect.test.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { isSpoofedBot, isVerifiedBot, isMissingUserAgent } from "../index.js";
 import {
+  type ArcjetRuleState,
   ArcjetBotReason,
   ArcjetErrorReason,
   ArcjetRuleResult,
-  ArcjetRuleState,
 } from "@arcjet/protocol";
 
 describe("isSpoofedBot", () => {


### PR DESCRIPTION
Rollup warns that a value is imported but not used.
This commit marks it as a `type`, making the warning go away.