### PR TITLE
fix: support ESM types in dependencies

### DIFF
--- a/analyze-wasm/index.ts
+++ b/analyze-wasm/index.ts
@@ -1,3 +1,7 @@
+// Support `?js` and such:
+//
+/// <reference types="./wasm.js" />
+
 import { instantiate } from "./wasm/arcjet_analyze_js_req.component.js";
 import type { ImportObject } from "./wasm/arcjet_analyze_js_req.component.js";
 

--- a/redact-wasm/index.ts
+++ b/redact-wasm/index.ts
@@ -1,3 +1,7 @@
+// Support `?js` and such:
+//
+/// <reference types="./wasm.js" />
+
 import { instantiate } from "./wasm/arcjet_analyze_bindings_redact.component.js";
 import type { ImportObject } from "./wasm/arcjet_analyze_bindings_redact.component.js";
 import type { ArcjetRedactCustomRedact } from "./wasm/interfaces/arcjet-redact-custom-redact.js";

--- a/rollup-config/index.js
+++ b/rollup-config/index.js
@@ -207,6 +207,11 @@ export function createConfig(root, options) {
         preventAssignment: true,
       }),
       typescript({
+        // `@rollup/plugin-typescript` does not support several values from `extends`.
+        // So it is needed to pass these explicitly.
+        // Reference: <https://github.com/rollup/plugins/issues/1583>.
+        moduleResolution: "bundler",
+        module: "esnext",
         tsconfig: "./tsconfig.json",
         // Override the `excludes` specified in the tsconfig so we don't
         // generate definition files for our tests
@@ -216,6 +221,9 @@ export function createConfig(root, options) {
         noEmitOnError: true,
       }),
       typescript({
+        // Same as above, have to pass these explicitly.
+        moduleResolution: "bundler",
+        module: "esnext",
         tsconfig: "./tsconfig.json",
         // Override the `includes` specified in the tsconfig so we don't
         // generate definition files for our tests

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,11 @@
     "exactOptionalPropertyTypes": true,
     "incremental": false,
     "lib": ["esnext"],
-    "moduleResolution": "node",
+    // `@rollup/plugin-typescript` does not support several values from `extends`.
+    // So it is needed to pass `moduleResolution` and `module` explicitly.
+    // Reference: <https://github.com/rollup/plugins/issues/1583>.
+    // When changing these, also update `rollup-config/index.js`.
+    "moduleResolution": "bundler",
     "module": "esnext",
     "preserveWatchOutput": true,
     "skipLibCheck": true,


### PR DESCRIPTION
While this repo uses ESM everywhere, this was not really enabled in TypeScript, as that used `moduleResolution: "node"` (an alias for `node10`), which only really supports `require` and importing files.

See: <https://www.typescriptlang.org/tsconfig/#moduleResolution>.

This surfaces for example in Astro using export maps to point people to their Zod in GH-5266. That probably surfaces because of withastro/astro@ad26fa22.

As the word is `node`, we could use `nodenext` (alias `node16`), but as that would require that `module: "esnext"` be changed to something Node-specific too, using the modern `moduleResolution: "bundler"` is likely a better idea. That value does more than is needed for export maps, but it at least does not force more Node-specific configuration.

The next problem is that `@rollup/plugin-typescript` has bugs. which are not very visible because they use a stale-bot to close issues. See rollup/plugins#1583.
For that reason, these `moduleResolution` and `module` fields are explicit in `rollup-config/index.js` too.

The `bundler` module resolution algorithm slightly changes the handling of the internal types, which is why `analyze-wasm` and `redact-wasm` now reference the `wasm.d.ts` files, which importantly ***does not*** leak into the generated `.d.ts` files.

Related-to: GH-5266.