### PR TITLE
deps(examples): update fastify in /examples/fastify to 5.8.5 [security]

### DIFF
--- a/examples/fastify/package-lock.json
+++ b/examples/fastify/package-lock.json
@@ -16,25 +16,25 @@
     },
     "../../arcjet-fastify": {
       "name": "@arcjet/fastify",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
-        "fastify": "5.8.4",
+        "fastify": "5.8.5",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -327,9 +327,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
Bumps `fastify` in `examples/fastify/package-lock.json` from 5.8.4 to 5.8.5 to fix [GHSA-247c-9743-5963](https://github.com/fastify/fastify/security/advisories/GHSA-247c-9743-5963) (CVE-2026-33806): a body schema validation bypass via a leading space in the `Content-Type` header, affecting `fastify` >=5.3.2, <=5.8.4.

Lockfile-only change; the declared range in `package.json` (`^5.7.4`) already accepts 5.8.5 so no manifest edits were needed.

## Why this isn't already fixed
PR #6000 patched the root workspace (`arcjet-fastify/` + root `package-lock.json`) on 2026-04-22, but `examples/fastify/` is a standalone project with its own lockfile and wasn't touched. Dependabot alert #1416 is explicitly scoped to `examples/fastify/package-lock.json`, so it remained open.

## Test plan
- [ ] CI passes on the examples/fastify build
- [ ] Alert #1416 auto-resolves on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)