### PR TITLE
chore(nosecone): expose named export, deprecate default

### DIFF
--- a/nosecone/index.ts
+++ b/nosecone/index.ts
@@ -943,7 +943,7 @@ export function createXssProtection() {
  * @returns
  *   `Headers` with the configured security headers.
  */
-export default function nosecone(options?: Options | undefined) {
+export function nosecone(options?: Options | undefined) {
   let contentSecurityPolicy =
     options?.contentSecurityPolicy ?? defaults.contentSecurityPolicy;
   let crossOriginEmbedderPolicy =
@@ -1079,6 +1079,14 @@ export default function nosecone(options?: Options | undefined) {
 
   return headers;
 }
+
+/**
+ * Create security headers.
+ *
+ * @deprecated
+ *   Use the named export `nosecone` instead.
+ */
+export default nosecone;
 
 /**
  * Augment some Nosecone configuration with the values necessary for using the

--- a/nosecone/test/nosecone.test.ts
+++ b/nosecone/test/nosecone.test.ts
@@ -46,10 +46,10 @@ test("nosecone", async function (t) {
       "createReferrerPolicy",
       "createStrictTransportSecurity",
       "createXssProtection",
-      // TODO(@wooorm-arcjet): use named exports.
       "default",
       // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
       "defaults",
+      "nosecone",
       "withVercelToolbar",
     ]);
   });


### PR DESCRIPTION
This commit adds a named export for `nosecone`.
The default export is still supported but deprecated.

Related-to: GH-4860.
Related-to: GH-4875.
Related-to: GH-4876.