### PR TITLE
test(protocol): add type guard tests for `ArcjetIpDetails`

### DIFF
--- a/protocol/test/ip-details.ts
+++ b/protocol/test/ip-details.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ArcjetIpDetails } from "../index.js";
+
+test("ArcjetIpDetails", async function (t) {
+  await t.test("hasASN", function () {
+    const details = createIpDetails();
+
+    if (details.hasASN()) {
+      const asnCountry_: string = details.asnCountry;
+      const asnDomain_: string = details.asnDomain;
+      const asnName_: string = details.asnName;
+      const asnType_: string = details.asnType;
+      const asn_: string = details.asn;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasAccuracyRadius", function () {
+    const details = createIpDetails();
+
+    if (details.hasAccuracyRadius()) {
+      const accuracyRadius_: number = details.accuracyRadius;
+      const latitude_: number = details.latitude;
+      const longitude_: number = details.longitude;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasCity", function () {
+    const details = createIpDetails();
+
+    if (details.hasCity()) {
+      const city_: string = details.city;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasContintent", function () {
+    const details = createIpDetails();
+
+    if (details.hasContintent()) {
+      const continentName_: string = details.continentName;
+      const continent_: string = details.continent;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasCountry", function () {
+    const details = createIpDetails();
+
+    if (details.hasCountry()) {
+      const countryName_: string = details.countryName;
+      const country_: string = details.country;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasLatitude", function () {
+    const details = createIpDetails();
+
+    if (details.hasLatitude()) {
+      const accuracyRadius_: number = details.accuracyRadius;
+      const latitude_: number = details.latitude;
+      // TODO(#4884): fix.
+      const longitude_: number | undefined = details.longitude;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasLongitude", function () {
+    const details = createIpDetails();
+
+    if (details.hasLongitude()) {
+      const accuracyRadius_: number = details.accuracyRadius;
+      // TODO(#4884): fix.
+      const latitude_: number | undefined = details.latitude;
+      const longitude_: number = details.longitude;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasPostalCode", function () {
+    const details = createIpDetails();
+
+    if (details.hasPostalCode()) {
+      const postalCode_: string = details.postalCode;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasRegion", function () {
+    const details = createIpDetails();
+
+    if (details.hasRegion()) {
+      const region_: string = details.region;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasService", function () {
+    const details = createIpDetails();
+
+    // Not defined on our example.
+    if (details.hasService()) {
+      assert.fail();
+    }
+  });
+
+  await t.test("hasTimezone", function () {
+    const details = createIpDetails();
+
+    if (details.hasTimezone()) {
+      const timezone_: string = details.timezone;
+    } else {
+      assert.fail();
+    }
+  });
+
+  await t.test("isHosting", function () {
+    const details = createIpDetails();
+    assert.equal(details.isHosting(), false);
+  });
+
+  await t.test("isProxy", function () {
+    const details = createIpDetails();
+    assert.equal(details.isProxy(), false);
+  });
+
+  await t.test("isRelay", function () {
+    const details = createIpDetails();
+    assert.equal(details.isRelay(), false);
+  });
+
+  await t.test("isTor", function () {
+    const details = createIpDetails();
+    assert.equal(details.isTor(), false);
+  });
+
+  await t.test("isVpn", function () {
+    const details = createIpDetails();
+    assert.equal(details.isVpn(), false);
+  });
+});
+
+function createIpDetails(): ArcjetIpDetails {
+  // Example from an IP by GH: `185.199.108.153`.
+  return new ArcjetIpDetails({
+    accuracyRadius: 2,
+    asnName: "Fastly, Inc.",
+    asnDomain: "fastly.com",
+    asn: "54113",
+    city: "Uniontown",
+    continentName: "North America",
+    continent: "NA",
+    countryName: "United States",
+    country: "US",
+    isHosting: false,
+    isProxy: false,
+    isRelay: false,
+    isTor: false,
+    isVpn: false,
+    latitude: 39.90008,
+    longitude: -79.71643,
+    postalCode: "15472",
+    region: "Pennsylvania",
+    service: undefined,
+    timezone: "America/New_York",
+  });
+}

--- a/protocol/test/protocol.test.ts
+++ b/protocol/test/protocol.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ArcjetIpDetails, ArcjetReason, ArcjetRuleResult } from "../index.js";
-import { IpDetails } from "../proto/decide/v1alpha1/decide_pb.js";
+import { ArcjetReason, ArcjetRuleResult } from "../index.js";
 
 test("@arcjet/protocol", async function (t) {
   await t.test("should expose the public api", async function () {
@@ -46,93 +45,6 @@ test("protocol", async (t) => {
       });
 
       assert.equal(result.isDenied(), false);
-    });
-  });
-
-  await t.test("ArcjetIpDetails", async (t) => {
-    const ipDetails = new ArcjetIpDetails(
-      new IpDetails({
-        asnCountry: "a",
-        asnDomain: "b",
-        asnName: "c",
-        asnType: "d",
-        asn: "e",
-        city: "f",
-        continentName: "g",
-        continent: "h",
-        countryName: "i",
-        country: "j",
-        latitude: 40.7127,
-        longitude: 74.0059,
-        postalCode: "k",
-        region: "l",
-        service: "m",
-        timezone: "America/New_York",
-      }),
-    );
-
-    await t.test("hasASN", () => {
-      assert.equal(ipDetails.hasASN(), true);
-    });
-
-    await t.test("hasAccuracyRadius", () => {
-      assert.equal(ipDetails.hasAccuracyRadius(), true);
-    });
-
-    await t.test("hasCity", () => {
-      assert.equal(ipDetails.hasCity(), true);
-    });
-
-    await t.test("hasContintent", () => {
-      assert.equal(ipDetails.hasContintent(), true);
-    });
-
-    await t.test("hasCountry", () => {
-      assert.equal(ipDetails.hasCountry(), true);
-    });
-
-    await t.test("hasLatitude", () => {
-      assert.equal(ipDetails.hasLatitude(), true);
-    });
-
-    await t.test("hasLongitude", () => {
-      assert.equal(ipDetails.hasLongitude(), true);
-    });
-
-    await t.test("hasPostalCode", () => {
-      assert.equal(ipDetails.hasPostalCode(), true);
-    });
-
-    await t.test("hasRegion", () => {
-      assert.equal(ipDetails.hasRegion(), true);
-    });
-
-    await t.test("hasService", () => {
-      assert.equal(ipDetails.hasService(), true);
-    });
-
-    await t.test("hasTimezone", () => {
-      assert.equal(ipDetails.hasTimezone(), true);
-    });
-
-    await t.test("isHosting", () => {
-      assert.equal(ipDetails.isHosting(), false);
-    });
-
-    await t.test("isProxy", () => {
-      assert.equal(ipDetails.isProxy(), false);
-    });
-
-    await t.test("isRelay", () => {
-      assert.equal(ipDetails.isRelay(), false);
-    });
-
-    await t.test("isTor", () => {
-      assert.equal(ipDetails.isTor(), false);
-    });
-
-    await t.test("isVpn", () => {
-      assert.equal(ipDetails.isVpn(), false);
     });
   });
 });


### PR DESCRIPTION
This commit adds real data to tests of the `ArcjetIpDetails` class.
It also adds tests for whether the type system guards.

Related-to: GH-4859.