### PR TITLE
fix(sveltekit): swallow sveltekit error on missing ip

### DIFF
--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -305,15 +305,18 @@ export default function arcjet<
     const xArcjetIp = isDevelopment(env)
       ? headers.get("x-arcjet-ip")
       : undefined;
+
+    let maybeIp: string | undefined;
+
+    try {
+      maybeIp = event.getClientAddress();
+    } catch {
+      // Swallow error.
+    }
+
     let ip =
       xArcjetIp ||
-      findIp(
-        {
-          ip: event.getClientAddress(),
-          headers,
-        },
-        { platform: platform(env), proxies },
-      );
+      findIp({ ip: maybeIp, headers }, { platform: platform(env), proxies });
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.


### PR DESCRIPTION
SvelteKit itself sometimes throws an error when getting the client ip:

https://github.com/sveltejs/kit/blob/2140546af29c1fae747e1c4f54c09ef0fed139ad/packages/kit/src/exports/vite/dev/index.js#L563-L567

This prevents `@arcjet/sveltekit`s own default handling (such as header lookups, `127.0.0.1` in dev, warning in prod) from working:

https://github.com/arcjet/arcjet-js/blob/ca5a64a30fe4293db9715785aa69899efd7abcc0/arcjet-sveltekit/index.ts#L317-L327

I extracted this code, which was needed for GH-5533 to work, so that it can go in its own commit.