### PR TITLE
docs: add uniform license section to readmes

### DIFF
--- a/analyze-wasm/README.md
+++ b/analyze-wasm/README.md
@@ -57,7 +57,7 @@ properly support consistent asset bundling techniques.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [mdn-data-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs

--- a/analyze/README.md
+++ b/analyze/README.md
@@ -61,7 +61,7 @@ a combined higher-level api for calling our core functionality in Wasm.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/arcjet-astro/README.md
+++ b/arcjet-astro/README.md
@@ -231,7 +231,7 @@ export const GET: APIRoute = async ({ request }) => {
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [astro]: https://astro.build/

--- a/arcjet-bun/README.md
+++ b/arcjet-bun/README.md
@@ -121,7 +121,7 @@ export default {
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [bun-sh]: https://bun.sh/

--- a/arcjet-deno/README.md
+++ b/arcjet-deno/README.md
@@ -108,7 +108,7 @@ Deno.serve(
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [deno]: https://deno.com/

--- a/arcjet-fastify/README.md
+++ b/arcjet-fastify/README.md
@@ -175,7 +175,7 @@ await fastify.listen({ port: 3000 });
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com

--- a/arcjet-nest/README.md
+++ b/arcjet-nest/README.md
@@ -91,7 +91,7 @@ bootstrap();
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [nest-js]: https://nestjs.com/

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -282,7 +282,7 @@ Arcjet helps.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [next-js]: https://nextjs.org/

--- a/arcjet-node/README.md
+++ b/arcjet-node/README.md
@@ -135,7 +135,7 @@ server.listen(8000);
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [node-js]: https://nodejs.org/

--- a/arcjet-remix/README.md
+++ b/arcjet-remix/README.md
@@ -132,7 +132,7 @@ export default function Index() {
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [remix]: https://remix.run/

--- a/arcjet-sveltekit/README.md
+++ b/arcjet-sveltekit/README.md
@@ -136,7 +136,7 @@ export async function handle({
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [sveltekit]: https://kit.svelte.dev/

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -122,7 +122,7 @@ Reference documentation is available at [docs.arcjet.com][ts-sdk-docs].
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [ts-sdk-docs]: https://docs.arcjet.com/reference/ts-js

--- a/body/README.md
+++ b/body/README.md
@@ -53,7 +53,7 @@ was also changed to only support promises rather than the sync implementation pr
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [node-raw-body]: https://github.com/stream-utils/raw-body/blob/191e4b6506dcf77198eed01c8feb4b6817008342/test/index.js

--- a/cache/README.md
+++ b/cache/README.md
@@ -101,7 +101,7 @@ if (cachedValue && ttl > 0) {
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/decorate/README.md
+++ b/decorate/README.md
@@ -67,7 +67,7 @@ export default async function handler(
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/duration/README.md
+++ b/duration/README.md
@@ -50,7 +50,7 @@ normalizing the values for our protocol.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [go-parser]: https://github.com/golang/go/blob/c18ddc84e1ec6406b26f7e9d0e1ee3d1908d7c27/src/time/format.go#L1589-L1686

--- a/env/README.md
+++ b/env/README.md
@@ -68,7 +68,7 @@ env.apiKey({ ARCJET_KEY: "invalid" }) === undefined;
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/eslint-config/README.md
+++ b/eslint-config/README.md
@@ -40,7 +40,7 @@ module.exports = {
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/headers/README.md
+++ b/headers/README.md
@@ -44,7 +44,7 @@ that are not strings, such as `{ "abc": undefined }`.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/inspect/README.md
+++ b/inspect/README.md
@@ -71,7 +71,7 @@ export default async function handler(
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/ip/README.md
+++ b/ip/README.md
@@ -73,7 +73,7 @@ even though it seems to change infrequently.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [rust-parser]: https://github.com/rust-lang/rust/blob/07921b50ba6dcb5b2984a1dba039a38d85bffba2/library/core/src/net/parser.rs#L34

--- a/logger/README.md
+++ b/logger/README.md
@@ -47,7 +47,7 @@ to one of: `"DEBUG"`, `"LOG"`, `"WARN"`, or `"ERROR"`.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [pino-api]: https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger

--- a/nosecone-next/README.md
+++ b/nosecone-next/README.md
@@ -65,6 +65,7 @@ export default async function RootLayout({
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/nosecone-sveltekit/README.md
+++ b/nosecone-sveltekit/README.md
@@ -68,6 +68,7 @@ export const handle = sequence(
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/nosecone/README.md
+++ b/nosecone/README.md
@@ -39,6 +39,7 @@ const secureResponse = new Response(null, {
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -42,7 +42,7 @@ In progress.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
-[arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/redact-wasm/README.md
+++ b/redact-wasm/README.md
@@ -86,9 +86,9 @@ properly support consistent asset bundling techniques.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+[apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [mdn-data-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 [wasm-base64-blog]: https://blobfolio.com/2019/better-binary-batter-mixing-base64-and-uint8array/
-[apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/redact/README.md
+++ b/redact/README.md
@@ -52,8 +52,8 @@ console.log(unredacted); // Your email address is john@example.com
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+[apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [redact-ref]: https://docs.arcjet.com/redact/reference
-[apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/rollup-config/README.md
+++ b/rollup-config/README.md
@@ -39,7 +39,7 @@ export default createConfig(import.meta.url);
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
-[arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -48,10 +48,10 @@ with licenses included in our source code.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+[apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [runtime-keys]: https://runtime-keys.proposal.wintercg.org/
 [wintercg]: https://wintercg.org/
 [std-env]: https://github.com/unjs/std-env
-[apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/sprintf/README.md
+++ b/sprintf/README.md
@@ -66,10 +66,10 @@ format strings.
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+[apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [node-util]: https://nodejs.org/docs/latest-v18.x/api/util.html#utilformatformat-args
 [quick-format-unescaped]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64c2f2e182f97923a423d468757b9a24a63/index.js
 [pino]: https://github.com/pinojs/pino
-[apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/stable-hash/README.md
+++ b/stable-hash/README.md
@@ -43,7 +43,7 @@ const id = hasher.hash(
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
-[arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/transport/README.md
+++ b/transport/README.md
@@ -38,7 +38,7 @@ const transport = createTransport("https://decide.arcjet.com");
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
-[arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com

--- a/tsconfig/README.md
+++ b/tsconfig/README.md
@@ -40,7 +40,7 @@ In your `tsconfig.json` file:
 
 ## License
 
-Licensed under the [Apache License, Version 2.0][apache-license].
+[Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
-[arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet]: https://arcjet.com


### PR DESCRIPTION
This PR adds a uniform license section to everything.

* no prefix sentence implied by heading
* add mention of copyright holder (which people need to put into their forks)
* add link to arcjet

Related-to: GH-4338.