### PR TITLE
chore(logger): rename `LoggerOptions` to `Options`

### DIFF
--- a/logger/index.ts
+++ b/logger/index.ts
@@ -25,12 +25,20 @@ export type LogLevel = "debug" | "info" | "warn" | "error";
 /**
  * Configuration.
  */
-export interface LoggerOptions {
+export interface Options {
   /**
    * Log level.
    */
   level: LogLevel;
 }
+
+/**
+ * Configuration.
+ *
+ * @deprecated
+ *   Use `Options` instead.
+ */
+export type LoggerOptions = Options;
 
 const PREFIX = "✦Aj";
 
@@ -94,7 +102,7 @@ export class Logger {
    * @returns
    *   Logger.
    */
-  constructor(options: LoggerOptions) {
+  constructor(options: Options) {
     if (typeof options.level !== "string") {
       throw new Error(`Invalid log level`);
     }


### PR DESCRIPTION
This removes the module name as a prefix from the type. Especially for modules that do one thing, which expose one primary class with one single configuration type,
I don’t think it is needed to prefix the configuration.

The old `LoggerOptions` name is still allowed but deprecated.