### PR TITLE
docs: add uniform install section to readmes

### DIFF
--- a/analyze-wasm/README.md
+++ b/analyze-wasm/README.md
@@ -25,10 +25,13 @@ This package provides WebAssembly bindings to [Arcjet's][arcjet] local analysis 
 - [npm package (`@arcjet/analyze-wasm`)](https://www.npmjs.com/package/@arcjet/analyze-wasm)
 - [GitHub source code (`analyze-wasm/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/analyze-wasm)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/analyze-wasm
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/analyze-wasm
 ```
 
 ## Use

--- a/analyze/README.md
+++ b/analyze/README.md
@@ -25,10 +25,13 @@ This is the [Arcjet][arcjet] local analysis engine.
 - [npm package (`@arcjet/analyze`)](https://www.npmjs.com/package/@arcjet/analyze)
 - [GitHub source code (`analyze/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/analyze)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/analyze
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/analyze
 ```
 
 ## Use

--- a/arcjet-astro/README.md
+++ b/arcjet-astro/README.md
@@ -34,9 +34,12 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
-## Installation
+## Install
 
-```shell
+This package is ESM only.
+Install with npm and the Astro CLI in Node.js:
+
+```sh
 npx astro add @arcjet/astro
 ```
 

--- a/arcjet-bun/README.md
+++ b/arcjet-bun/README.md
@@ -34,9 +34,12 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
-## Installation
+## Install
 
-```shell
+This package is ESM only.
+Install with Bun:
+
+```sh
 bun add @arcjet/bun
 ```
 

--- a/arcjet-deno/README.md
+++ b/arcjet-deno/README.md
@@ -25,18 +25,14 @@ This is the [Arcjet][arcjet] SDK for [Deno][deno].
 - [npm package (`@arcjet/deno`)](https://www.npmjs.com/package/@arcjet/deno)
 - [GitHub source code (`arcjet-deno/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/arcjet-deno)
 
-<!--
-
 ## Install
 
 This package is ESM only.
-Install with XXX:
+Install with Deno:
 
 ```sh
-TODO: what should we recommend?
+deno install npm:@arcjet/deno
 ```
-
--->
 
 ## Use
 

--- a/arcjet-deno/README.md
+++ b/arcjet-deno/README.md
@@ -25,6 +25,19 @@ This is the [Arcjet][arcjet] SDK for [Deno][deno].
 - [npm package (`@arcjet/deno`)](https://www.npmjs.com/package/@arcjet/deno)
 - [GitHub source code (`arcjet-deno/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/arcjet-deno)
 
+<!--
+
+## Install
+
+This package is ESM only.
+Install with XXX:
+
+```sh
+TODO: what should we recommend?
+```
+
+-->
+
 ## Use
 
 ```ts

--- a/arcjet-fastify/README.md
+++ b/arcjet-fastify/README.md
@@ -29,6 +29,9 @@ Visit the [quick start guide][arcjet-quick-start-fastify] to get started.
 
 ## Install
 
+This package is ESM only.
+Install with npm in Node.js:
+
 ```sh
 npm install @arcjet/fastify
 ```

--- a/arcjet-nest/README.md
+++ b/arcjet-nest/README.md
@@ -37,10 +37,13 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/nest
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/nest
 ```
 
 ## Use

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -50,6 +50,15 @@ Arcjet security features for protecting Next.js apps:
 - 🚅 [Nosecone][nosecone-quick-start] - set security headers such as
   `Content-Security-Policy` (CSP).
 
+## Install
+
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/next
+```
+
 ## Quick start
 
 This example will protect a Next.js API route with a rate limit, bot detection,
@@ -57,10 +66,13 @@ and Shield WAF.
 
 You can also find this [quick start guide][quick-start] in the docs.
 
-### 1. Installation
+## Install
 
-```shell
-npm i @arcjet/next
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/next
 ```
 
 ## Use

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -50,15 +50,6 @@ Arcjet security features for protecting Next.js apps:
 - 🚅 [Nosecone][nosecone-quick-start] - set security headers such as
   `Content-Security-Policy` (CSP).
 
-## Install
-
-This package is ESM only.
-Install with npm in Node.js:
-
-```sh
-npm install @arcjet/next
-```
-
 ## Quick start
 
 This example will protect a Next.js API route with a rate limit, bot detection,

--- a/arcjet-node/README.md
+++ b/arcjet-node/README.md
@@ -37,10 +37,13 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/node
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/node
 ```
 
 ## Use

--- a/arcjet-remix/README.md
+++ b/arcjet-remix/README.md
@@ -30,9 +30,12 @@ This is the [Arcjet][arcjet] SDK for [Remix][remix].
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
-## Installation
+## Install
 
-```shell
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
 npm install @arcjet/remix
 ```
 

--- a/arcjet-sveltekit/README.md
+++ b/arcjet-sveltekit/README.md
@@ -34,10 +34,13 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/sveltekit
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/sveltekit
 ```
 
 ## Use

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -34,10 +34,13 @@ as [`@arcjet/next`](../arcjet-next/README.md) for Next.js. However, this package
 can be used to interact with Arcjet if your framework does not have an
 integration.
 
-## Installation
+## Install
 
-```shell
-npm install -S arcjet
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install arcjet
 ```
 
 ## Use

--- a/body/README.md
+++ b/body/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/body`)](https://www.npmjs.com/package/@arcjet/body)
 - [GitHub source code (`body/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/body)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/body
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/body
 ```
 
 ## Use

--- a/cache/README.md
+++ b/cache/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/cache`)](https://www.npmjs.com/package/@arcjet/cache)
 - [GitHub source code (`cache/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/cache)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/cache
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/cache
 ```
 
 ## Use

--- a/decorate/README.md
+++ b/decorate/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/decorate`)](https://www.npmjs.com/package/@arcjet/decorate)
 - [GitHub source code (`decorate/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/decorate)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/decorate
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/decorate
 ```
 
 ## Example

--- a/duration/README.md
+++ b/duration/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/duration`)](https://www.npmjs.com/package/@arcjet/duration)
 - [GitHub source code (`duration/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/duration)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/duration
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/duration
 ```
 
 ## Example

--- a/env/README.md
+++ b/env/README.md
@@ -34,10 +34,13 @@ type Env = {
 - [npm package (`@arcjet/env`)](https://www.npmjs.com/package/@arcjet/env)
 - [GitHub source code (`env/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/env)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/env
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/env
 ```
 
 ## Example

--- a/eslint-config/README.md
+++ b/eslint-config/README.md
@@ -21,10 +21,13 @@ Custom eslint config for [Arcjet][arcjet] projects.
 - [npm package (`@arcjet/eslint-config`)](https://www.npmjs.com/package/@arcjet/eslint-config)
 - [GitHub source code (`eslint-config/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/eslint-config)
 
-## Installation
+## Install
 
-```shell
-npm install -D @arcjet/eslint-config
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install --save-dev @arcjet/eslint-config
 ```
 
 ## Use

--- a/headers/README.md
+++ b/headers/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/headers`)](https://www.npmjs.com/package/@arcjet/headers)
 - [GitHub source code (`headers/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/headers)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/headers
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/headers
 ```
 
 ## Use

--- a/inspect/README.md
+++ b/inspect/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/inspect`)](https://www.npmjs.com/package/@arcjet/inspect)
 - [GitHub source code (`inspect/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/inspect)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/inspect
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/inspect
 ```
 
 ## Example

--- a/ip/README.md
+++ b/ip/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/ip`)](https://www.npmjs.com/package/@arcjet/ip)
 - [GitHub source code (`ip/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/ip)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/ip
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/ip
 ```
 
 ## Example

--- a/logger/README.md
+++ b/logger/README.md
@@ -22,10 +22,13 @@ structured logger interface.
 - [npm package (`@arcjet/logger`)](https://www.npmjs.com/package/@arcjet/logger)
 - [GitHub source code (`logger/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/logger)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/logger
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/logger
 ```
 
 ## Example

--- a/nosecone-next/README.md
+++ b/nosecone-next/README.md
@@ -21,10 +21,13 @@ Protect your Next.js application with secure headers.
 - [npm package (`@nosecone/next`)](https://www.npmjs.com/package/@nosecone/next)
 - [GitHub source code (`nosecone-next/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/nosecone-next)
 
-## Installation
+## Install
 
-```shell
-npm install -S @nosecone/next
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @nosecone/next
 ```
 
 ## Use

--- a/nosecone-sveltekit/README.md
+++ b/nosecone-sveltekit/README.md
@@ -21,10 +21,13 @@ Protect your SvelteKit application with secure headers.
 - [npm package (`@nosecone/sveltekit`)](https://www.npmjs.com/package/@nosecone/sveltekit)
 - [GitHub source code (`nosecone-sveltekit/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/nosecone-sveltekit)
 
-## Installation
+## Install
 
-```shell
-npm install -S @nosecone/sveltekit
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @nosecone/sveltekit
 ```
 
 ## Example

--- a/nosecone/README.md
+++ b/nosecone/README.md
@@ -21,10 +21,13 @@ Protect your `Response` with secure headers.
 - [npm package (`nosecone`)](https://www.npmjs.com/package/nosecone)
 - [GitHub source code (`nosecone/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/nosecone)
 
-## Installation
+## Install
 
-```shell
-npm install -S nosecone
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install nosecone
 ```
 
 ## Example

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -21,10 +21,13 @@ The TypeScript & JavaScript interface into the [Arcjet][arcjet] protocol.
 - [npm package (`@arcjet/protocol`)](https://www.npmjs.com/package/@arcjet/protocol)
 - [GitHub source code (`protocol/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/protocol)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/protocol
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/protocol
 ```
 
 ## Example

--- a/redact-wasm/README.md
+++ b/redact-wasm/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/redact-wasm`)](https://www.npmjs.com/package/@arcjet/redact-wasm)
 - [GitHub source code (`redact-wasm/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/redact-wasm)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/redact-wasm
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/redact-wasm
 ```
 
 ## Use

--- a/redact/README.md
+++ b/redact/README.md
@@ -26,10 +26,13 @@ redaction library.
 - [npm package (`@arcjet/redact`)](https://www.npmjs.com/package/@arcjet/redact)
 - [GitHub source code (`redact/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/redact)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/redact
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/redact
 ```
 
 ## Reference

--- a/rollup-config/README.md
+++ b/rollup-config/README.md
@@ -21,10 +21,13 @@ Custom rollup config for [Arcjet][arcjet] projects.
 - [npm package (`@arcjet/rollup-config`)](https://www.npmjs.com/package/@arcjet/rollup-config)
 - [GitHub source code (`rollup-config/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/rollup-config)
 
-## Installation
+## Install
 
-```shell
-npm install -D @arcjet/rollup-config
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/rollup-config
 ```
 
 ## Use

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -24,10 +24,13 @@ defined by the [WinterCG][wintercg].
 - [npm package (`@arcjet/runtime`)](https://www.npmjs.com/package/@arcjet/runtime)
 - [GitHub source code (`runtime/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/runtime)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/runtime
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/runtime
 ```
 
 ## Use

--- a/sprintf/README.md
+++ b/sprintf/README.md
@@ -23,10 +23,13 @@ This package is platform-independent in order to support multiple runtimes in va
 - [npm package (`@arcjet/sprintf`)](https://www.npmjs.com/package/@arcjet/sprintf)
 - [GitHub source code (`sprintf/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/sprintf)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/sprintf
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/sprintf
 ```
 
 ## Use

--- a/stable-hash/README.md
+++ b/stable-hash/README.md
@@ -21,10 +21,13 @@
 - [npm package (`@arcjet/stable-hash`)](https://www.npmjs.com/package/@arcjet/stable-hash)
 - [GitHub source code (`stable-hash/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/stable-hash)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/stable-hash
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/stable-hash
 ```
 
 ## Example

--- a/transport/README.md
+++ b/transport/README.md
@@ -21,10 +21,13 @@ Transport mechanisms for the [Arcjet][arcjet] protocol.
 - [npm package (`@arcjet/transport`)](https://www.npmjs.com/package/@arcjet/transport)
 - [GitHub source code (`transport/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/transport)
 
-## Installation
+## Install
 
-```shell
-npm install -S @arcjet/transport
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/transport
 ```
 
 ## Example

--- a/tsconfig/README.md
+++ b/tsconfig/README.md
@@ -21,10 +21,13 @@ Custom tsconfig for [Arcjet][arcjet] projects.
 - [npm package (`@arcjet/tsconfig`)](https://www.npmjs.com/package/@arcjet/tsconfig)
 - [GitHub source code (`tsconfig/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/tsconfig)
 
-## Installation
+## Install
 
-```shell
-npm install -D @arcjet/tsconfig
+This package is ESM only.
+Install with npm in Node.js:
+
+```sh
+npm install @arcjet/tsconfig
 ```
 
 ## Use


### PR DESCRIPTION
This PR adds a uniform install section to everything.

Some changes with reasons:

* `Install` instead of `Installation` — I just don’t see the need for the extra characters
* `sh` instead of `shell` — same, people often use shorter flags here rather than entire language names (they are interchangeable on GH and in all tools that I am aware of)
* no `-S` flag, which is the current behavior, and for people that choose to install with particular flags, this allows that.
* mention `npm` and specifically also `Node.js` and here
* explain that things are ESM only

Related-to: GH-4338.