### PR TITLE
ci: Allow release-please to run for 2 minutes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # Release Please is very fast, so we set a tiny timeout
-    timeout-minutes: 1
+    timeout-minutes: 2
     # Release Please creates a Pull Request with changes to files
     permissions:
       contents: write


### PR DESCRIPTION
Release Please is exceeding the 1 minute timeout we gave it. This will double the amount of time it is allowed to run.