### PR TITLE
build(deps): bump qs to 6.15.2 in examples

### DIFF
--- a/examples/express-bots/package-lock.json
+++ b/examples/express-bots/package-lock.json
@@ -17,25 +17,25 @@
     },
     "../../arcjet-node": {
       "name": "@arcjet/node",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
-        "@rollup/wasm-node": "4.59.0",
-        "@types/node": "24.11.0",
-        "eslint": "9.39.3",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
+        "@rollup/wasm-node": "4.60.0",
+        "@types/node": "24.12.0",
+        "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -44,17 +44,17 @@
     },
     "../../inspect": {
       "name": "@arcjet/inspect",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/protocol": "1.3.1"
+        "@arcjet/protocol": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
-        "@rollup/wasm-node": "4.59.0",
-        "@types/node": "24.11.0",
-        "eslint": "9.39.3",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
+        "@rollup/wasm-node": "4.60.0",
+        "@types/node": "24.12.0",
+        "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/express-newman/package-lock.json
+++ b/examples/express-newman/package-lock.json
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/express-rate-limit/package-lock.json
+++ b/examples/express-rate-limit/package-lock.json
@@ -16,25 +16,25 @@
     },
     "../../arcjet-node": {
       "name": "@arcjet/node",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
-        "@rollup/wasm-node": "4.59.0",
-        "@types/node": "24.11.0",
-        "eslint": "9.39.3",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
+        "@rollup/wasm-node": "4.60.0",
+        "@types/node": "24.12.0",
+        "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/express-sensitive-info/package-lock.json
+++ b/examples/express-sensitive-info/package-lock.json
@@ -16,25 +16,25 @@
     },
     "../../arcjet-node": {
       "name": "@arcjet/node",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
-        "@rollup/wasm-node": "4.59.0",
-        "@types/node": "24.11.0",
-        "eslint": "9.39.3",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
+        "@rollup/wasm-node": "4.60.0",
+        "@types/node": "24.12.0",
+        "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/express-validate-email/package-lock.json
+++ b/examples/express-validate-email/package-lock.json
@@ -16,25 +16,25 @@
     },
     "../../arcjet-node": {
       "name": "@arcjet/node",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.3.1",
-        "@arcjet/env": "1.3.1",
-        "@arcjet/headers": "1.3.1",
-        "@arcjet/ip": "1.3.1",
-        "@arcjet/logger": "1.3.1",
-        "@arcjet/protocol": "1.3.1",
-        "@arcjet/transport": "1.3.1",
-        "arcjet": "1.3.1"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.3.1",
-        "@arcjet/eslint-config": "1.3.1",
-        "@arcjet/rollup-config": "1.3.1",
-        "@rollup/wasm-node": "4.59.0",
-        "@types/node": "24.11.0",
-        "eslint": "9.39.3",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/eslint-config": "1.4.0",
+        "@arcjet/rollup-config": "1.4.0",
+        "@rollup/wasm-node": "4.60.0",
+        "@types/node": "24.12.0",
+        "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/nestjs/package-lock.json
+++ b/examples/nestjs/package-lock.json
@@ -4375,9 +4375,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/react-router-middleware/package-lock.json
+++ b/examples/react-router-middleware/package-lock.json
@@ -41,8 +41,8 @@
         "@arcjet/cache": "1.4.0",
         "@arcjet/eslint-config": "1.4.0",
         "@arcjet/rollup-config": "1.4.0",
-        "eslint": "9.39.3",
-        "react-router": "7.13.1",
+        "eslint": "9.39.4",
+        "react-router": "7.13.2",
         "typescript": "5.9.3"
       },
       "peerDependencies": {
@@ -2824,9 +2824,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/react-router-middleware/package.json
+++ b/examples/react-router-middleware/package.json
@@ -17,6 +17,9 @@
     "vite": "^7.3.2"
   },
   "name": "react-router-middleware",
+  "overrides": {
+    "qs": "6.15.2"
+  },
   "private": true,
   "scripts": {
     "build": "react-router build",

--- a/examples/react-router/package-lock.json
+++ b/examples/react-router/package-lock.json
@@ -41,8 +41,8 @@
         "@arcjet/cache": "1.4.0",
         "@arcjet/eslint-config": "1.4.0",
         "@arcjet/rollup-config": "1.4.0",
-        "eslint": "9.39.3",
-        "react-router": "7.13.1",
+        "eslint": "9.39.4",
+        "react-router": "7.13.2",
         "typescript": "5.9.3"
       },
       "peerDependencies": {
@@ -2824,9 +2824,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -17,6 +17,9 @@
     "vite": "^7.3.2"
   },
   "name": "react-router",
+  "overrides": {
+    "qs": "6.15.2"
+  },
   "private": true,
   "scripts": {
     "build": "react-router build",

--- a/examples/remix-express/package-lock.json
+++ b/examples/remix-express/package-lock.json
@@ -59,8 +59,8 @@
       "devDependencies": {
         "@arcjet/eslint-config": "1.4.0",
         "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.59.0",
-        "eslint": "9.39.3",
+        "@rollup/wasm-node": "4.60.0",
+        "eslint": "9.39.4",
         "typescript": "5.9.3"
       }
     },
@@ -10067,9 +10067,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/examples/remix-express/package.json
+++ b/examples/remix-express/package.json
@@ -47,6 +47,7 @@
     "@vanilla-extract/integration": ">=8.0.1",
     "cookie": "0.7.1",
     "esbuild": ">=0.25.0",
+    "qs": "6.15.2",
     "tar": ">=7.5.7",
     "vite-node": ">=3.1.2"
   },


### PR DESCRIPTION
Resolves the open Dependabot alerts for **qs** (GHSA-q8mj-m7cp-5q26) across the example apps — 9 alerts total.

## Changes
- **6 `^6.14.x` consumers** (express-bots, express-rate-limit, express-sensitive-info, express-validate-email, nestjs, express-newman): pick up `qs@6.15.2` via a plain lockfile bump.
- **3 Express 4 examples** (react-router, react-router-middleware, remix-express): `express@4.22.1` / `body-parser` pin qs to `~6.14.0`, and there's no upstream Express 4 release that allows the fix. These get an `overrides: { "qs": "6.15.2" }` entry instead. qs 6.15.2 is a patch within 6.x (API-stable), so the override is safe.

Incidental: regenerating the lockfiles refreshed stale `@arcjet/inspect` / `@arcjet/node` linked-package versions (1.3.1 → 1.4.0) in a few examples.

## Verification
`npm audit --package-lock-only` reports qs clean in all nine examples.

## Out of scope
The **uuid** alerts (#1646, #1657) are intentionally not included — the fix is a major bump (8/10 → 11.1.1) blocked by parents (`postman-*` pin `uuid@8.3.2`, `typeid-js` wants `^10`), so those are left for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)