### PR TITLE
chore(example): Update Gatsby overrides

### DIFF
--- a/examples/gatsby-rate-limit/package-lock.json
+++ b/examples/gatsby-rate-limit/package-lock.json
@@ -8939,18 +8939,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -13092,15 +13080,6 @@
       "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.0.tgz",
       "integrity": "sha512-IQh2aMfMIDbPjI/8a3Edr+PiOpcsB7yo8NdW7aHWVaoR/pcDldunMvnnwbk/auPGqmKeAdxtZl7MHX/QmPwhvQ==",
       "license": "MIT"
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/own-keys": {
       "version": "1.0.1",

--- a/examples/gatsby-rate-limit/package.json
+++ b/examples/gatsby-rate-limit/package.json
@@ -28,7 +28,6 @@
   },
   "overrides": {
     "cookie": "^0.7.1",
-    "multer": "^2.0.0",
-    "path-to-regexp": "0.1.12"
+    "tmp": "0.2.5"
   }
 }


### PR DESCRIPTION
Overriding `tmp` deep in the Gatsby dependency tree to resolve https://github.com/arcjet/arcjet-js/security/dependabot/453

I also cleaned up the overrides since Gatsby updated some dependency ranges.