### PR TITLE
refactor(examples): move `characteristics` to rules

### DIFF
--- a/examples/bun-hono-rate-limit/index.ts
+++ b/examples/bun-hono-rate-limit/index.ts
@@ -3,7 +3,6 @@ import { Hono } from "hono";
 
 const aj = arcjet({
   key: Bun.env.ARCJET_KEY!,
-  characteristics: ["userId"], // track requests by a custom user ID
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -11,6 +10,7 @@ const aj = arcjet({
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
+      characteristics: ["userId"], // track requests by a custom user ID
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       refillRate: 5, // refill 5 tokens per interval
       interval: 10, // refill every 10 seconds

--- a/examples/bun-rate-limit/index.ts
+++ b/examples/bun-rate-limit/index.ts
@@ -2,14 +2,14 @@ import arcjet, { shield, tokenBucket } from "@arcjet/bun";
 
 const aj = arcjet({
   key: Bun.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
-  // We specify a custom fingerprint so we can dynamically build it within each
-  // demo route.
-  characteristics: ["userId"],
   rules: [
     // Shield protects your app from common attacks like SQL injection
     shield({ mode: "LIVE" }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
+      // We specify a custom fingerprint so we can dynamically build it within each
+      // demo route.
+      characteristics: ["userId"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       refillRate: 5, // refill 5 tokens per interval
       interval: 10, // refill every 10 seconds

--- a/examples/express-rate-limit/index.js
+++ b/examples/express-rate-limit/index.js
@@ -14,8 +14,6 @@ if (!arcjetKey) {
 
 const aj = arcjet({
   key: arcjetKey,
-  // Limiting by ip.src is the default if not specified
-  //characteristics: ["ip.src"],
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -24,6 +22,8 @@ const aj = arcjet({
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      // characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       window: "1m", // 1 min fixed window
       max: 1, // allow a single request (for demo purposes)

--- a/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
+++ b/examples/nextjs-14-nextauth-4/app/api/arcjet/route.ts
@@ -18,9 +18,6 @@ const authOptions = {
 // The arcjet instance is created outside of the handler
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
-  // We specify a custom fingerprint so we can dynamically build it within each
-  // demo route.
-  characteristics: ["fingerprint"],
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -40,14 +37,6 @@ export async function GET(req: NextRequest, res: Response) {
 
   let decision: ArcjetDecision;
   if (session && session.user && session.user!.email) {
-    // A very simple hash to avoid sending PII to Arcjet. You may wish to add a
-  // unique salt prefix to protect against reverse lookups.
-  const email = session.user!.email;
-  const emailHash = require("crypto")
-    .createHash("sha256")
-    .update(email)
-    .digest("hex");
-
     // Allow higher limits for signed in users.
     const rl = aj.withRule(
       // Create a token bucket rate limit. Other algorithms are supported.
@@ -59,10 +48,8 @@ export async function GET(req: NextRequest, res: Response) {
       })
     );
 
-    const fingerprint = emailHash; // Use the email hash as the fingerprint
-
     // Deduct 5 tokens from the token bucket
-    decision = await rl.protect(req, { fingerprint, requested: 5 });
+    decision = await rl.protect(req, { requested: 5 });
     console.log("Arcjet logged in decision", decision)
   } else {
     const fingerprint = ip(req);
@@ -79,7 +66,7 @@ export async function GET(req: NextRequest, res: Response) {
     );
 
     // Deduct 5 tokens from the token bucket
-    decision = await rl.protect(req, { fingerprint, requested: 5 });
+    decision = await rl.protect(req, { requested: 5 });
     console.log("Arcjet logged out decision", decision)
   }
 

--- a/examples/nextjs-app-dir-rate-limit/app/api/arcjet/route.ts
+++ b/examples/nextjs-app-dir-rate-limit/app/api/arcjet/route.ts
@@ -6,12 +6,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // Limiting by ip.src is the default if not specified
-  characteristics: ["ip.src"],
   rules: [
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       window: "1m", // 1 min fixed window
       max: 1, // allow a single request (for demo purposes)

--- a/examples/nextjs-authjs-5/app/api/protected/route.ts
+++ b/examples/nextjs-authjs-5/app/api/protected/route.ts
@@ -4,7 +4,6 @@ import { auth } from "auth";
 // The arcjet instance is created outside of the handler
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
-  characteristics: ["userId"], // Rate limit based on the Clerk userId
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -12,6 +11,7 @@ const aj = arcjet({
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
+      characteristics: ["userId"], // Rate limit based on the Clerk userId
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       refillRate: 5, // refill 5 tokens per interval
       interval: 10, // refill every 10 seconds

--- a/examples/nextjs-authjs-5/middleware.ts
+++ b/examples/nextjs-authjs-5/middleware.ts
@@ -3,7 +3,6 @@ import { auth } from "auth";
 
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
-  characteristics: ["userId"], // track requests by a custom user ID
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -11,6 +10,7 @@ const aj = arcjet({
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
+      characteristics: ["userId"], // track requests by a custom user ID
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       refillRate: 5, // refill 5 tokens per interval
       interval: 10, // refill every 10 seconds

--- a/examples/nextjs-better-auth/app/api/auth/[...all]/route.ts
+++ b/examples/nextjs-better-auth/app/api/auth/[...all]/route.ts
@@ -17,7 +17,6 @@ import { NextRequest } from "next/server";
 // The arcjet instance is created outside of the handler
 const aj = arcjet({
   key: process.env.ARCJET_KEY, // Get your site key from https://app.arcjet.com
-  characteristics: ["userId"],
   rules: [
     // Protect against common attacks with Arcjet Shield. Other rules are
     // added dynamically using `withRule`.
@@ -60,16 +59,6 @@ async function protect(req: NextRequest): Promise<ArcjetDecision> {
     headers: req.headers,
   });
 
-  // If the user is logged in we'll use their ID as the identifier. This
-  // allows limits to be applied across all devices and sessions (you could
-  // also use the session ID). Otherwise, fall back to the IP address.
-  let userId: string;
-  if (session?.user.id) {
-    userId = session.user.id;
-  } else {
-    userId = ip(req) || "127.0.0.1"; // Fall back to local IP if none
-  }
-
   // If this is a signup then use the special protectSignup rule
   // See https://docs.arcjet.com/signup-protection/quick-start
   if (req.nextUrl.pathname.startsWith("/api/auth/sign-up")) {
@@ -82,17 +71,17 @@ async function protect(req: NextRequest): Promise<ArcjetDecision> {
     if (typeof body.email === "string") {
       return aj
         .withRule(protectSignup(signupOptions))
-        .protect(req, { email: body.email, userId });
+        .protect(req, { email: body.email });
     } else {
       // Otherwise use rate limit and detect bot
       return aj
         .withRule(detectBot(botOptions))
         .withRule(slidingWindow(rateLimitOptions))
-        .protect(req, { userId });
+        .protect(req);
     }
   } else {
     // For all other auth requests
-    return aj.withRule(detectBot(botOptions)).protect(req, { userId });
+    return aj.withRule(detectBot(botOptions)).protect(req);
   }
 }
 

--- a/examples/nextjs-clerk-rate-limit/app/api/arcjet/route.ts
+++ b/examples/nextjs-clerk-rate-limit/app/api/arcjet/route.ts
@@ -6,9 +6,6 @@ import ip from "@arcjet/ip";
 // The root Arcjet client is created outside of the handler.
 const aj = arcjet({
   key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
-  // We specify a custom fingerprint so we can dynamically build it within each
-  // demo route.
-  characteristics: ["fingerprint"],
   rules: [
     shield({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
@@ -37,7 +34,7 @@ export async function GET(req: NextRequest) {
     const fingerprint = user.id; // Use the user ID as the fingerprint
 
     // Deduct 5 tokens from the token bucket
-    decision = await rl.protect(req, { fingerprint, requested: 5 });
+    decision = await rl.protect(req, { requested: 5 });
   } else {
     // Limit the amount of requests for anonymous users.
     const rl = aj.withRule(
@@ -53,7 +50,7 @@ export async function GET(req: NextRequest) {
     const fingerprint = ip(req) || "127.0.0.1"; // Fall back to local IP if none
 
     // Deduct 5 tokens from the token bucket
-    decision = await rl.protect(req, { fingerprint, requested: 5 });
+    decision = await rl.protect(req, { requested: 5 });
   }
 
   if (decision.isDenied()) {

--- a/examples/nextjs-decorate/app/api-app/arcjet/route.ts
+++ b/examples/nextjs-decorate/app/api-app/arcjet/route.ts
@@ -7,8 +7,6 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // Limiting by ip.src is the default if not specified
-  //characteristics: ["ip.src"],
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -17,6 +15,8 @@ const aj = arcjet({
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       window: "2m", // 2 min fixed window
       max: 1, // allow a single request (for demo purposes)

--- a/examples/nextjs-decorate/pages/api/arcjet.ts
+++ b/examples/nextjs-decorate/pages/api/arcjet.ts
@@ -7,12 +7,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // Limiting by ip.src is the default if not specified
-  //characteristics: ["ip.src"],
   rules: [
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       window: "1m", // 1 min fixed window
       max: 1, // allow a single request (for demo purposes)

--- a/examples/nextjs-openai/app/api/chat/route.ts
+++ b/examples/nextjs-openai/app/api/chat/route.ts
@@ -25,12 +25,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
-  characteristics: ["ip.src"], // track requests by IP address
   rules: [
     shield({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
     }),
     tokenBucket({
+      characteristics: ["ip.src"], // track requests by IP address
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       refillRate: 2_000, // fill the bucket up by 2,000 tokens
       interval: "1h", // every hour

--- a/examples/nextjs-openai/app/api/chat_userid/route.ts
+++ b/examples/nextjs-openai/app/api/chat_userid/route.ts
@@ -26,12 +26,12 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY,
-  characteristics: ["userId"], // track requests by user ID
   rules: [
     shield({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
     }),
     tokenBucket({
+      characteristics: ["userId"], // track requests by user ID
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       refillRate: 2_000, // fill the bucket up by 2,000 tokens
       interval: "1h", // every hour

--- a/examples/nextjs-pages-wrap/pages/api/arcjet-edge.ts
+++ b/examples/nextjs-pages-wrap/pages/api/arcjet-edge.ts
@@ -11,8 +11,6 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // Limiting by ip.src is the default if not specified
-  //characteristics: ["ip.src"],
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -21,6 +19,8 @@ const aj = arcjet({
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      // characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       window: "1m", // 1 min fixed window
       max: 1, // allow a single request (for demo purposes)

--- a/examples/nextjs-pages-wrap/pages/api/arcjet.ts
+++ b/examples/nextjs-pages-wrap/pages/api/arcjet.ts
@@ -7,8 +7,6 @@ const aj = arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // Limiting by ip.src is the default if not specified
-  //characteristics: ["ip.src"],
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -17,6 +15,8 @@ const aj = arcjet({
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      // characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       window: "1m", // 1 min fixed window
       max: 1, // allow a single request (for demo purposes)

--- a/examples/nextjs-permit/src/lib/arcjet.ts
+++ b/examples/nextjs-permit/src/lib/arcjet.ts
@@ -5,8 +5,6 @@ export const arcjet = _arcjet({
   // and set it as an environment variable rather than hard coding.
   // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
   key: process.env.ARCJET_KEY!,
-  // Define a global characteristic that we can use to identify users
-  characteristics: ["fingerprint"],
   // Define the global rules that we want to run on every request
   rules: [
     // Shield detects suspicious behavior, such as SQL injection and cross-site

--- a/examples/nextjs-server-actions/app/actions.ts
+++ b/examples/nextjs-server-actions/app/actions.ts
@@ -4,8 +4,6 @@ import arcjet, { request, validateEmail } from "@arcjet/next";
 
 const aj = arcjet({
   key: process.env.ARCJET_KEY!,
-  // Use the `uid` cookie that is set by the middleware to fingerprint requests
-  characteristics: ['http.request.cookie["uid"]'],
   rules: [
     validateEmail({
       mode: "LIVE",

--- a/examples/nodejs-hono-rate-limit/index.ts
+++ b/examples/nodejs-hono-rate-limit/index.ts
@@ -4,7 +4,6 @@ import { Hono } from "hono";
 
 const aj = arcjet({
   key: process.env.ARCJET_KEY!,
-  characteristics: ["userId"], // track requests by a custom user ID
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -12,6 +11,7 @@ const aj = arcjet({
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({
+      characteristics: ["userId"], // track requests by a custom user ID
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only      
       refillRate: 5, // refill 5 tokens per interval
       interval: 10, // refill every 10 seconds

--- a/examples/nodejs-rate-limit/index.js
+++ b/examples/nodejs-rate-limit/index.js
@@ -14,8 +14,6 @@ const aj = arcjet({
   // Get your site key from https://app.arcjet.com and set it as an environment
   // variable rather than hard coding.
   key: arcjetKey,
-  // Limiting by ip.src is the default if not specified
-  //characteristics: ["ip.src"],
   rules: [
     // Protect against common attacks with Arcjet Shield
     shield({
@@ -24,6 +22,8 @@ const aj = arcjet({
     // Fixed window rate limit. Arcjet also supports sliding window and token
     // bucket.
     fixedWindow({
+      // Limiting by ip.src is the default if not specified
+      // characteristics: ["ip.src"],
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
       window: "1m", // 1 min fixed window
       max: 1, // allow a single request (for demo purposes)


### PR DESCRIPTION
To solve GH-4553, I looked for `characteristics`.
I moved every case to a rule, when that type-checked. If there was no rule used that accepted them,
I assumed that they were not needed,
and removed them.

I only found top-level use inside the examples,
so I think this closes GH-4553.