### PR TITLE
chore(env)!: remove unused `apiKey` utility function

### DIFF
--- a/env/README.md
+++ b/env/README.md
@@ -58,13 +58,7 @@ npm install @arcjet/env
 
 ```ts
 import process from "node:process";
-import {
-  apiKey,
-  baseUrl,
-  isDevelopment,
-  logLevel,
-  platform,
-} from "@arcjet/env";
+import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 
 console.log(platform({ FLY_APP_NAME: "foobar" })); // => "fly-io"
 console.log(platform({})); // => undefined
@@ -78,8 +72,6 @@ console.log(logLevel({ ARCJET_LOG_LEVEL: "warn" })); // => "warn"
 console.log(logLevel({ ARCJET_LOG_LEVEL: "error" })); // => "error"
 console.log(logLevel({ ARCJET_LOG_LEVEL: "" })); // => "warn"
 console.log(baseUrl(process.env)); // => "https://decide.arcjet.com"
-console.log(apiKey({ ARCJET_KEY: "ajkey_abc123" })); // => "ajkey_abc123"
-console.log(apiKey({ ARCJET_KEY: "invalid" })); // => undefined
 ```
 
 ## License

--- a/env/index.ts
+++ b/env/index.ts
@@ -12,10 +12,6 @@ export type Env = {
    */
   ARCJET_ENV?: string | undefined;
   /**
-   * Key for Arcjet API.
-   */
-  ARCJET_KEY?: string | undefined;
-  /**
    * Log level of Arcjet SDK.
    */
   ARCJET_LOG_LEVEL?: string | undefined;
@@ -162,19 +158,4 @@ export function baseUrl(environment: Env) {
   }
 
   return "https://decide.arcjet.com";
-}
-
-/**
- * Get the key for an Arcjet API.
- *
- * @param environment
- *   Environment.
- * @returns
- *   Key for Arcjet API if found.
- */
-export function apiKey(environment: Env) {
-  const key = environment["ARCJET_KEY"];
-  if (typeof key === "string" && key.startsWith("ajkey_")) {
-    return key;
-  }
 }

--- a/env/test/env.test.ts
+++ b/env/test/env.test.ts
@@ -5,7 +5,6 @@ import * as env from "../index.ts";
 test("@arcjet/env", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../index.js")).sort(), [
-      "apiKey",
       "baseUrl",
       "isDevelopment",
       "logLevel",
@@ -142,11 +141,5 @@ describe("env", () => {
       }),
       "https://decide.arcjet.orb.local/",
     );
-  });
-
-  test("apiKey", () => {
-    assert.equal(env.apiKey({}), undefined);
-    assert.equal(env.apiKey({ ARCJET_KEY: "invalid" }), undefined);
-    assert.equal(env.apiKey({ ARCJET_KEY: "ajkey_abc123" }), "ajkey_abc123");
   });
 });


### PR DESCRIPTION
This function is unused.
All SDKs require users to retrieve API keys themselves and pass them explicitly.
The only exception is the Arcjet Astro SDK,
which does not use this function but retrieves the key the regular Astro way.
As this function is unused and undocumented (on the site, in examples),
and probably also not recommended for use,
I’d recommend removing it.

Closes GH-5453.