### PR TITLE
refactor(redact)!: improve types around custom entities

### DIFF
--- a/redact/test/index.test.ts
+++ b/redact/test/index.test.ts
@@ -82,6 +82,23 @@ describe("ArcjetRedact", () => {
     test("it will use a custom replacement where configured", async () => {
       const text = "email test@example.com phone 011234567 ip 10.12.234.2";
       const expected =
+        "email redacted-email phone <Redacted phone number #1> ip <Redacted IP address #2>";
+      const [redacted] = await redact(text, {
+        replace: (entityType, plaintext) => {
+          if (entityType === "email") {
+            assert.equal(plaintext, "test@example.com");
+            return "redacted-email";
+          } else if (entityType === "ip-address") {
+            assert.equal(plaintext, "10.12.234.2");
+          }
+        },
+      });
+      assert.equal(redacted, expected);
+    });
+
+    test("it will use a custom replacement where configured w/ `entities`", async () => {
+      const text = "email test@example.com phone 011234567 ip 10.12.234.2";
+      const expected =
         "email redacted-email phone 011234567 ip <Redacted IP address #1>";
       const [redacted] = await redact(text, {
         entities: ["email", "ip-address"],
@@ -115,6 +132,23 @@ describe("ArcjetRedact", () => {
     });
 
     test("it can detect entities using a custom detect function", async () => {
+      const text = "email test@example.com phone 011234567 ip 10.12.234.2";
+      const expected =
+        "email <Redacted email #0> <Redacted my-custom-entity #1> <Redacted phone number #2> ip <Redacted IP address #3>";
+      const [redacted] = await redact(text, {
+        contextWindowSize: 1,
+        detect: (tokens: string[]) => {
+          if (tokens[0] === "phone") {
+            return ["my-custom-entity"];
+          } else {
+            return [];
+          }
+        },
+      });
+      assert.equal(redacted, expected);
+    });
+
+    test("it can detect entities using a custom detect function w/ `entities`", async () => {
       const text = "email test@example.com phone 011234567 ip 10.12.234.2";
       const expected =
         "email test@example.com <Redacted my-custom-entity #0> 011234567 ip 10.12.234.2";

--- a/redact/test/index.test.ts
+++ b/redact/test/index.test.ts
@@ -201,7 +201,7 @@ describe("ArcjetRedact", () => {
       assert.equal(unredacted, expectedUnredacted);
     });
 
-    test("it will redact and unredact custom entities", async () => {
+    test("it will redact and unredact custom `detect` functions", async () => {
       const text = "email test@example.com phone 011234567 ip 10.12.234.2";
       const expectedRedacted =
         "email my-custom-email-replacement phone <Redacted phone number #1> ip 10.12.234.2";
@@ -211,8 +211,14 @@ describe("ArcjetRedact", () => {
           if (entityType === "email") {
             assert.equal(plaintext, "test@example.com");
             return "my-custom-email-replacement";
-          } else if (entityType === "ip-address") {
-            assert.equal(plaintext, "10.12.234.2");
+          }
+          // @ts-expect-error: this type error is expected because `ip-address` is not listed in `entities` above.
+          else if (entityType === "ip-address") {
+            assert.fail();
+          } else if (entityType === "phone-number") {
+            assert.equal(plaintext, "011234567");
+            // No return type to test for the default.
+            return undefined;
           }
         },
       });


### PR DESCRIPTION
The `redact` function accepts two type parameters.
The second type parameter `CustomEntities` is not used. Looking at the tests (or the examples in #4982). It is always `string`. Never something more specific.
The first type parameter, `Detect`, is an entire function, whose variadic part is that unused `CustomEntities`.
Still, it is accepted as a `const` and used in `RedactOptions`, where it does work to influence the `entities` and `replace` options.
However, it is not *needed* to put an entire function into a type parameter, if only a small part is variadic. This is not a real issue. Just a tiny bit smelly.

Still, there are some cases where type errors happen for valid use cases. This PR changes the type parameters and internal code to allow these valid use cases. With tests.

Closes GH-4982.