### PR TITLE
docs: add sections on what packages are, when to use

### DIFF
--- a/analyze-wasm/README.md
+++ b/analyze-wasm/README.md
@@ -82,3 +82,4 @@ Use [`@arcjet/analyze`][file-analyze] instead.
 [wasm-base64-blog]: https://blobfolio.com/2019/better-binary-batter-mixing-base64-and-uint8array/
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [github-arcjet-analyze]: https://github.com/arcjet/arcjet-js/tree/main/analyze
+[tc39-proposal-import-bytes]: https://github.com/tc39/proposal-import-bytes

--- a/analyze-wasm/README.md
+++ b/analyze-wasm/README.md
@@ -25,6 +25,40 @@ This package provides WebAssembly bindings to [Arcjet's][arcjet] local analysis 
 - [npm package (`@arcjet/analyze-wasm`)](https://www.npmjs.com/package/@arcjet/analyze-wasm)
 - [GitHub source code (`analyze-wasm/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/analyze-wasm)
 
+## What is this?
+
+This package provides logic in WebAssembly to locally analyze requests.
+
+To load these binary files everywhere until something like
+[_Import Bytes_][tc39-proposal-import-bytes] is available,
+we settled on a technique that seems to work well everywhere.
+This technique gives us compatibility with for example Next.js which right now
+requires a special experimental `asyncWebAssembly` webpack configuration,
+
+The file `_virtual/arcjet_analyze_js_req.component.core.js` contains the
+WebAssembly inlined as a [`data:` URL][mdn-data-url].
+This is about 3 times smaller than using a `Uint8Array` (see
+[_Better Binary Batter: Mixing Base64 and Uint8Array_][wasm-base64-blog] for more
+info).
+That URL is then turned into an `ArrayBuffer` and passed to
+`WebAssembly.compile`.
+
+The files here are generated.
+They are wrapped up into [`@arcjet/analyze`][github-arcjet-analyze] for use in
+JavaScript,
+in turn exposed in our core package
+([`arcjet`][github-arcjet-arcjet])
+and our adapters (such as `@arcjet/next`).
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
+## When should I use this?
+
+You should not use this but use one of the adapters that integrate with a
+framework instead.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.
@@ -38,30 +72,6 @@ npm install @arcjet/analyze-wasm
 
 Use [`@arcjet/analyze`][file-analyze] instead.
 
-## Implementation
-
-This package provides analyze logic implemented as a WebAssembly module which
-will run local analysis on request details.
-
-The `_virtual/arcjet_analyze_js_req.component.core.js` file contains the binary inlined as
-a base64 [Data URL][mdn-data-url] with the `application/wasm` MIME type.
-
-This was chosen to save on storage space over inlining the file directly as a
-Uint8Array, which would take up ~3x the space of the Wasm file. See
-[Better Binary Batter: Mixing Base64 and Uint8Array][wasm-base64-blog] for more
-details.
-
-It is then decoded into an ArrayBuffer to be used directly via WebAssembly's
-`compile()` function in our entry point file.
-
-This is all done to avoid trying to read or bundle the Wasm asset in various
-ways based on the platform or bundler a user is targeting. One example being
-that Next.js requires special `asyncWebAssembly` webpack config to load our
-Wasm file if we don't do this.
-
-In the future, we hope to do away with this workaround when all bundlers
-properly support consistent asset bundling techniques.
-
 ## License
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
@@ -71,3 +81,4 @@ properly support consistent asset bundling techniques.
 [mdn-data-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 [wasm-base64-blog]: https://blobfolio.com/2019/better-binary-batter-mixing-base64-and-uint8array/
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[github-arcjet-analyze]: https://github.com/arcjet/arcjet-js/tree/main/analyze

--- a/analyze/README.md
+++ b/analyze/README.md
@@ -25,6 +25,30 @@ This is the [Arcjet][arcjet] local analysis engine.
 - [npm package (`@arcjet/analyze`)](https://www.npmjs.com/package/@arcjet/analyze)
 - [GitHub source code (`analyze/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/analyze)
 
+## What is this?
+
+This package provides functionality to analyze requests.
+The work is done in WebAssembly but is called here from JavaScript.
+The functionality is wrapped up into rules in our core package
+([`arcjet`][github-arcjet-arcjet]),
+in turn exposed from our adapters (such as `@arcjet/next`).
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
+The WebAssembly files are in
+[`@arcjet/analyze-wasm`][github-arcjet-analyze-wasm].
+They are separate because we need to change the import structure for each
+runtime that we support in the bindings.
+Separate packages lets us not duplicate code while providing a combined
+higher-level API for calling our core functionality.
+
+## When should I use this?
+
+You should not use this but use one of the adapters that integrate with a
+framework instead.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.
@@ -58,19 +82,11 @@ console.log(result);
 // => { blocked: [], validity: "valid" }
 ```
 
-## Implementation
-
-This package uses the Wasm bindings provided by `@arcjet/analyze-wasm` to
-call various functions that are exported by our wasm bindings.
-
-We chose to put this logic in a separate package because we need to change the
-import structure for each runtime that we support in the wasm bindings. Moving
-this to a separate package allows us not to have to duplicate code while providing
-a combined higher-level api for calling our core functionality in Wasm.
-
 ## License
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[github-arcjet-analyze-wasm]: https://github.com/arcjet/arcjet-js/tree/main/analyze-wasm
+[github-arcjet-arcjet]: https://github.com/arcjet/arcjet-js/tree/main/arcjet

--- a/arcjet-astro/README.md
+++ b/arcjet-astro/README.md
@@ -34,6 +34,20 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Astro.
+Arcjet helps you secure your Astro website.
+This package exists so that we can provide the best possible experience to
+Astro users.
+
+## When should I use this?
+
+You can use this if you are using Astro.
+Use a different adapter if you use a different framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-bun/README.md
+++ b/arcjet-bun/README.md
@@ -34,6 +34,20 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Bun.
+Arcjet helps you secure your Bun server.
+This package exists so that we can provide the best possible experience to
+Bun users.
+
+## When should I use this?
+
+You can use this if you are using Bun.
+Use a different adapter if you use a different runtime.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-deno/README.md
+++ b/arcjet-deno/README.md
@@ -25,6 +25,20 @@ This is the [Arcjet][arcjet] SDK for [Deno][deno].
 - [npm package (`@arcjet/deno`)](https://www.npmjs.com/package/@arcjet/deno)
 - [GitHub source code (`arcjet-deno/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/arcjet-deno)
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Deno.
+Arcjet helps you secure your Deno server.
+This package exists so that we can provide the best possible experience to
+Deno users.
+
+## When should I use this?
+
+You can use this if you are using Deno.
+Use a different adapter if you use a different runtime.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-fastify/README.md
+++ b/arcjet-fastify/README.md
@@ -27,6 +27,20 @@ This is the [Arcjet][] SDK for [Fastify][].
 
 Visit the [quick start guide][arcjet-quick-start-fastify] to get started.
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Fastify.
+Arcjet helps you secure your Fastify server.
+This package exists so that we can provide the best possible experience to
+Fastify users.
+
+## When should I use this?
+
+You can use this if you are using Fastify.
+Use a different adapter if you use a different framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-nest/README.md
+++ b/arcjet-nest/README.md
@@ -37,6 +37,20 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
+## What is this?
+
+This is our adapter to integrate Arcjet into NestJS.
+Arcjet helps you secure your Nest server.
+This package exists so that we can provide the best possible experience to
+Nest users.
+
+## When should I use this?
+
+You can use this if you are using NestJS.
+Use a different adapter if you use a different framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-next/README.md
+++ b/arcjet-next/README.md
@@ -57,6 +57,20 @@ and Shield WAF.
 
 You can also find this [quick start guide][quick-start] in the docs.
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Next.js.
+Arcjet helps you secure your Next web application.
+This package exists so that we can provide the best possible experience to
+Next users.
+
+## When should I use this?
+
+You can use this if you are using Next.js.
+Use a different adapter if you use a different framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-node/README.md
+++ b/arcjet-node/README.md
@@ -37,6 +37,21 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Node.js.
+Arcjet helps you secure your Node server.
+This package exists so that we can provide the best possible experience to
+Node users.
+
+## When should I use this?
+
+You can use this if you are using Node.js.
+Use a different adapter if you use a different runtime.
+There are also adapters that are more specific such as Astro or Next.js.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-remix/README.md
+++ b/arcjet-remix/README.md
@@ -30,6 +30,20 @@ This is the [Arcjet][arcjet] SDK for [Remix][remix].
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
+## What is this?
+
+This is our adapter to integrate Arcjet into Remix.
+Arcjet helps you secure your Remix website.
+This package exists so that we can provide the best possible experience to
+Remix users.
+
+## When should I use this?
+
+You can use this if you are using Remix.
+Use a different adapter if you use a different framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet-sveltekit/README.md
+++ b/arcjet-sveltekit/README.md
@@ -34,6 +34,20 @@ Visit the [quick start guide][quick-start] to get started.
 Try an Arcjet protected app live at [https://example.arcjet.com][example-url]
 ([source code][example-source]).
 
+## What is this?
+
+This is our adapter to integrate Arcjet into SvelteKit.
+Arcjet helps you secure your SvelteKit web application.
+This package exists so that we can provide the best possible experience to
+SvelteKit users.
+
+## When should I use this?
+
+You can use this if you are using SvelteKit.
+Use a different adapter if you use a different framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
 ## Install
 
 This package is ESM only.

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -29,10 +29,23 @@ This is the [Arcjet][arcjet] TypeScript and JavaScript SDK core.
 
 Visit [docs.arcjet.com](https://docs.arcjet.com) to get started.
 
-Generally, you'll want to use the Arcjet SDK for your specific framework, such
-as [`@arcjet/next`](../arcjet-next/README.md) for Next.js. However, this package
-can be used to interact with Arcjet if your framework does not have an
-integration.
+## What is this?
+
+This is our core package.
+It exposes the functionality for the many types of protection that Arcjet
+provides which can be configured and combined by users.
+The functionality here is exposed from our adapters (such as `@arcjet/next`)
+that each integrate with a particular framework.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
+
+## When should I use this?
+
+You should generally use an adapters that integrates with your framework.
+This package can be used to interact with Arcjet if your framework does not
+yet have an integration.
+
+<!-- TODO(@wooorm-arcjet): link `adapters` above when the main repo is up to date. -->
 
 ## Install
 

--- a/body/README.md
+++ b/body/README.md
@@ -21,6 +21,21 @@
 - [npm package (`@arcjet/body`)](https://www.npmjs.com/package/@arcjet/body)
 - [GitHub source code (`body/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/body)
 
+## What is this?
+
+This is an internal utility to help us read streams from various frameworks.
+It’s a fork of [`stream-utils/raw-body`][node-raw-body].
+We chose to fork so that we can cut away functionality that we do not use
+and keep our dependency tree as light as possible.
+Specifically it always parses the stream as a UTF-8 string instead of a `Buffer`
+and only supports promises instead of callbacks.
+
+## When should I use this?
+
+You should not use this but use [`stream-utils/raw-body`][node-raw-body] or one
+of the alternatives instead.
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -39,17 +54,6 @@ import { readBody } from "@arcjet/body";
 const body = await readBody(fs.createReadStream("example.ts"), { limit: 1024 });
 console.log(body);
 ```
-
-## Implementation
-
-The implementation of this library is based on the [raw-body][node-raw-body]
-package. Licensed MIT with licenses included in our source code.
-
-We've chosen to re-implement the logic to read the body from the stream to keep
-the dependency tree for our packages as light as possible. Our implementation only
-provides the functionality that we need, specifically it excludes the functionality
-to return the stream as a buffer and always parses it as a utf-8 string. The interface
-was also changed to only support promises rather than the sync implementation provided by `raw-body`.
 
 ## License
 

--- a/cache/README.md
+++ b/cache/README.md
@@ -21,6 +21,14 @@
 - [npm package (`@arcjet/cache`)](https://www.npmjs.com/package/@arcjet/cache)
 - [GitHub source code (`cache/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/cache)
 
+## What is this?
+
+This is an internal utility to help us cache some things in memory.
+
+## When should I use this?
+
+Do not use this!
+
 ## Install
 
 This package is ESM only.

--- a/decorate/README.md
+++ b/decorate/README.md
@@ -21,6 +21,18 @@
 - [npm package (`@arcjet/decorate`)](https://www.npmjs.com/package/@arcjet/decorate)
 - [GitHub source code (`decorate/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/decorate)
 
+## What is this?
+
+This is a utility that lets you decorate responses based on Arcjet decisions.
+It currently supports experimental rate limit headers.
+
+## When should I use this?
+
+You can use this package if you use the rate limit rule and want to set
+experimental `RateLimit-Policy` and `RateLimit` headers.
+See [_RateLimit header fields for HTTP_ on `ietf.org`][ietf-rate-limit] for
+more info.
+
 ## Install
 
 This package is ESM only.
@@ -81,3 +93,4 @@ server.listen(8000);
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[ietf-rate-limit]: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-08

--- a/duration/README.md
+++ b/duration/README.md
@@ -21,6 +21,20 @@
 - [npm package (`@arcjet/duration`)](https://www.npmjs.com/package/@arcjet/duration)
 - [GitHub source code (`duration/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/duration)
 
+## What is this?
+
+This is an internal utility that exists so our users can pass meaningful
+duration strings such as `1h` instead of having to manually calculate seconds
+or milliseconds.
+We turned the Go [`ParseDuration`][go-parser] into TypeScript so that we have
+the exact same functionality in both languages.
+
+## When should I use this?
+
+You should not use this but use one of the many alternatives such as
+[`vercel/ms`][github-vercel-ms].
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -39,18 +53,6 @@ const seconds = parse("1h");
 console.log(seconds); // prints 3600
 ```
 
-## Implementation
-
-The implementation of this library is based on the [ParseDuration][go-parser]
-function in the Go stdlib. Originally licensed BSD-3.0 with the license included
-in our source code.
-
-We've chosen the approach of porting this to TypeScript because our protocol
-operates exclusively on unsigned 32-bit integers representing seconds. However,
-we don't want to require our SDK users to manually calculate seconds. By
-providing this utility, our SDK can accept duration strings and numbers while
-normalizing the values for our protocol.
-
 ## License
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
@@ -58,3 +60,4 @@ normalizing the values for our protocol.
 [arcjet]: https://arcjet.com
 [go-parser]: https://github.com/golang/go/blob/c18ddc84e1ec6406b26f7e9d0e1ee3d1908d7c27/src/time/format.go#L1589-L1686
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[github-vercel-ms]: https://github.com/vercel/ms

--- a/env/README.md
+++ b/env/README.md
@@ -34,6 +34,17 @@ type Env = {
 - [npm package (`@arcjet/env`)](https://www.npmjs.com/package/@arcjet/env)
 - [GitHub source code (`env/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/env)
 
+## What is this?
+
+This is a utility that reads configuration for us from `process.env` and
+similar.
+It exists so that we can access that configuration throughout our packages.
+
+## When should I use this?
+
+You should probably not use this but there are some edge cases where we let
+users swap more advanced features out and then it may be useful.
+
 ## Install
 
 This package is ESM only.

--- a/eslint-config/README.md
+++ b/eslint-config/README.md
@@ -21,6 +21,14 @@ Custom eslint config for [Arcjet][arcjet] projects.
 - [npm package (`@arcjet/eslint-config`)](https://www.npmjs.com/package/@arcjet/eslint-config)
 - [GitHub source code (`eslint-config/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/eslint-config)
 
+## What is this?
+
+This is our ESLint configuration that we share across our codebase.
+
+## When should I use this?
+
+You should not use this but instead configure ESLint yourself.
+
 ## Install
 
 This package is ESM only.

--- a/headers/README.md
+++ b/headers/README.md
@@ -21,6 +21,17 @@
 - [npm package (`@arcjet/headers`)](https://www.npmjs.com/package/@arcjet/headers)
 - [GitHub source code (`headers/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/headers)
 
+## What is this?
+
+This is an internal utility to help us deal with [`Headers`][mdn-headers].
+This exists to prevent the `cookie` header from being set and non-string values
+from being set.
+
+## When should I use this?
+
+You should not use this but use `Headers` or plain objects instead.
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -40,14 +51,10 @@ const headers = new ArcjetHeaders({ abc: "123" });
 console.log(headers.get("abc")); // => "123"
 ```
 
-## Considerations
-
-This package will filter the `cookie` header and all headers with keys or values
-that are not strings, such as `{ "abc": undefined }`.
-
 ## License
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[mdn-headers]: https://developer.mozilla.org/en-US/docs/Web/API/Headers

--- a/inspect/README.md
+++ b/inspect/README.md
@@ -21,6 +21,17 @@
 - [npm package (`@arcjet/inspect`)](https://www.npmjs.com/package/@arcjet/inspect)
 - [GitHub source code (`inspect/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/inspect)
 
+## What is this?
+
+Arcjet attaches lots of metadata to every decision.
+This package exists to more easily interact with Arcjet decisions for common
+patterns.
+
+## When should I use this?
+
+You can access metadata on decisions directly but you can use this package for
+common patterns.
+
 ## Install
 
 This package is ESM only.

--- a/ip/README.md
+++ b/ip/README.md
@@ -76,8 +76,5 @@ are detected, an empty string is returned.
 
 [arcjet]: https://arcjet.com
 [rust-parser]: https://github.com/rust-lang/rust/blob/07921b50ba6dcb5b2984a1dba039a38d85bffba2/library/core/src/net/parser.rs#L34
-[rust-global-ipv4]: https://github.com/rust-lang/rust/blob/87e1447aadaa2899ff6ccabe1fa669eb50fb60a1/library/core/src/net/ip_addr.rs#L749
-[rust-global-ipv6]: https://github.com/rust-lang/rust/blob/87e1447aadaa2899ff6ccabe1fa669eb50fb60a1/library/core/src/net/ip_addr.rs#L1453
-[request-ip-headers]: https://github.com/pbojinov/request-ip/blob/e1d0f4b89edf26c77cf62b5ef662ba1a0bd1c9fd/src/index.js#L55
 [request-ip]: https://github.com/pbojinov/request-ip/tree/e1d0f4b89edf26c77cf62b5ef662ba1a0bd1c9fd
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/ip/README.md
+++ b/ip/README.md
@@ -21,6 +21,28 @@
 - [npm package (`@arcjet/ip`)](https://www.npmjs.com/package/@arcjet/ip)
 - [GitHub source code (`ip/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/ip)
 
+## What is this?
+
+This is an internal utility to help us deal with IP addresses.
+It includes code from the Rust standard library code to parse
+[IPv4 and IPv6][rust-parser] and also contains some code from
+[`pbojinov/request-ip`][request-ip].
+We turned the Rust IP parser into TypeScript so that we have the exact same
+functionality in both languages.
+Similar functionality in alternative JavaScript libraries often uses regular
+expressions but those can cause ReDoS attacks.
+We sidestep that problem because the Rust IP parser algorithm does not use
+regular expressions.
+We chose to copy code from `request-ip` so that we only keep the functionality
+that we use and keep our dependency tree as light as possible.
+Our code is different: if we know we are running on Cloudflare for example then
+we do not trust headers typically set by fly.io.
+
+## When should I use this?
+
+You should not use this but use one of the alternatives instead.
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -47,21 +69,6 @@ platform is supplied in the `options` argument.
 
 If a private/internal address is encountered, it will be skipped. If only those
 are detected, an empty string is returned.
-
-## Implementation
-
-The implementation of this library is based on the [Parser][rust-parser],
-[global ipv4 comparisons][rust-global-ipv4], and
-[global ipv6 comparisons][rust-global-ipv6] in the Rust stdlib and the [header
-lookups][request-ip-headers] in the [request-ip] package. Both licensed MIT with
-licenses included in our source code.
-
-We've chosen the approach of porting Rust's IP Parser because capturing RegExps
-can be the source of ReDoS attacks, which we need to avoid. We also wanted to
-keep our implementation as close to Rust as possible because we will be relying
-on the Rust stdlib implementation in the future, with a fallback to this
-implementation. As such, we'll need to track changes in Rust's implementation,
-even though it seems to change infrequently.
 
 ## License
 

--- a/logger/README.md
+++ b/logger/README.md
@@ -22,6 +22,17 @@ structured logger interface.
 - [npm package (`@arcjet/logger`)](https://www.npmjs.com/package/@arcjet/logger)
 - [GitHub source code (`logger/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/logger)
 
+## What is this?
+
+This is an internal utility to help us log things.
+It provides a small interface, a bit like [Pino][github-pino],
+so that users with custom needs can swap it for their own logger.
+
+## When should I use this?
+
+You should probably not use this but use one of the alternatives instead.
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -55,5 +66,6 @@ to one of: `"DEBUG"`, `"LOG"`, `"WARN"`, or `"ERROR"`.
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [arcjet]: https://arcjet.com
+[github-pino]: https://github.com/pinojs/pino
 [pino-api]: https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/nosecone-next/README.md
+++ b/nosecone-next/README.md
@@ -21,6 +21,20 @@ Protect your Next.js application with secure headers.
 - [npm package (`@nosecone/next`)](https://www.npmjs.com/package/@nosecone/next)
 - [GitHub source code (`nosecone-next/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/nosecone-next)
 
+## What is this?
+
+This is our adapter to integrate Nosecone into Next.js.
+Nosecone makes it easy to add and configure security headers.
+This package exists so that we can provide the best possible experience to
+Next users.
+
+## When should I use this?
+
+You can use this package with or without Arcjet to protect your app if you are
+using Next.js.
+Use [`@nosecone/sveltekit`][github-nosecone-sveltekit] if you use Sveltekit and
+use [`nosecone`][github-nosecone] itself if you use a different framework.
+
 ## Install
 
 This package is ESM only.
@@ -72,3 +86,5 @@ export default createMiddleware();
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
+[github-nosecone-sveltekit]: https://github.com/arcjet/arcjet-js/tree/main/nosecone-sveltekit
+[github-nosecone]: https://github.com/arcjet/arcjet-js/tree/main/nosecone

--- a/nosecone-sveltekit/README.md
+++ b/nosecone-sveltekit/README.md
@@ -21,6 +21,20 @@ Protect your SvelteKit application with secure headers.
 - [npm package (`@nosecone/sveltekit`)](https://www.npmjs.com/package/@nosecone/sveltekit)
 - [GitHub source code (`nosecone-sveltekit/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/nosecone-sveltekit)
 
+## What is this?
+
+This is our adapter to integrate Nosecone into SvelteKit.
+Nosecone makes it easy to add and configure security headers.
+This package exists so that we can provide the best possible experience to
+SvelteKit users.
+
+## When should I use this?
+
+You can use this package with or without Arcjet to protect your app if you are
+using SvelteKit.
+Use [`@nosecone/next`][github-nosecone-next] if you use Next.js and
+use [`nosecone`][github-nosecone] itself if you use a different framework.
+
 ## Install
 
 This package is ESM only.
@@ -74,3 +88,5 @@ export const handle = sequence(
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
+[github-nosecone-next]: https://github.com/arcjet/arcjet-js/tree/main/nosecone-next
+[github-nosecone]: https://github.com/arcjet/arcjet-js/tree/main/nosecone

--- a/nosecone/README.md
+++ b/nosecone/README.md
@@ -21,6 +21,20 @@ Protect your `Response` with secure headers.
 - [npm package (`nosecone`)](https://www.npmjs.com/package/nosecone)
 - [GitHub source code (`nosecone/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/nosecone)
 
+## What is this?
+
+Nosecone makes it easy to add and configure security headers.
+This package exists so that you can secure your server even if you do not use
+Arcjet.
+
+## When should I use this?
+
+You can use this package with or without Arcjet to protect your server.
+You can use `@nosecone/next` or `@nosecone/sveltekit` if you are using those
+frameworks.
+
+<!-- TODO(@wooorm-arcjet): discuss when someone should use Helmet instead. -->
+
 ## Install
 
 This package is ESM only.

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -21,6 +21,15 @@ The TypeScript & JavaScript interface into the [Arcjet][arcjet] protocol.
 - [npm package (`@arcjet/protocol`)](https://www.npmjs.com/package/@arcjet/protocol)
 - [GitHub source code (`protocol/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/protocol)
 
+## What is this?
+
+This package provides access to our protocol.
+It talks with our API from JavaScript.
+
+## When should I use this?
+
+Do not use this!
+
 ## Install
 
 This package is ESM only.

--- a/redact-wasm/README.md
+++ b/redact-wasm/README.md
@@ -21,6 +21,21 @@
 - [npm package (`@arcjet/redact-wasm`)](https://www.npmjs.com/package/@arcjet/redact-wasm)
 - [GitHub source code (`redact-wasm/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/redact-wasm)
 
+## What is this?
+
+This package provides logic in WebAssembly to locally redact sensitive info.
+The files here are generated.
+They are wrapped up into [`@arcjet/redact`][github-arcjet-redact] for use in
+JavaScript.
+For more info on why we maintain our WebAssembly and JavaScript projects like
+this,
+see [“What is this?” in the readme of
+`@arcjet/analyze-wasm`][github-arcjet-analyze-wasm-what].
+
+## When should I use this?
+
+You should not use this but use [`@arcjet/redact`][github-arcjet-redact] instead.
+
 ## Install
 
 This package is ESM only.
@@ -34,30 +49,6 @@ npm install @arcjet/redact-wasm
 
 Use [`@arcjet/redact`][file-redact] instead.
 
-## Implementation
-
-This package provides sensitive information identification and redaction logic implemented as a
-WebAssembly module which will run local analysis on the provided string.
-
-The generated `_virtual/arcjet_analyze_bindings_redact.component.js` file contains the binary inlined as
-a base64 [Data URL][mdn-data-url] with the `application/wasm` MIME type.
-
-This was chosen to save on storage space over inlining the file directly as a
-Uint8Array, which would take up ~3x the space of the Wasm file. See
-[Better Binary Batter: Mixing Base64 and Uint8Array][wasm-base64-blog] for more
-details.
-
-It is then decoded into an ArrayBuffer to be used directly via WebAssembly's
-`compile()` function in our entry point file.
-
-This is all done to avoid trying to read or bundle the Wasm asset in various
-ways based on the platform or bundler a user is targeting. One example being
-that Next.js requires special `asyncWebAssembly` webpack config to load our
-Wasm file if we don't do this.
-
-In the future, we hope to do away with this workaround when all bundlers
-properly support consistent asset bundling techniques.
-
 ## License
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
@@ -67,3 +58,5 @@ properly support consistent asset bundling techniques.
 [file-redact]: ../redact/
 [mdn-data-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 [wasm-base64-blog]: https://blobfolio.com/2019/better-binary-batter-mixing-base64-and-uint8array/
+[github-arcjet-analyze-wasm-what]: https://github.com/arcjet/arcjet-js/tree/main/analyze-wasm#what-is-this
+[github-arcjet-redact]: https://github.com/arcjet/arcjet-js/tree/main/redact

--- a/redact-wasm/README.md
+++ b/redact-wasm/README.md
@@ -56,7 +56,5 @@ Use [`@arcjet/redact`][file-redact] instead.
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [file-redact]: ../redact/
-[mdn-data-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
-[wasm-base64-blog]: https://blobfolio.com/2019/better-binary-batter-mixing-base64-and-uint8array/
 [github-arcjet-analyze-wasm-what]: https://github.com/arcjet/arcjet-js/tree/main/analyze-wasm#what-is-this
 [github-arcjet-redact]: https://github.com/arcjet/arcjet-js/tree/main/redact

--- a/redact/README.md
+++ b/redact/README.md
@@ -26,6 +26,23 @@ redaction library.
 - [npm package (`@arcjet/redact`)](https://www.npmjs.com/package/@arcjet/redact)
 - [GitHub source code (`redact/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/redact)
 
+## What is this?
+
+This package provides functionality to redact sensitive info.
+The work is done in WebAssembly but is called here from JavaScript.
+
+The WebAssembly files are in [`@arcjet/redact-wasm`][github-arcjet-redact-wasm].
+For more info on why we maintain our WebAssembly and JavaScript projects like
+this,
+see [“What is this?” in the readme of
+`@arcjet/analyze-wasm`][github-arcjet-analyze-wasm-what].
+
+## When should I use this?
+
+You can use this package to redact sensitive information locally.
+You can redact email addresses, credit card numbers, and more.
+It is also possible to reverse the process: to un-redact what was found.
+
 ## Install
 
 This package is ESM only.
@@ -63,3 +80,5 @@ console.log(unredacted); // "Your email address is john@example.com"
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
 [arcjet]: https://arcjet.com
 [redact-ref]: https://docs.arcjet.com/redact/reference
+[github-arcjet-analyze-wasm-what]: https://github.com/arcjet/arcjet-js/tree/main/analyze-wasm#what-is-this
+[github-arcjet-redact-wasm]: https://github.com/arcjet/arcjet-js/tree/main/redact-wasm

--- a/rollup-config/README.md
+++ b/rollup-config/README.md
@@ -21,6 +21,14 @@ Custom rollup config for [Arcjet][arcjet] projects.
 - [npm package (`@arcjet/rollup-config`)](https://www.npmjs.com/package/@arcjet/rollup-config)
 - [GitHub source code (`rollup-config/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/rollup-config)
 
+## What is this?
+
+This is our Rollup configuration that we share across our codebase.
+
+## When should I use this?
+
+You should not use this but instead configure Rollup yourself.
+
 ## Install
 
 This package is ESM only.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -24,6 +24,20 @@ defined by the [WinterCG][wintercg].
 - [npm package (`@arcjet/runtime`)](https://www.npmjs.com/package/@arcjet/runtime)
 - [GitHub source code (`runtime/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/runtime)
 
+## What is this?
+
+This is an internal utility to help us figure out what platform we are running on.
+It’s a fork of [`unjs/std-env`][std-env].
+We chose to fork so that we can cut away functionality that we do not use
+and keep our dependency tree as light as possible.
+We only need the runtime detection.
+
+## When should I use this?
+
+You should not use this but use [`unjs/std-env`][std-env] or one of the
+alternatives instead.
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -40,11 +54,6 @@ import { runtime } from "@arcjet/runtime";
 
 console.log(runtime()); // => "bun" or "node" and such
 ```
-
-## Implementation
-
-Improvements of this library were informed by [std-env], which is licensed MIT
-with licenses included in our source code.
 
 ## License
 

--- a/sprintf/README.md
+++ b/sprintf/README.md
@@ -23,6 +23,20 @@ This package is platform-independent in order to support multiple runtimes in va
 - [npm package (`@arcjet/sprintf`)](https://www.npmjs.com/package/@arcjet/sprintf)
 - [GitHub source code (`sprintf/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/sprintf)
 
+## What is this?
+
+This is an internal utility to help us format log messages.
+It’s a fork of [`pinojs/quick-format-unescaped`][quick-format-unescaped].
+We chose to fork so that we can maintain as much compatibility as possible
+while being more restrictive.
+
+## When should I use this?
+
+You should not use this but use
+[`pinojs/quick-format-unescaped`][quick-format-unescaped] or one of the
+alternatives instead.
+This package matches our current needs which are likely different from yours.
+
 ## Install
 
 This package is ESM only.
@@ -57,15 +71,6 @@ Object substitution supports any value that is not `undefined`.
   or `<anonymous>` if unnamed.
 - `%s` - Replaced if provided with a string.
 - `%%` - Replaced by the literal `%` character.
-
-## Implementation
-
-This implementation of this library is based on [quick-format-unescaped], which
-is licensed MIT with licenses included in our source code.
-
-The goal of this library is to be more restrictive than `quick-format-unescaped`
-while maintaining as much compatibility as possible, since [pino] uses it to
-format strings.
 
 ## License
 

--- a/sprintf/README.md
+++ b/sprintf/README.md
@@ -80,4 +80,3 @@ Object substitution supports any value that is not `undefined`.
 [arcjet]: https://arcjet.com
 [node-util]: https://nodejs.org/docs/latest-v18.x/api/util.html#utilformatformat-args
 [quick-format-unescaped]: https://github.com/pinojs/quick-format-unescaped/blob/20ebf64c2f2e182f97923a423d468757b9a24a63/index.js
-[pino]: https://github.com/pinojs/pino

--- a/stable-hash/README.md
+++ b/stable-hash/README.md
@@ -21,6 +21,16 @@
 - [npm package (`@arcjet/stable-hash`)](https://www.npmjs.com/package/@arcjet/stable-hash)
 - [GitHub source code (`stable-hash/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/stable-hash)
 
+## What is this?
+
+This is an internal utility to help us create stable hashes.
+It’s super minimal and matches similar internal code in other languages.
+This exists to make sure things work the same across languages.
+
+## When should I use this?
+
+Do not use this!
+
 ## Install
 
 This package is ESM only.

--- a/transport/README.md
+++ b/transport/README.md
@@ -21,6 +21,14 @@ Transport mechanisms for the [Arcjet][arcjet] protocol.
 - [npm package (`@arcjet/transport`)](https://www.npmjs.com/package/@arcjet/transport)
 - [GitHub source code (`transport/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/transport)
 
+## What is this?
+
+This package provides a way to talk to our protocol.
+
+## When should I use this?
+
+Do not use this!
+
 ## Install
 
 This package is ESM only.

--- a/tsconfig/README.md
+++ b/tsconfig/README.md
@@ -21,6 +21,14 @@ Custom tsconfig for [Arcjet][arcjet] projects.
 - [npm package (`@arcjet/tsconfig`)](https://www.npmjs.com/package/@arcjet/tsconfig)
 - [GitHub source code (`tsconfig/` in `arcjet/arcjet-js`)](https://github.com/arcjet/arcjet-js/tree/main/tsconfig)
 
+## What is this?
+
+This is our TypeScript configuration that we share across our codebase.
+
+## When should I use this?
+
+You should not use this but instead configure TypeScript yourself.
+
 ## Install
 
 This package is ESM only.


### PR DESCRIPTION
This adds 2 sections at the relative top of package readmes.
They explain to people stumbling on them what this package is and when they should use it.
The goal is for humans to quickly get answers to their most pressing questions before they see install instructions and examples and API docs and such.

I have two questions:

* Should we suggest that people use `arcjet` core if their is no adapter for their framework? The current text was open to that, but from what I hear from people it may not be desirable for people to make their own adapters just yet. This also relates to whether we *currently* suggest that, whether it’s ready for use, we can revisit this if we have more guidance on how to use it.
* Is `@arcjet/ip` recommended for people to use? Do we want people to parse IPs with it? For finding IPs in headers on requests, should we recommend the upstream `request-ip`?
* I imagine a question that people have when stumbling on Nosecone to be: how does this compare to Helmet? I don’t have the answer to this yet.

Related-to: GH-4338.
Related-to: GH-4654.
