### PR TITLE
refactor(redact): reuse exposed types

### DIFF
--- a/redact-wasm/index.ts
+++ b/redact-wasm/index.ts
@@ -1,10 +1,5 @@
 import { instantiate } from "./wasm/arcjet_analyze_bindings_redact.component.js";
-import type {
-  ImportObject,
-  RedactedSensitiveInfoEntity,
-  RedactSensitiveInfoConfig,
-  SensitiveInfoEntity,
-} from "./wasm/arcjet_analyze_bindings_redact.component.js";
+import type { ImportObject } from "./wasm/arcjet_analyze_bindings_redact.component.js";
 import type { ArcjetRedactCustomRedact } from "./wasm/interfaces/arcjet-redact-custom-redact.js";
 
 import { wasm as componentCoreWasm } from "./wasm/arcjet_analyze_bindings_redact.component.core.wasm?js";
@@ -66,7 +61,7 @@ export async function initializeWasm(
  * @returns
  *   Array of detected entities.
  */
-export type CustomDetect = typeof ArcjetRedactCustomRedact.detectSensitiveInfo;
+type CustomDetect = typeof ArcjetRedactCustomRedact.detectSensitiveInfo;
 
 /**
  * Redact sensitive info.
@@ -78,10 +73,10 @@ export type CustomDetect = typeof ArcjetRedactCustomRedact.detectSensitiveInfo;
  * @returns
  *   Redacted string.
  */
-export type CustomRedact = typeof ArcjetRedactCustomRedact.redactSensitiveInfo;
+type CustomRedact = typeof ArcjetRedactCustomRedact.redactSensitiveInfo;
 
-export {
-  type RedactedSensitiveInfoEntity,
-  type RedactSensitiveInfoConfig,
-  type SensitiveInfoEntity,
-};
+export type {
+  RedactedSensitiveInfoEntity,
+  RedactSensitiveInfoConfig,
+  SensitiveInfoEntity,
+} from "./wasm/arcjet_analyze_bindings_redact.component.js";


### PR DESCRIPTION
Some of the types from `@arcjet/redact-wasm` are not used anywhere. Other ones were redefined in `@arcjet/redact` itself. This commit removes the duplication and removes the (completely internal) unused API surface from `@arcjet/redact-wasm`.

Some of the exposed API surface did not specify return types either. This adds return types so that we can verify that the API matches what we want instead of returning arbitrary objects (with `const`s).