### PR TITLE
chore: remove redundant esbuild and flatted overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "@sveltejs/kit": {
       "cookie": "0.7.2"
     },
-    "esbuild": ">=0.25.0",
-    "flatted": ">=3.4.0",
     "postcss": "^8.5.10",
     "rollup": "npm:@rollup/wasm-node"
   }


### PR DESCRIPTION
## Summary
Drops two root \`overrides\` entries that are no longer doing any work — they were security floors set in past PRs, but every transitive that currently pulls these packages already declares a range above the floor, so the override is a no-op.

| Override | Current parents | Why redundant |
| --- | --- | --- |
| \`esbuild: ">=0.25.0"\` | \`vite@^0.27.0\`, \`vite@^0.27.0 \|\| ^0.28.0\`, \`astro@^0.27.3\` | every parent's natural lowest is ≥ 0.27.0 |
| \`flatted: ">=3.4.0"\` | \`flat-cache@^3.2.9\` | naturally resolves to 3.4.2 |

Confirmed by removing the entries and running \`npm install --package-lock-only\`: the lockfile diff is **empty**. \`esbuild\` stays at 0.27.3, \`flatted\` stays at 3.4.2.

## What this *doesn't* touch
The other root overrides stay because they actively force a different version than the natural resolution:

- \`postcss: ^8.5.10\` — evicts next.js's pinned \`postcss@8.4.31\` (from #6018)
- \`@sveltejs/kit.cookie: 0.7.2\` — patches sveltekit's transitive \`cookie@^0.6.0\`
- \`@bufbuild/protobuf: 2.12.0\` — Bun build pin from #6014
- \`rollup: npm:@rollup/wasm-node\` — Bun build replacement from #6014

If a future transitive ever drops back to a vulnerable range, we can re-add a floor then.

## Test plan
- [ ] CI green
- [ ] No package-lock.json diff (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)