### PR TITLE
build(deps): bump turbo, svelte, @sveltejs/kit and transitives

### DIFF
--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -63,11 +63,11 @@
     "@arcjet/eslint-config": "1.4.0",
     "@arcjet/rollup-config": "1.4.0",
     "@rollup/wasm-node": "4.60.0",
-    "@sveltejs/kit": "2.58.0",
+    "@sveltejs/kit": "2.60.1",
     "@sveltejs/vite-plugin-svelte": "7.0.0",
     "@types/node": "24.12.0",
     "eslint": "9.39.4",
-    "svelte": "5.55.0",
+    "svelte": "5.55.7",
     "typescript": "5.9.3",
     "vite": "8.0.10"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "!arcjet-guard"
       ],
       "devDependencies": {
-        "turbo": "2.8.20"
+        "turbo": "2.9.14"
       },
       "engines": {
         "node": ">=20"
@@ -3242,9 +3242,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.58.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
-      "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
+      "integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3253,7 +3253,7 @@
         "@types/cookie": "^0.6.0",
         "acorn": "^8.14.1",
         "cookie": "^0.6.0",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
@@ -3360,9 +3360,9 @@
       "license": "MIT"
     },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.8.20.tgz",
-      "integrity": "sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.14.tgz",
+      "integrity": "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==",
       "cpu": [
         "x64"
       ],
@@ -3373,9 +3373,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.8.20.tgz",
-      "integrity": "sha512-Gpyh9ATFGThD6/s9L95YWY54cizg/VRWl2B67h0yofG8BpHf67DFAh9nuJVKG7bY0+SBJDAo5cMur+wOl9YOYw==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.14.tgz",
+      "integrity": "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==",
       "cpu": [
         "arm64"
       ],
@@ -3386,9 +3386,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.8.20.tgz",
-      "integrity": "sha512-p2QxWUYyYUgUFG0b0kR+pPi8t7c9uaVlRtjTTI1AbCvVqkpjUfCcReBn6DgG/Hu8xrWdKLuyQFaLYFzQskZbcA==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.14.tgz",
+      "integrity": "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==",
       "cpu": [
         "x64"
       ],
@@ -3399,9 +3399,9 @@
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.8.20.tgz",
-      "integrity": "sha512-Gn5yjlZGLRZWarLWqdQzv0wMqyBNIdq1QLi48F1oY5Lo9kiohuf7BPQWtWxeNVS2NgJ1+nb/DzK1JduYC4AWOA==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.14.tgz",
+      "integrity": "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==",
       "cpu": [
         "arm64"
       ],
@@ -3412,9 +3412,9 @@
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.8.20.tgz",
-      "integrity": "sha512-vyaDpYk/8T6Qz5V/X+ihKvKFEZFUoC0oxYpC1sZanK6gaESJlmV3cMRT3Qhcg4D2VxvtC2Jjs9IRkrZGL+exLw==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.14.tgz",
+      "integrity": "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==",
       "cpu": [
         "x64"
       ],
@@ -3425,9 +3425,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.8.20.tgz",
-      "integrity": "sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.14.tgz",
+      "integrity": "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==",
       "cpu": [
         "arm64"
       ],
@@ -3731,9 +3731,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4190,9 +4190,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5127,12 +5127,20 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
-      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -9130,9 +9138,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.0.tgz",
-      "integrity": "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -9144,9 +9152,9 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -9385,20 +9393,20 @@
       "license": "0BSD"
     },
     "node_modules/turbo": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.20.tgz",
-      "integrity": "sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.14.tgz",
+      "integrity": "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==",
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.8.20",
-        "@turbo/darwin-arm64": "2.8.20",
-        "@turbo/linux-64": "2.8.20",
-        "@turbo/linux-arm64": "2.8.20",
-        "@turbo/windows-64": "2.8.20",
-        "@turbo/windows-arm64": "2.8.20"
+        "@turbo/darwin-64": "2.9.14",
+        "@turbo/darwin-arm64": "2.9.14",
+        "@turbo/linux-64": "2.9.14",
+        "@turbo/linux-arm64": "2.9.14",
+        "@turbo/windows-64": "2.9.14",
+        "@turbo/windows-arm64": "2.9.14"
       }
     },
     "node_modules/type-check": {
@@ -10149,11 +10157,11 @@
         "@arcjet/eslint-config": "1.4.0",
         "@arcjet/rollup-config": "1.4.0",
         "@rollup/wasm-node": "4.60.0",
-        "@sveltejs/kit": "2.58.0",
+        "@sveltejs/kit": "2.60.1",
         "@sveltejs/vite-plugin-svelte": "7.0.0",
         "@types/node": "24.12.0",
         "eslint": "9.39.4",
-        "svelte": "5.55.0",
+        "svelte": "5.55.7",
         "typescript": "5.9.3",
         "vite": "8.0.10"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "turbo test"
   },
   "devDependencies": {
-    "turbo": "2.8.20"
+    "turbo": "2.9.14"
   },
   "overrides": {
     "@bufbuild/protobuf": "2.12.0",


### PR DESCRIPTION
Resolves the root-workspace Dependabot alerts (15 alerts).

## Changes
- **turbo** 2.8.20 → 2.9.14 — GHSA-hcf7-66rw-9f5r, GHSA-3qcw-2rhx-2726 (root `package.json`)
- **svelte** 5.55.0 → 5.55.7 in `nosecone-sveltekit` — GHSA-9rmh-mm8f-r9h6, GHSA-f3cj-j4f6-wq85, GHSA-pr6f-5x2q-rwfp, GHSA-rcqx-6q8c-2c42 (clears both the nosecone direct deps and the root transitive instances)
- **@sveltejs/kit** 2.58.0 → 2.60.1 in `nosecone-sveltekit` — GHSA-hgv7-v322-mmgr
- **brace-expansion** 5.0.5 → 5.0.6 — GHSA-jxxr-4gwj-5jf2
- **cookie** 0.6.0 → 0.7.2 — GHSA-pxg6-pf52-xh8x

Incidental: the svelte bump pulls `esrap` 2.2.3 → 2.2.9 (svelte compiler dep); `brace-expansion` 1.x line moved 1.1.13 → 1.1.15.

## Verification
`npm audit --package-lock-only` reports all of the above clean. Lockfile updated in conservative mode (small, reviewable diff) — a full regen was avoided because the committed lock was generated with a different npm version and would have produced a 3600-line diff.

## Out of scope
- **postcss** (GHSA-qx2v-qp2m-jg93, #1439): `next@16.2.6` pins postcss to exactly `8.4.31`, and npm will not apply the existing `overrides` entry to next's edge (confirmed in both conservative and from-scratch resolution). Left pending an upstream Next.js bump.
- **uuid** (#1656): major bump blocked by parents, parked with the other uuid alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)