### PR TITLE
chore: add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,12 @@
+name: Publish
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  id-token: write
 jobs:
   publish:
     environment: npm-publish
@@ -17,12 +26,3 @@ jobs:
       # UNKNOWN(2): this should work when everything is set up correctly, but `--dry-run` for now.
       - name: Publish packages
         run: npm publish --dry-run --workspaces
-name: Publish
-on:
-  push:
-    tags:
-      - v*
-  workflow_dispatch: {}
-permissions:
-  contents: read
-  id-token: write


### PR DESCRIPTION
This adds `publish.yml` workflow based on
<https://docs.npmjs.com/trusted-publishers#github-actions-configuration>. Together with configuration of each package on `npmjs.com`, this sets up both automatic publishing (after a PR such as GH-5461 is merged) and automatic provenance (reference: https://docs.npmjs.com/trusted-publishers#automatic-provenance-generation).

There are a couple things to discuss, such as:

1. which node to publish with: I’d say 24
2. whether this will work: this uses `--dry-run` for now to prevent accidents
3. what trigger to use: this uses tags matching `v[0-9]+.*` now

I believe that the correct corresponding config on `npmjs.com` for all packages is:

* organization: `arcjet`
* repository: `arcjet-js`
* filename: `publish.yml`
* environment:`npm-publish`

<img width="818" height="480" alt="Screenshot 2026-01-05 at 11 10 13 AM" src="https://github.com/user-attachments/assets/f0db20a2-4026-4586-9240-e1e26ef42c5f" />

Closes GH-29.