### PR TITLE
chore(nosecone-sveltekit): expose named export, deprecate default

### DIFF
--- a/nosecone-sveltekit/index.ts
+++ b/nosecone-sveltekit/index.ts
@@ -24,7 +24,14 @@ export const defaults = {
   },
 } as const;
 
-// We export `nosecone` as the default so it can be used with `new Response()`
+export { nosecone };
+
+/**
+ * Create security headers.
+ *
+ * @deprecated
+ *   Use the named export `nosecone` instead.
+ */
 export default nosecone;
 
 /**

--- a/nosecone-sveltekit/test/index.test.ts
+++ b/nosecone-sveltekit/test/index.test.ts
@@ -6,10 +6,10 @@ test("@nosecone/sveltekit", async function (t) {
     assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
       "createHook",
       "csp",
-      // TODO(@wooorm-arcjet): use named exports.
       "default",
       // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
       "defaults",
+      "nosecone",
       "withVercelToolbar",
     ]);
   });


### PR DESCRIPTION
This commit adds a named export for `nosecone`.
The default export is still supported but deprecated.

Related-to: GH-4723.
Related-to: GH-4860.
Related-to: GH-4875.
Related-to: GH-4878.
Related-to: GH-4879.