### PR TITLE
docs: add info on derivative works to license sections

### DIFF
--- a/body/README.md
+++ b/body/README.md
@@ -59,6 +59,11 @@ console.log(body);
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+Derivative work based on [`raw-body`][node-raw-body] licensed under
+[MIT][node-raw-body-license] © Jonathan Ong and Douglas Christopher Wilson.
+Our work removes features that we do not use: no buffers, no sync interface.
+
 [arcjet]: https://arcjet.com
-[node-raw-body]: https://github.com/stream-utils/raw-body/blob/191e4b6506dcf77198eed01c8feb4b6817008342/test/index.js
+[node-raw-body-license]: https://github.com/stream-utils/raw-body/blob/191e4b6/LICENSE
+[node-raw-body]: https://github.com/stream-utils/raw-body/blob/191e4b6/test/index.js
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/duration/README.md
+++ b/duration/README.md
@@ -57,7 +57,12 @@ console.log(seconds); // prints 3600
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+Derivative work based on [`time.ParseDuration`][go-parse-duration] from
+`golang/go` licensed under [BSD-3.0][go-parse-duration-license] © The Go Authors.
+Our work ports to TypeScript.
+
 [arcjet]: https://arcjet.com
-[go-parser]: https://github.com/golang/go/blob/c18ddc84e1ec6406b26f7e9d0e1ee3d1908d7c27/src/time/format.go#L1589-L1686
+[go-parse-duration-license]: https://github.com/golang/go/blob/c18ddc84e/LICENSE
+[go-parse-duration]: https://github.com/golang/go/blob/c18ddc84e/src/time/format.go#L1589-L1686
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [github-vercel-ms]: https://github.com/vercel/ms

--- a/ip/README.md
+++ b/ip/README.md
@@ -74,7 +74,26 @@ are detected, an empty string is returned.
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+Derivative work based on [`Parser` in `std::net`][rust-parser],
+[`is_global` on `Ipv4Addr`][rust-ipv4-is-global], and
+[`is_global` on `Ipv6Addr`][rust-ipv6-is-global]
+from `rust-lang/rust`,
+dual licensed under [MIT][rust-license-mit] and
+[Apache-2.0][rust-license-apache] © contributors.
+Our work ports to TypeScript so that we have the same functionality in both
+languages.
+
+Derivative work based on [`getClientIp` from `request-ip`][request-ip-client-ip]
+licensed under [MIT][request-ip-license] © Petar Bojinov.
+Our work cherry picks only what we need.
+
 [arcjet]: https://arcjet.com
-[rust-parser]: https://github.com/rust-lang/rust/blob/07921b50ba6dcb5b2984a1dba039a38d85bffba2/library/core/src/net/parser.rs#L34
-[request-ip]: https://github.com/pbojinov/request-ip/tree/e1d0f4b89edf26c77cf62b5ef662ba1a0bd1c9fd
+[request-ip-client-ip]: https://github.com/pbojinov/request-ip/blob/e1d0f4b/src/index.js#L55
+[request-ip-license]: https://github.com/pbojinov/request-ip/blob/e1d0f4b/LICENSE.md
+[request-ip]: https://github.com/pbojinov/request-ip
+[rust-ipv4-is-global]: https://github.com/rust-lang/rust/blob/87e1447/library/core/src/net/ip_addr.rs#L749
+[rust-ipv6-is-global]: https://github.com/rust-lang/rust/blob/87e1447/library/core/src/net/ip_addr.rs#L1453
+[rust-license-apache]: https://github.com/rust-lang/rust/blob/07921b5/LICENSE-APACHE
+[rust-license-mit]: https://github.com/rust-lang/rust/blob/07921b5/LICENSE-MIT
+[rust-parser]: https://github.com/rust-lang/rust/blob/07921b5/library/core/src/net/parser.rs#L34
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -59,8 +59,13 @@ console.log(runtime()); // => "bun" or "node" and such
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+Derivative work based on [`std-env`][std-env] licensed under
+[MIT][std-env-license] © Pooya Parsa.
+Our work cherry picks only what we need.
+
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [runtime-keys]: https://runtime-keys.proposal.wintercg.org/
 [wintercg]: https://wintercg.org/
-[std-env]: https://github.com/unjs/std-env
+[std-env-license]: https://github.com/unjs/std-env/blob/7e8cb7b/LICENCE
+[std-env]: https://github.com/unjs/std-env/blob/d57a5d8/src/runtimes.ts

--- a/sprintf/README.md
+++ b/sprintf/README.md
@@ -86,4 +86,3 @@ possible.
 [node-util]: https://nodejs.org/docs/latest-v18.x/api/util.html#utilformatformat-args
 [quick-format-unescaped-license]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64/LICENSE
 [quick-format-unescaped]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64/index.js
-[pino]: https://github.com/pinojs/pino

--- a/sprintf/README.md
+++ b/sprintf/README.md
@@ -76,7 +76,14 @@ Object substitution supports any value that is not `undefined`.
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
+Derivative work based on [`quick-format-unescaped`][quick-format-unescaped]
+licensed under [MIT][quick-format-unescaped-license] © David Mark Clements.
+Our work is more restrictive while maintaining as much compatibility as
+possible.
+
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [node-util]: https://nodejs.org/docs/latest-v18.x/api/util.html#utilformatformat-args
-[quick-format-unescaped]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64c2f2e182f97923a423d468757b9a24a63/index.js
+[quick-format-unescaped-license]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64/LICENSE
+[quick-format-unescaped]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64/index.js
+[pino]: https://github.com/pinojs/pino


### PR DESCRIPTION
Several readmes have `## Implementation` sections. Most but not all of those sections relate to which derivative works the implementation was inspired by and how it differs.

While this information often doesn’t have to be top of mind, it is important for people who wonder about license stuff. So I think it is best to put it *inside* the license section. Using a similar format. Also mentioning the copyright holders.