### PR TITLE
refactor(ip): rename identifiers to match other casing

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -227,7 +227,7 @@ export function createArcjetClient<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    let ip = findIP(
+    let ip = findIp(
       {
         ip: clientAddress,
         headers,

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -10,7 +10,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import type { Server } from "bun";
 import { env } from "bun";
@@ -223,7 +223,7 @@ export default function arcjet<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    let ip = findIP(
+    let ip = findIp(
       {
         // This attempts to lookup the IP in the `ipCache`. This is primarily a
         // workaround to the API design in Bun that requires access to the

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -10,7 +10,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -225,7 +225,7 @@ export default function arcjet<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    let ip = findIP(
+    let ip = findIp(
       {
         // This attempts to lookup the IP in the `ipCache`. This is primarily a
         // workaround to the API design in Deno that requires access to the

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -13,7 +13,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -242,7 +242,7 @@ function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    let ip = findIP(
+    let ip = findIp(
       {
         ip: request.ip,
         socket: request.socket,

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -18,7 +18,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -436,7 +436,7 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    let ip = findIP(
+    let ip = findIp(
       {
         ip: request.ip,
         socket: request.socket,

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import type { Env } from "@arcjet/env";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
@@ -265,7 +265,7 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    let ip = findIP(
+    let ip = findIp(
       {
         socket: request.socket,
         headers,

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -202,7 +202,7 @@ export default function arcjet<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    let ip = findIP(
+    let ip = findIp(
       {
         // The `getLoadContext` API will attach the `ip` to the context
         ip: context?.ip,

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -9,7 +9,7 @@ import type {
   Arcjet,
   CharacteristicProps,
 } from "arcjet";
-import findIP, { parseProxy } from "@arcjet/ip";
+import findIp, { parseProxy } from "@arcjet/ip";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
@@ -218,7 +218,7 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(event.request.headers);
 
-    let ip = findIP(
+    let ip = findIp(
       {
         ip: event.getClientAddress(),
         headers,


### PR DESCRIPTION
When working on the fastify integration, i used `@arcjet/ip`.

I noticed that I needed the `Cidr` type, which is a return value of `parseProxy` from there.
So I expose it here.

I also noticed that there are 2 functions, `parseProxy` as a named export and `findIp` as the default export.
I expose the latter as a named export too, and deprecate the default symbol.

Internally, the casing of abbreviations was more capital heavy, and not always consistent (`parseCIDR` and `isIPv4Cidr`). Especially around symbols such as `isIPv4Cidr` (previous casing), I find it hard to come up with good arguments why that `P` is uppercase but `v` lowercase.
I like using capitals only for word boundaries: `parseCidr`, `isIpv4Cidr`, `Cidr`.
So, before exposing values, I changed their internal names. See GH-4478 for more on that.