### PR TITLE
fix(ip): throw on proxy CIDR range in string form

### DIFF
--- a/ip/index.ts
+++ b/ip/index.ts
@@ -853,6 +853,17 @@ export function findIp(
   options?: Options | null | undefined,
 ): string {
   const { platform, proxies } = options || {};
+
+  for (const proxy of proxies || []) {
+    if (typeof proxy === "string" && proxy.includes("/")) {
+      throw new Error(
+        "Unexpected CIDR notation for trusted proxy, expected parsed CIDR object, pass `" +
+          proxy +
+          "` through `parseProxy`",
+      );
+    }
+  }
+
   // Prefer anything available via the platform over headers since headers can
   // be set by users. Only if we don't have an IP available in `request` do we
   // search the `headers`.

--- a/ip/test/ip.test.ts
+++ b/ip/test/ip.test.ts
@@ -249,6 +249,15 @@ test("`findIp`", async (t) => {
     },
   );
 
+  await t.test(
+    "throws if a CIDR range is passed in `proxies` as a string",
+    () => {
+      assert.throws(function () {
+        findIp({ ip: "1.1.1.1", headers: {} }, { proxies: ["1.1.1.0/24"] });
+      }, /Unexpected CIDR notation for trusted proxy, expected parsed CIDR object, pass `1\.1\.1\.0\/24` through `parseProxy`/);
+    },
+  );
+
   await t.test("request: `ip`", async (t) => {
     for (const [message, input, expected, proxies] of cases) {
       await t.test(message, () => {


### PR DESCRIPTION
It is also possible to throw this error in `isTrustedProxy`. The downside of that is that the check then occurs for every potential IP, and that the error would not happen if no potential IP is found. This verifies the input options once.

An alternative approach is to call `parseProxy` instead of throwing. The downside of that is that it would be faster if users do that initially and once.

Closes GH-5382.