### PR TITLE
ci: split update duties between Dependabot (security) and Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
+      # Required field but unused while open-pull-requests-limit is 0.
+      # Revisit the cadence if that limit is ever raised.
       interval: "daily"
     open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
+      # Required field but unused while open-pull-requests-limit is 0.
+      # Revisit the cadence if that limit is ever raised.
       interval: "daily"
     open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependency updates for this repository are managed by Renovate
+# (see `renovate.json`), including vulnerability alerts. This file
+# exists solely to stop Dependabot from opening duplicate version-update
+# PRs. `open-pull-requests-limit: 0` disables version updates for each
+# listed ecosystem.
+#
+# Dependabot security updates (the repo-level feature that auto-opens
+# security PRs independently of this file) should be disabled under
+# Settings > Code security so Renovate's `vulnerabilityAlerts` is the
+# single source of security PRs.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
-# Dependency updates for this repository are managed by Renovate
-# (see `renovate.json`), including vulnerability alerts. This file
-# exists solely to stop Dependabot from opening duplicate version-update
-# PRs. `open-pull-requests-limit: 0` disables version updates for each
-# listed ecosystem.
+# Split of responsibilities:
+#   - Dependabot handles security updates (enabled via the repo-level
+#     "Dependabot security updates" toggle under Settings > Code security;
+#     those PRs open independently of this file).
+#   - Renovate (see `renovate.json`) handles everything else, including
+#     regular version updates.
 #
-# Dependabot security updates (the repo-level feature that auto-opens
-# security PRs independently of this file) should be disabled under
-# Settings > Code security so Renovate's `vulnerabilityAlerts` is the
-# single source of security PRs.
+# This file exists to stop Dependabot from also opening version-update
+# PRs. `open-pull-requests-limit: 0` disables version updates for each
+# listed ecosystem without affecting Dependabot security updates.
 version: 2
 updates:
   - package-ecosystem: "npm"

--- a/renovate.json
+++ b/renovate.json
@@ -49,12 +49,6 @@
   "prBodyColumns": ["Package", "Change"],
   "ignorePresets": ["mergeConfidence:all-badges"],
   "vulnerabilityAlerts": {
-    "groupName": null,
-    "dependencyDashboardApproval": true,
-    "rangeStrategy": "update-lockfile",
-    "commitMessageSuffix": "[security]",
-    "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
-    "prCreation": "immediate",
-    "vulnerabilityFixStrategy": "lowest"
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Summary
Define a clean split so there are no duplicate PRs:
- **Dependabot** — security updates only. Enabled via the repo-level *Settings → Code security → Dependabot security updates* toggle. New `.github/dependabot.yml` sets `open-pull-requests-limit: 0` on the `npm` and `github-actions` ecosystems at `/` so Dependabot version updates are off (while security updates still open).
- **Renovate** — everything except security. `renovate.json`'s `vulnerabilityAlerts` block is now `{ \"enabled\": false }` so Renovate no longer raises vulnerability PRs.

## Why
Without an explicit Dependabot config, Dependabot was still opening version-update PRs — including duplicate, subdir-scoped PRs for npm workspace members (e.g. #6002 for `/arcjet-astro`, #5999 for `/arcjet-fastify`). Those subdir-scoped PRs can't update the root `package-lock.json` and always fail CI.

Previously both Renovate and Dependabot were set up to create security PRs, so turning off Renovate's vulnerability side removes the duplication going forward.

## Test plan
- [ ] After merge, confirm no new Dependabot version PRs open on the next scan cycle
- [ ] Confirm Dependabot security PRs still open when a vulnerability is detected
- [ ] Confirm Renovate continues to open regular version PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)