### PR TITLE
fix(astro): swallow astro error on missing ip

### DIFF
--- a/arcjet-astro/middleware.ts
+++ b/arcjet-astro/middleware.ts
@@ -6,8 +6,16 @@ import { defineMiddleware } from "astro/middleware";
 const ipSymbol = Symbol.for("arcjet.ip");
 
 export const onRequest = defineMiddleware((ctx, next) => {
+  let ip: string | undefined;
+
+  try {
+    ip = ctx.clientAddress;
+  } catch {
+    // Swallow error.
+  }
+
   if (!ctx.isPrerendered) {
-    Reflect.set(ctx.request, ipSymbol, ctx.clientAddress);
+    Reflect.set(ctx.request, ipSymbol, ip);
   }
 
   return next();


### PR DESCRIPTION
Astro itself sometimes throws an error when getting the client ip:

https://github.com/withastro/astro/blob/16f3994fdb83d1b3421491c00bfd5ac9f7e37a5c/packages/astro/src/core/middleware/index.ts#L103-L110

This prevents `@arcjet/astro`s own error from being thrown:

https://github.com/arcjet/arcjet-js/blob/ca5a64a30fe4293db9715785aa69899efd7abcc0/arcjet-astro/internal.ts#L267-L270

I extracted this code, which was needed for GH-5533 to work, so that it can go in its own commit.