### PR TITLE
feat(env): Support trailing slashes on ARCJET_BASE_URL

### DIFF
--- a/env/index.ts
+++ b/env/index.ts
@@ -117,6 +117,12 @@ const baseUrlAllowed = [
   "https://fly.decide.arcjet.com",
   "https://fly.decide.arcjettest.com",
   "https://decide.arcjet.orb.local",
+  // Allow trailing slashes
+  "https://decide.arcjet.com/",
+  "https://decide.arcjettest.com/",
+  "https://fly.decide.arcjet.com/",
+  "https://fly.decide.arcjettest.com/",
+  "https://decide.arcjet.orb.local/",
 ];
 
 /**

--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -102,6 +102,38 @@ describe("env", () => {
       env.baseUrl({ FLY_APP_NAME: "foobar" }),
       "https://fly.decide.arcjet.com",
     );
+
+    // Trailing slash.
+    assert.equal(
+      env.baseUrl({
+        ARCJET_BASE_URL: "https://decide.arcjet.com/",
+      }),
+      "https://decide.arcjet.com/",
+    );
+    assert.equal(
+      env.baseUrl({
+        ARCJET_BASE_URL: "https://decide.arcjettest.com/",
+      }),
+      "https://decide.arcjettest.com/",
+    );
+    assert.equal(
+      env.baseUrl({
+        ARCJET_BASE_URL: "https://fly.decide.arcjet.com/",
+      }),
+      "https://fly.decide.arcjet.com/",
+    );
+    assert.equal(
+      env.baseUrl({
+        ARCJET_BASE_URL: "https://fly.decide.arcjettest.com/",
+      }),
+      "https://fly.decide.arcjettest.com/",
+    );
+    assert.equal(
+      env.baseUrl({
+        ARCJET_BASE_URL: "https://decide.arcjet.orb.local/",
+      }),
+      "https://decide.arcjet.orb.local/",
+    );
   });
 
   test("apiKey", () => {


### PR DESCRIPTION
Closes #4984

Alternative to #4981

I prefer less moving parts and am hesitant to normalize the environment variable the user gives us (instead deferring that to Connect RPC). Given that, I'd rather we enumerate all the URLs that we support with and without a trailing slash.