### PR TITLE
deps(examples): update postcss to 8.5.10 across examples [security]

### DIFF
--- a/examples/astro/package-lock.json
+++ b/examples/astro/package-lock.json
@@ -3836,9 +3836,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/examples/nextjs-app-dir-rate-limit/package-lock.json
+++ b/examples/nextjs-app-dir-rate-limit/package-lock.json
@@ -30,21 +30,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5284,9 +5284,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nextjs-app-dir-validate-email/package-lock.json
+++ b/examples/nextjs-app-dir-validate-email/package-lock.json
@@ -30,21 +30,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -62,14 +62,14 @@
     },
     "../../nosecone-next": {
       "name": "@nosecone/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nosecone": "1.3.1"
+        "nosecone": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5250,9 +5250,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nextjs-bot-categories/package-lock.json
+++ b/examples/nextjs-bot-categories/package-lock.json
@@ -29,21 +29,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5222,9 +5222,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nextjs-decorate/package-lock.json
+++ b/examples/nextjs-decorate/package-lock.json
@@ -30,21 +30,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -62,15 +62,15 @@
     },
     "../../decorate": {
       "name": "@arcjet/decorate",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/sprintf": "1.3.1"
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/sprintf": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5247,9 +5247,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nextjs-ip-details/package-lock.json
+++ b/examples/nextjs-ip-details/package-lock.json
@@ -30,21 +30,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -62,11 +62,11 @@
     },
     "../../ip": {
       "name": "@arcjet/ip",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5243,9 +5243,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nextjs-pages-wrap/package-lock.json
+++ b/examples/nextjs-pages-wrap/package-lock.json
@@ -29,21 +29,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5222,9 +5222,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nextjs-react-hook-form/package-lock.json
+++ b/examples/nextjs-react-hook-form/package-lock.json
@@ -41,21 +41,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -4988,9 +4988,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/examples/nextjs-sensitive-info/package-lock.json
+++ b/examples/nextjs-sensitive-info/package-lock.json
@@ -29,21 +29,21 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "@types/node": "24.11.0",
         "eslint": "9.39.3",
@@ -5222,9 +5222,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/nuxt/package-lock.json
+++ b/examples/nuxt/package-lock.json
@@ -19,21 +19,21 @@
     },
     "../../arcjet-nuxt": {
       "name": "@arcjet/nuxt",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@nuxt/kit": "4.3.1",
         "@nuxt/schema": "4.3.1",
         "eslint": "9.39.3",
@@ -7355,9 +7355,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/examples/react-router-middleware/package-lock.json
+++ b/examples/react-router-middleware/package-lock.json
@@ -25,22 +25,22 @@
     },
     "../../arcjet-react-router": {
       "name": "@arcjet/react-router",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "eslint": "9.39.3",
         "react-router": "7.13.1",
         "typescript": "5.9.3"
@@ -2766,9 +2766,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/react-router/package-lock.json
+++ b/examples/react-router/package-lock.json
@@ -25,22 +25,22 @@
     },
     "../../arcjet-react-router": {
       "name": "@arcjet/react-router",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "eslint": "9.39.3",
         "react-router": "7.13.1",
         "typescript": "5.9.3"
@@ -2766,9 +2766,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/remix-express/package-lock.json
+++ b/examples/remix-express/package-lock.json
@@ -44,21 +44,21 @@
     },
     "../../arcjet-remix": {
       "name": "@arcjet/remix",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.59.0",
         "eslint": "9.39.3",
         "typescript": "5.9.3"
@@ -9736,9 +9736,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/examples/sveltekit/package-lock.json
+++ b/examples/sveltekit/package-lock.json
@@ -34,21 +34,21 @@
 		},
 		"../../arcjet-sveltekit": {
 			"name": "@arcjet/sveltekit",
-			"version": "1.3.1",
+			"version": "1.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@arcjet/body": "1.3.1",
-				"@arcjet/env": "1.3.1",
-				"@arcjet/headers": "1.3.1",
-				"@arcjet/ip": "1.3.1",
-				"@arcjet/logger": "1.3.1",
-				"@arcjet/protocol": "1.3.1",
-				"@arcjet/transport": "1.3.1",
-				"arcjet": "1.3.1"
+				"@arcjet/body": "1.4.0",
+				"@arcjet/env": "1.4.0",
+				"@arcjet/headers": "1.4.0",
+				"@arcjet/ip": "1.4.0",
+				"@arcjet/logger": "1.4.0",
+				"@arcjet/protocol": "1.4.0",
+				"@arcjet/transport": "1.4.0",
+				"arcjet": "1.4.0"
 			},
 			"devDependencies": {
-				"@arcjet/eslint-config": "1.3.1",
-				"@arcjet/rollup-config": "1.3.1",
+				"@arcjet/eslint-config": "1.4.0",
+				"@arcjet/rollup-config": "1.4.0",
 				"@rollup/wasm-node": "4.59.0",
 				"@types/node": "24.11.0",
 				"eslint": "9.39.3",
@@ -63,14 +63,14 @@
 		},
 		"../../nosecone-sveltekit": {
 			"name": "@nosecone/sveltekit",
-			"version": "1.3.1",
+			"version": "1.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"nosecone": "1.3.1"
+				"nosecone": "1.4.0"
 			},
 			"devDependencies": {
-				"@arcjet/eslint-config": "1.3.1",
-				"@arcjet/rollup-config": "1.3.1",
+				"@arcjet/eslint-config": "1.4.0",
+				"@arcjet/rollup-config": "1.4.0",
 				"@rollup/wasm-node": "4.59.0",
 				"@sveltejs/kit": "2.53.4",
 				"@sveltejs/vite-plugin-svelte": "6.2.4",
@@ -2693,9 +2693,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## Summary
Bumps `postcss` to 8.5.10 in 14 of the 16 affected `package-lock.json` files to address [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (CVE-2026-41305): XSS via unescaped `</style>` in CSS stringify output, affecting `postcss <8.5.10`.

Each example project has its own independent lockfile, so updates are per-example.

## What this resolves cleanly
The following alerts should auto-resolve on merge:
- #1424 (`examples/astro`)
- #1434 (`examples/nuxt`)
- #1435 (`examples/react-router-middleware`)
- #1436 (`examples/react-router`)
- #1437 (`examples/remix-express`)
- #1438 (`examples/sveltekit`)

## What this only partially addresses
The 8 Next.js example alerts (#1425-#1432, ignoring #1433) get their top-level `node_modules/postcss` bumped to 8.5.10, but **Next.js 16.x exact-pins `postcss` to `8.4.31`** in its own `dependencies`, so each example also keeps a vulnerable `node_modules/next/node_modules/postcss@8.4.31`. Dependabot scans every postcss instance in the lockfile, so these alerts likely won't auto-resolve until Next bumps that pin upstream.

The bump is still worth shipping: it patches the postcss copy that tools like tailwindcss actually use in these examples.

## Not touched in this PR (manual dismissal recommended)
- **Alert #1439** (root `package-lock.json`) — same Next pin issue, propagated through `arcjet-next` and `nosecone-next` workspaces. `npm` overrides silently refuse to replace Next's exact version pin.
- **Alert #1433** (`examples/nextjs-server-actions`) — only postcss in the lockfile is the next-internal pinned 8.4.31. Nothing to bump cleanly without forking Next.

For these, suggest dismissing as **Tolerable risk** with rationale: *postcss is pinned to 8.4.31 by Next.js's exact-version dependency; the XSS-via-stringify vulnerability is not exposed in Next's runtime CSS pipeline.*

## Diff noise note
The Next-using example lockfile diffs include a refresh of cross-workspace `@arcjet/*` references from `1.3.1` to `1.4.0`. Those were stale relative to the 1.4.0 release; `npm update postcss` happened to refresh them at the same time.

## Test plan
- [ ] CI passes
- [ ] After merge, alerts #1424, #1434-#1438 auto-resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)