### PR TITLE
refactor: sort packages in release please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -28,16 +28,12 @@
       "component": "root",
       "include-component-in-tag": false
     },
-    "analyze": {
-      "component": "@arcjet/analyze",
-      "skip-github-release": true
-    },
     "analyze-wasm": {
       "component": "@arcjet/analyze-wasm",
       "skip-github-release": true
     },
-    "arcjet": {
-      "component": "arcjet",
+    "analyze": {
+      "component": "@arcjet/analyze",
       "skip-github-release": true
     },
     "arcjet-astro": {
@@ -74,6 +70,10 @@
     },
     "arcjet-sveltekit": {
       "component": "@arcjet/sveltekit",
+      "skip-github-release": true
+    },
+    "arcjet": {
+      "component": "arcjet",
       "skip-github-release": true
     },
     "body": {
@@ -116,28 +116,16 @@
       "component": "@arcjet/logger",
       "skip-github-release": true
     },
-    "nosecone": {
-      "component": "nosecone",
-      "skip-github-release": true
-    },
-    "nosecone-next": {
-      "component": "@nosecone/next",
-      "skip-github-release": true
-    },
-    "nosecone-sveltekit": {
-      "component": "@nosecone/sveltekit",
-      "skip-github-release": true
-    },
     "protocol": {
       "component": "@arcjet/protocol",
       "skip-github-release": true
     },
-    "redact": {
-      "component": "@arcjet/redact",
-      "skip-github-release": true
-    },
     "redact-wasm": {
       "component": "@arcjet/redact-wasm",
+      "skip-github-release": true
+    },
+    "redact": {
+      "component": "@arcjet/redact",
       "skip-github-release": true
     },
     "rollup-config": {
@@ -163,6 +151,18 @@
     "tsconfig": {
       "component": "@arcjet/tsconfig",
       "skip-github-release": true
+    },
+    "nosecone-next": {
+      "component": "@nosecone/next",
+      "skip-github-release": true
+    },
+    "nosecone-sveltekit": {
+      "component": "@nosecone/sveltekit",
+      "skip-github-release": true
+    },
+    "nosecone": {
+      "component": "nosecone",
+      "skip-github-release": true
     }
   },
   "plugins": [
@@ -175,40 +175,40 @@
       "groupName": "arcjet-js",
       "components": [
         "root",
-        "@arcjet/analyze",
         "@arcjet/analyze-wasm",
-        "arcjet",
+        "@arcjet/analyze",
         "@arcjet/astro",
+        "@arcjet/body",
         "@arcjet/bun",
-        "@arcjet/deno",
-        "@arcjet/fastify",
-        "@arcjet/nest",
-        "@arcjet/next",
-        "@arcjet/node",
-        "@arcjet/remix",
-        "@arcjet/sveltekit",
+        "@arcjet/cache",
         "@arcjet/decorate",
+        "@arcjet/deno",
         "@arcjet/duration",
         "@arcjet/env",
         "@arcjet/eslint-config",
+        "@arcjet/fastify",
         "@arcjet/headers",
         "@arcjet/inspect",
         "@arcjet/ip",
-        "@arcjet/body",
-        "@arcjet/cache",
         "@arcjet/logger",
-        "nosecone",
-        "@nosecone/next",
-        "@nosecone/sveltekit",
+        "@arcjet/nest",
+        "@arcjet/next",
+        "@arcjet/node",
         "@arcjet/protocol",
-        "@arcjet/redact",
         "@arcjet/redact-wasm",
+        "@arcjet/redact",
+        "@arcjet/remix",
         "@arcjet/rollup-config",
         "@arcjet/runtime",
         "@arcjet/sprintf",
         "@arcjet/stable-hash",
+        "@arcjet/sveltekit",
         "@arcjet/transport",
-        "@arcjet/tsconfig"
+        "@arcjet/tsconfig",
+        "@nosecone/next",
+        "@nosecone/sveltekit",
+        "arcjet",
+        "nosecone"
       ]
     }
   ]


### PR DESCRIPTION
In the release video by Blaine, Quinn noted that `@arcjet/cache` appeared to be missing.
After some searching, Blaine commented that it was there, just that the sorting was not up to date.
This solves that: makes sure everything is sorted again, potentially preventing a future problem where a newly added package was forgotten.

I was wondering whether the sorting may be important: e.g., `arcjet` was pretty high before all the integrations, making it publish before integrations, which may seem like a good idea. However, `arcjet` *depends* on packages further down. Defeating that purpose. So as that argument doesn’t hold, it can just as well be sorted alphabetically.

With sorting, I do put `analyze-wasm` *before* `analyze`. So sorting `-` before EOF. The inverse can also be argued. I can see arguments for either way. And myself slightly prefer this.

An adjacent idea that the reviewer will probably note, that can be discussed now, but can also be deferred to a later point, is that some folders use an `arcjet-` prefix whereas others don’t. Specifically, integrations. So, `env` refers to `@arcjet/env` and `arcjet-bun` refers to `@arcjet/bun`. I don‘t like the inconsistency, perhaps we can do without. I see that having the integrations next to each other is nice, but now this block breaks up the unprefixed utilities. Perhaps just folders such as `integrations/bun/` is an alternative way to group integrations.