### PR TITLE
feat: send extra `vercel-git-commit-sha` field to cloud api

### DIFF
--- a/arcjet-astro/internal.ts
+++ b/arcjet-astro/internal.ts
@@ -292,8 +292,19 @@ export function createArcjetClient<
       }
     }
 
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      // @ts-expect-error: types in GH-5456.
+      extra["vercel-git-commit-sha"] = env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
+
     return {
       ...props,
+      ...extra,
       ip,
       method: request.method,
       protocol: url.protocol,

--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -299,8 +299,18 @@ export default function arcjet<
       }
     }
 
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      extra["vercel-git-commit-sha"] = env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
+
     return {
       ...props,
+      ...extra,
       ip,
       method: request.method,
       protocol: url.protocol,

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -298,8 +298,18 @@ export default function arcjet<
       }
     }
 
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      extra["vercel-git-commit-sha"] = env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
+
     return {
       ...props,
+      ...extra,
       ip,
       method: request.method,
       protocol: url.protocol,

--- a/arcjet-fastify/index.ts
+++ b/arcjet-fastify/index.ts
@@ -412,8 +412,18 @@ function toArcjetRequest<Properties extends PlainObject>(
     path = request.url ?? "";
   }
 
+  const extra: Record<PropertyKey, string> = {};
+
+  // Add extra info from `env` on Vercel.
+  if (platform(process.env) === "vercel") {
+    // Vercel git commit SHA.
+    // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+    extra["vercel-git-commit-sha"] = process.env.VERCEL_GIT_COMMIT_SHA ?? "";
+  }
+
   return {
     ...properties,
+    ...extra,
     cookies,
     headers,
     host,

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -421,8 +421,18 @@ function arcjet<
       path = request.url ?? "";
     }
 
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(process.env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      extra["vercel-git-commit-sha"] = process.env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
+
     return {
       ...props,
+      ...extra,
       ip,
       method,
       protocol,

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -626,23 +626,15 @@ export default function arcjet<
     }
     const cookies = cookiesToString(request.cookies);
 
-    const extra: { [key: string]: string } = {};
+    const extra: Record<PropertyKey, string> = {};
 
-    // If we're running on Vercel, we can add some extra information
-    if (process.env["VERCEL"]) {
-      // Vercel ID https://vercel.com/docs/concepts/edge-network/headers
-      extra["vercel-id"] = headers.get("x-vercel-id") ?? "";
-      // Vercel deployment URL
-      // https://vercel.com/docs/concepts/edge-network/headers
-      extra["vercel-deployment-url"] =
-        headers.get("x-vercel-deployment-url") ?? "";
-      // Vercel git commit SHA
-      // https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables
-      extra["vercel-git-commit-sha"] =
-        process.env["VERCEL_GIT_COMMIT_SHA"] ?? "";
-      extra["vercel-git-commit-sha"] =
-        process.env["VERCEL_GIT_COMMIT_SHA"] ?? "";
+    // Add extra info from `env` on Vercel.
+    if (platform(process.env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      extra["vercel-git-commit-sha"] = process.env.VERCEL_GIT_COMMIT_SHA ?? "";
     }
+
     return {
       ...props,
       ...extra,

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -424,8 +424,19 @@ export default function arcjet<
       path = request.url ?? "";
     }
 
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      // @ts-expect-error: types in GH-5456.
+      extra["vercel-git-commit-sha"] = env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
+
     return {
       ...props,
+      ...extra,
       ip,
       method,
       protocol,

--- a/arcjet-nuxt/internal.ts
+++ b/arcjet-nuxt/internal.ts
@@ -455,8 +455,18 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
     path = event.node.req.url ?? "";
   }
 
+  const extra: Record<PropertyKey, string> = {};
+
+  // Add extra info from `env` on Vercel.
+  if (platform(process.env) === "vercel") {
+    // Vercel git commit SHA.
+    // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+    extra["vercel-git-commit-sha"] = process.env.VERCEL_GIT_COMMIT_SHA ?? "";
+  }
+
   return {
     ...properties,
+    ...extra,
     cookies: headers.get("cookie") ?? undefined,
     headers,
     host,

--- a/arcjet-react-router/index.ts
+++ b/arcjet-react-router/index.ts
@@ -343,8 +343,18 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
 
   const url = new URL(details.request.url);
 
+  const extra: Record<PropertyKey, string> = {};
+
+  // Add extra info from `env` on Vercel.
+  if (platform(process.env) === "vercel") {
+    // Vercel git commit SHA.
+    // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+    extra["vercel-git-commit-sha"] = process.env.VERCEL_GIT_COMMIT_SHA ?? "";
+  }
+
   return {
     ...properties,
+    ...extra,
     cookies: details.request.headers.get("cookie") ?? undefined,
     headers,
     host: url.host,

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -288,8 +288,18 @@ export default function arcjet<
       }
     }
 
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(process.env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      extra["vercel-git-commit-sha"] = process.env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
+
     return {
       ...props,
+      ...extra,
       ip,
       method: request.method,
       protocol: url.protocol,

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -330,9 +330,19 @@ export default function arcjet<
     const path = event.url.pathname;
     const query = event.url.search;
     const protocol = event.url.protocol;
+    const extra: Record<PropertyKey, string> = {};
+
+    // Add extra info from `env` on Vercel.
+    if (platform(env) === "vercel") {
+      // Vercel git commit SHA.
+      // <https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_GIT_COMMIT_SHA>
+      // @ts-expect-error: types in GH-5456.
+      extra["vercel-git-commit-sha"] = env.VERCEL_GIT_COMMIT_SHA ?? "";
+    }
 
     return {
       ...props,
+      ...extra,
       ip,
       method,
       protocol,


### PR DESCRIPTION
In `@arcjet/next`, some headers and an env variable were sent in `extra` on Vercel. As `arcjet` does not have access to the environment, such behavior must be in integrations. This PR changes each integration to send such information on Vercel.

As headers are already sent in headers, I removed that, but that can be added.

As an alternative to this PR, this behavior could also be removed from `@arcjet/next`.

Related-to: GH-5456.