### PR TITLE
feat(ip): expose `Cidr` type

### DIFF
--- a/ip/index.ts
+++ b/ip/index.ts
@@ -1023,6 +1023,6 @@ function findIp(
 /**
  * One of the CIDR ranges.
  */
-type Cidr = Ipv4Cidr | Ipv6Cidr;
+export type Cidr = Ipv4Cidr | Ipv6Cidr;
 
 export default findIp;


### PR DESCRIPTION
This exposes the `Cidr` type which is useful in other places, such as integrations.

Related-to: GH-4723.