### PR TITLE
fix(ip): support readonly arrays, null, and exact optional props

### DIFF
--- a/arcjet-fastify/index.ts
+++ b/arcjet-fastify/index.ts
@@ -301,8 +301,7 @@ function toArcjetRequest<Properties extends PlainObject>(
 
   let ip = findIp(
     { headers, socket: request.socket },
-    // TODO(@wooorm-arcjet): readonly support in `findIp`.
-    { platform: platform(process.env), proxies: proxies ? [...proxies] : [] },
+    { platform: platform(process.env), proxies },
   );
 
   if (ip === "") {

--- a/ip/index.ts
+++ b/ip/index.ts
@@ -55,8 +55,8 @@ function isIPv6Cidr(cidr: unknown): cidr is IPv6CIDR {
 
 function isTrustedProxy(
   ip: string,
-  segments: number[],
-  proxies?: Array<string | CIDR>,
+  segments: ReadonlyArray<number>,
+  proxies?: ReadonlyArray<string | CIDR> | null | undefined,
 ) {
   if (Array.isArray(proxies) && proxies.length > 0) {
     return proxies.some((proxy) => {
@@ -471,7 +471,7 @@ const IPV4_BROADCAST = u32FromBytes([255, 255, 255, 255]);
 
 function isGlobalIPv4(
   s: unknown,
-  proxies: Array<string | CIDR> | undefined,
+  proxies: ReadonlyArray<string | CIDR> | null | undefined,
 ): s is string {
   if (typeof s !== "string") {
     return false;
@@ -570,7 +570,7 @@ function isGlobalIPv4(
 
 function isGlobalIPv6(
   s: unknown,
-  proxies: Array<string | CIDR> | undefined,
+  proxies: ReadonlyArray<string | CIDR> | null | undefined,
 ): s is string {
   if (typeof s !== "string") {
     return false;
@@ -721,7 +721,7 @@ function isGlobalIPv6(
 
 function isGlobalIP(
   s: unknown,
-  proxies: Array<string | CIDR> | undefined,
+  proxies: ReadonlyArray<string | CIDR> | null | undefined,
 ): s is string {
   if (isGlobalIPv4(s, proxies)) {
     return true;
@@ -761,18 +761,18 @@ export type HeaderLike =
 export type RequestLike = {
   ip?: unknown;
 
-  socket?: PartialSocket;
+  socket?: PartialSocket | null | undefined;
 
-  info?: PartialInfo;
+  info?: PartialInfo | null | undefined;
 
-  requestContext?: PartialRequestContext;
+  requestContext?: PartialRequestContext | null | undefined;
 } & HeaderLike;
 
 export type Platform = "cloudflare" | "fly-io" | "vercel" | "render";
 
 export interface Options {
-  platform?: Platform;
-  proxies?: Array<string | CIDR>;
+  platform?: Platform | null | undefined;
+  proxies?: ReadonlyArray<string | CIDR> | null | undefined;
 }
 
 function isHeaders(val: HeaderLike["headers"]): val is Headers {
@@ -813,8 +813,11 @@ function getHeader(headers: HeaderLike["headers"], headerKey: string) {
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-function findIP(request: RequestLike, options: Options = {}): string {
-  const { platform, proxies } = options;
+function findIP(
+  request: RequestLike,
+  options?: Options | null | undefined,
+): string {
+  const { platform, proxies } = options || {};
   // Prefer anything available via the platform over headers since headers can
   // be set by users. Only if we don't have an IP available in `request` do we
   // search the `headers`.

--- a/ip/tsconfig.json
+++ b/ip/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }


### PR DESCRIPTION
When working on GH-4538 I noticed that readonly arrays were not allowed in the types but looking at the code it does seem intentional that parameters are not mutated (a good thing to not touch them of course).

Additionally users that configure TypeScript with
`exactOptionalPropertyTypes`, would get a type error if an `undefined` value was explicitly passed, instead of an option not set. This adds `undefined` as an allowed type for options next to being omitted.

Finally, I explicitly added `null` in the allowed types for options and parameters too.
While I do hope that people use `undefined` in almost all cases, I think that it is good for our APIs to *handle* `null` as well.

Related-to: GH-4538.