### PR TITLE
docs(fastify): mention quick start example in readme

### DIFF
--- a/arcjet-fastify/README.md
+++ b/arcjet-fastify/README.md
@@ -23,17 +23,9 @@ against common attacks.
 
 This is the [Arcjet][] SDK for [Fastify][].
 
-<!--
-
 ## Getting started
 
-TODO(@wooorm-arcjet): this does not exist yet.
-
 Visit the [quick start guide][arcjet-quick-start-fastify] to get started.
-
-[arcjet-quick-start-fastify]: https://docs.arcjet.com/get-started/fastify
-
--->
 
 ## Install
 
@@ -115,5 +107,6 @@ see the [Arcjet Fastify SDK reference][arcjet-reference-fastify] on our website.
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[arcjet-quick-start-fastify]: https://docs.arcjet.com/get-started/fastify
 [arcjet]: https://arcjet.com
 [fastify]: https://fastify.dev/


### PR DESCRIPTION
I noticed that the fastify quick start is now live, so, added it.

@qw-in There are still commented out references to `https://docs.arcjet.com/reference/fastify` and `https://example.arcjet.com` for when that is live.

@qw-in I also noticed that there are many references to `https://github.com/arcjet/arcjet-js-example` as a link to the source code of `https://example.arcjet.com`. It looks like that now redirects to `https://github.com/arcjet/example-nextjs`. Is that correct, for the source code of *all* examples? Should there be another URL?