### PR TITLE
fix!: Require quotes for `'script'` in `require-trusted-types-for` directive

### DIFF
--- a/nosecone/index.ts
+++ b/nosecone/index.ts
@@ -92,7 +92,7 @@ export interface CspDirectives {
   navigateTo?: StaticOrDynamic<Source | ActionSource> | undefined;
   reportUri?: string[] | undefined;
   reportTo?: string[] | undefined;
-  requireTrustedTypesFor?: ReadonlyArray<"script"> | undefined;
+  requireTrustedTypesFor?: ReadonlyArray<"'script'"> | undefined;
   trustedTypes?:
     | ReadonlyArray<"none" | "allow-duplicates" | "*" | string>
     | undefined;


### PR DESCRIPTION
This pull request makes a minor adjustment to the `CspDirectives` interface in `nosecone/index.ts`, specifically updating the type for the `requireTrustedTypesFor` property to ensure it matches the expected string literal format. 

* Type definition update:
  * Changed the type of `requireTrustedTypesFor` from `ReadonlyArray<"script">` to `ReadonlyArray<"'script'">` in the `CspDirectives` interface to correctly reflect the required string literal format.