### PR TITLE
chore(ip): expose named export, deprecate default

### DIFF
--- a/ip/index.ts
+++ b/ip/index.ts
@@ -804,7 +804,7 @@ function getHeader(headers: HeaderLike["headers"], headerKey: string) {
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-function findIp(
+export function findIp(
   request: RequestLike,
   options?: Options | null | undefined,
 ): string {
@@ -1025,4 +1025,10 @@ function findIp(
  */
 type Cidr = Ipv4Cidr | Ipv6Cidr;
 
+/**
+ * Find an IP address.
+ *
+ * @deprecated
+ *   Use the named export `findIp` instead.
+ */
 export default findIp;

--- a/ip/test/ip.test.ts
+++ b/ip/test/ip.test.ts
@@ -185,8 +185,8 @@ const cases: Array<Case> = [
 test("@arcjet/ip", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
-      // TODO(@wooorm-arcjet): use named exports.
       "default",
+      "findIp",
       "parseProxy",
     ]);
   });


### PR DESCRIPTION
This commit adds a named export for `findIp`.
The default export is still supported but deprecated.

Related-to: GH-4723.
Related-to: GH-4860.
Related-to: GH-4875.