### PR TITLE
build: remove unused env variable

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,6 @@
     "ARCJET_ENV",
     "ARCJET_KEY",
     "ARCJET_BASE_URL",
-    "ARCJET_RUNTIME",
     "ARCJET_LOG_LEVEL",
     "OPENAI_API_KEY",
     "FLY_APP_NAME",


### PR DESCRIPTION
I see no hits for `ARCJET_RUNTIME` on GH in the `arcjet` org.