### PR TITLE
chore: add missing bun workspaces

### DIFF
--- a/examples/bun-hono-rate-limit/package.json
+++ b/examples/bun-hono-rate-limit/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "workspaces": [
     "../../analyze",
+    "../../analyze-wasm",
     "../../arcjet",
     "../../arcjet-bun",
+    "../../cache",
     "../../duration",
     "../../env",
     "../../eslint-config",
@@ -16,6 +18,7 @@
     "../../protocol",
     "../../rollup-config",
     "../../runtime",
+    "../../stable-hash",
     "../../sprintf",
     "../../transport",
     "../../tsconfig"

--- a/examples/bun-rate-limit/package.json
+++ b/examples/bun-rate-limit/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "workspaces": [
     "../../analyze",
+    "../../analyze-wasm",
     "../../arcjet",
     "../../arcjet-bun",
+    "../../cache",
     "../../duration",
     "../../env",
     "../../eslint-config",
@@ -17,6 +19,7 @@
     "../../rollup-config",
     "../../runtime",
     "../../sprintf",
+    "../../stable-hash",
     "../../transport",
     "../../tsconfig"
   ],


### PR DESCRIPTION
Releasing is locked because `bun install` cannot find 3 packages, which are updated by release please to 1.0.0-beta.10, but because they are not linked, bun tries to find them online, where they do not exist.
These 3 are added here to the 2 bun examples.