### PR TITLE
docs: add JSDocs to exposed API in 10 utilities

### DIFF
--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -37,9 +37,13 @@ type AnalyzeRequest = {
 };
 
 export {
+  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type EmailValidationConfig,
+  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type BotConfig,
+  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type SensitiveInfoEntity,
+  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type DetectedSensitiveInfoEntity,
 };
 

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -111,7 +111,7 @@ function createCoreImports(detect?: DetectSensitiveInfoFunction): ImportObject {
  * @param request
  *   Request.
  * @returns
- *   Promise to a SHA-256 fingerprint.
+ *   Promise for a SHA-256 fingerprint.
  */
 export async function generateFingerprint(
   context: AnalyzeContext,
@@ -144,7 +144,7 @@ export async function generateFingerprint(
  * @param options
  *   Configuration.
  * @returns
- *   Promise to a result.
+ *   Promise for a result.
  */
 export async function isValidEmail(
   context: AnalyzeContext,
@@ -175,7 +175,7 @@ export async function isValidEmail(
  * @param options
  *   Configuration.
  * @returns
- *   Promise to a result.
+ *   Promise for a result.
  */
 /// TODO(@wooorm-arcjet): expose `BotEntity`, `BotResult`.
 export async function detectBot(
@@ -211,7 +211,7 @@ export async function detectBot(
  * @param detect
  *   Function to detect sensitive info (optional).
  * @returns
- *   Promise to a result.
+ *   Promise for a result.
  */
 // TODO(@wooorm-arcjet): expose `DetectSensitiveInfoFunction`, `SensitiveInfoEntities`, `SensitiveInfoResult`.
 // TODO(@wooorm-arcjet): less parameters, `5` is a lot.

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -1,10 +1,14 @@
 import { initializeWasm } from "@arcjet/analyze-wasm";
 import type {
+  // TODO(@wooorm-arcjet): rename to `DetectBotOptions`.
   BotConfig,
+  // TODO(@wooorm-arcjet): expose, rename to `DetectBotResult`.
   BotResult,
   DetectedSensitiveInfoEntity,
   DetectSensitiveInfoFunction,
+  // TODO(@wooorm-arcjet): rename to `ValidateEmailOptions`.
   EmailValidationConfig,
+  // TODO(@wooorm-arcjet): expose, rename to `ValidateEmailResult`.
   EmailValidationResult,
   SensitiveInfoEntities,
   SensitiveInfoEntity,
@@ -13,11 +17,13 @@ import type {
 } from "@arcjet/analyze-wasm";
 import type { ArcjetLogger } from "@arcjet/protocol";
 
+/// TODO(@wooorm-arcjet): expose, as `Context`.
 interface AnalyzeContext {
   log: ArcjetLogger;
   characteristics: string[];
 }
 
+/// TODO(@wooorm-arcjet): expose, as `Request`.
 type AnalyzeRequest = {
   ip?: string;
   method?: string;
@@ -92,13 +98,20 @@ function createCoreImports(detect?: DetectSensitiveInfoFunction): ImportObject {
   };
 }
 
-// TODO(@wooorm-arcjet): document what is used to fingerprint.
 /**
- * Generate a fingerprint for the client. This is used to identify the client
- * across multiple requests.
- * @param context - The Arcjet Analyze context.
- * @param request - The request to fingerprint.
- * @returns A SHA-256 string fingerprint.
+ * Generate a fingerprint.
+ *
+ * Fingerprints can be used to identify the client across multiple requests.
+ *
+ * This considers different things on the `request` based on the passed
+ * `context.characteristics`.
+ *
+ * @param context
+ *   Context.
+ * @param request
+ *   Request.
+ * @returns
+ *   Promise to a SHA-256 fingerprint.
  */
 export async function generateFingerprint(
   context: AnalyzeContext,
@@ -121,10 +134,21 @@ export async function generateFingerprint(
   return "";
 }
 
-// TODO(@wooorm-arcjet): docs.
+/**
+ * Check whether an email is valid.
+ *
+ * @param context
+ *   Context.
+ * @param value
+ *   Value.
+ * @param options
+ *   Configuration.
+ * @returns
+ *   Promise to a result.
+ */
 export async function isValidEmail(
   context: AnalyzeContext,
-  candidate: string,
+  value: string,
   options: EmailValidationConfig,
 ): Promise<EmailValidationResult> {
   const { log } = context;
@@ -132,7 +156,7 @@ export async function isValidEmail(
   const analyze = await initializeWasm(coreImports);
 
   if (typeof analyze !== "undefined") {
-    return analyze.isValidEmail(candidate, options);
+    return analyze.isValidEmail(value, options);
     // Ignore the `else` branch as we test in places that have WebAssembly.
     /* node:coverage ignore next 4 */
   }
@@ -141,7 +165,19 @@ export async function isValidEmail(
   return { blocked: [], validity: "valid" };
 }
 
-// TODO(@wooorm-arcjet): docs.
+/**
+ * Detect whether a request is by a bot.
+ *
+ * @param context
+ *   Context.
+ * @param request
+ *   Request.
+ * @param options
+ *   Configuration.
+ * @returns
+ *   Promise to a result.
+ */
+/// TODO(@wooorm-arcjet): expose `BotEntity`, `BotResult`.
 export async function detectBot(
   context: AnalyzeContext,
   request: AnalyzeRequest,
@@ -161,12 +197,30 @@ export async function detectBot(
   return { allowed: [], denied: [], spoofed: false, verified: false };
 }
 
-// TODO(@wooorm-arcjet): docs.
+/**
+ * Detect sensitive info in a value.
+ *
+ * @param context
+ *   Context.
+ * @param value
+ *   Value.
+ * @param entities
+ *   Entities to detect.
+ * @param contextWindowSize
+ *   Number of tokens to pass to `detect`.
+ * @param detect
+ *   Function to detect sensitive info (optional).
+ * @returns
+ *   Promise to a result.
+ */
+// TODO(@wooorm-arcjet): expose `DetectSensitiveInfoFunction`, `SensitiveInfoEntities`, `SensitiveInfoResult`.
+// TODO(@wooorm-arcjet): less parameters, `5` is a lot.
 export async function detectSensitiveInfo(
   context: AnalyzeContext,
-  candidate: string,
+  value: string,
   entities: SensitiveInfoEntities,
   contextWindowSize: number,
+  // TODO(@wooorm-arcjet): allow `null`, `undefined`.
   detect?: DetectSensitiveInfoFunction,
 ): Promise<SensitiveInfoResult> {
   const { log } = context;
@@ -175,7 +229,7 @@ export async function detectSensitiveInfo(
 
   if (typeof analyze !== "undefined") {
     const skipCustomDetect = typeof detect !== "function";
-    return analyze.detectSensitiveInfo(candidate, {
+    return analyze.detectSensitiveInfo(value, {
       entities,
       contextWindowSize,
       skipCustomDetect,

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -100,6 +100,9 @@ function createCoreImports(detect?: DetectSensitiveInfoFunction): ImportObject {
  * This considers different things on the `request` based on the passed
  * `context.characteristics`.
  *
+ * See [*Fingerprints* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/fingerprints/) for more info.
+ *
  * @param context
  *   Context.
  * @param request

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -1,14 +1,10 @@
 import { initializeWasm } from "@arcjet/analyze-wasm";
 import type {
-  // TODO(@wooorm-arcjet): rename to `DetectBotOptions`.
   BotConfig,
-  // TODO(@wooorm-arcjet): expose, rename to `DetectBotResult`.
   BotResult,
   DetectedSensitiveInfoEntity,
   DetectSensitiveInfoFunction,
-  // TODO(@wooorm-arcjet): rename to `ValidateEmailOptions`.
   EmailValidationConfig,
-  // TODO(@wooorm-arcjet): expose, rename to `ValidateEmailResult`.
   EmailValidationResult,
   SensitiveInfoEntities,
   SensitiveInfoEntity,
@@ -17,13 +13,11 @@ import type {
 } from "@arcjet/analyze-wasm";
 import type { ArcjetLogger } from "@arcjet/protocol";
 
-/// TODO(@wooorm-arcjet): expose, as `Context`.
 interface AnalyzeContext {
   log: ArcjetLogger;
   characteristics: string[];
 }
 
-/// TODO(@wooorm-arcjet): expose, as `Request`.
 type AnalyzeRequest = {
   ip?: string;
   method?: string;
@@ -37,13 +31,9 @@ type AnalyzeRequest = {
 };
 
 export {
-  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type EmailValidationConfig,
-  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type BotConfig,
-  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type SensitiveInfoEntity,
-  // TODO(@wooorm-arcjet): add JSDocs to values from WebAssembly.
   type DetectedSensitiveInfoEntity,
 };
 
@@ -181,7 +171,6 @@ export async function isValidEmail(
  * @returns
  *   Promise for a result.
  */
-/// TODO(@wooorm-arcjet): expose `BotEntity`, `BotResult`.
 export async function detectBot(
   context: AnalyzeContext,
   request: AnalyzeRequest,
@@ -219,14 +208,11 @@ export async function detectBot(
  * @returns
  *   Promise for a result.
  */
-// TODO(@wooorm-arcjet): expose `DetectSensitiveInfoFunction`, `SensitiveInfoEntities`, `SensitiveInfoResult`.
-// TODO(@wooorm-arcjet): less parameters, `5` is a lot.
 export async function detectSensitiveInfo(
   context: AnalyzeContext,
   value: string,
   entities: SensitiveInfoEntities,
   contextWindowSize: number,
-  // TODO(@wooorm-arcjet): allow `null`, `undefined`.
   detect?: DetectSensitiveInfoFunction,
 ): Promise<SensitiveInfoResult> {
   const { log } = context;

--- a/analyze/index.ts
+++ b/analyze/index.ts
@@ -209,7 +209,9 @@ export async function detectBot(
  * @param value
  *   Value.
  * @param entities
- *   Entities to detect.
+ *   Strategy to use for detecting sensitive info;
+ *   either by denying everything and allowing certain tags or by allowing
+ *   everything and denying certain tags.
  * @param contextWindowSize
  *   Number of tokens to pass to `detect`.
  * @param detect

--- a/body/index.ts
+++ b/body/index.ts
@@ -1,9 +1,7 @@
-// TODO(@wooorm-arcjet): rename to `Options`.
 /**
  * Configuration.
  */
 export interface ReadBodyOpts {
-  // TODO(@wooorm-arcjet): must this be required?
   /**
    * Length of the stream in bytes (optional);
    * an error is returned if the contents of the stream do not add up to this length;

--- a/body/index.ts
+++ b/body/index.ts
@@ -1,7 +1,7 @@
 /**
  * Configuration.
  */
-export interface ReadBodyOpts {
+export type ReadBodyOpts = {
   /**
    * Length of the stream in bytes (optional);
    * an error is returned if the contents of the stream do not add up to this length;
@@ -14,7 +14,7 @@ export interface ReadBodyOpts {
    * used to prevent reading too much data from malicious clients.
    */
   limit: number;
-}
+};
 
 type EventHandlerLike = (
   event: string,

--- a/body/index.ts
+++ b/body/index.ts
@@ -1,18 +1,35 @@
-export type ReadBodyOpts = {
-  limit: number;
+// TODO(@wooorm-arcjet): rename to `Options`.
+/**
+ * Configuration.
+ */
+export interface ReadBodyOpts {
+  // TODO(@wooorm-arcjet): must this be required?
+  /**
+   * Length of the stream in bytes (optional);
+   * an error is returned if the contents of the stream do not add up to this length;
+   * useful when the exact size is known.
+   */
   expectedLength?: number | null | undefined;
-};
+  /**
+   * Limit of the body in bytes (required);
+   * an error is returned if the body ends up being larger than this limit;
+   * used to prevent reading too much data from malicious clients.
+   */
+  limit: number;
+}
 
 type EventHandlerLike = (
   event: string,
   listener: (...args: any[]) => void,
 ) => void;
 
-// The fields from stream.Readable that we use
+/**
+ * Stream.
+ */
 export interface ReadableStreamLike {
   on?: EventHandlerLike | null | undefined;
-  removeListener?: EventHandlerLike | null | undefined;
   readable?: boolean | null | undefined;
+  removeListener?: EventHandlerLike | null | undefined;
 }
 
 // This `readBody` function is a derivitive of the `getRawBody` function in the `raw-body`
@@ -46,19 +63,30 @@ export interface ReadableStreamLike {
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+/**
+ * Read the body of a stream.
+ *
+ * @param stream
+ *   Stream.
+ * @param options
+ *   Configuration (required).
+ * @returns
+ *   Promise to a concatenated body.
+ */
 export async function readBody(
   stream: ReadableStreamLike,
-  opts: ReadBodyOpts,
+  // TODO(@wooorm-arcjet): make optional.
+  options: ReadBodyOpts,
 ): Promise<string> {
   const decoder = new TextDecoder("utf-8");
   let buffer = "";
   let complete = false;
   let received = 0;
-  const limit = opts.limit;
+  const limit = options.limit;
   if (typeof limit !== "number") {
     return Promise.reject(new Error("must set a limit"));
   }
-  const length = opts.expectedLength || null;
+  const length = options.expectedLength || null;
 
   if (typeof stream.readable !== "undefined" && !stream.readable) {
     return Promise.reject(new Error("stream is not readable"));

--- a/cache/index.ts
+++ b/cache/index.ts
@@ -1,23 +1,33 @@
+/**
+ * Interface for a cache.
+ */
 export interface Cache<T = unknown> {
   /**
-   * Attempts to retrieve a value from the cache. If a value exists, it will be
-   * returned with the remaining time-to-live (in seconds).
+   * Retrieve a value from the cache;
+   * it will be returned with the remaining time-to-live (in seconds) if it exists.
    *
-   * @param namespace A isolated segement of the cache where keys are tracked.
-   * @param key The identifier used to retrieve the value.
-   * @returns A promise for a 2-element tuple containing the value and TTL in
-   * seconds. If no value is retrieved, the value will be `undefined` and the
-   * TTL will be `0`.
+   * @param namespace
+   *   Isolated segment of the cache where keys are tracked.
+   * @param key
+   *   Key.
+   * @returns
+   *   Promise for a tuple with the value and TTL in seconds;
+   *   value will be `undefined` and TTL will be `0` if not found.
    */
   get(namespace: string, key: string): Promise<[T | undefined, number]>;
   /**
-   * If the cache implementation supports storing values, `set` makes a best
-   * attempt at storing the value provided until the time-to-live specified.
+   * Store a value in the cache.
    *
-   * @param namespace A isolated segement of the cache where keys are tracked.
-   * @param key The identifier used to store the value.
-   * @param value The value to be stored under the key.
-   * @param ttl The amount of seconds the value stays valid in the cache.
+   * @param namespace
+   *   Isolated segment of the cache where keys are tracked.
+   * @param key
+   *   Key.
+   * @param value
+   *   Value.
+   * @param ttl
+   *   Number of seconds the entry stays valid.
+   * @returns
+   *   Nothing.
    */
   set(namespace: string, key: string, value: T, ttl: number): void;
 }
@@ -58,9 +68,18 @@ class Bucket<T> {
   }
 }
 
+/**
+ * In-memory cache.
+ */
 export class MemoryCache<T> implements Cache<T> {
+  /**
+   * Data.
+   */
   namespaces: Map<string, Bucket<T>>;
 
+  /**
+   * Create a new in-memory cache.
+   */
   constructor() {
     this.namespaces = new Map();
   }

--- a/decorate/index.ts
+++ b/decorate/index.ts
@@ -8,8 +8,8 @@ import {
 
 // If these are defined, we can expect to be working with `Headers` directly.
 interface HeaderLike {
-  has(name: string): boolean;
   get(name: string): string | null;
+  has(name: string): boolean;
   set(name: string, value: string): void;
 }
 
@@ -22,12 +22,12 @@ interface ResponseLike {
 // Otherwise, we'll be working with an `http.OutgoingMessage` and we'll need
 // to use these values.
 interface OutgoingMessageLike {
+  getHeader: (name: string) => string[] | number | string | undefined;
   headersSent: boolean;
   hasHeader: (name: string) => boolean;
-  getHeader: (name: string) => number | string | string[] | undefined;
   setHeader: (
     name: string,
-    value: number | string | ReadonlyArray<string>,
+    value: ReadonlyArray<string> | number | string,
   ) => unknown;
 }
 
@@ -154,14 +154,19 @@ function nearestLimit(
 }
 
 /**
- * Decorates an object with `RateLimit` and `RateLimit-Policy` headers based
- * on an {@link ArcjetDecision} and conforming to the [Rate Limit fields for
+ * Decorate something based on an Arcjet decision with rate limit headers.
+ *
+ * Sets `RateLimit-Policy` and `RateLimit` and conform to the
+ * [Rate Limit fields for
  * HTTP](https://ietf-wg-httpapi.github.io/ratelimit-headers/draft-ietf-httpapi-ratelimit-headers.html)
  * draft specification.
  *
- * @param value The object to decorate—must be similar to {@link Headers}, {@link Response} or
- * {@link OutgoingMessage}.
- * @param decision The {@link ArcjetDecision} that was made by calling `protect()` on the SDK.
+ * @param value
+ *   Decorable value.
+ * @param decision
+ *   Decision from `protect()`.
+ * @returns
+ *   Nothing.
  */
 export function setRateLimitHeaders(
   value: ArcjetCanDecorate,
@@ -177,6 +182,8 @@ export function setRateLimitHeaders(
     const policies = new Map<number, number>();
     for (const reason of rateLimitReasons) {
       if (policies.has(reason.max)) {
+        // TODO(@wooorm-arcjet): should we throw errors?
+        // Other Arcjet things use a custom logger, this doesn’t?
         console.error(
           "Invalid rate limit policy—two policies should not share the same limit",
         );
@@ -189,6 +196,7 @@ export function setRateLimitHeaders(
         typeof reason.remaining !== "number" ||
         typeof reason.reset !== "number"
       ) {
+        // TODO(@wooorm-arcjet): throw errors?
         console.error(format("Invalid rate limit encountered: %o", reason));
         return;
       }
@@ -213,6 +221,7 @@ export function setRateLimitHeaders(
         typeof decision.reason.remaining !== "number" ||
         typeof decision.reason.reset !== "number"
       ) {
+        // TODO(@wooorm-arcjet): throw errors?
         console.error(
           format("Invalid rate limit encountered: %o", decision.reason),
         );
@@ -228,6 +237,7 @@ export function setRateLimitHeaders(
 
   if (isHeaderLike(value)) {
     if (value.has("RateLimit")) {
+      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
@@ -237,6 +247,7 @@ export function setRateLimitHeaders(
       );
     }
     if (value.has("RateLimit-Policy")) {
+      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
@@ -255,6 +266,7 @@ export function setRateLimitHeaders(
 
   if (isResponseLike(value)) {
     if (value.headers.has("RateLimit")) {
+      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
@@ -264,6 +276,7 @@ export function setRateLimitHeaders(
       );
     }
     if (value.headers.has("RateLimit-Policy")) {
+      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
@@ -282,6 +295,7 @@ export function setRateLimitHeaders(
 
   if (isOutgoingMessageLike(value)) {
     if (value.headersSent) {
+      // TODO(@wooorm-arcjet): throw errors?
       console.error(
         "Headers have already been sent—cannot set RateLimit header",
       );
@@ -289,6 +303,7 @@ export function setRateLimitHeaders(
     }
 
     if (value.hasHeader("RateLimit")) {
+      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
@@ -299,6 +314,7 @@ export function setRateLimitHeaders(
     }
 
     if (value.hasHeader("RateLimit-Policy")) {
+      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
@@ -315,6 +331,7 @@ export function setRateLimitHeaders(
     return;
   }
 
+  // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
   console.debug(
     "Cannot determine if response is Response or OutgoingMessage type",
   );

--- a/decorate/index.ts
+++ b/decorate/index.ts
@@ -182,8 +182,6 @@ export function setRateLimitHeaders(
     const policies = new Map<number, number>();
     for (const reason of rateLimitReasons) {
       if (policies.has(reason.max)) {
-        // TODO(@wooorm-arcjet): should we throw errors?
-        // Other Arcjet things use a custom logger, this doesn’t?
         console.error(
           "Invalid rate limit policy—two policies should not share the same limit",
         );
@@ -196,7 +194,6 @@ export function setRateLimitHeaders(
         typeof reason.remaining !== "number" ||
         typeof reason.reset !== "number"
       ) {
-        // TODO(@wooorm-arcjet): throw errors?
         console.error(format("Invalid rate limit encountered: %o", reason));
         return;
       }
@@ -221,7 +218,6 @@ export function setRateLimitHeaders(
         typeof decision.reason.remaining !== "number" ||
         typeof decision.reason.reset !== "number"
       ) {
-        // TODO(@wooorm-arcjet): throw errors?
         console.error(
           format("Invalid rate limit encountered: %o", decision.reason),
         );
@@ -237,7 +233,6 @@ export function setRateLimitHeaders(
 
   if (isHeaderLike(value)) {
     if (value.has("RateLimit")) {
-      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
@@ -247,7 +242,6 @@ export function setRateLimitHeaders(
       );
     }
     if (value.has("RateLimit-Policy")) {
-      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
@@ -266,7 +260,6 @@ export function setRateLimitHeaders(
 
   if (isResponseLike(value)) {
     if (value.headers.has("RateLimit")) {
-      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
@@ -276,7 +269,6 @@ export function setRateLimitHeaders(
       );
     }
     if (value.headers.has("RateLimit-Policy")) {
-      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
@@ -295,7 +287,6 @@ export function setRateLimitHeaders(
 
   if (isOutgoingMessageLike(value)) {
     if (value.headersSent) {
-      // TODO(@wooorm-arcjet): throw errors?
       console.error(
         "Headers have already been sent—cannot set RateLimit header",
       );
@@ -303,7 +294,6 @@ export function setRateLimitHeaders(
     }
 
     if (value.hasHeader("RateLimit")) {
-      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit` header\n  Original: %s\n  New: %s",
@@ -314,7 +304,6 @@ export function setRateLimitHeaders(
     }
 
     if (value.hasHeader("RateLimit-Policy")) {
-      // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
       console.warn(
         format(
           "Response already contains `RateLimit-Policy` header\n  Original: %s\n  New: %s",
@@ -331,7 +320,6 @@ export function setRateLimitHeaders(
     return;
   }
 
-  // TODO(@wooorm-arcjet): should we use a custom logger like the rest of Arcjet?
   console.debug(
     "Cannot determine if response is Response or OutgoingMessage type",
   );

--- a/duration/index.ts
+++ b/duration/index.ts
@@ -68,69 +68,73 @@ function leadingInt(s: string): [number, string] {
 }
 
 /**
- * Parses a duration into a number representing seconds while ensuring the value
+ * Parse a duration into a number representing seconds while ensuring the value
  * fits within an unsigned 32-bit integer.
  *
- * If a JavaScript number is provided to the function, it is validated and
- * returned verbatim.
+ * If a number is passed it is validated and returned.
  *
- * If a string is provided to the function, it must be in the form of digits
- * followed by a unit. Supported units are `s` (seconds), `m` (minutes), `h`
- * (hours), and `d` (days).
- *
- * @param s The value to parse into seconds.
- * @returns A number representing seconds parsed from the provided duration.
+ * If a string is passed it must be in the form of digits followed by a unit.
+ * Supported units are `s` (seconds),
+ * `m` (minutes),
+ * `h` (hours),
+ * and `d` (days).
  *
  * @example
- * parse("1s") === 1
- * parse("1m") === 60
- * parse("1h") === 3600
- * parse("1d") === 86400
+ *   ```ts
+ *   console.log(parse("1s")) // => 1
+ *   console.log(parse("1m")) // => 60
+ *   console.log(parse("1h")) // => 3600
+ *   console.log(parse("1d")) // => 86400
+ *   ```
+ * @param value
+ *   Value to parse.
+ * @returns
+ *   Parsed seconds.
  */
-export function parse(s: string | number): number {
-  const original = s;
+export function parse(value: number | string): number {
+  const original = value;
 
-  if (typeof s === "number") {
-    if (s > maxUint32) {
+  if (typeof value === "number") {
+    if (value > maxUint32) {
       throw new Error(`invalid duration: ${original}`);
     }
 
-    if (s < 0) {
+    if (value < 0) {
       throw new Error(`invalid duration: ${original}`);
     }
 
-    if (!Number.isInteger(s)) {
+    if (!Number.isInteger(value)) {
       throw new Error(`invalid duration: ${original}`);
     }
 
-    return s;
+    return value;
   }
 
-  if (typeof s !== "string") {
+  if (typeof value !== "string") {
     throw new Error("can only parse a duration string");
   }
 
   let d = 0;
 
   // Special case: if all that is left is "0", this is zero.
-  if (s === "0") {
+  if (value === "0") {
     return 0;
   }
-  if (s === "") {
+  if (value === "") {
     throw new Error(`invalid duration: ${original}`);
   }
 
-  while (s !== "") {
+  while (value !== "") {
     let v = 0;
 
     // The next character must be [0-9]
-    if (!integers.includes(s[0])) {
+    if (!integers.includes(value[0])) {
       throw new Error(`invalid duration: ${original}`);
     }
     // Consume [0-9]*
-    [v, s] = leadingInt(s);
+    [v, value] = leadingInt(value);
     // Error on decimal (\.[0-9]*)?
-    if (s !== "" && s[0] == ".") {
+    if (value !== "" && value[0] == ".") {
       // TODO: We could support decimals that turn into non-decimal seconds—e.g.
       // 1.5hours becomes 5400 seconds
       throw new Error(`unsupported decimal duration: ${original}`);
@@ -138,8 +142,8 @@ export function parse(s: string | number): number {
 
     // Consume unit.
     let i = 0;
-    for (; i < s.length; i++) {
-      const c = s[i];
+    for (; i < value.length; i++) {
+      const c = value[i];
       if (integers.includes(c)) {
         break;
       }
@@ -147,8 +151,8 @@ export function parse(s: string | number): number {
     if (i == 0) {
       throw new Error(`missing unit in duration: ${original}`);
     }
-    const u = s.slice(0, i);
-    s = s.slice(i);
+    const u = value.slice(0, i);
+    value = value.slice(i);
     const unit = units.get(u);
     if (typeof unit === "undefined") {
       throw new Error(`unknown unit "${u}" in duration ${original}`);

--- a/env/index.ts
+++ b/env/index.ts
@@ -1,7 +1,6 @@
 /**
  * Environment.
  */
-// TODO(@wooorm-arcjet): rename to `Environment`.
 export interface Env {
   [key: string]: unknown;
   /**
@@ -42,7 +41,6 @@ export interface Env {
   VERCEL?: string | undefined;
 }
 
-// TODO(@wooorm-arcjet): expose.
 type Platform = "fly-io" | "render" | "vercel";
 
 /**
@@ -93,7 +91,6 @@ export function isDevelopment(environment: Env): boolean {
   );
 }
 
-// TODO(@wooorm-arcjet): expose.
 type Level = "debug" | "error" | "info" | "warn";
 
 /**

--- a/env/index.ts
+++ b/env/index.ts
@@ -1,7 +1,7 @@
 /**
  * Environment.
  */
-export interface Env {
+export type Env = {
   [key: string]: unknown;
   /**
    * Base URL of Arcjet API.
@@ -39,7 +39,7 @@ export interface Env {
    * Vercel environment variable.
    */
   VERCEL?: string | undefined;
-}
+};
 
 type Platform = "fly-io" | "render" | "vercel";
 

--- a/env/index.ts
+++ b/env/index.ts
@@ -1,41 +1,111 @@
-export type Env = {
+/**
+ * Environment.
+ */
+// TODO(@wooorm-arcjet): rename to `Environment`.
+export interface Env {
   [key: string]: unknown;
-  FLY_APP_NAME?: string | undefined;
-  VERCEL?: string | undefined;
-  RENDER?: string | undefined;
-  MODE?: string | undefined;
-  NODE_ENV?: string | undefined;
-  ARCJET_KEY?: string | undefined;
-  ARCJET_ENV?: string | undefined;
-  ARCJET_LOG_LEVEL?: string | undefined;
+  /**
+   * Base URL of Arcjet API.
+   */
   ARCJET_BASE_URL?: string | undefined;
-};
+  /**
+   * Environment of Arcjet SDK.
+   */
+  ARCJET_ENV?: string | undefined;
+  /**
+   * Key for Arcjet API.
+   */
+  ARCJET_KEY?: string | undefined;
+  /**
+   * Log level of Arcjet SDK.
+   */
+  ARCJET_LOG_LEVEL?: string | undefined;
+  /**
+   * Name of Fly.io app.
+   */
+  FLY_APP_NAME?: string | undefined;
+  /**
+   * Vite mode.
+   */
+  MODE?: string | undefined;
+  /**
+   * Environment of Node.js.
+   */
+  NODE_ENV?: string | undefined;
+  /**
+   * Render environment variable.
+   */
+  RENDER?: string | undefined;
+  /**
+   * Vercel environment variable.
+   */
+  VERCEL?: string | undefined;
+}
 
-export function platform(env: Env) {
-  if (typeof env["FLY_APP_NAME"] === "string" && env["FLY_APP_NAME"] !== "") {
-    return "fly-io" as const;
+// TODO(@wooorm-arcjet): expose.
+type Platform = "fly-io" | "render" | "vercel";
+
+/**
+ * Detect the platform.
+ *
+ * @param environment
+ *   Environment.
+ * @returns
+ *   Name of platform if found.
+ */
+export function platform(environment: Env): Platform | undefined {
+  if (
+    typeof environment["FLY_APP_NAME"] === "string" &&
+    environment["FLY_APP_NAME"] !== ""
+  ) {
+    return "fly-io";
   }
 
-  if (typeof env["VERCEL"] === "string" && env["VERCEL"] === "1") {
-    return "vercel" as const;
+  if (
+    typeof environment["VERCEL"] === "string" &&
+    environment["VERCEL"] === "1"
+  ) {
+    return "vercel";
   }
 
   // https://render.com/docs/environment-variables
-  if (typeof env["RENDER"] === "string" && env["RENDER"] === "true") {
-    return "render" as const;
+  if (
+    typeof environment["RENDER"] === "string" &&
+    environment["RENDER"] === "true"
+  ) {
+    return "render";
   }
 }
 
-export function isDevelopment(env: Env) {
+/**
+ * Check if the environment is development.
+ *
+ * @param environment
+ *   Environment.
+ * @returns
+ *   Whether the environment is development.
+ */
+export function isDevelopment(environment: Env): boolean {
   return (
-    env.NODE_ENV === "development" ||
-    env.MODE === "development" ||
-    env.ARCJET_ENV === "development"
+    environment.NODE_ENV === "development" ||
+    environment.MODE === "development" ||
+    environment.ARCJET_ENV === "development"
   );
 }
 
-export function logLevel(env: Env) {
-  const level = env["ARCJET_LOG_LEVEL"];
+// TODO(@wooorm-arcjet): expose.
+type Level = "debug" | "error" | "info" | "warn";
+
+/**
+ * Get the log level.
+ *
+ * @param environment
+ *   Environment.
+ * @returns
+ *   Log level.
+ */
+export function logLevel(environment: Env): Level {
+  const level = environment["ARCJET_LOG_LEVEL"];
   switch (level) {
     case "debug":
     case "info":
@@ -56,27 +126,43 @@ const baseUrlAllowed = [
   "https://decide.arcjet.orb.local:4082",
 ];
 
-export function baseUrl(env: Env) {
+/**
+ * Get the base URL of an Arcjet API.
+ *
+ * @param environment
+ *   Environment.
+ * @returns
+ *   Base URL of Arcjet API.
+ */
+export function baseUrl(environment: Env) {
   // Use ARCJET_BASE_URL if it is set and belongs to our allowlist; otherwise
   // use the hardcoded default.
   if (
-    typeof env["ARCJET_BASE_URL"] === "string" &&
-    baseUrlAllowed.includes(env["ARCJET_BASE_URL"])
+    typeof environment["ARCJET_BASE_URL"] === "string" &&
+    baseUrlAllowed.includes(environment["ARCJET_BASE_URL"])
   ) {
-    return env["ARCJET_BASE_URL"];
+    return environment["ARCJET_BASE_URL"];
   }
 
   // If we're running on fly.io, use the Arcjet Decide Service hosted on fly
   // Ref: https://fly.io/docs/machines/runtime-environment/#environment-variables
-  if (platform(env) === "fly-io") {
+  if (platform(environment) === "fly-io") {
     return "https://fly.decide.arcjet.com";
   }
 
   return "https://decide.arcjet.com";
 }
 
-export function apiKey(env: Env) {
-  const key = env["ARCJET_KEY"];
+/**
+ * Get the key for an Arcjet API.
+ *
+ * @param environment
+ *   Environment.
+ * @returns
+ *   Key for Arcjet API if found.
+ */
+export function apiKey(environment: Env): string | undefined {
+  const key = environment["ARCJET_KEY"];
   if (typeof key === "string" && key.startsWith("ajkey_")) {
     return key;
   }

--- a/env/index.ts
+++ b/env/index.ts
@@ -41,8 +41,6 @@ export type Env = {
   VERCEL?: string | undefined;
 };
 
-type Platform = "fly-io" | "render" | "vercel";
-
 /**
  * Detect the platform.
  *
@@ -51,19 +49,19 @@ type Platform = "fly-io" | "render" | "vercel";
  * @returns
  *   Name of platform if found.
  */
-export function platform(environment: Env): Platform | undefined {
+export function platform(environment: Env) {
   if (
     typeof environment["FLY_APP_NAME"] === "string" &&
     environment["FLY_APP_NAME"] !== ""
   ) {
-    return "fly-io";
+    return "fly-io" as const;
   }
 
   if (
     typeof environment["VERCEL"] === "string" &&
     environment["VERCEL"] === "1"
   ) {
-    return "vercel";
+    return "vercel" as const;
   }
 
   // https://render.com/docs/environment-variables
@@ -71,7 +69,7 @@ export function platform(environment: Env): Platform | undefined {
     typeof environment["RENDER"] === "string" &&
     environment["RENDER"] === "true"
   ) {
-    return "render";
+    return "render" as const;
   }
 }
 
@@ -83,15 +81,13 @@ export function platform(environment: Env): Platform | undefined {
  * @returns
  *   Whether the environment is development.
  */
-export function isDevelopment(environment: Env): boolean {
+export function isDevelopment(environment: Env) {
   return (
     environment.NODE_ENV === "development" ||
     environment.MODE === "development" ||
     environment.ARCJET_ENV === "development"
   );
 }
-
-type Level = "debug" | "error" | "info" | "warn";
 
 /**
  * Get the log level.
@@ -101,7 +97,7 @@ type Level = "debug" | "error" | "info" | "warn";
  * @returns
  *   Log level.
  */
-export function logLevel(environment: Env): Level {
+export function logLevel(environment: Env) {
   const level = environment["ARCJET_LOG_LEVEL"];
   switch (level) {
     case "debug":
@@ -158,7 +154,7 @@ export function baseUrl(environment: Env) {
  * @returns
  *   Key for Arcjet API if found.
  */
-export function apiKey(environment: Env): string | undefined {
+export function apiKey(environment: Env) {
   const key = environment["ARCJET_KEY"];
   if (typeof key === "string" && key.startsWith("ajkey_")) {
     return key;

--- a/eslint-config/eslint.config.js
+++ b/eslint-config/eslint.config.js
@@ -1,8 +1,17 @@
+/**
+ * @import {Linter} from "eslint";
+ */
+
 import js from "@eslint/js";
 import ts from "typescript-eslint";
 import turbo from "eslint-config-turbo/flat";
 import prettier from "eslint-config-prettier";
 
+/**
+ * ESLint configuration for internal Arcjet projects.
+ *
+ * @type {Array<Linter.Config>}
+ */
 export default [
   {
     files: ["**/*.ts"],

--- a/headers/index.ts
+++ b/headers/index.ts
@@ -3,21 +3,17 @@ function isIterable(val: any): val is Iterable<any> {
 }
 
 /**
- * This Fetch API interface allows you to perform various actions on HTTP
- * request and response headers. These actions include retrieving, setting,
- * adding to, and removing. A Headers object has an associated header list,
- * which is initially empty and consists of zero or more name and value pairs.
+ * Arcjet headers.
  *
- * You can add to this using methods like `append()`.
+ * This exists to prevent the `cookie` header from being set
+ * and non-string values from being set.
  *
- * In all methods of this interface, header names are matched by
- * case-insensitive byte sequence.
- *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers)
+ * @see
+ *   [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers).
  */
 export class ArcjetHeaders extends Headers {
   constructor(
-    init?: HeadersInit | Record<string, string | string[] | undefined>,
+    init?: HeadersInit | Record<string, string[] | string | undefined>,
   ) {
     super();
     if (
@@ -31,7 +27,7 @@ export class ArcjetHeaders extends Headers {
         }
       } else {
         for (const [key, value] of Object.entries(
-          init as Record<string, string | string[] | undefined>,
+          init as Record<string, string[] | string | undefined>,
         )) {
           if (typeof value === "undefined") {
             continue;
@@ -50,13 +46,17 @@ export class ArcjetHeaders extends Headers {
   }
 
   /**
-   * Append a key and value to the headers, while filtering any key named
-   * `cookie`.
+   * Append a header while ignoring `cookie`.
    *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append)
+   * @see
+   *   [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append)
    *
-   * @param key The key to append in the headers
-   * @param value The value to append for the key in the headers
+   * @param key
+   *   Header name.
+   * @param value
+   *   Header value.
+   * @returns
+   *   Nothing.
    */
   append(key: string, value: string): void {
     if (typeof key !== "string" || typeof value !== "string") {
@@ -68,12 +68,17 @@ export class ArcjetHeaders extends Headers {
     }
   }
   /**
-   * Set a key and value in the headers, but filtering any key named `cookie`.
+   * Set a header while ignoring `cookie`.
    *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set)
+   * @see
+   *   [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set)
    *
-   * @param key The key to set in the headers
-   * @param value The value to set for the key in the headers
+   * @param key
+   *   Header key.
+   * @param value
+   *   Header value.
+   * @returns
+   *   Nothing.
    */
   set(key: string, value: string): void {
     if (typeof key !== "string" || typeof value !== "string") {

--- a/inspect/index.ts
+++ b/inspect/index.ts
@@ -62,6 +62,86 @@ function isActive(
  * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/reference#bot-verification)
  * for more info.
  *
+ * @example
+ *   ```ts
+ *   import { isSpoofedBot } from "@arcjet/inspect";
+ *   import arcjet, { detectBot } from "@arcjet/next";
+ *   import type { NextApiRequest, NextApiResponse } from "next";
+ *
+ *   const aj = arcjet({
+ *     key: process.env.ARCJET_KEY!,
+ *     rules: [
+ *       detectBot({
+ *         mode: "LIVE",
+ *         allow: [
+ *           "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+ *         ],
+ *       }),
+ *     ],
+ *   });
+ *
+ *   export async function GET(request: NextApiRequest, response: NextApiResponse) {
+ *     const decision = await aj.protect(request);
+ *
+ *     if (decision.isDenied()) {
+ *       return response.status(403).json({ message: "Forbidden" });
+ *     }
+ *
+ *     if (decision.results.some(isSpoofedBot)) {
+ *       return response
+ *         .status(403)
+ *         .json({ message: "You are pretending to be a good bot!" });
+ *     }
+ *
+ *     response.status(200).json({ message: "Hello world" });
+ *   }
+ *   ```
+ *
+ * @example
+ *   ```ts
+ *   import http from "node:http";
+ *   import { isSpoofedBot } from "@arcjet/inspect";
+ *   import arcjet, { detectBot } from "@arcjet/node";
+ *
+ *   const aj = arcjet({
+ *     key: process.env.ARCJET_KEY!,
+ *     rules: [
+ *       detectBot({
+ *         mode: "LIVE",
+ *         allow: [
+ *           "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+ *         ],
+ *       }),
+ *     ],
+ *   });
+ *
+ *   const server = http.createServer(async function (
+ *     request: http.IncomingMessage,
+ *     response: http.ServerResponse,
+ *   ) {
+ *     const decision = await aj.protect(request);
+ *
+ *     if (decision.isDenied()) {
+ *       response.writeHead(403, { "Content-Type": "application/json" });
+ *       response.end(JSON.stringify({ message: "Forbidden" }));
+ *       return;
+ *     }
+ *
+ *     if (decision.results.some(isSpoofedBot)) {
+ *       response.writeHead(403, { "Content-Type": "application/json" });
+ *       response.end(
+ *         JSON.stringify({ message: "You are pretending to be a good bot!" }),
+ *       );
+ *       return;
+ *     }
+ *
+ *     response.writeHead(200, { "Content-Type": "application/json" });
+ *     response.end(JSON.stringify({ message: "Hello world" }));
+ *   });
+ *
+ *   server.listen(8000);
+ *   ```
+ *
  * @param result
  *   Rule result.
  * @returns
@@ -99,6 +179,84 @@ export function isSpoofedBot(result: ArcjetRuleResult): boolean | undefined {
  * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/reference#bot-verification)
  * for more info.
  *
+ * @example
+ *   ```ts
+ *   import { isVerifiedBot } from "@arcjet/inspect";
+ *   import arcjet, { detectBot } from "@arcjet/next";
+ *   import type { NextApiRequest, NextApiResponse } from "next";
+ *
+ *   const aj = arcjet({
+ *     key: process.env.ARCJET_KEY!,
+ *     rules: [
+ *       detectBot({
+ *         mode: "LIVE",
+ *         allow: [
+ *           "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+ *         ],
+ *       }),
+ *     ],
+ *   });
+ *
+ *   export async function GET(request: NextApiRequest, response: NextApiResponse) {
+ *     const decision = await aj.protect(request);
+ *
+ *     // Ignore all other signals and always allow verified search engine bots
+ *     if (decision.results.some(isVerifiedBot)) {
+ *       return response.status(200).json({ message: "Hello bot!" });
+ *     }
+ *
+ *     if (decision.isDenied()) {
+ *       return response.status(403).json({ message: "Forbidden" });
+ *     }
+ *
+ *     response.status(200).json({ message: "Hello world" });
+ *   }
+ *   ```
+ *
+ * @example
+ *   ```ts
+ *   import http from "node:http";
+ *   import { isVerifiedBot } from "@arcjet/inspect";
+ *   import arcjet, { detectBot } from "@arcjet/next";
+ *
+ *   const aj = arcjet({
+ *     key: process.env.ARCJET_KEY!,
+ *     rules: [
+ *       detectBot({
+ *         mode: "LIVE",
+ *         allow: [
+ *           "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+ *         ],
+ *       }),
+ *     ],
+ *   });
+ *
+ *   const server = http.createServer(async function (
+ *     request: http.IncomingMessage,
+ *     response: http.ServerResponse,
+ *   ) {
+ *     const decision = await aj.protect(request);
+ *
+ *     // Ignore all other signals and always allow verified search engine bots
+ *     if (decision.results.some(isVerifiedBot)) {
+ *       response.writeHead(200, { "Content-Type": "application/json" });
+ *       response.end(JSON.stringify({ message: "Hello bot!" }));
+ *       return;
+ *     }
+ *
+ *     if (decision.isDenied()) {
+ *       response.writeHead(403, { "Content-Type": "application/json" });
+ *       response.end(JSON.stringify({ message: "Forbidden" }));
+ *       return;
+ *     }
+ *
+ *     response.writeHead(200, { "Content-Type": "application/json" });
+ *     response.end(JSON.stringify({ message: "Hello world" }));
+ *   });
+ *
+ *   server.listen(8000);
+ *   ```
+ *
  * @param result
  *   Rule result.
  * @returns
@@ -135,6 +293,84 @@ export function isVerifiedBot(result: ArcjetRuleResult): boolean | undefined {
  * See [*Error handling* on
  * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/reference#error-handling)
  * for more info.
+ *
+ * @example
+ *   ```ts
+ *  import { isMissingUserAgent } from "@arcjet/inspect";
+ *  import arcjet, { detectBot } from "@arcjet/next";
+ *  import type { NextApiRequest, NextApiResponse } from "next";
+ *
+ *  const aj = arcjet({
+ *    key: process.env.ARCJET_KEY!,
+ *    rules: [
+ *      detectBot({
+ *        mode: "LIVE",
+ *        allow: [
+ *          "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+ *        ],
+ *      }),
+ *    ],
+ *  });
+ *
+ *  export async function GET(request: NextApiRequest, response: NextApiResponse) {
+ *    const decision = await aj.protect(request);
+ *
+ *    if (decision.isDenied()) {
+ *      return response.status(403).json({ message: "Forbidden" });
+ *    }
+ *
+ *    // We expect all non-bot clients to have the User-Agent header
+ *    if (decision.results.some(isMissingUserAgent)) {
+ *      return response.status(403).json({ message: "You are a bot!" });
+ *    }
+ *
+ *    response.status(200).json({ message: "Hello world" });
+ *  }
+ *   ```
+ *
+ * @example
+ *   ```ts
+ *   import http from "node:http";
+ *   import { isMissingUserAgent } from "@arcjet/inspect";
+ *   import arcjet, { detectBot } from "@arcjet/next";
+ *
+ *   const aj = arcjet({
+ *     key: process.env.ARCJET_KEY!,
+ *     rules: [
+ *       detectBot({
+ *         mode: "LIVE",
+ *         allow: [
+ *           "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+ *         ],
+ *       }),
+ *     ],
+ *   });
+ *
+ *   const server = http.createServer(async function (
+ *     request: http.IncomingMessage,
+ *     response: http.ServerResponse,
+ *   ) {
+ *     const decision = await aj.protect(request);
+ *
+ *     if (decision.isDenied()) {
+ *       response.writeHead(403, { "Content-Type": "application/json" });
+ *       response.end(JSON.stringify({ message: "Forbidden" }));
+ *       return;
+ *     }
+ *
+ *     // We expect all non-bot clients to have the User-Agent header
+ *     if (decision.results.some(isMissingUserAgent)) {
+ *       response.writeHead(403, { "Content-Type": "application/json" });
+ *       response.end(JSON.stringify({ message: "You are a bot!" }));
+ *       return;
+ *     }
+ *
+ *     response.writeHead(200, { "Content-Type": "application/json" });
+ *     response.end(JSON.stringify({ message: "Hello world" }));
+ *   });
+ *
+ *   server.listen(8000);
+ *   ```
  *
  * @param result
  *   Rule result.

--- a/inspect/index.ts
+++ b/inspect/index.ts
@@ -44,57 +44,30 @@ function isActive(
 }
 
 /**
- * Determines if a non-`"DRY_RUN"` bot rule detected a spoofed request. If
- * `true`, the request was likely spoofed and you may want to block it.
+ * Check for a spoofed bot.
  *
- * For `allow` rules, Arcjet verifies the authenticity of detected bots by
- * checking IP data and performing reverse DNS lookups. This helps protect
- * against spoofed bots where malicious clients pretend to be a well-behaving
- * bot.
+ * You may want to block such requests because they were likely spoofed.
  *
- * Note that spoofed bot detection is not available on free plans.
+ * ###### Availability
  *
- * @param {ArcjetRuleResult} result - The rule result to inspect.
- * @returns `true` if the bot rule result was not `"DRY_RUN"` and a spoofed bot
- * was detected, `false` if the bot rule result was not `"DRY_RUN"` and a
- * spoofed bot was not detected, or `undefined` if the rule result was from a
- * `"DRY_RUN"` bot rule or a non-bot rule.
+ * Bot protection is available if `detectBot` is used.
+ * See [*Bot protection* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/quick-start)
+ * for more info.
  *
- * @example
- * ```ts
- * import arcjet, { detectBot } from "@arcjet/next";
- * import { isSpoofedBot } from "@arcjet/inspect";
+ * Spoofed bot detection is part of advanced bot protection features which
+ * are not available on free plans but are available on the starter and
+ * business plans.
+ * See [*Bot verification* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/reference#bot-verification)
+ * for more info.
  *
- * const aj = arcjet({
- *  key: process.env.ARCJET_KEY!,
- *  rules: [
- *    detectBot({
- *      mode: "LIVE",
- *      allow: [
- *        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
- *      ],
- *    }),
- *  ],
- * });
- *
- * export async function GET(request: Request) {
- *  const decision = await aj.protect(request);
- *
- *  if (decision.isDenied()) {
- *    return res.status(403).json({ error: "Forbidden" });
- *  }
- *
- *  if (decision.results.some(isSpoofedBot)) {
- *    return res
- *      .status(403)
- *      .json({ error: "You are pretending to be a good bot!" });
- *  }
- *
- *  res.status(200).json({ name: "Hello world" });
- * }
- * ```
- *
- * @link https://docs.arcjet.com/bot-protection/reference#bot-verification
+ * @param result
+ *   Rule result.
+ * @returns
+ *   `true` if the bot rule result was `LIVE` and detected a spoofed bot,
+ *   `false` if the bot rule result was `LIVE` and did not detect a spoofed bot,
+ *   `undefined` if the rule result was non-bot or `DRY_RUN`.
  */
 export function isSpoofedBot(result: ArcjetRuleResult): boolean | undefined {
   // Use `unknown` argument helpers to guard around the wrong data being passed
@@ -108,56 +81,30 @@ export function isSpoofedBot(result: ArcjetRuleResult): boolean | undefined {
 }
 
 /**
- * Determines if a non-`"DRY_RUN"` bot rule detected a request from a verified
- * bot. If `true`, the bot was verified as legitimate and you may want to ignore
- * other signals.
+ * Check for a verified bot.
  *
- * For `allow` rules, Arcjet verifies the authenticity of detected bots by
- * checking IP data and performing reverse DNS lookups. A verified bot is a bot
- * that has passed these checks.
+ * You may want to ignore other signals for such requests.
  *
- * Note that verified bot detection is not available on free plans.
+ * ###### Availability
  *
- * @param {ArcjetRuleResult} result - The rule result to inspect.
- * @returns `true` if the bot rule result was not `"DRY_RUN"` and a verified bot
- * was detected, `false` if the bot rule result was not `"DRY_RUN"` and a
- * verified bot was not detected, or `undefined` if the rule result was from a
- * `"DRY_RUN"` bot rule or a non-bot rule.
+ * Bot protection is available if `detectBot` is used.
+ * See [*Bot protection* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/quick-start)
+ * for more info.
  *
- * @example
- * ```ts
- * import arcjet, { detectBot } from "@arcjet/next";
- * import { isVerifiedBot } from "@arcjet/inspect";
+ * Verified bot detection is part of advanced bot protection features which
+ * are not available on free plans but are available on the starter and
+ * business plans.
+ * See [*Bot verification* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/reference#bot-verification)
+ * for more info.
  *
- * const aj = arcjet({
- *  key: process.env.ARCJET_KEY!,
- *  rules: [
- *    detectBot({
- *      mode: "LIVE",
- *      allow: [
- *        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
- *      ],
- *    }),
- *  ],
- * });
- *
- * export async function GET(request: Request) {
- *  const decision = await aj.protect(request);
- *
- *  // Ignore all other signals and always allow verified search engine bots
- *  if (decision.results.some(isVerifiedBot)) {
- *    return res.status(200).json({ name: "Hello bot!" });
- *  }
- *
- *  if (decision.isDenied()) {
- *    return res.status(403).json({ error: "Forbidden" });
- *  }
- *
- *  res.status(200).json({ name: "Hello world" });
- * }
- * ```
- *
- * @link https://docs.arcjet.com/bot-protection/reference#bot-verification
+ * @param result
+ *   Rule result.
+ * @returns
+ *   `true` if the bot rule result was `LIVE` and detected a verified bot,
+ *   `false` if the bot rule result was `LIVE` and did not detect a verified bot,
+ *   `undefined` if the rule result was non-bot or `DRY_RUN`.
  */
 export function isVerifiedBot(result: ArcjetRuleResult): boolean | undefined {
   // Use `unknown` argument helpers to guard around the wrong data being passed
@@ -171,50 +118,30 @@ export function isVerifiedBot(result: ArcjetRuleResult): boolean | undefined {
 }
 
 /**
- * Determines if a non-`"DRY_RUN"` bot rule errored due to a missing User-Agent
- * header on the request. If `true`, you may want to block the request because a
- * missing User-Agent header is a good indicator of a malicious request since
- * it is recommended by
- * {@link https://datatracker.ietf.org/doc/html/rfc9110#field.user-agent}.
+ * Check for a bot missing a `User-Agent` header.
  *
- * @param {ArcjetRuleResult} result - The rule result to inspect.
- * @returns `true` if the rule result was not `"DRY_RUN"` and the request was
- * missing a User-Agent header, `false` if the rule result was not `"DRY_RUN"`
- * and the request had a User-Agent header, or `undefined` if the rule result
- * was from a `"DRY_RUN"` bot rule or a non-bot rule.
+ * You may want to block such requests because a missing `User-Agent` header is
+ * a good indicator of a malicious request since it is recommended by
+ * [*HTTP Semantics* from IETF](https://datatracker.ietf.org/doc/html/rfc9110#field.user-agent).
  *
- * @example
- * ```ts
- * import arcjet, { detectBot } from "@arcjet/next";
- * import { isMissingUserAgent } from "@arcjet/inspect";
+ * ###### Availability
  *
- * const aj = arcjet({
- *  key: process.env.ARCJET_KEY!,
- *  rules: [
- *    detectBot({
- *      mode: "LIVE",
- *      allow: [
- *        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
- *      ],
- *    }),
- *  ],
- * });
+ * Bot protection is available if `detectBot` is used.
+ * See [*Bot protection* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/quick-start)
+ * for more info.
  *
- * export async function GET(request: Request) {
- *  const decision = await aj.protect(request);
+ * Missing `User-Agent` detection is part of all plans including the free plans.
+ * See [*Error handling* on
+ * `docs.arcjet.com`](https://docs.arcjet.com/bot-protection/reference#error-handling)
+ * for more info.
  *
- *  if (decision.isDenied()) {
- *    return res.status(403).json({ error: "Forbidden" });
- *  }
- *
- *  // We expect all non-bot clients to have the User-Agent header
- *  if (decision.results.some(isMissingUserAgent)) {
- *    return res.status(403).json({ error: "You are a bot!" });
- *  }
- *
- *  res.status(200).json({ name: "Hello world" });
- * }
- * ```
+ * @param result
+ *   Rule result.
+ * @returns
+ *   `true` if the bot rule result was `LIVE` and the request had no `User-Agent` header,
+ *   `false` if the bot rule result was `LIVE` and the request had a `User-Agent` header,
+ *   `undefined` if the rule result was non-bot or `DRY_RUN`.
  */
 export function isMissingUserAgent(
   result: ArcjetRuleResult,

--- a/ip/index.ts
+++ b/ip/index.ts
@@ -759,18 +759,18 @@ interface PartialRequestContext {
 /**
  * Interface with `headers`.
  */
-export interface HeaderLike {
+export type HeaderLike = {
   /**
    * Headers.
    */
   headers: Headers | Record<string, string[] | string | undefined>;
-}
+};
 
 /**
  * Interface that looks like a request,
  * of which `headers` is required and several other fields may exist.
  */
-export interface RequestLike extends HeaderLike {
+export type RequestLike = {
   /**
    * Some platforms pass `info`.
    */
@@ -788,7 +788,7 @@ export interface RequestLike extends HeaderLike {
    * Some platforms pass a `socket`.
    */
   socket?: PartialSocket | null | undefined;
-}
+} & HeaderLike;
 
 /**
  * Platform name.

--- a/ip/index.ts
+++ b/ip/index.ts
@@ -759,7 +759,6 @@ interface PartialRequestContext {
 /**
  * Interface with `headers`.
  */
-// TODO(@wooorm-arcjet): do not expose.
 export interface HeaderLike {
   /**
    * Headers.
@@ -771,7 +770,6 @@ export interface HeaderLike {
  * Interface that looks like a request,
  * of which `headers` is required and several other fields may exist.
  */
-// TODO(@wooorm-arcjet): rename to `Request`.
 export interface RequestLike extends HeaderLike {
   /**
    * Some platforms pass `info`.

--- a/ip/index.ts
+++ b/ip/index.ts
@@ -192,13 +192,19 @@ function isCidr(address: string): address is `${string}/${string}` {
   return address.includes("/");
 }
 
-// Converts a string that looks like a Cidr address into the corresponding class
-// while ignoring non-Cidr IP addresses.
-export function parseProxy(proxy: string): string | Cidr {
-  if (isCidr(proxy)) {
-    return parseCidr(proxy);
+/**
+ * Parse CIDR addresses and keep non-CIDR IP addresses.
+ *
+ * @param value
+ *   Value to parse.
+ * @returns
+ *   Parsed CIDR or given `value`.
+ */
+export function parseProxy(value: string): string | Cidr {
+  if (isCidr(value)) {
+    return parseCidr(value);
   } else {
-    return proxy;
+    return value;
   }
 }
 
@@ -725,10 +731,16 @@ function isGlobalIp(
   return false;
 }
 
+/**
+ * Socket-like interface.
+ */
 interface PartialSocket {
   remoteAddress?: string | null | undefined;
 }
 
+/**
+ * Interface that looks like info.
+ */
 interface PartialInfo {
   remoteAddress?: string | null | undefined;
 }
@@ -737,32 +749,66 @@ interface PartialIdentiy {
   sourceIp?: string | null | undefined;
 }
 
+/**
+ * Interface that looks like a request context.
+ */
 interface PartialRequestContext {
   identity?: PartialIdentiy | null | undefined;
 }
 
-export type HeaderLike =
-  | {
-      headers: Headers;
-    }
-  | {
-      headers: Record<string, string | string[] | undefined>;
-    };
+/**
+ * Interface with `headers`.
+ */
+// TODO(@wooorm-arcjet): do not expose.
+export interface HeaderLike {
+  /**
+   * Headers.
+   */
+  headers: Headers | Record<string, string[] | string | undefined>;
+}
 
-export type RequestLike = {
-  ip?: unknown;
-
-  socket?: PartialSocket | null | undefined;
-
+/**
+ * Interface that looks like a request,
+ * of which `headers` is required and several other fields may exist.
+ */
+// TODO(@wooorm-arcjet): rename to `Request`.
+export interface RequestLike extends HeaderLike {
+  /**
+   * Some platforms pass `info`.
+   */
   info?: PartialInfo | null | undefined;
-
+  /**
+   * Some platforms such as Cloudflare and Vercel provide `ip` directly on
+   * `request`.
+   */
+  ip?: unknown;
+  /**
+   * Some platforms pass info in `requestContext`.
+   */
   requestContext?: PartialRequestContext | null | undefined;
-} & HeaderLike;
+  /**
+   * Some platforms pass a `socket`.
+   */
+  socket?: PartialSocket | null | undefined;
+}
 
-export type Platform = "cloudflare" | "fly-io" | "vercel" | "render";
+/**
+ * Platform name.
+ */
+export type Platform = "cloudflare" | "fly-io" | "render" | "vercel";
 
+/**
+ * Configuration.
+ */
 export interface Options {
+  /**
+   * Platform the code is running on;
+   * used to allow only known more trustworthy headers.
+   */
   platform?: Platform | null | undefined;
+  /**
+   * Trusted proxies.
+   */
   proxies?: ReadonlyArray<string | Cidr> | null | undefined;
 }
 


### PR DESCRIPTION
This commit adds JSDoc documentation to everything exposed from 10 of the about 30 packages.

There’s a lot we are exposing that we don’t need to expose, but also things that are in parameters/return values/elsewhere which we should probably expose, which I noted inline.

As for `@arcjet/inspect`, that’s something that was already documented, but also (more up to date) on the website. I kept some small useful things in the code and the readme here, but mostly deferred with links to the website.

Related-to: GH-3327.