### PR TITLE
fix(protocol): Remove change that disjoined IP details and assertions (#4859)

### DIFF
--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -8,7 +8,9 @@ export type * from "./well-known-bots.js";
 // Re-export the Bot categories from the generated file
 export { categories as botCategories } from "./well-known-bots.js";
 
-type RequiredProps<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
+type RequiredProps<T, K extends keyof T> = {
+  [P in K]-?: Exclude<T[P], undefined>;
+};
 
 /**
  * Mode of a rule.

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -8,6 +8,8 @@ export type * from "./well-known-bots.js";
 // Re-export the Bot categories from the generated file
 export { categories as botCategories } from "./well-known-bots.js";
 
+type RequiredProps<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
+
 /**
  * Mode of a rule.
  */
@@ -1034,7 +1036,7 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has latitude info.
    */
-  hasLatitude(): this is { accuracyRadius: number; latitude: number } {
+  hasLatitude(): this is RequiredProps<this, "latitude" | "accuracyRadius"> {
     return typeof this.latitude !== "undefined";
   }
 
@@ -1045,7 +1047,7 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has longitude info.
    */
-  hasLongitude(): this is { accuracyRadius: number; longitude: number } {
+  hasLongitude(): this is RequiredProps<this, "longitude" | "accuracyRadius"> {
     return typeof this.longitude !== "undefined";
   }
 
@@ -1056,11 +1058,10 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has accuracy info.
    */
-  hasAccuracyRadius(): this is {
-    accuracyRadius: number;
-    latitude: number;
-    longitude: number;
-  } {
+  hasAccuracyRadius(): this is RequiredProps<
+    this,
+    "latitude" | "longitude" | "accuracyRadius"
+  > {
     return typeof this.accuracyRadius !== "undefined";
   }
 
@@ -1070,7 +1071,7 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has timezone info.
    */
-  hasTimezone(): this is { timezone: string } {
+  hasTimezone(): this is RequiredProps<this, "timezone"> {
     return typeof this.timezone !== "undefined";
   }
 
@@ -1080,7 +1081,7 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has postcal code info.
    */
-  hasPostalCode(): this is { postalCode: string } {
+  hasPostalCode(): this is RequiredProps<this, "postalCode"> {
     return typeof this.postalCode !== "undefined";
   }
 
@@ -1091,7 +1092,7 @@ export class ArcjetIpDetails {
    *   Whether the IP address has city info.
    */
   // TODO: If we have city, what other data are we sure to have?
-  hasCity(): this is { city: string } {
+  hasCity(): this is RequiredProps<this, "city"> {
     return typeof this.city !== "undefined";
   }
 
@@ -1102,7 +1103,7 @@ export class ArcjetIpDetails {
    *   Whether the IP address has region info.
    */
   // TODO: If we have region, what other data are we sure to have?
-  hasRegion(): this is { region: string } {
+  hasRegion(): this is RequiredProps<this, "region"> {
     return typeof this.region !== "undefined";
   }
 
@@ -1114,7 +1115,7 @@ export class ArcjetIpDetails {
    *   Whether the IP address has country info.
    */
   // TODO: If we have country, should we also have continent?
-  hasCountry(): this is { countryName: string; country: string } {
+  hasCountry(): this is RequiredProps<this, "country" | "countryName"> {
     return typeof this.country !== "undefined";
   }
 
@@ -1125,7 +1126,7 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has continent info.
    */
-  hasContintent(): this is { continentName: string; continent: string } {
+  hasContintent(): this is RequiredProps<this, "continent" | "continentName"> {
     return typeof this.continent !== "undefined";
   }
 
@@ -1138,13 +1139,10 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has ASN info.
    */
-  hasASN(): this is {
-    asnCountry: string;
-    asnDomain: string;
-    asnName: string;
-    asnType: string;
-    asn: string;
-  } {
+  hasASN(): this is RequiredProps<
+    this,
+    "asn" | "asnName" | "asnDomain" | "asnType" | "asnCountry"
+  > {
     return this.hasAsn();
   }
 
@@ -1155,13 +1153,10 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has ASN info.
    */
-  hasAsn(): this is {
-    asnCountry: string;
-    asnDomain: string;
-    asnName: string;
-    asnType: string;
-    asn: string;
-  } {
+  hasAsn(): this is RequiredProps<
+    this,
+    "asn" | "asnName" | "asnDomain" | "asnType" | "asnCountry"
+  > {
     return typeof this.asn !== "undefined";
   }
 
@@ -1171,7 +1166,7 @@ export class ArcjetIpDetails {
    * @returns
    *   Whether the IP address has a service.
    */
-  hasService(): this is { service: string } {
+  hasService(): this is RequiredProps<this, "service"> {
     return typeof this.service !== "undefined";
   }
 


### PR DESCRIPTION
This reverts commit 0a638ae8e2d680fbe3c33556f3011f4ad733f5ad.

As stated at https://github.com/arcjet/arcjet-js/pull/4859#issuecomment-3181025930, this change made the assertions disjoint from the initial definition. This means that a change in the definition is not reflected in TypeScript failing.