### PR TITLE
fix(arcjet): do not deny a dry run

### DIFF
--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -1403,7 +1403,7 @@ export function sensitiveInfo<
           fingerprint,
           ttl: 0,
           state,
-          conclusion: "DENY",
+          conclusion: state === "DRY_RUN" ? "ALLOW" : "DENY",
           reason,
         });
       }
@@ -1614,7 +1614,7 @@ export function validateEmail(
           fingerprint,
           ttl: 0,
           state,
-          conclusion: "DENY",
+          conclusion: state === "DRY_RUN" ? "ALLOW" : "DENY",
           reason: new ArcjetEmailReason({
             emailTypes: typedEmailTypes,
           }),
@@ -1823,7 +1823,7 @@ export function detectBot(options: BotOptions): Primitive<{}> {
           fingerprint,
           ttl: 60,
           state,
-          conclusion: "DENY",
+          conclusion: state === "DRY_RUN" ? "ALLOW" : "DENY",
           reason: new ArcjetBotReason({
             allowed: result.allowed,
             denied: result.denied,

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -572,7 +572,7 @@ describe("Primitive > detectBot", () => {
     });
     assert.equal(rule.type, "BOT");
     const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
+    assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetBotReason);
     assert.deepEqual(result.reason.allowed, []);
     assert.deepEqual(result.reason.denied, ["CURL"]);
@@ -1628,7 +1628,7 @@ describe("Primitive > validateEmail", () => {
     const [rule] = validateEmail({ mode: "DRY_RUN", allow: [] });
     assert.equal(rule.type, "EMAIL");
     const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
+    assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetEmailReason);
     assert.deepEqual(result.reason.emailTypes, ["INVALID"]);
     assert.equal(result.state, "DRY_RUN");
@@ -2210,7 +2210,7 @@ describe("Primitive > sensitiveInfo", () => {
     });
     assert.equal(rule.type, "SENSITIVE_INFO");
     const result = await rule.protect(context, details);
-    assert.equal(result.conclusion, "DENY");
+    assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetSensitiveInfoReason);
     assert.deepEqual(result.reason.allowed, []);
     assert.deepEqual(result.reason.denied, [


### PR DESCRIPTION
The local bot, email, and sensitive info rules can return a deny. Regardless of whether `mode` is `"DRY_RUN"`.
That should not happen.

Closes GH-4561.