### PR TITLE
chore(headers): expose named export, deprecate default

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -10,7 +10,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -11,7 +11,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import type { Server } from "bun";
 import { env } from "bun";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -11,7 +11,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";

--- a/arcjet-fastify/index.ts
+++ b/arcjet-fastify/index.ts
@@ -5,7 +5,7 @@ import {
   logLevel,
   platform,
 } from "@arcjet/env";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 // TODO(@wooorm-arcjet): Expose `Cidr` from `@arcjet/ip`.
 import findIp, { parseProxy } from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -14,7 +14,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -19,7 +19,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -10,7 +10,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import type { Env } from "@arcjet/env";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -10,7 +10,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -10,7 +10,7 @@ import type {
   CharacteristicProps,
 } from "arcjet";
 import findIP, { parseProxy } from "@arcjet/ip";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { Logger } from "@arcjet/logger";
 import { createClient } from "@arcjet/protocol/client.js";

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -41,7 +41,7 @@ import type {
   EmailValidationConfig,
 } from "@arcjet/analyze";
 import * as duration from "@arcjet/duration";
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 import { runtime } from "@arcjet/runtime";
 import * as hasher from "@arcjet/stable-hash";
 import { MemoryCache } from "@arcjet/cache";

--- a/headers/README.md
+++ b/headers/README.md
@@ -44,7 +44,7 @@ npm install @arcjet/headers
 ## Use
 
 ```ts
-import ArcjetHeaders from "@arcjet/headers";
+import { ArcjetHeaders } from "@arcjet/headers";
 
 const headers = new ArcjetHeaders({ abc: "123" });
 

--- a/headers/index.ts
+++ b/headers/index.ts
@@ -15,7 +15,7 @@ function isIterable(val: any): val is Iterable<any> {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers)
  */
-export default class ArcjetHeaders extends Headers {
+export class ArcjetHeaders extends Headers {
   constructor(
     init?: HeadersInit | Record<string, string | string[] | undefined>,
   ) {
@@ -85,3 +85,9 @@ export default class ArcjetHeaders extends Headers {
     }
   }
 }
+
+/**
+ * @deprecated
+ *   Use the named export `ArcjetHeaders` instead.
+ */
+export default ArcjetHeaders;

--- a/headers/test/headers.test.ts
+++ b/headers/test/headers.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import ArcjetHeaders from "../index.js";
+import { ArcjetHeaders } from "../index.js";
 
 test("@arcjet/headers", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
-      // TODO(@wooorm-arcjet): use named exports.
+      "ArcjetHeaders",
       "default",
     ]);
   });


### PR DESCRIPTION
This commit adds a named export for `ArcjetHeaders`. The default export is still supported but deprecated.