### PR TITLE
chore(nosecone-next): expose named export, deprecate default

### DIFF
--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -27,7 +27,14 @@ export const defaults = {
   },
 } as const;
 
-// We export `nosecone` as the default so it can be used with `new Response()`
+export { nosecone };
+
+/**
+ * Create security headers.
+ *
+ * @deprecated
+ *   Use the named export `nosecone` instead.
+ */
 export default nosecone;
 
 function nonce() {

--- a/nosecone-next/test/index.test.ts
+++ b/nosecone-next/test/index.test.ts
@@ -5,10 +5,10 @@ test("@nosecone/next", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
       "createMiddleware",
-      // TODO(@wooorm-arcjet): use named exports.
       "default",
       // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
       "defaults",
+      "nosecone",
       "withVercelToolbar",
     ]);
   });


### PR DESCRIPTION
This commit adds a named export for `nosecone`.
The default export is still supported but deprecated.

Related-to: GH-4723.
Related-to: GH-4860.
Related-to: GH-4875.
Related-to: GH-4878.