### PR TITLE
chore(examples): remove `experimental.nodeMiddleware` from example

### DIFF
--- a/examples/nextjs-app-dir-rate-limit/next.config.js
+++ b/examples/nextjs-app-dir-rate-limit/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-    experimental: {
-        nodeMiddleware: true,
-    },
-};
+const nextConfig = {};
 
 module.exports = nextConfig


### PR DESCRIPTION
This gave a warning, that it was unrecognized.

Closes GH-5123.
