### PR TITLE
refactor(ip): simplify which headers are used when

### DIFF
--- a/ip/index.ts
+++ b/ip/index.ts
@@ -955,7 +955,7 @@ const candidatesByPlatform: Record<Platform, ReadonlyArray<Candidate>> = {
 /**
  * Generic candidates.
  */
-const genericCanidates: ReadonlyArray<Candidate> = [
+const genericCandidates: ReadonlyArray<Candidate> = [
   // Standard headers used by Amazon EC2, Heroku, and others.
   { format: "ip", header: "x-client-ip" },
   // Load-balancers (AWS ELB) or proxies.
@@ -1000,7 +1000,7 @@ function findIpInHeaders(
   const candidates =
     platform && platform in candidatesByPlatform
       ? candidatesByPlatform[platform]
-      : genericCanidates;
+      : genericCandidates;
 
   if (headers && typeof headers === "object") {
     for (const { format, header } of candidates) {


### PR DESCRIPTION
Given that more platforms are added, more headers are added, and potentially users can configure platforms/headers too, and potentially different formats are added, this moves 200 lines of if statements into configuration, to improve and prepare for these changes.