### PR TITLE
chore: add `.claude/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 
 # turborepo
 .turbo/
+
+# Claude
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to exclude Claude Code local configuration from version control

## Test plan
- [x] Verify `.claude/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)