### PR TITLE
test(react-router): fix tests on Node `24.9.0`

### DIFF
--- a/arcjet-react-router/test/index.test.ts
+++ b/arcjet-react-router/test/index.test.ts
@@ -443,7 +443,11 @@ test("`default`", async function (t) {
         const request = new Request("https://example.com/", {
           body: {
             [Symbol.asyncIterator]() {
-              throw new Error("boom!");
+              return {
+                next() {
+                  return Promise.reject(new Error("boom!"));
+                },
+              };
             },
           },
           duplex: "half",


### PR DESCRIPTION
Closes GH-5226.