### PR TITLE
feat(node): expose body at `request.body` after reading

### DIFF
--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -461,7 +461,7 @@ export default function arcjet<
         const getBody = async () => {
           try {
             // If request.body is present then the body was likely read by a package like express' `body-parser`.
-            // If it's not present then we attempt to read the bytes from the IncomingMessage ourselves.
+            // If it's not present then we read the bytes from the IncomingMessage ourselves.
             if (typeof request.body === "string") {
               return request.body;
             } else if (
@@ -494,6 +494,7 @@ export default function arcjet<
                 limit: 1048576,
                 expectedLength,
               });
+              request.body = body;
               return body;
             }
 

--- a/arcjet-node/test/index.test.ts
+++ b/arcjet-node/test/index.test.ts
@@ -114,43 +114,38 @@ test("`@arcjet/node`", async function (t) {
     },
   );
 
-  // TODO(GH-5516): this hangs indefinitely.
-  // Fix bug, probably by calling `request.clone()`?
-  // await t.test("should support reading body after `sensitiveInfo`", async function () {
-  //   const restore = capture();
-  //   let body = "";
+  await t.test(
+    "should support accessing body after `sensitiveInfo`",
+    async function () {
+      const restore = capture();
+      let body = "";
 
-  //   const arcjet = arcjetNode({
-  //     key: exampleKey,
-  //     rules: [sensitiveInfo({ deny: ["EMAIL"], mode: "LIVE" })],
-  //   });
+      const arcjet = arcjetNode({
+        key: exampleKey,
+        rules: [sensitiveInfo({ deny: ["EMAIL"], mode: "LIVE" })],
+      });
 
-  //   const { server, url } = await createSimpleServer({
-  //     async after(request) {
-  //       return new Promise(function (resolve) {
-  //         request.on("data", function (chunk) {
-  //           body += chunk;
-  //         });
-  //         request.on("end", function () {
-  //           resolve(undefined);
-  //         });
-  //       });
-  //     },
-  //     arcjet,
-  //   });
+      const { server, url } = await createSimpleServer({
+        async after(request) {
+          // @ts-expect-error: non-standard but common field.
+          body = request.body;
+        },
+        arcjet,
+      });
 
-  //   const response = await fetch(url, {
-  //     body: "My email is alice@arcjet.com",
-  //     headers: { "Content-Type": "text/plain" },
-  //     method: "POST",
-  //   });
+      const response = await fetch(url, {
+        body: "My email is alice@arcjet.com",
+        headers: { "Content-Type": "text/plain" },
+        method: "POST",
+      });
 
-  //   server.close();
-  //   restore();
+      server.close();
+      restore();
 
-  //   assert.equal(response.status, 403);
-  //   assert.equal(body, "My email is alice@arcjet.com");
-  // });
+      assert.equal(response.status, 403);
+      assert.equal(body, "My email is alice@arcjet.com");
+    },
+  );
 
   await t.test("should support `sensitiveInfo` on JSON", async function () {
     const restore = capture();


### PR DESCRIPTION
If the Arcjet Node SDK is used, and it needs access to the body, users cannot read the body too. Neither before nor after. This is because Node stream can be read once.

It is possible to use a tool like `body-parser` to read the body *before* Arcjet. That works because after reading it stashes what it found as `request.body`. Arcjet then takes that.

It is possible to recommend that users do that. Use `body-parser` or when they read the stream manually, to stash the body there.

But with other Arcjet SDKs, only the inverse order works: call `.protect` first, then (optionally) read the body later. This ordering seems more natural.

In the case of Arcjet reading the streaming body, it can also stash the body at `request.body`. Then it works like other tools, which can be documented.

Closes GH-5516.