### PR TITLE
build(examples): add strict type checking

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -54,6 +54,9 @@ jobs:
         working-directory: examples/gatsby-rate-limit
         run: npm run build
 
+      - working-directory: examples/gatsby-rate-limit
+        run: npm run typecheck
+
   nestjs:
     name: NestJS
     runs-on: ubuntu-latest
@@ -96,6 +99,9 @@ jobs:
       - name: Build
         working-directory: examples/nestjs
         run: npm run build
+
+      - working-directory: examples/nestjs
+        run: npm run typecheck
 
   nestjs-fastify:
     name: NestJS + Fastify
@@ -140,6 +146,9 @@ jobs:
         working-directory: examples/nestjs-fastify
         run: npm run build
 
+      - working-directory: examples/nestjs-fastify
+        run: npm run typecheck
+
   nestjs-graphql:
     name: NestJS + GraphQL
     runs-on: ubuntu-latest
@@ -183,6 +192,9 @@ jobs:
         working-directory: examples/nestjs-graphql
         run: npm run build
 
+      - working-directory: examples/nestjs-graphql
+        run: npm run typecheck
+
   nestjs-launchdarkly:
     name: NestJS + LaunchDarkly
     runs-on: ubuntu-latest
@@ -225,6 +237,9 @@ jobs:
       - name: Build
         working-directory: examples/nestjs-launchdarkly
         run: npm run build
+
+      - working-directory: examples/nestjs-launchdarkly
+        run: npm run typecheck
 
   nextjs-14-nextauth-4:
     name: Next.js 14 + NextAuth 4
@@ -272,6 +287,9 @@ jobs:
         working-directory: examples/nextjs-14-nextauth-4
         run: npm run build
 
+      - working-directory: examples/nextjs-14-nextauth-4
+        run: npm run typecheck
+
   nextjs-app-dir-rate-limit:
     name: Next.js + App Router + Rate Limit
     runs-on: ubuntu-latest
@@ -318,6 +336,9 @@ jobs:
         working-directory: examples/nextjs-app-dir-rate-limit
         run: npm run build
 
+      - working-directory: examples/nextjs-app-dir-rate-limit
+        run: npm run typecheck
+
   nextjs-app-dir-validate-email:
     name: Next.js + App Router + Validate Email
     runs-on: ubuntu-latest
@@ -363,6 +384,9 @@ jobs:
       - name: Build
         working-directory: examples/nextjs-app-dir-validate-email
         run: npm run build
+
+      - working-directory: examples/nextjs-app-dir-validate-email
+        run: npm run typecheck
 
   nextjs-authjs-5:
     name: Next.js + Auth.js 5
@@ -412,6 +436,9 @@ jobs:
           AUTH_SECRET: TEST_SECRET
         run: npm run build
 
+      - working-directory: examples/nextjs-authjs-5
+        run: npm run typecheck
+
   nextjs-authjs-nosecone:
     name: Next.js + Auth.js 5 + Nosecone
     runs-on: ubuntu-latest
@@ -459,6 +486,9 @@ jobs:
         env:
           AUTH_SECRET: TEST_SECRET
         run: npm run build
+
+      - working-directory: examples/nextjs-authjs-nosecone
+        run: npm run typecheck
 
   nextjs-better-auth:
     name: Next.js + Better-Auth
@@ -510,6 +540,9 @@ jobs:
           BETTER_AUTH_SECRET: TEST_SECRET
         run: npm run build
 
+      - working-directory: examples/nextjs-better-auth
+        run: npm run typecheck
+
   nextjs-bot-categories:
     name: Next.js + Bot categories
     runs-on: ubuntu-latest
@@ -555,6 +588,9 @@ jobs:
       - name: Build
         working-directory: examples/nextjs-bot-categories
         run: npm run build
+
+      - working-directory: examples/nextjs-bot-categories
+        run: npm run typecheck
 
   nextjs-clerk-rate-limit:
     name: Next.js + Clerk + Rate Limit
@@ -605,6 +641,9 @@ jobs:
           # This is the smallest dummy token that passes the Clerk validation
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_LiQ=
 
+      - working-directory: examples/nextjs-clerk-rate-limit
+        run: npm run typecheck
+
   nextjs-clerk-shield:
     name: Next.js + Clerk + Shield
     runs-on: ubuntu-latest
@@ -654,6 +693,9 @@ jobs:
           # This is the smallest dummy token that passes the Clerk validation
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_LiQ=
 
+      - working-directory: examples/nextjs-clerk-shield
+        run: npm run typecheck
+
   nextjs-decorate:
     name: Next.js + Decorate
     runs-on: ubuntu-latest
@@ -699,6 +741,9 @@ jobs:
       - name: Build
         working-directory: examples/nextjs-decorate
         run: npm run build
+
+      - working-directory: examples/nextjs-decorate
+        run: npm run typecheck
 
   nextjs-ip-details:
     name: Next.js + IP Details
@@ -746,6 +791,9 @@ jobs:
         working-directory: examples/nextjs-ip-details
         run: npm run build
 
+      - working-directory: examples/nextjs-ip-details
+        run: npm run typecheck
+
   nextjs-openai:
     name: Next.js + OpenAI
     runs-on: ubuntu-latest
@@ -792,6 +840,9 @@ jobs:
         working-directory: examples/nextjs-openai
         run: npm run build
 
+      - working-directory: examples/nextjs-openai
+        run: npm run typecheck
+
   nextjs-pages-wrap:
     name: Next.js + Page Router + withArcjet
     runs-on: ubuntu-latest
@@ -837,6 +888,9 @@ jobs:
       - name: Build
         working-directory: examples/nextjs-pages-wrap
         run: npm run build
+
+      - working-directory: examples/nextjs-pages-wrap
+        run: npm run typecheck
 
   nextjs-permit:
     name: Next.js + Permit
@@ -887,6 +941,9 @@ jobs:
           # This is the smallest dummy token that passes the Clerk validation
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_LiQ=
 
+      - working-directory: examples/nextjs-permit
+        run: npm run typecheck
+
   nextjs-sensitive-info:
     name: Next.js + Sensitive Info
     runs-on: ubuntu-latest
@@ -932,6 +989,9 @@ jobs:
       - name: Build
         working-directory: examples/nextjs-sensitive-info
         run: npm run build
+
+      - working-directory: examples/nextjs-sensitive-info
+        run: npm run typecheck
 
   nextjs-server-actions:
     name: Next.js + Server Actions
@@ -979,6 +1039,9 @@ jobs:
         working-directory: examples/nextjs-server-actions
         run: npm run build
 
+      - working-directory: examples/nextjs-server-actions
+        run: npm run typecheck
+
   nodejs-hono-rate-limit:
     name: Node.js + Hono + Rate Limit
     runs-on: ubuntu-latest
@@ -1021,6 +1084,9 @@ jobs:
       - name: Build
         working-directory: examples/nodejs-hono-rate-limit
         run: npm run build
+
+      - working-directory: examples/nodejs-hono-rate-limit
+        run: npm run typecheck
 
   remix-express:
     name: Remix + Express
@@ -1065,6 +1131,9 @@ jobs:
         working-directory: examples/remix-express
         run: npm run build
 
+      - working-directory: examples/remix-express
+        run: npm run typecheck
+
   sveltekit:
     name: SvelteKit
     runs-on: ubuntu-latest
@@ -1108,6 +1177,10 @@ jobs:
       - name: Build
         working-directory: examples/sveltekit
         run: npm run build
+
+      - working-directory: examples/sveltekit
+        run: npm run typecheck
+
   astro:
     name: Astro
     runs-on: ubuntu-latest
@@ -1153,3 +1226,6 @@ jobs:
         env:
           ARCJET_KEY: ajkey_dummy
           ASTRO_TELEMETRY_DISABLED: 1
+
+      - working-directory: examples/astro-integration
+        run: npm run typecheck

--- a/examples/astro-integration/package-lock.json
+++ b/examples/astro-integration/package-lock.json
@@ -10,29 +10,30 @@
       "dependencies": {
         "@arcjet/astro": "file:../../arcjet-astro",
         "@astrojs/node": "^9.3.0",
-        "astro": "^5.5.5"
+        "astro": "^5.5.5",
+        "typescript": "^5.8.3"
       }
     },
     "../../arcjet-astro": {
       "name": "@arcjet/astro",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/env": "1.0.0-beta.8",
-        "@arcjet/headers": "1.0.0-beta.8",
-        "@arcjet/ip": "1.0.0-beta.8",
-        "@arcjet/logger": "1.0.0-beta.8",
-        "@arcjet/protocol": "1.0.0-beta.8",
-        "@arcjet/transport": "1.0.0-beta.8",
-        "arcjet": "1.0.0-beta.8"
+        "@arcjet/env": "1.0.0-beta.9",
+        "@arcjet/headers": "1.0.0-beta.9",
+        "@arcjet/ip": "1.0.0-beta.9",
+        "@arcjet/logger": "1.0.0-beta.9",
+        "@arcjet/protocol": "1.0.0-beta.9",
+        "@arcjet/transport": "1.0.0-beta.9",
+        "arcjet": "1.0.0-beta.9"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.0.0-beta.8",
-        "@arcjet/rollup-config": "1.0.0-beta.8",
-        "@arcjet/tsconfig": "1.0.0-beta.8",
-        "@rollup/wasm-node": "4.44.1",
-        "astro": "5.10.0",
-        "eslint": "9.29.0",
+        "@arcjet/eslint-config": "1.0.0-beta.9",
+        "@arcjet/rollup-config": "1.0.0-beta.9",
+        "@arcjet/tsconfig": "1.0.0-beta.9",
+        "@rollup/wasm-node": "4.44.2",
+        "astro": "5.11.0",
+        "eslint": "9.30.1",
         "typescript": "5.8.3"
       },
       "peerDependencies": {
@@ -4446,11 +4447,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/astro-integration/package.json
+++ b/examples/astro-integration/package.json
@@ -6,11 +6,13 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/astro": "file:../../arcjet-astro",
     "@astrojs/node": "^9.3.0",
-    "astro": "^5.5.5"
+    "astro": "^5.5.5",
+    "typescript": "^5.8.3"
   }
 }

--- a/examples/astro-integration/src/actions/index.ts
+++ b/examples/astro-integration/src/actions/index.ts
@@ -8,7 +8,7 @@ export const server = {
     input: z.object({
       content: z.string(),
     }),
-    handler: async (input, { request }) => {
+    handler: async (_input, { request }) => {
       const decision = await aj
         .withRule(sensitiveInfo({ mode: "LIVE", allow: [] }))
         .protect(request);

--- a/examples/astro-integration/tsconfig.json
+++ b/examples/astro-integration/tsconfig.json
@@ -1,5 +1,5 @@
 {
+  "exclude": ["dist/"],
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
 }

--- a/examples/gatsby-rate-limit/src/api/arcjet.ts
+++ b/examples/gatsby-rate-limit/src/api/arcjet.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error: TS1479: TS emits ESM/CJS error, which Gatsby solves.
 import arcjet, { slidingWindow } from "@arcjet/node";
 import type { GatsbyFunctionRequest, GatsbyFunctionResponse } from 'gatsby';
 

--- a/examples/gatsby-rate-limit/tsconfig.json
+++ b/examples/gatsby-rate-limit/tsconfig.json
@@ -1,102 +1,11 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Enable incremental compilation */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "esnext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["dom", "esnext"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
-    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-
-    /* Modules */
-    "module": "esnext",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files */
-    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
-    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
-    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "jsx": "react",
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "module": "node16",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022"
   },
-  "include": ["./src/**/*", "./gatsby-node.ts", "./gatsby-config.ts", "./plugins/**/*"]
+  "include": [ "./plugins/**/*", "./src/**/*", "./gatsby-config.ts", "./gatsby-node.ts"]
 }

--- a/examples/nestjs-fastify/package.json
+++ b/examples/nestjs-fastify/package.json
@@ -14,7 +14,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/nest": "file:../../arcjet-nest",

--- a/examples/nestjs-fastify/src/app.module.ts
+++ b/examples/nestjs-fastify/src/app.module.ts
@@ -18,7 +18,8 @@ import { ValidateEmailModule } from './validate-email/validate-email.module.js';
     }),
     ArcjetModule.forRoot({
       isGlobal: true,
-      key: process.env.ARCJET_KEY,
+      // `!` because `envFilePath` loads it.
+      key: process.env.ARCJET_KEY!,
       rules: [shield({ mode: 'LIVE' })],
     }),
     RateLimitModule,

--- a/examples/nestjs-fastify/tsconfig.build.json
+++ b/examples/nestjs-fastify/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
-}

--- a/examples/nestjs-fastify/tsconfig.json
+++ b/examples/nestjs-fastify/tsconfig.json
@@ -1,22 +1,12 @@
 {
   "compilerOptions": {
-    "module": "node16",
-    "moduleResolution": "node16",
-    "declaration": true,
-    "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
-    "sourceMap": true,
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "incremental": true,
+    "module": "node16",
+    "outDir": "./dist/",
     "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022",
   }
 }

--- a/examples/nestjs-graphql/package.json
+++ b/examples/nestjs-graphql/package.json
@@ -14,7 +14,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@apollo/server": "^4.12.2",

--- a/examples/nestjs-graphql/src/app.module.ts
+++ b/examples/nestjs-graphql/src/app.module.ts
@@ -20,7 +20,8 @@ import { RecipesModule } from './recipes/recipes.module.js';
     }),
     ArcjetModule.forRoot({
       isGlobal: true,
-      key: process.env.ARCJET_KEY,
+      // `!` because `envFilePath` loads it.
+      key: process.env.ARCJET_KEY!,
       rules: [shield({ mode: 'LIVE' }), detectBot({ mode: 'LIVE', allow: [] })],
     }),
   ],

--- a/examples/nestjs-graphql/src/recipes/models/recipe.model.ts
+++ b/examples/nestjs-graphql/src/recipes/models/recipe.model.ts
@@ -3,14 +3,14 @@ import { Field, ID, ObjectType } from '@nestjs/graphql';
 @ObjectType({ description: 'recipe ' })
 export class Recipe {
   @Field(() => ID)
-  id: string;
+  id: string = '';
 
   @Field()
-  title: string;
+  title: string = '';
 
   @Field({ nullable: true })
   description?: string;
 
   @Field(() => [String])
-  ingredients: string[];
+  ingredients: string[] = [];
 }

--- a/examples/nestjs-graphql/tsconfig.build.json
+++ b/examples/nestjs-graphql/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
-}

--- a/examples/nestjs-graphql/tsconfig.json
+++ b/examples/nestjs-graphql/tsconfig.json
@@ -1,22 +1,12 @@
 {
   "compilerOptions": {
-    "module": "node16",
-    "moduleResolution": "node16",
-    "declaration": true,
-    "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
-    "sourceMap": true,
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "incremental": true,
+    "module": "node16",
+    "outDir": "./dist/",
     "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
   }
 }

--- a/examples/nestjs-launchdarkly/package.json
+++ b/examples/nestjs-launchdarkly/package.json
@@ -14,7 +14,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/nest": "file:../../arcjet-nest",

--- a/examples/nestjs-launchdarkly/src/config/arcjet.ts
+++ b/examples/nestjs-launchdarkly/src/config/arcjet.ts
@@ -16,8 +16,9 @@ export class ArcjetConfig {
   constructor(private configService: ConfigService) {}
 
   async create() {
+    const launchdarklySdkKey = this.configService.get('LAUNCHDARKLY_SDK_KEY')
     // Initialize LaunchDarkly client
-    const client = ld.init(this.configService.get('LAUNCHDARKLY_SDK_KEY'));
+    const client = ld.init(launchdarklySdkKey);
 
     // Wait for the LaunchDarkly client to be initialized
     await client.waitForInitialization({ timeout: 1 });
@@ -47,7 +48,11 @@ export class ArcjetConfig {
       ArcjetConfig.defaultConfig.rateLimitWindow,
     )) as string | number;
 
-    const key: string = this.configService.get('ARCJET_KEY');
+    const key = this.configService.get('ARCJET_KEY');
+
+    if (!key) {
+      throw new Error("Cannot find `ARCJET_KEY` environment variable");
+    }
 
     return {
       key,

--- a/examples/nestjs-launchdarkly/tsconfig.json
+++ b/examples/nestjs-launchdarkly/tsconfig.json
@@ -1,22 +1,12 @@
 {
   "compilerOptions": {
-    "module": "node16",
-    "moduleResolution": "node16",
-    "declaration": true,
-    "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
-    "sourceMap": true,
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "incremental": true,
+    "module": "node16",
+    "outDir": "./dist/",
     "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
   }
 }

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -14,7 +14,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/nest": "file:../../arcjet-nest",

--- a/examples/nestjs/src/app.module.ts
+++ b/examples/nestjs/src/app.module.ts
@@ -18,7 +18,8 @@ import { ValidateEmailModule } from './validate-email/validate-email.module.js';
     }),
     ArcjetModule.forRoot({
       isGlobal: true,
-      key: process.env.ARCJET_KEY,
+      // `!` because `envFilePath` loads it.
+      key: process.env.ARCJET_KEY!,
       rules: [shield({ mode: 'LIVE' })],
     }),
     RateLimitModule,

--- a/examples/nestjs/tsconfig.build.json
+++ b/examples/nestjs/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
-}

--- a/examples/nestjs/tsconfig.json
+++ b/examples/nestjs/tsconfig.json
@@ -1,22 +1,12 @@
 {
   "compilerOptions": {
-    "module": "node16",
-    "moduleResolution": "node16",
-    "declaration": true,
-    "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "ES2021",
-    "sourceMap": true,
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "incremental": true,
+    "module": "node16",
+    "outDir": "./dist/",
     "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022",
   }
 }

--- a/examples/nextjs-14-nextauth-4/package.json
+++ b/examples/nextjs-14-nextauth-4/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/ip": "file:../../ip",

--- a/examples/nextjs-14-nextauth-4/tsconfig.json
+++ b/examples/nextjs-14-nextauth-4/tsconfig.json
@@ -1,27 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-app-dir-rate-limit/package.json
+++ b/examples/nextjs-app-dir-rate-limit/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-app-dir-rate-limit/tsconfig.json
+++ b/examples/nextjs-app-dir-rate-limit/tsconfig.json
@@ -1,27 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-app-dir-validate-email/package.json
+++ b/examples/nextjs-app-dir-validate-email/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-app-dir-validate-email/tsconfig.json
+++ b/examples/nextjs-app-dir-validate-email/tsconfig.json
@@ -1,27 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-authjs-5/package.json
+++ b/examples/nextjs-authjs-5/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-authjs-5/tsconfig.json
+++ b/examples/nextjs-authjs-5/tsconfig.json
@@ -1,35 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"],
+      "auth": ["./auth"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"],
-      "auth": ["./auth"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": [
-    "process.d.ts",
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-authjs-nosecone/package.json
+++ b/examples/nextjs-authjs-nosecone/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@nosecone/next": "file:../../nosecone-next",

--- a/examples/nextjs-authjs-nosecone/tsconfig.json
+++ b/examples/nextjs-authjs-nosecone/tsconfig.json
@@ -1,35 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"],
+      "auth": ["./auth"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"],
-      "auth": ["./auth"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": [
-    "process.d.ts",
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-better-auth/package.json
+++ b/examples/nextjs-better-auth/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-better-auth/tsconfig.json
+++ b/examples/nextjs-better-auth/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-bot-categories/package.json
+++ b/examples/nextjs-bot-categories/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-bot-categories/tsconfig.json
+++ b/examples/nextjs-bot-categories/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-clerk-rate-limit/package.json
+++ b/examples/nextjs-clerk-rate-limit/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-clerk-rate-limit/tsconfig.json
+++ b/examples/nextjs-clerk-rate-limit/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-clerk-shield/package.json
+++ b/examples/nextjs-clerk-shield/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-clerk-shield/tsconfig.json
+++ b/examples/nextjs-clerk-shield/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-decorate/package.json
+++ b/examples/nextjs-decorate/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/decorate": "file:../../decorate",

--- a/examples/nextjs-decorate/tsconfig.json
+++ b/examples/nextjs-decorate/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-ip-details/package.json
+++ b/examples/nextjs-ip-details/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/ip": "file:../../ip",

--- a/examples/nextjs-ip-details/tsconfig.json
+++ b/examples/nextjs-ip-details/tsconfig.json
@@ -1,22 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-openai/package.json
+++ b/examples/nextjs-openai/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1",

--- a/examples/nextjs-openai/tsconfig.json
+++ b/examples/nextjs-openai/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-pages-wrap/package.json
+++ b/examples/nextjs-pages-wrap/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-pages-wrap/tsconfig.json
+++ b/examples/nextjs-pages-wrap/tsconfig.json
@@ -1,22 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-permit/package.json
+++ b/examples/nextjs-permit/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/ip": "file:../../ip",

--- a/examples/nextjs-permit/tsconfig.json
+++ b/examples/nextjs-permit/tsconfig.json
@@ -1,40 +1,20 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    },
-    "target": "ES2017"
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-sensitive-info/package.json
+++ b/examples/nextjs-sensitive-info/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-sensitive-info/tsconfig.json
+++ b/examples/nextjs-sensitive-info/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nextjs-server-actions/package.json
+++ b/examples/nextjs-server-actions/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/next": "file:../../arcjet-next",

--- a/examples/nextjs-server-actions/tsconfig.json
+++ b/examples/nextjs-server-actions/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom.iterable", "dom", "esnext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [".next/types/**/*.ts", "**/*.tsx", "**/*.ts"],
 }

--- a/examples/nodejs-hono-rate-limit/package.json
+++ b/examples/nodejs-hono-rate-limit/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "prestart": "npm run build",
     "start": "node --env-file .env.local ./index.js",
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@arcjet/node": "file:../../arcjet-node",

--- a/examples/nodejs-hono-rate-limit/tsconfig.json
+++ b/examples/nodejs-hono-rate-limit/tsconfig.json
@@ -1,9 +1,10 @@
 {
-    "compilerOptions": {
-        "module": "ESNext",
-        "moduleResolution": "Node",
-        "target": "ES2022"
-    },
-    "include": ["index.ts"],
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "lib": ["dom.iterable", "dom", "es2022"],
+    "module": "node16",
+    "strict": true,
+    "target": "es2022"
+  },
+  "exclude": ["node_modules/"],
+  "include": ["**/*.ts"]
 }

--- a/examples/remix-express/tsconfig.json
+++ b/examples/remix-express/tsconfig.json
@@ -1,32 +1,15 @@
 {
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "**/.server/**/*.ts",
-    "**/.server/**/*.tsx",
-    "**/.client/**/*.ts",
-    "**/.client/**/*.tsx"
-  ],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@remix-run/node", "vite/client"],
-    "isolatedModules": true,
-    "esModuleInterop": true,
     "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "target": "ES2022",
-    "strict": true,
-    "allowJs": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
+    "lib": ["dom.iterable", "dom", "es2022"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
     "paths": {
       "~/*": ["./app/*"]
     },
-
-    // Vite takes care of building everything, not tsc.
-    "noEmit": true
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
   }
 }

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -10,7 +10,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+    "typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@arcjet/sveltekit": "file:../../arcjet-sveltekit",

--- a/examples/sveltekit/tsconfig.json
+++ b/examples/sveltekit/tsconfig.json
@@ -1,19 +1,9 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
-	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
-	//
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+		"moduleResolution": "bundler",
+		"module": "es2022"
+	},
+	"extends": "./.svelte-kit/tsconfig.json",
 }

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -2,5 +2,6 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+	// @ts-expect-error: there is some weird deep type error that says it doesn’t match.
 	plugins: [sveltekit()]
 });


### PR DESCRIPTION
This adds a `typecheck` npm script that runs a type check with `strict: true`.
Otherwise, I removed everything that was not needed from `tsconfig.json`s.
And applied some small fixes that were caught by the stricter type requirement.
This should help us catch more problems.

I also noticed that the following are not used in the reusable examples workflow.

* `bun-hono-rate-limit`
* `bun-rate-limit`
* `deno-sensitive-info`
* `express-bots`
* `express-newman`
* `express-sensitive-info`
* `nextjs-react-hook-form`
* `nodejs-express-launchdarkly`
* `nodejs-express-rate-limit`
* `nodejs-express-validate-email`
* `nodejs-rate-limit`