### PR TITLE
chore(sprintf): expose named export, deprecate default

### DIFF
--- a/sprintf/index.ts
+++ b/sprintf/index.ts
@@ -58,10 +58,7 @@ const LOWERCASE_S_CODE = 115; /* s */
  * @returns
  *   Formatted string.
  */
-export default function sprintf(
-  template: string,
-  ...values: unknown[]
-): string {
+export function sprintf(template: string, ...values: unknown[]): string {
   if (typeof template !== "string") {
     throw new TypeError("First argument must be a string");
   }
@@ -190,3 +187,11 @@ export default function sprintf(
 
   return output;
 }
+
+/**
+ * Format a string.
+ *
+ * @deprecated
+ *   Use `sprintf` instead.
+ */
+export default sprintf;

--- a/sprintf/test/index.test.ts
+++ b/sprintf/test/index.test.ts
@@ -4,8 +4,8 @@ import test from "node:test";
 test("@arcjet/sprintf", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
-      // TODO(@wooorm-arcjet): named exports.
       "default",
+      "sprintf",
     ]);
   });
 });


### PR DESCRIPTION
This commit adds a named export for `sprintf`.
The default export is still supported but deprecated.

Related-to: GH-4860.