### PR TITLE
feat: support `ip` field in all integrations

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -169,6 +169,18 @@ export type ArcjetOptions<
 >;
 
 /**
+ * Request object that also supports overriding IP addressess.
+ *
+ * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * Instance of the Astro integration of Arcjet.
  *
  * Primarily has a `protect()` method to make a decision about how a request
@@ -194,7 +206,7 @@ export interface ArcjetAstro<Props extends PlainObject> {
    *   Arcjet’s decision about the request.
    */
   protect(
-    request: Request,
+    request: RequestWithIp,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
     ...props: Props extends WithoutCustomProps ? [] : [Props]
@@ -257,7 +269,7 @@ export function createArcjetClient<
   }
 
   function toArcjetRequest<Props extends PlainObject>(
-    request: Request,
+    request: RequestWithIp,
     props: Props,
   ): ArcjetRequest<Props> {
     const clientAddress = Reflect.get(request, ipSymbol);
@@ -273,7 +285,7 @@ export function createArcjetClient<
     const url = new URL(request.url);
     let ip = findIp(
       {
-        ip: clientAddress,
+        ip: request.ip || clientAddress,
         headers,
       },
       { platform: platform(env), proxies },
@@ -312,7 +324,7 @@ export function createArcjetClient<
         return withClient(client);
       },
       async protect(
-        request: Request,
+        request: RequestWithIp,
         ...[props]: ExtraProps<Rules> extends WithoutCustomProps
           ? []
           : [ExtraProps<Rules>]

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -147,6 +147,18 @@ export type ArcjetOptions<
 >;
 
 /**
+ * Request object that also supports overriding IP addressess.
+ *
+ * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * Instance of the Bun integration of Arcjet.
  *
  * Primarily has a `protect()` method to make a decision about how a Bun request
@@ -174,7 +186,7 @@ export interface ArcjetBun<Props extends PlainObject> {
    *   Arcjet’s decision about the request.
    */
   protect(
-    request: Request,
+    request: RequestWithIp,
     // We use this neat trick from https://stackoverflow.com/a/52318137 to make a single spread parameter
     // that is required if the ExtraProps aren't strictly an empty object
     ...props: Props extends WithoutCustomProps ? [] : [Props]
@@ -244,7 +256,7 @@ export default function arcjet<
   // Assuming the `handler()` function was used around Bun's fetch handler this
   // WeakMap should be populated with IP addresses inspected via
   // `server.requestIP()`
-  const ipCache = new WeakMap<Request, string>();
+  const ipCache = new WeakMap<RequestWithIp, string>();
 
   const log = options.log
     ? options.log
@@ -263,7 +275,7 @@ export default function arcjet<
   }
 
   function toArcjetRequest<Props extends PlainObject>(
-    request: Request,
+    request: RequestWithIp,
     props: Props,
   ): ArcjetRequest<Props> {
     const cookies = request.headers.get("cookie") ?? undefined;
@@ -277,7 +289,7 @@ export default function arcjet<
         // This attempts to lookup the IP in the `ipCache`. This is primarily a
         // workaround to the API design in Bun that requires access to the
         // `Server` to lookup an IP.
-        ip: ipCache.get(request),
+        ip: request.ip || ipCache.get(request),
         headers,
       },
       { platform: platform(env), proxies },
@@ -316,7 +328,7 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(
-        request: Request,
+        request: RequestWithIp,
         ...[props]: ExtraProps<Rules> extends WithoutCustomProps
           ? []
           : [ExtraProps<Rules>]

--- a/arcjet-fastify/index.ts
+++ b/arcjet-fastify/index.ts
@@ -150,6 +150,13 @@ export interface ArcjetFastifyRequest {
   headers: Record<string, Array<string> | string | undefined>;
 
   /**
+   * IP address of the client making the request.
+   *
+   * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+   */
+  ip?: string | null | undefined;
+
+  /**
    * HTTP method of the request.
    */
   method: string;
@@ -365,7 +372,7 @@ function toArcjetRequest<Properties extends PlainObject>(
   const headers = new ArcjetHeaders(requestHeaders);
 
   let ip = findIp(
-    { headers, socket: request.socket },
+    { ip: request.ip, headers, socket: request.socket },
     { platform: platform(process.env), proxies },
   );
 

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -173,6 +173,8 @@ export interface ArcjetNestRequest {
   id?: string;
   /**
    * IP address of the client.
+   *
+   * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
    */
   ip?: string;
   /**

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -208,6 +208,8 @@ export interface ArcjetNextRequest {
 
   /**
    * IP address of the client.
+   *
+   * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
    */
   ip?: string;
 

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -174,6 +174,13 @@ export interface ArcjetNodeRequest {
   headers?: Record<string, string | string[] | undefined>;
 
   /**
+   * IP address of the client making the request.
+   *
+   * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+   */
+  ip?: string | null | undefined;
+
+  /**
    * `net.Socket` object associated with the connection.
    *
    * See <https://nodejs.org/api/http.html#messagesocket>.
@@ -370,6 +377,7 @@ export default function arcjet<
 
     let ip = findIp(
       {
+        ip: request.ip,
         socket: request.socket,
         headers,
       },

--- a/arcjet-nuxt/internal.ts
+++ b/arcjet-nuxt/internal.ts
@@ -74,6 +74,13 @@ interface ArcjetH3NodeRequest {
   httpVersion?: string | null | undefined;
 
   /**
+   * IP address of the client making the request.
+   *
+   * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+   */
+  ip?: string | null | undefined;
+
+  /**
    * HTTP method of the request.
    */
   method?: string | null | undefined;

--- a/arcjet-react-router/index.ts
+++ b/arcjet-react-router/index.ts
@@ -59,6 +59,18 @@ interface ContextProvider {
 }
 
 /**
+ * Request object that also supports overriding IP addressess.
+ *
+ * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * Request for the React Router integration of Arcjet.
  */
 export interface ArcjetReactRouterRequest {
@@ -76,7 +88,7 @@ export interface ArcjetReactRouterRequest {
   /**
    * DOM request.
    */
-  request: Request;
+  request: RequestWithIp;
 }
 
 /**

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -123,6 +123,18 @@ export function createRemoteClient(options?: RemoteClientOptions) {
 }
 
 /**
+ * Request object that also supports overriding IP addressess.
+ *
+ * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * Request for the Remix integration of Arcjet.
  *
  * This is a minimal version of `LoaderFunctionArgs` from Remix.
@@ -131,7 +143,7 @@ export type ArcjetRemixRequest = {
   /**
    * Original Remix request.
    */
-  request: Request;
+  request: RequestWithIp;
   /**
    * Context for the Remix request.
    */
@@ -266,7 +278,7 @@ export default function arcjet<
     let ip = findIp(
       {
         // The `getLoadContext` API will attach the `ip` to the context
-        ip: context?.ip,
+        ip: request.ip || context?.ip,
         headers,
       },
       { platform: platform(process.env), proxies },

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -145,6 +145,18 @@ interface Cookies {
 }
 
 /**
+ * Request object that also supports overriding IP addressess.
+ *
+ * See “[Concepts: Client IP](https://docs.arcjet.com/concepts/client-ip)” for more info.
+ */
+export interface RequestWithIp extends Request {
+  /**
+   * IP address of the client making the request.
+   */
+  ip?: string | null | undefined;
+}
+
+/**
  * Request for the SvelteKit integration of Arcjet.
  *
  * This is the minimum interface similar to `RequestEvent`.
@@ -163,7 +175,7 @@ export interface ArcjetSvelteKitRequestEvent {
   /**
    * Original request object.
    */
-  request: Request;
+  request: RequestWithIp;
   /**
    * Requested URL.
    */
@@ -304,7 +316,7 @@ export default function arcjet<
 
     let ip = findIp(
       {
-        ip: event.getClientAddress(),
+        ip: event.request.ip || event.getClientAddress(),
         headers,
       },
       { platform: platform(env), proxies },


### PR DESCRIPTION
Some already support `request.ip`.
This brings that same field to all integrations. So that it works the exact same way for everyone.
Alternatively, it is possible to do different things per integration.

Closes GH-5380.