### PR TITLE
chore(nosecone): expose `Options`, deprecate `NoseconeOptions`

### DIFF
--- a/examples/nextjs-authjs-nosecone/middleware.ts
+++ b/examples/nextjs-authjs-nosecone/middleware.ts
@@ -1,9 +1,9 @@
-import { type NoseconeOptions, createMiddleware, defaults } from "@nosecone/next";
+import { type Options, createMiddleware, defaults } from "@nosecone/next";
 import { auth } from "auth";
 
 // Nosecone security headers configuration
 // https://docs.arcjet.com/nosecone/quick-start
-const noseconeOptions: NoseconeOptions = {
+const noseconeOptions: Options = {
   ...defaults,
 };
 

--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -1,7 +1,11 @@
 import nosecone, { defaults as baseDefaults } from "nosecone";
-import type { NoseconeOptions } from "nosecone";
+import type { Options } from "nosecone";
 
-export { withVercelToolbar, type NoseconeOptions } from "nosecone";
+export {
+  withVercelToolbar,
+  type Options,
+  type NoseconeOptions,
+} from "nosecone";
 
 /**
  * Nosecone Next.js defaults.
@@ -49,7 +53,7 @@ function nextStyleSrc() {
  * @returns
  *   Next.js middleware that sets secure headers.
  */
-export function createMiddleware(options: NoseconeOptions = defaults) {
+export function createMiddleware(options: Options = defaults) {
   return async () => {
     const headers = nosecone(options);
     // Setting this specific header is the way that Next.js implements

--- a/nosecone-sveltekit/index.ts
+++ b/nosecone-sveltekit/index.ts
@@ -4,10 +4,14 @@ import nosecone, {
   defaults as baseDefaults,
   NoseconeValidationError,
 } from "nosecone";
-import type { CspDirectives, NoseconeOptions } from "nosecone";
+import type { CspDirectives, Options } from "nosecone";
 import type { Handle, KitConfig } from "@sveltejs/kit";
 
-export { withVercelToolbar, type NoseconeOptions } from "nosecone";
+export {
+  withVercelToolbar,
+  type Options,
+  type NoseconeOptions,
+} from "nosecone";
 
 /**
  * Nosecone SvelteKit defaults.
@@ -31,7 +35,7 @@ export default nosecone;
  * @returns
  *   SvelteKit hook that sets secure headers.
  */
-export function createHook(options: NoseconeOptions = defaults): Handle {
+export function createHook(options: Options = defaults): Handle {
   return async ({ event, resolve }) => {
     const response = await resolve(event);
 

--- a/nosecone/index.ts
+++ b/nosecone/index.ts
@@ -205,7 +205,7 @@ export interface PermittedCrossDomainPoliciesConfig {
 /**
  * Configuration.
  */
-export interface NoseconeOptions {
+export interface Options {
   /**
    * Configure the `Content-Security-Policy` header, which helps mitigate a
    * large number of attacks, such as cross-site scripting.
@@ -370,6 +370,14 @@ export interface NoseconeOptions {
    */
   xXssProtection?: boolean;
 }
+
+/**
+ * Nosecone options.
+ *
+ * @deprecated
+ *   Use `Options` instead.
+ */
+export type NoseconeOptions = Options;
 
 /**
  * Map of configuration options to the kebab-case names for
@@ -907,7 +915,7 @@ export function createXssProtection() {
  * @returns
  *   `Headers` with the configured security headers.
  */
-export default function nosecone(options?: NoseconeOptions) {
+export default function nosecone(options?: Options) {
   let contentSecurityPolicy =
     options?.contentSecurityPolicy ?? defaults.contentSecurityPolicy;
   let crossOriginEmbedderPolicy =
@@ -1056,7 +1064,7 @@ export default function nosecone(options?: NoseconeOptions) {
  * @returns
  *   Augmented configuration to allow Vercel Toolbar
  */
-export function withVercelToolbar(config: NoseconeOptions) {
+export function withVercelToolbar(config: Options) {
   let contentSecurityPolicy = config.contentSecurityPolicy;
   if (contentSecurityPolicy === true) {
     contentSecurityPolicy = defaults.contentSecurityPolicy;


### PR DESCRIPTION
Admittedly pretty small.
But nosecone is a brand name.
A nice name.
But I don’t think it needs to be repeated as a prefix before its types. Or, in fact, once.
I think `Options` is fine for a module with one primary exported function.