### PR TITLE
fix: support passing `ip` to `protect` in more integrations

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -146,6 +146,19 @@ export type ArcjetOptions<
 >;
 
 /**
+ * Request object that also supports overriding IP addressess for Arcjet’s IP
+ * geolocation and VPN and proxy detection.
+ *
+ * @link https://docs.arcjet.com/troubleshooting#override-development-ip
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * The IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * The ArcjetAstro client provides a public `protect()` method to
  * make a decision about how an Astro request should be handled.
  */
@@ -160,7 +173,7 @@ export interface ArcjetAstro<Props extends PlainObject> {
    * @returns An {@link ArcjetDecision} indicating Arcjet's decision about the request.
    */
   protect(
-    request: Request,
+    request: RequestWithIp,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
     ...props: Props extends WithoutCustomProps ? [] : [Props]
@@ -213,7 +226,7 @@ export function createArcjetClient<
   }
 
   function toArcjetRequest<Props extends PlainObject>(
-    request: Request,
+    request: RequestWithIp,
     props: Props,
   ): ArcjetRequest<Props> {
     const clientAddress = Reflect.get(request, ipSymbol);
@@ -229,7 +242,7 @@ export function createArcjetClient<
     const url = new URL(request.url);
     let ip = findIp(
       {
-        ip: clientAddress,
+        ip: request.ip || clientAddress,
         headers,
       },
       { platform: platform(env), proxies },
@@ -268,7 +281,7 @@ export function createArcjetClient<
         return withClient(client);
       },
       async protect(
-        request: Request,
+        request: RequestWithIp,
         ...[props]: ExtraProps<Rules> extends WithoutCustomProps
           ? []
           : [ExtraProps<Rules>]

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -124,6 +124,19 @@ export type ArcjetOptions<
 >;
 
 /**
+ * Request object that also supports overriding IP addressess for Arcjet’s IP
+ * geolocation and VPN and proxy detection.
+ *
+ * @link https://docs.arcjet.com/troubleshooting#override-development-ip
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * The IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * The ArcjetBun client provides a public `protect()` method to
  * make a decision about how a Bun.sh request should be handled.
  */
@@ -138,7 +151,7 @@ export interface ArcjetBun<Props extends PlainObject> {
    * @returns An {@link ArcjetDecision} indicating Arcjet's decision about the request.
    */
   protect(
-    request: Request,
+    request: RequestWithIp,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
     ...props: Props extends WithoutCustomProps ? [] : [Props]
@@ -195,7 +208,7 @@ export default function arcjet<
   // Assuming the `handler()` function was used around Bun's fetch handler this
   // WeakMap should be populated with IP addresses inspected via
   // `server.requestIP()`
-  const ipCache = new WeakMap<Request, string>();
+  const ipCache = new WeakMap<RequestWithIp, string>();
 
   const log = options.log
     ? options.log
@@ -214,7 +227,7 @@ export default function arcjet<
   }
 
   function toArcjetRequest<Props extends PlainObject>(
-    request: Request,
+    request: RequestWithIp,
     props: Props,
   ): ArcjetRequest<Props> {
     const cookies = request.headers.get("cookie") ?? undefined;
@@ -228,7 +241,7 @@ export default function arcjet<
         // This attempts to lookup the IP in the `ipCache`. This is primarily a
         // workaround to the API design in Bun that requires access to the
         // `Server` to lookup an IP.
-        ip: ipCache.get(request),
+        ip: request.ip || ipCache.get(request),
         headers,
       },
       { platform: platform(env), proxies },
@@ -267,7 +280,7 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(
-        request: Request,
+        request: RequestWithIp,
         ...[props]: ExtraProps<Rules> extends WithoutCustomProps
           ? []
           : [ExtraProps<Rules>]

--- a/arcjet-fastify/index.ts
+++ b/arcjet-fastify/index.ts
@@ -300,7 +300,7 @@ function toArcjetRequest<Properties extends PlainObject>(
   const headers = new ArcjetHeaders(requestHeaders);
 
   let ip = findIp(
-    { headers, socket: request.socket },
+    { headers, ip: request.ip, socket: request.socket },
     { platform: platform(process.env), proxies },
   );
 

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -146,8 +146,17 @@ type EventHandlerLike = (
 
 // Interface of fields that the Arcjet Node.js SDK expects on `IncomingMessage`
 // objects.
+//
+// Also supports overriding IP addressess for Arcjet’s IP geolocation and VPN
+// and proxy detection.
+//
+// See: <https://docs.arcjet.com/troubleshooting#override-development-ip>.
 export interface ArcjetNodeRequest {
   headers?: Record<string, string | string[] | undefined>;
+  /**
+   * The IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
   socket?: Partial<{ remoteAddress: string; encrypted: boolean }>;
   method?: string;
   httpVersion?: string;
@@ -267,6 +276,7 @@ export default function arcjet<
 
     let ip = findIp(
       {
+        ip: request.ip,
         socket: request.socket,
         headers,
       },


### PR DESCRIPTION
This adds support in types and in actual code for passing `ip` in `request` to `protect`.
This applies to the astro, bun, deno, fastify, and node integrations. The nest and next integrations already support this. Remix and Sveltekit have custom ways to pass IPs in and do not receive a regular `request` so I left them as-is.

This method is documented on the website at: <https://docs.arcjet.com/troubleshooting#override-development-ip>.

Closes GH-4808.