### PR TITLE
chore(protocol): `latitude` and `longitude` exist together

### DIFF
--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -878,23 +878,29 @@ export class ArcjetIpDetails {
 
   /**
    * Check if the IP address has geo `latitude` info.
-   * This also implies that `accuracyRadius` is available.
+   * This also implies that `accuracyRadius` and `longitude` are available.
    *
    * @returns
    *   Whether the IP address has latitude info.
    */
-  hasLatitude(): this is RequiredProps<this, "latitude" | "accuracyRadius"> {
+  hasLatitude(): this is RequiredProps<
+    this,
+    "accuracyRadius" | "latitude" | "longitude"
+  > {
     return typeof this.latitude !== "undefined";
   }
 
   /**
    * Check if the IP address has geo `longitude` info.
-   * This also implies that `accuracyRadius` is available.
+   * This also implies that `accuracyRadius` and `latitude` are available.
    *
    * @returns
    *   Whether the IP address has longitude info.
    */
-  hasLongitude(): this is RequiredProps<this, "longitude" | "accuracyRadius"> {
+  hasLongitude(): this is RequiredProps<
+    this,
+    "accuracyRadius" | "latitude" | "longitude"
+  > {
     return typeof this.longitude !== "undefined";
   }
 


### PR DESCRIPTION
While reading through this, I assumed this was a bug. I cannot imagine a `latitude` (and `accuracyRadius`) to exist but no `longitude`, and inverse?
Especially because these *are* checking for `accuracyRadius`, and there is also a `hasAccuracyRadius` which *does* have a predicate that if it exists,
both `latitude` and `longitude` exist too.

This is also what I saw in the data,
though I have not seen too much data.