### PR TITLE
build: only test built JavaScript files

### DIFF
--- a/analyze-wasm/package.json
+++ b/analyze-wasm/package.json
@@ -56,8 +56,8 @@
     "build": "npm run build:jco && npm run build:rollup",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -40,8 +40,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/arcjet-astro/package.json
+++ b/arcjet-astro/package.json
@@ -47,8 +47,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/arcjet-nuxt/package.json
+++ b/arcjet-nuxt/package.json
@@ -65,8 +65,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepack": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "type": "module",

--- a/arcjet-react-router/package.json
+++ b/arcjet-react-router/package.json
@@ -61,9 +61,9 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
+    "test-api": "node --test -- test/*.test.js",
     "test-coverage#": "TODO: after node 20, use: ` --test-coverage-branches=100  --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=100`",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "type": "module",

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -42,8 +42,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/body/package.json
+++ b/body/package.json
@@ -39,8 +39,8 @@
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/cache/package.json
+++ b/cache/package.json
@@ -38,8 +38,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/decorate/package.json
+++ b/decorate/package.json
@@ -38,8 +38,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/duration/package.json
+++ b/duration/package.json
@@ -39,8 +39,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/env/package.json
+++ b/env/package.json
@@ -38,8 +38,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/headers/package.json
+++ b/headers/package.json
@@ -38,8 +38,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -39,8 +39,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/ip/package.json
+++ b/ip/package.json
@@ -38,8 +38,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/logger/package.json
+++ b/logger/package.json
@@ -39,8 +39,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/nosecone-next/package.json
+++ b/nosecone-next/package.json
@@ -50,8 +50,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -50,8 +50,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/nosecone/package.json
+++ b/nosecone/package.json
@@ -48,8 +48,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -45,8 +45,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/redact-wasm/package.json
+++ b/redact-wasm/package.json
@@ -52,8 +52,8 @@
     "build": "npm run build:jco && npm run build:rollup",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/redact/package.json
+++ b/redact/package.json
@@ -38,8 +38,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -45,8 +45,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --experimental-vm-modules --test",
-    "test-coverage": "node --experimental-test-coverage --experimental-vm-modules --test",
+    "test-api": "node --experimental-vm-modules --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --experimental-vm-modules --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/sprintf/package.json
+++ b/sprintf/package.json
@@ -39,8 +39,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/stable-hash/package.json
+++ b/stable-hash/package.json
@@ -49,8 +49,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/transport/package.json
+++ b/transport/package.json
@@ -50,8 +50,8 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "test-api": "node --test",
-    "test-coverage": "node --experimental-test-coverage --test",
+    "test-api": "node --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {


### PR DESCRIPTION
This prevents running test suites twice on Node 24 and later, which otherwise read TypeScript files too.

Closes GH-4477.