### PR TITLE
types: add `exactOptionalPropertyTypes`

### DIFF
--- a/analyze-wasm/tsconfig.json
+++ b/analyze-wasm/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "edge-light.ts", "workerd.ts", "wasm.d.ts"]
 }

--- a/analyze/tsconfig.json
+++ b/analyze/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-astro/tsconfig.json
+++ b/arcjet-astro/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "internal.ts", "middleware.ts", "astro-env.d.ts"]
 }

--- a/arcjet-bun/tsconfig.json
+++ b/arcjet-bun/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-deno/tsconfig.json
+++ b/arcjet-deno/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-fastify/tsconfig.json
+++ b/arcjet-fastify/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -502,7 +502,7 @@ export class ArcjetModule {
     };
 
     return {
-      global: options.isGlobal,
+      global: options.isGlobal || false,
       module: this,
       providers: [
         {
@@ -574,7 +574,7 @@ export class ArcjetModule {
     }
 
     return {
-      global: options.isGlobal,
+      global: options.isGlobal || false,
       module: this,
       providers,
       exports: [ARCJET],

--- a/arcjet-nest/tsconfig.json
+++ b/arcjet-nest/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-next/tsconfig.json
+++ b/arcjet-next/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-node/tsconfig.json
+++ b/arcjet-node/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-remix/tsconfig.json
+++ b/arcjet-remix/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/arcjet-sveltekit/tsconfig.json
+++ b/arcjet-sveltekit/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "env.d.ts"]
 }

--- a/body/index.ts
+++ b/body/index.ts
@@ -1,6 +1,6 @@
 export type ReadBodyOpts = {
   limit: number;
-  expectedLength?: number;
+  expectedLength?: number | null | undefined;
 };
 
 type EventHandlerLike = (
@@ -10,9 +10,9 @@ type EventHandlerLike = (
 
 // The fields from stream.Readable that we use
 export interface ReadableStreamLike {
-  on?: EventHandlerLike;
-  removeListener?: EventHandlerLike;
-  readable?: boolean;
+  on?: EventHandlerLike | null | undefined;
+  removeListener?: EventHandlerLike | null | undefined;
+  readable?: boolean | null | undefined;
 }
 
 // This `readBody` function is a derivitive of the `getRawBody` function in the `raw-body`
@@ -81,7 +81,10 @@ export async function readBody(
       stream.on("error", onEnd);
     }
 
-    function done(err?: Error, buffer?: string) {
+    function done(
+      err?: Error | null | undefined,
+      buffer?: string | null | undefined,
+    ) {
       // Ensure we avoid double resolve/reject if called more than once
       if (complete) return;
 
@@ -90,7 +93,7 @@ export async function readBody(
       cleanup();
       if (typeof err !== "undefined") {
         reject(err);
-      } else if (typeof buffer !== "undefined") {
+      } else if (buffer !== null && buffer !== undefined) {
         // Need to call it one final time to flush any remaining chars.
         buffer += decoder.decode();
         resolve(buffer);

--- a/body/tsconfig.json
+++ b/body/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/cache/tsconfig.json
+++ b/cache/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/decorate/tsconfig.json
+++ b/decorate/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/duration/tsconfig.json
+++ b/duration/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/env/index.ts
+++ b/env/index.ts
@@ -1,14 +1,14 @@
 export type Env = {
   [key: string]: unknown;
-  FLY_APP_NAME?: string;
-  VERCEL?: string;
-  RENDER?: string;
-  MODE?: string;
-  NODE_ENV?: string;
-  ARCJET_KEY?: string;
-  ARCJET_ENV?: string;
-  ARCJET_LOG_LEVEL?: string;
-  ARCJET_BASE_URL?: string;
+  FLY_APP_NAME?: string | undefined;
+  VERCEL?: string | undefined;
+  RENDER?: string | undefined;
+  MODE?: string | undefined;
+  NODE_ENV?: string | undefined;
+  ARCJET_KEY?: string | undefined;
+  ARCJET_ENV?: string | undefined;
+  ARCJET_LOG_LEVEL?: string | undefined;
+  ARCJET_BASE_URL?: string | undefined;
 };
 
 export function platform(env: Env) {

--- a/env/tsconfig.json
+++ b/env/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/headers/tsconfig.json
+++ b/headers/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/inspect/tsconfig.json
+++ b/inspect/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/ip/index.ts
+++ b/ip/index.ts
@@ -316,7 +316,7 @@ class Parser {
 
   readNumber(
     radix: 10 | 16,
-    maxDigits?: number,
+    maxDigits?: number | undefined,
     allowZeroPrefix: boolean = false,
   ) {
     return this.readAtomically((p) => {
@@ -735,19 +735,19 @@ function isGlobalIP(
 }
 
 interface PartialSocket {
-  remoteAddress?: string;
+  remoteAddress?: string | null | undefined;
 }
 
 interface PartialInfo {
-  remoteAddress?: string;
+  remoteAddress?: string | null | undefined;
 }
 
 interface PartialIdentiy {
-  sourceIp?: string;
+  sourceIp?: string | null | undefined;
 }
 
 interface PartialRequestContext {
-  identity?: PartialIdentiy;
+  identity?: PartialIdentiy | null | undefined;
 }
 
 export type HeaderLike =

--- a/logger/tsconfig.json
+++ b/logger/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/nosecone-next/tsconfig.json
+++ b/nosecone-next/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/nosecone-sveltekit/index.ts
+++ b/nosecone-sveltekit/index.ts
@@ -114,8 +114,9 @@ export function csp(
 ): SvelteKitCsp {
   return {
     mode: options.mode ? options.mode : "auto",
-    directives: directivesToSvelteKitConfig(
-      options.directives ?? defaults.contentSecurityPolicy.directives,
-    ),
+    directives:
+      directivesToSvelteKitConfig(
+        options.directives ?? defaults.contentSecurityPolicy.directives,
+      ) || {},
   };
 }

--- a/nosecone-sveltekit/tsconfig.json
+++ b/nosecone-sveltekit/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/nosecone/index.ts
+++ b/nosecone/index.ts
@@ -50,47 +50,53 @@ export type Source = HostSource | SchemeSource | CryptoSource | BaseSource;
 export type StaticOrDynamic<S> = boolean | null | ReadonlyArray<S | (() => S)>;
 
 export interface CspDirectives {
-  baseUri?: StaticOrDynamic<Source | ActionSource>;
-  childSrc?: StaticOrDynamic<Source>;
-  defaultSrc?: StaticOrDynamic<Source | ActionSource>;
-  frameSrc?: StaticOrDynamic<Source>;
-  workerSrc?: StaticOrDynamic<Source>;
-  connectSrc?: StaticOrDynamic<Source>;
-  fontSrc?: StaticOrDynamic<Source>;
-  imgSrc?: StaticOrDynamic<Source>;
-  manifestSrc?: StaticOrDynamic<Source>;
-  mediaSrc?: StaticOrDynamic<Source>;
-  objectSrc?: StaticOrDynamic<Source>;
-  prefetchSrc?: StaticOrDynamic<Source>;
-  scriptSrc?: StaticOrDynamic<Source | ActionSource>;
-  scriptSrcElem?: StaticOrDynamic<Source>;
-  scriptSrcAttr?: StaticOrDynamic<Source>;
-  styleSrc?: StaticOrDynamic<Source | ActionSource>;
-  styleSrcElem?: StaticOrDynamic<Source>;
-  styleSrcAttr?: StaticOrDynamic<Source>;
-  sandbox?: ReadonlyArray<
-    | "allow-downloads-without-user-activation"
-    | "allow-forms"
-    | "allow-modals"
-    | "allow-orientation-lock"
-    | "allow-pointer-lock"
-    | "allow-popups"
-    | "allow-popups-to-escape-sandbox"
-    | "allow-presentation"
-    | "allow-same-origin"
-    | "allow-scripts"
-    | "allow-storage-access-by-user-activation"
-    | "allow-top-navigation"
-    | "allow-top-navigation-by-user-activation"
-  >;
-  formAction?: StaticOrDynamic<Source | ActionSource>;
-  frameAncestors?: StaticOrDynamic<HostSource | SchemeSource | FrameSource>;
-  navigateTo?: StaticOrDynamic<Source | ActionSource>;
-  reportUri?: string[];
-  reportTo?: string[];
-  requireTrustedTypesFor?: ReadonlyArray<"script">;
-  trustedTypes?: ReadonlyArray<"none" | "allow-duplicates" | "*" | string>;
-  upgradeInsecureRequests?: boolean;
+  baseUri?: StaticOrDynamic<Source | ActionSource> | undefined;
+  childSrc?: StaticOrDynamic<Source> | undefined;
+  defaultSrc?: StaticOrDynamic<Source | ActionSource> | undefined;
+  frameSrc?: StaticOrDynamic<Source> | undefined;
+  workerSrc?: StaticOrDynamic<Source> | undefined;
+  connectSrc?: StaticOrDynamic<Source> | undefined;
+  fontSrc?: StaticOrDynamic<Source> | undefined;
+  imgSrc?: StaticOrDynamic<Source> | undefined;
+  manifestSrc?: StaticOrDynamic<Source> | undefined;
+  mediaSrc?: StaticOrDynamic<Source> | undefined;
+  objectSrc?: StaticOrDynamic<Source> | undefined;
+  prefetchSrc?: StaticOrDynamic<Source> | undefined;
+  scriptSrc?: StaticOrDynamic<Source | ActionSource> | undefined;
+  scriptSrcElem?: StaticOrDynamic<Source> | undefined;
+  scriptSrcAttr?: StaticOrDynamic<Source> | undefined;
+  styleSrc?: StaticOrDynamic<Source | ActionSource> | undefined;
+  styleSrcElem?: StaticOrDynamic<Source> | undefined;
+  styleSrcAttr?: StaticOrDynamic<Source> | undefined;
+  sandbox?:
+    | ReadonlyArray<
+        | "allow-downloads-without-user-activation"
+        | "allow-forms"
+        | "allow-modals"
+        | "allow-orientation-lock"
+        | "allow-pointer-lock"
+        | "allow-popups"
+        | "allow-popups-to-escape-sandbox"
+        | "allow-presentation"
+        | "allow-same-origin"
+        | "allow-scripts"
+        | "allow-storage-access-by-user-activation"
+        | "allow-top-navigation"
+        | "allow-top-navigation-by-user-activation"
+      >
+    | undefined;
+  formAction?: StaticOrDynamic<Source | ActionSource> | undefined;
+  frameAncestors?:
+    | StaticOrDynamic<HostSource | SchemeSource | FrameSource>
+    | undefined;
+  navigateTo?: StaticOrDynamic<Source | ActionSource> | undefined;
+  reportUri?: string[] | undefined;
+  reportTo?: string[] | undefined;
+  requireTrustedTypesFor?: ReadonlyArray<"script"> | undefined;
+  trustedTypes?:
+    | ReadonlyArray<"none" | "allow-duplicates" | "*" | string>
+    | undefined;
+  upgradeInsecureRequests?: boolean | undefined;
 }
 
 export type ReferrerPolicyToken =
@@ -105,41 +111,50 @@ export type ReferrerPolicyToken =
   | "";
 
 export interface ContentSecurityPolicyConfig {
-  directives?: Readonly<CspDirectives>;
+  directives?: Readonly<CspDirectives> | undefined;
 }
 
 export interface CrossOriginEmbedderPolicyConfig {
-  policy?: "require-corp" | "credentialless" | "unsafe-none";
+  policy?: "require-corp" | "credentialless" | "unsafe-none" | undefined;
 }
 
 export interface CrossOriginOpenerPolicyConfig {
-  policy?: "same-origin" | "same-origin-allow-popups" | "unsafe-none";
+  policy?:
+    | "same-origin"
+    | "same-origin-allow-popups"
+    | "unsafe-none"
+    | undefined;
 }
 
 export interface CrossOriginResourcePolicyConfig {
-  policy?: "same-origin" | "same-site" | "cross-origin";
+  policy?: "same-origin" | "same-site" | "cross-origin" | undefined;
 }
 
 export interface ReferrerPolicyConfig {
-  policy?: ReadonlyArray<ReferrerPolicyToken>;
+  policy?: ReadonlyArray<ReferrerPolicyToken> | undefined;
 }
 
 export interface StrictTransportSecurityConfig {
-  maxAge?: number;
-  includeSubDomains?: boolean;
-  preload?: boolean;
+  maxAge?: number | undefined;
+  includeSubDomains?: boolean | undefined;
+  preload?: boolean | undefined;
 }
 
 export interface DnsPrefetchControlConfig {
-  allow?: boolean;
+  allow?: boolean | undefined;
 }
 
 export interface FrameOptionsConfig {
-  action?: "deny" | "sameorigin";
+  action?: "deny" | "sameorigin" | undefined;
 }
 
 export interface PermittedCrossDomainPoliciesConfig {
-  permittedPolicies?: "none" | "master-only" | "by-content-type" | "all";
+  permittedPolicies?:
+    | "none"
+    | "master-only"
+    | "by-content-type"
+    | "all"
+    | undefined;
 }
 
 export interface NoseconeOptions {
@@ -155,7 +170,7 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
    * - https://owasp.org/www-project-secure-headers/#content-security-policy
    */
-  contentSecurityPolicy?: ContentSecurityPolicyConfig | boolean;
+  contentSecurityPolicy?: ContentSecurityPolicyConfig | boolean | undefined;
   /**
    * Configure the `Cross-Origin-Embedder-Policy` header, which helps control
    * what resources can be loaded cross-origin.
@@ -168,7 +183,10 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
    * - https://owasp.org/www-project-secure-headers/#cross-origin-embedder-policy
    */
-  crossOriginEmbedderPolicy?: CrossOriginEmbedderPolicyConfig | boolean;
+  crossOriginEmbedderPolicy?:
+    | CrossOriginEmbedderPolicyConfig
+    | boolean
+    | undefined;
   /**
    * Configure the `Cross-Origin-Opener-Policy` header, which helps
    * process-isolate your page.
@@ -181,7 +199,7 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
    * - https://owasp.org/www-project-secure-headers/#cross-origin-opener-policy
    */
-  crossOriginOpenerPolicy?: CrossOriginOpenerPolicyConfig | boolean;
+  crossOriginOpenerPolicy?: CrossOriginOpenerPolicyConfig | boolean | undefined;
   /**
    * Configure the `Cross-Origin-Resource-Policy` header, which blocks others
    * from loading your resources cross-origin in some cases.
@@ -195,7 +213,10 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
    * - https://owasp.org/www-project-secure-headers/#cross-origin-resource-policy
    */
-  crossOriginResourcePolicy?: CrossOriginResourcePolicyConfig | boolean;
+  crossOriginResourcePolicy?:
+    | CrossOriginResourcePolicyConfig
+    | boolean
+    | undefined;
   /**
    * Configure the `Origin-Agent-Cluster` header, which provides a mechanism to
    * allow web applications to isolate their origins from other processes.
@@ -205,7 +226,7 @@ export interface NoseconeOptions {
    * See also:
    * - https://whatpr.org/html/6214/origin.html#origin-keyed-agent-clusters
    */
-  originAgentCluster?: boolean;
+  originAgentCluster?: boolean | undefined;
   /**
    * Configure the `Referrer-Policy` header, which controls what information is
    * set in the `Referer` request header.
@@ -218,7 +239,7 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
    * - https://owasp.org/www-project-secure-headers/#referrer-policy
    */
-  referrerPolicy?: ReferrerPolicyConfig | boolean;
+  referrerPolicy?: ReferrerPolicyConfig | boolean | undefined;
   /**
    * Configure the `Strict-Transport-Security` header, which tells browsers to
    * prefer HTTPS instead of insecure HTTP.
@@ -231,7 +252,7 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
    * - https://owasp.org/www-project-secure-headers/#strict-transport-security
    */
-  strictTransportSecurity?: StrictTransportSecurityConfig | boolean;
+  strictTransportSecurity?: StrictTransportSecurityConfig | boolean | undefined;
   /**
    * Configure the `X-Content-Type-Options` header, which helps mitigate MIME
    * type sniffing that can cause security issues.
@@ -243,7 +264,7 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types#mime_sniffing
    * - https://owasp.org/www-project-secure-headers/#x-content-type-options
    */
-  xContentTypeOptions?: boolean;
+  xContentTypeOptions?: boolean | undefined;
   /**
    * Configure the `X-DNS-Prefetch-Control` header, which helps control DNS
    * prefetching to improve user privacy at the expense of performance.
@@ -254,7 +275,7 @@ export interface NoseconeOptions {
    * See also:
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control
    */
-  xDnsPrefetchControl?: DnsPrefetchControlConfig | boolean;
+  xDnsPrefetchControl?: DnsPrefetchControlConfig | boolean | undefined;
   /**
    * Configure the `X-Download-Options` header, which prevents a user from
    * opening a file directly in Internet Explorer 8 to avoid prevent script
@@ -265,7 +286,7 @@ export interface NoseconeOptions {
    * See also:
    * - https://learn.microsoft.com/en-us/archive/blogs/ie/ie8-security-part-v-comprehensive-protection#mime-handling-force-save
    */
-  xDownloadOptions?: boolean;
+  xDownloadOptions?: boolean | undefined;
   /**
    * Configure the `X-Frame-Options` header, which help mitigate clickjacking
    * attacks in legacy browsers. This header is superceded by a directive in the
@@ -278,7 +299,7 @@ export interface NoseconeOptions {
    * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
    * - https://owasp.org/www-project-secure-headers/#x-frame-options
    */
-  xFrameOptions?: FrameOptionsConfig | boolean;
+  xFrameOptions?: FrameOptionsConfig | boolean | undefined;
   /**
    * Configure the `X-Permitted-Cross-Domain-Policies` header, which tells some
    * clients, like Adobe products, your domain's policy for loading cross-domain
@@ -291,7 +312,10 @@ export interface NoseconeOptions {
    * See also:
    * - https://owasp.org/www-project-secure-headers/#x-permitted-cross-domain-policies
    */
-  xPermittedCrossDomainPolicies?: PermittedCrossDomainPoliciesConfig | boolean;
+  xPermittedCrossDomainPolicies?:
+    | PermittedCrossDomainPoliciesConfig
+    | boolean
+    | undefined;
   /**
    * Disable the `X-XSS-Protection` header, which could introduce a browser
    * side-channel in legacy browsers if enabled.
@@ -305,7 +329,7 @@ export interface NoseconeOptions {
    * - https://owasp.org/www-project-secure-headers/#x-xss-protection
    * - https://portswigger.net/daily-swig/new-xs-leak-techniques-reveal-fresh-ways-to-expose-user-information
    */
-  xXssProtection?: boolean;
+  xXssProtection?: boolean | undefined;
 }
 
 // Map of configuration options to the kebab-case names for
@@ -977,18 +1001,12 @@ export function withVercelToolbar(config: NoseconeOptions) {
     crossOriginEmbedderPolicy = defaults.crossOriginEmbedderPolicy;
   }
 
-  let augmentedCrossOriginEmbedderPolicy = crossOriginEmbedderPolicy;
-  if (crossOriginEmbedderPolicy) {
-    augmentedCrossOriginEmbedderPolicy = {
-      policy: crossOriginEmbedderPolicy.policy
-        ? "unsafe-none"
-        : crossOriginEmbedderPolicy.policy,
-    };
-  }
-
   return {
     ...config,
     contentSecurityPolicy: augmentedContentSecurityPolicy,
-    crossOriginEmbedderPolicy: augmentedCrossOriginEmbedderPolicy,
+    crossOriginEmbedderPolicy:
+      crossOriginEmbedderPolicy && crossOriginEmbedderPolicy.policy
+        ? ({ policy: "unsafe-none" } as const)
+        : crossOriginEmbedderPolicy,
   } as const;
 }

--- a/nosecone/tsconfig.json
+++ b/nosecone/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -88,24 +88,28 @@ export function createClient(options: ClientOptions): Client {
         protoRules.push(ArcjetRuleToProtocol(rule));
       }
 
+      const cleanDetails = {
+        ip: details.ip,
+        method: details.method,
+        protocol: details.protocol,
+        host: details.host,
+        path: details.path,
+        headers: Object.fromEntries(details.headers.entries()),
+        cookies: details.cookies,
+        query: details.query,
+        extra: details.extra,
+      };
+
       // Build the request object from the Protobuf generated class.
       const decideRequest = new DecideRequest({
         sdkStack,
         sdkVersion,
         characteristics: context.characteristics,
-        details: {
-          ip: details.ip,
-          method: details.method,
-          protocol: details.protocol,
-          host: details.host,
-          path: details.path,
-          headers: Object.fromEntries(details.headers.entries()),
-          cookies: details.cookies,
-          query: details.query,
-          extra: details.extra,
-          // Note: `email` is passed to `protect` and dynamic, hence the extra check.
-          email: typeof details.email === "string" ? details.email : undefined,
-        },
+        // `email` is an optional field but not allowed to be `undefined`.
+        details:
+          typeof details.email === "string"
+            ? { ...cleanDetails, email: details.email }
+            : cleanDetails,
         rules: protoRules,
       });
 
@@ -145,24 +149,28 @@ export function createClient(options: ClientOptions): Client {
     ): void {
       const { log } = context;
 
+      const cleanDetails = {
+        ip: details.ip,
+        method: details.method,
+        protocol: details.protocol,
+        host: details.host,
+        path: details.path,
+        headers: Object.fromEntries(details.headers.entries()),
+        cookies: details.cookies,
+        query: details.query,
+        extra: details.extra,
+      };
+
       // Build the request object from the Protobuf generated class.
       const reportRequest = new ReportRequest({
         sdkStack,
         sdkVersion,
         characteristics: context.characteristics,
-        details: {
-          ip: details.ip,
-          method: details.method,
-          protocol: details.protocol,
-          host: details.host,
-          path: details.path,
-          headers: Object.fromEntries(details.headers.entries()),
-          cookies: details.cookies,
-          query: details.query,
-          extra: details.extra,
-          // Note: `email` is passed to `protect` and dynamic, hence the extra check.
-          email: typeof details.email === "string" ? details.email : undefined,
-        },
+        // `email` is an optional field but not allowed to be `undefined`.
+        details:
+          typeof details.email === "string"
+            ? { ...cleanDetails, email: details.email }
+            : cleanDetails,
         decision: ArcjetDecisionToProtocol(decision),
         rules: rules.map(ArcjetRuleToProtocol),
       });

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -197,7 +197,8 @@ export class ArcjetReason {
     | "SHIELD"
     | "EMAIL"
     | "ERROR"
-    | "SENSITIVE_INFO";
+    | "SENSITIVE_INFO"
+    | undefined;
 
   isSensitiveInfo(): this is ArcjetSensitiveInfoReason {
     return this.type === "SENSITIVE_INFO";
@@ -252,14 +253,14 @@ export class ArcjetRateLimitReason extends ArcjetReason {
   remaining: number;
   reset: number;
   window: number;
-  resetTime?: Date;
+  resetTime?: Date | undefined;
 
   constructor(init: {
     max: number;
     remaining: number;
     reset: number;
     window: number;
-    resetTime?: Date;
+    resetTime?: Date | undefined;
   }) {
     super();
 
@@ -311,7 +312,7 @@ export class ArcjetShieldReason extends ArcjetReason {
 
   shieldTriggered: boolean;
 
-  constructor(init: { shieldTriggered?: boolean }) {
+  constructor(init: { shieldTriggered?: boolean | undefined }) {
     super();
 
     this.shieldTriggered = init.shieldTriggered ?? false;
@@ -323,7 +324,7 @@ export class ArcjetEmailReason extends ArcjetReason {
 
   emailTypes: ArcjetEmailType[];
 
-  constructor(init: { emailTypes?: ArcjetEmailType[] }) {
+  constructor(init: { emailTypes?: ArcjetEmailType[] | undefined }) {
     super();
     this.emailTypes = init.emailTypes ?? [];
   }
@@ -408,97 +409,97 @@ export class ArcjetIpDetails {
    * The estimated latitude of the IP address within the `accuracyRadius` margin
    * of error.
    */
-  latitude?: number;
+  latitude?: number | undefined;
   /**
    * The estimated longitude of the IP address - see accuracy_radius for the
    * margin of error.
    */
-  longitude?: number;
+  longitude?: number | undefined;
   /**
    * The accuracy radius of the IP address location in kilometers.
    */
-  accuracyRadius?: number;
+  accuracyRadius?: number | undefined;
   /**
    * The timezone of the IP address.
    */
-  timezone?: string;
+  timezone?: string | undefined;
   /**
    * The postal code of the IP address.
    */
-  postalCode?: string;
+  postalCode?: string | undefined;
   /**
    * The city the IP address is located in.
    */
-  city?: string;
+  city?: string | undefined;
   /**
    * The region the IP address is located in.
    */
-  region?: string;
+  region?: string | undefined;
   /**
    * The country code the IP address is located in.
    */
-  country?: string;
+  country?: string | undefined;
   /**
    * The country name the IP address is located in.
    */
-  countryName?: string;
+  countryName?: string | undefined;
   /**
    * The continent code the IP address is located in.
    */
-  continent?: string;
+  continent?: string | undefined;
   /**
    * The continent name the IP address is located in.
    */
-  continentName?: string;
+  continentName?: string | undefined;
   /**
    * The AS number the IP address belongs to.
    */
-  asn?: string;
+  asn?: string | undefined;
   /**
    * The AS name the IP address belongs to.
    */
-  asnName?: string;
+  asnName?: string | undefined;
   /**
    * The AS domain the IP address belongs to.
    */
-  asnDomain?: string;
+  asnDomain?: string | undefined;
   /**
    * The ASN type: ISP, hosting, business, or education
    */
-  asnType?: string;
+  asnType?: string | undefined;
   /**
    * The ASN country code the IP address belongs to.
    */
-  asnCountry?: string;
+  asnCountry?: string | undefined;
   /**
    * The name of the service the IP address belongs to.
    */
-  service?: string;
+  service?: string | undefined;
 
   constructor(
     init: {
-      latitude?: number;
-      longitude?: number;
-      accuracyRadius?: number;
-      timezone?: string;
-      postalCode?: string;
-      city?: string;
-      region?: string;
-      country?: string;
-      countryName?: string;
-      continent?: string;
-      continentName?: string;
-      asn?: string;
-      asnName?: string;
-      asnDomain?: string;
-      asnType?: string;
-      asnCountry?: string;
-      service?: string;
-      isHosting?: boolean;
-      isVpn?: boolean;
-      isProxy?: boolean;
-      isTor?: boolean;
-      isRelay?: boolean;
+      latitude?: number | undefined;
+      longitude?: number | undefined;
+      accuracyRadius?: number | undefined;
+      timezone?: string | undefined;
+      postalCode?: string | undefined;
+      city?: string | undefined;
+      region?: string | undefined;
+      country?: string | undefined;
+      countryName?: string | undefined;
+      continent?: string | undefined;
+      continentName?: string | undefined;
+      asn?: string | undefined;
+      asnName?: string | undefined;
+      asnDomain?: string | undefined;
+      asnType?: string | undefined;
+      asnCountry?: string | undefined;
+      service?: string | undefined;
+      isHosting?: boolean | undefined;
+      isVpn?: boolean | undefined;
+      isProxy?: boolean | undefined;
+      isTor?: boolean | undefined;
+      isRelay?: boolean | undefined;
     } = {},
   ) {
     this.latitude = init.latitude;

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -469,7 +469,6 @@ test("convert", async (t) => {
               max: 1,
               remaining: -1,
               resetInSeconds: 1000,
-              resetTime: undefined,
               windowInSeconds: 1000,
             },
           },

--- a/protocol/tsconfig.json
+++ b/protocol/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["*.ts", "test/*.ts"]
 }

--- a/redact-wasm/tsconfig.json
+++ b/redact-wasm/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "edge-light.ts", "workerd.ts", "wasm.d.ts"]
 }

--- a/redact/index.ts
+++ b/redact/index.ts
@@ -116,27 +116,35 @@ interface RedactedSensitiveInfoEntity {
 function getWasmOptions<
   const Detect extends DetectSensitiveInfoEntities<CustomEntities> | undefined,
   const CustomEntities extends string,
->(options?: RedactOptions<Detect>) {
+>(options?: RedactOptions<Detect> | undefined) {
   if (typeof options === "object" && options !== null) {
-    if (typeof options.entities !== "undefined") {
-      if (Array.isArray(options.entities)) {
-        if (options.entities.length < 1) {
-          throw new Error("no entities configured for redaction");
-        }
-      } else {
+    const entities = options.entities;
+
+    if (entities !== undefined) {
+      if (!Array.isArray(entities)) {
         throw new Error("entities must be an array");
+      }
+
+      if (entities.length < 1) {
+        throw new Error("no entities configured for redaction");
       }
     }
 
-    return {
-      entities: options.entities?.map(userEntitiesToWasm),
-      contextWindowSize: options.contextWindowSize || 1,
-      skipCustomDetect: typeof options.detect !== "function",
-      skipCustomRedact: typeof options.replace !== "function",
-    };
+    // `entities` is an optional field but not allowed to be `undefined`.
+    return entities
+      ? {
+          entities: entities.map(userEntitiesToWasm),
+          contextWindowSize: options.contextWindowSize || 1,
+          skipCustomDetect: typeof options.detect !== "function",
+          skipCustomRedact: typeof options.replace !== "function",
+        }
+      : {
+          contextWindowSize: options.contextWindowSize || 1,
+          skipCustomDetect: typeof options.detect !== "function",
+          skipCustomRedact: typeof options.replace !== "function",
+        };
   } else {
     return {
-      entities: undefined,
       contextWindowSize: 1,
       skipCustomDetect: true,
       skipCustomRedact: true,
@@ -149,7 +157,7 @@ async function callRedactWasm<
   const CustomEntities extends string,
 >(
   candidate: string,
-  options?: RedactOptions<Detect>,
+  options?: RedactOptions<Detect> | undefined,
 ): Promise<RedactedSensitiveInfoEntity[]> {
   let convertedDetect = noOpDetect;
   if (typeof options?.detect === "function") {

--- a/redact/tsconfig.json
+++ b/redact/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts", "test/*.ts"]
 }

--- a/runtime/tsconfig.json
+++ b/runtime/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["edge-light.ts", "index.ts", "test/*.ts"]
 }

--- a/sprintf/tsconfig.json
+++ b/sprintf/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["index.ts"]
 }

--- a/stable-hash/tsconfig.json
+++ b/stable-hash/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["*.ts", "test/*.ts"]
 }

--- a/transport/tsconfig.json
+++ b/transport/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
   "extends": "@arcjet/tsconfig/base",
   "include": ["bun.ts", "edge-light.ts", "index.ts"]
 }


### PR DESCRIPTION
This adds `exactOptionalPropertyTypes` to our packages’ `tsconfig.json`s.
Some people (including us) pass `undefined` as a value, instead of totally omitting a field/parameter.
They are two slightly different things, and this is now supported.

Notably, I did *not* touch the wasm built stuff, so the code around that is slightly awkward, as I am now explicitly omitting fields (as the wasm types want) instead of passing `undefined`.
