### PR TITLE
build: update `allowed-endpoints` for step security

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -16,7 +16,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-            release-assets.githubusercontent:443
+            registry.npmjs.org:443
           disable-sudo-and-containers: true
           egress-policy: block
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -43,9 +43,12 @@ jobs:
         with:
           allowed-endpoints: >
             api.github.com:443
+            deno.com:443
             github.com:443
+            jsr.io:443
             objects.githubusercontent.com:443
-            release-assets.githubusercontent:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
           disable-sudo-and-containers: true
           egress-policy: block
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -74,10 +77,17 @@ jobs:
         with:
           allowed-endpoints: >
             api.github.com:443
+            binaries.prisma.sh:443
+            decide.arcjet.com:443
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             github.com:443
+            nodejs.org:443
             objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
             registry.npmjs.org:443
-            release-assets.githubusercontent:443
+            release-assets.githubusercontent.com:443
+            unpkg.com:443
           disable-sudo-and-containers: true
           egress-policy: block
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -20,9 +20,10 @@ jobs:
         with:
           allowed-endpoints: >
             api.github.com:443
+            decide.arcjet.com:443
             github.com:443
             objects.githubusercontent.com:443
-            release-assets.githubusercontent:443
+            registry.npmjs.org:443
           disable-sudo-and-containers: true
           egress-policy: block
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -42,9 +43,12 @@ jobs:
         with:
           allowed-endpoints: >
             api.github.com:443
+            decide.arcjet.com:443
+            deno.com:443
             github.com:443
             objects.githubusercontent.com:443
-            release-assets.githubusercontent:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
           disable-sudo-and-containers: true
           egress-policy: block
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -79,11 +83,12 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            decide.arcjet.com:443
             github.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
-            release-assets.githubusercontent:443
+            release-assets.githubusercontent.com:443
 
       # Checkout
       # Most toolchains require checkout first


### PR DESCRIPTION
This makes CI work again, by listing all connections that are needed.

For some of these, things still work if StepSecurity blocks them, except that StepSecurity then fails. For example, `binaries.prisma.sh` or `unpkg.com` or fonts. I did not find a way for StepSecurity to block those, but not treat that block as a failure.