### PR TITLE
feat(protocol): Add `NUXT` to ArcjetStack

### DIFF
--- a/protocol/convert.ts
+++ b/protocol/convert.ts
@@ -134,6 +134,8 @@ export function ArcjetStackToProtocol(stack: ArcjetStack): SDKStack {
       return SDKStack.SDK_STACK_SVELTEKIT;
     case "NESTJS":
       return SDKStack.SDK_STACK_NESTJS;
+    case "NUXT":
+      return SDKStack.SDK_STACK_NUXT;
     default: {
       const _exhaustive: never = stack;
       return SDKStack.SDK_STACK_UNSPECIFIED;

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -66,10 +66,10 @@ export type ArcjetStack =
   | "NESTJS"
   | "NEXTJS"
   | "NODEJS"
+  | "NUXT"
   | "REACT_ROUTER"
   | "REMIX"
-  | "SVELTEKIT"
-  | "NUXT";
+  | "SVELTEKIT";
 
 /**
  * State of a rule after calling it.

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -68,7 +68,8 @@ export type ArcjetStack =
   | "NODEJS"
   | "REACT_ROUTER"
   | "REMIX"
-  | "SVELTEKIT";
+  | "SVELTEKIT"
+  | "NUXT";
 
 /**
  * State of a rule after calling it.

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -226,6 +226,10 @@ test("convert", async (t) => {
       );
     });
 
+    await t.test("should turn a `NUXT` stack into an SDK stack", () => {
+      assert.equal(ArcjetStackToProtocol("NUXT"), SDKStack.SDK_STACK_NUXT);
+    });
+
     await t.test("should fail on an unknown stack", () => {
       assert.equal(
         ArcjetStackToProtocol(


### PR DESCRIPTION
Closes #5241 

We already had `SDK_STACK_NUXT` in the Protobuf, so this just exposes it from our `@arcjet/protocol` package.