### PR TITLE
fix(bun, deno): do not read from `process.env`

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -256,7 +256,7 @@ export default function arcjet<
     ? options.proxies.map(parseProxy)
     : undefined;
 
-  if (isDevelopment(process.env)) {
+  if (isDevelopment(env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
     );

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -255,7 +255,7 @@ export default function arcjet<
     ? options.proxies.map(parseProxy)
     : undefined;
 
-  if (isDevelopment(process.env)) {
+  if (isDevelopment(env)) {
     log.warn(
       "Arcjet will use 127.0.0.1 when missing public IP address in development mode",
     );


### PR DESCRIPTION
The `@arcjet/bun` and  `@arcjet/deno` packages almost read from `{ env } from "bun"` / `Deno.env` correctly,
except for each a sole lonely `if (isDevelopment(process.env)) {` check.

Closes GH-5457.