### PR TITLE
refactor: simplify `withClient` types in adapters

### DIFF
--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -165,7 +165,7 @@ export interface ArcjetDeno<Props extends PlainObject> {
    * @param request
    *   Details about the {@linkcode Request} that Arcjet needs to make a
    *   decision.
-   * @param props
+   * @param rest
    *   Additional properties required for running rules against a request.
    * @returns
    *   Promise that resolves to an {@linkcode ArcjetDecision} indicating
@@ -175,7 +175,7 @@ export interface ArcjetDeno<Props extends PlainObject> {
     request: Request,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
-    ...props: Props extends WithoutCustomProps ? [] : [Props]
+    ...rest: Props extends WithoutCustomProps ? [] : [Props]
   ): Promise<ArcjetDecision>;
 
   /**
@@ -306,26 +306,18 @@ export default function arcjet<
     };
   }
 
-  function withClient<const Rules extends (Primitive | Product)[]>(
-    aj: Arcjet<ExtraProps<Rules>>,
-  ): ArcjetDeno<ExtraProps<Rules>> {
-    return Object.freeze({
-      withRule(rule: Primitive | Product) {
+  function withClient<Props extends PlainObject>(
+    aj: Arcjet<Props>,
+  ): ArcjetDeno<Props> {
+    const client: ArcjetDeno<Props> = {
+      withRule(rule) {
         const client = aj.withRule(rule);
         return withClient(client);
       },
-      async protect(
-        request: Request,
-        ...[props]: ExtraProps<Rules> extends WithoutCustomProps
-          ? []
-          : [ExtraProps<Rules>]
-      ): Promise<ArcjetDecision> {
-        // TODO(#220): The generic manipulations get really mad here, so we cast
-        // Further investigation makes it seem like it has something to do with
-        // the definition of `props` in the signature but it's hard to track down
-        const req = toArcjetRequest(request, props ?? {}) as ArcjetRequest<
-          ExtraProps<Rules>
-        >;
+      async protect(request, props?) {
+        // Cast of `{}` because here we switch from `undefined` (or
+        // `WithoutCustomProps`) to `Props`.
+        const req = toArcjetRequest(request, props ?? ({} as Props));
 
         const getBody = async () => {
           try {
@@ -362,7 +354,9 @@ export default function arcjet<
           return fn(request, info);
         };
       },
-    });
+    };
+
+    return Object.freeze(client);
   }
 
   const aj = core({ ...options, client, log });

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -325,7 +325,7 @@ export interface ArcjetNext<Props extends PlainObject> {
    * @param request
    *   Details about the {@linkcode ArcjetNextRequest} that Arcjet needs to make a
    *   decision.
-   * @param props
+   * @param rest
    *   Additional properties required for running rules against a request.
    *   Whether this is required depends on the rules you've configured.
    * @returns
@@ -430,7 +430,7 @@ export interface ArcjetNext<Props extends PlainObject> {
     request: ArcjetNextRequest,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
-    ...props: Props extends WithoutCustomProps ? [] : [Props]
+    ...rest: Props extends WithoutCustomProps ? [] : [Props]
   ): Promise<ArcjetDecision>;
 
   /**
@@ -652,26 +652,18 @@ export default function arcjet<
     };
   }
 
-  function withClient<const Rules extends (Primitive | Product)[]>(
-    aj: Arcjet<ExtraProps<Rules>>,
-  ): ArcjetNext<ExtraProps<Rules>> {
-    return Object.freeze({
-      withRule(rule: Primitive | Product) {
+  function withClient<Props extends PlainObject>(
+    aj: Arcjet<Props>,
+  ): ArcjetNext<Props> {
+    const client: ArcjetNext<Props> = {
+      withRule(rule) {
         const client = aj.withRule(rule);
         return withClient(client);
       },
-      async protect(
-        request: ArcjetNextRequest,
-        ...[props]: ExtraProps<Rules> extends WithoutCustomProps
-          ? []
-          : [ExtraProps<Rules>]
-      ): Promise<ArcjetDecision> {
-        // TODO(#220): The generic manipulations get really mad here, so we cast
-        // Further investigation makes it seem like it has something to do with
-        // the definition of `props` in the signature but it's hard to track down
-        const req = toArcjetRequest(request, props ?? {}) as ArcjetRequest<
-          ExtraProps<Rules>
-        >;
+      async protect(request, props?) {
+        // Cast of `{}` because here we switch from `undefined` (or
+        // `WithoutCustomProps`) to `Props`.
+        const req = toArcjetRequest(request, props ?? ({} as Props));
 
         const getBody = async () => {
           try {
@@ -704,7 +696,9 @@ export default function arcjet<
 
         return aj.protect({ getBody }, req);
       },
-    });
+    };
+
+    return Object.freeze(client);
   }
 
   const aj = core({ ...options, client, log });

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -283,7 +283,7 @@ export interface ArcjetNode<Props extends PlainObject> {
    * @param request
    *   Details about the {@linkcode ArcjetNodeRequest} that Arcjet needs to make a
    *   decision.
-   * @param props
+   * @param rest
    *   Additional properties required for running rules against a request.
    * @returns
    *   Promise that resolves to an {@linkcode ArcjetDecision} indicating
@@ -293,7 +293,7 @@ export interface ArcjetNode<Props extends PlainObject> {
     request: ArcjetNodeRequest,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
-    ...props: Props extends WithoutCustomProps ? [] : [Props]
+    ...rest: Props extends WithoutCustomProps ? [] : [Props]
   ): Promise<ArcjetDecision>;
 
   /**
@@ -432,26 +432,18 @@ export default function arcjet<
     };
   }
 
-  function withClient<const Rules extends (Primitive | Product)[]>(
-    aj: Arcjet<ExtraProps<Rules>>,
-  ): ArcjetNode<ExtraProps<Rules>> {
-    return Object.freeze({
-      withRule(rule: Primitive | Product) {
+  function withClient<Props extends PlainObject>(
+    aj: Arcjet<Props>,
+  ): ArcjetNode<Props> {
+    const client: ArcjetNode<Props> = {
+      withRule(rule) {
         const client = aj.withRule(rule);
         return withClient(client);
       },
-      async protect(
-        request: ArcjetNodeRequest,
-        ...[props]: ExtraProps<Rules> extends WithoutCustomProps
-          ? []
-          : [ExtraProps<Rules>]
-      ): Promise<ArcjetDecision> {
-        // TODO(#220): The generic manipulations get really mad here, so we cast
-        // Further investigation makes it seem like it has something to do with
-        // the definition of `props` in the signature but it's hard to track down
-        const req = toArcjetRequest(request, props ?? {}) as ArcjetRequest<
-          ExtraProps<Rules>
-        >;
+      async protect(request, props?) {
+        // Cast of `{}` because here we switch from `undefined` (or
+        // `WithoutCustomProps`) to `Props`.
+        const req = toArcjetRequest(request, props ?? ({} as Props));
 
         const getBody = async () => {
           try {
@@ -502,7 +494,9 @@ export default function arcjet<
 
         return aj.protect({ getBody }, req);
       },
-    });
+    };
+
+    return Object.freeze(client);
   }
 
   const aj = core({ ...options, client, log });


### PR DESCRIPTION
This removes a gnarly type problem, which was solved with a cast, by simplifying the types and well, sadly, still having a type cast.

But the new type cast is on a much smaller value, the default. And it kinda makes sense that TS says `{}` is not `Props`. And the rest of the code is simpler now anyway, so I think it’s good to have.

(I think this is enough to close 31)

Closes GH-31.
