### PR TITLE
fix: update @bufbuild/protobuf to 2.12.0 and add root override to fix Bun build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,7 +298,7 @@
         "@arcjet/eslint-config": "1.4.0",
         "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
-        "astro": "^6.1.6",
+        "astro": "6.1.6",
         "eslint": "9.39.3",
         "typescript": "5.9.3"
       },
@@ -691,7 +691,7 @@
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
-        "fastify": "^5.8.5",
+        "fastify": "5.8.5",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -3856,10 +3856,11 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bytecodealliance/componentize-js": {
       "version": "0.11.4",
@@ -12426,7 +12427,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@arcjet/cache": "1.4.0",
-        "@bufbuild/protobuf": "2.11.0",
+        "@bufbuild/protobuf": "2.12.0",
         "@connectrpc/connect": "2.1.1",
         "typeid-js": "1.2.0"
       },
@@ -13252,7 +13253,7 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "2.11.0",
+        "@bufbuild/protobuf": "2.12.0",
         "@connectrpc/connect": "2.1.1",
         "@connectrpc/connect-node": "2.1.1",
         "@connectrpc/connect-web": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "turbo": "2.8.12"
   },
   "overrides": {
+    "@bufbuild/protobuf": "2.12.0",
     "@sveltejs/kit": {
       "cookie": "0.7.2"
     },

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@arcjet/cache": "1.4.0",
-    "@bufbuild/protobuf": "2.11.0",
+    "@bufbuild/protobuf": "2.12.0",
     "@connectrpc/connect": "2.1.1",
     "typeid-js": "1.2.0"
   },

--- a/transport/package.json
+++ b/transport/package.json
@@ -54,7 +54,7 @@
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "2.11.0",
+    "@bufbuild/protobuf": "2.12.0",
     "@connectrpc/connect": "2.1.1",
     "@connectrpc/connect-node": "2.1.1",
     "@connectrpc/connect-web": "2.1.1"


### PR DESCRIPTION
When Bun ignores the npm lockfile and resolves dependencies independently, @connectrpc/connect's peer dep ^2.7.0 resolves to @bufbuild/protobuf@2.12.0 at root while workspaces pinned 2.11.0. Version 2.12.0 added utf8Validation which 2.11.0 lacks, causing TypeScript type mismatch errors during build.

- Update @bufbuild/protobuf from 2.11.0 to 2.12.0 in transport and protocol
- Add @bufbuild/protobuf override to root package.json to force consistent resolution across all workspaces under Bun

Agent-Logs-Url: https://github.com/arcjet/arcjet-js/sessions/e80853e0-598e-47b7-842f-8790866a010f