### PR TITLE
build(deps): bump svelte and @sveltejs/kit in examples/sveltekit

### DIFF
--- a/examples/sveltekit/package-lock.json
+++ b/examples/sveltekit/package-lock.json
@@ -49,9 +49,9 @@
 			"devDependencies": {
 				"@arcjet/eslint-config": "1.4.0",
 				"@arcjet/rollup-config": "1.4.0",
-				"@rollup/wasm-node": "4.59.0",
-				"@types/node": "24.11.0",
-				"eslint": "9.39.3",
+				"@rollup/wasm-node": "4.60.0",
+				"@types/node": "24.12.0",
+				"eslint": "9.39.4",
 				"typescript": "5.9.3"
 			},
 			"engines": {
@@ -71,14 +71,14 @@
 			"devDependencies": {
 				"@arcjet/eslint-config": "1.4.0",
 				"@arcjet/rollup-config": "1.4.0",
-				"@rollup/wasm-node": "4.59.0",
-				"@sveltejs/kit": "2.53.4",
-				"@sveltejs/vite-plugin-svelte": "6.2.4",
-				"@types/node": "24.11.0",
-				"eslint": "9.39.3",
-				"svelte": "5.53.7",
+				"@rollup/wasm-node": "4.60.0",
+				"@sveltejs/kit": "2.58.0",
+				"@sveltejs/vite-plugin-svelte": "7.0.0",
+				"@types/node": "24.12.0",
+				"eslint": "9.39.4",
+				"svelte": "5.55.0",
 				"typescript": "5.9.3",
-				"vite": "7.3.2"
+				"vite": "8.0.10"
 			},
 			"engines": {
 				"node": ">=20"
@@ -1221,9 +1221,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
-			"integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+			"integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -1241,18 +1241,18 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.55.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.55.0.tgz",
-			"integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
+			"version": "2.61.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.1.tgz",
+			"integrity": "sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.9",
 				"@types/cookie": "^0.6.0",
-				"acorn": "^8.14.1",
+				"acorn": "^8.16.0",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -1270,7 +1270,7 @@
 				"@opentelemetry/api": "^1.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"typescript": "^5.3.3",
+				"typescript": "^5.3.3 || ^6.0.0",
 				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -1897,9 +1897,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.4",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-			"integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2137,14 +2137,21 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
-			"integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+			"integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"peerDependencies": {
 				"@typescript-eslint/types": "^8.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/esrecurse": {
@@ -3053,24 +3060,24 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.1.tgz",
-			"integrity": "sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.0.tgz",
+			"integrity": "sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.10",
 				"@types/estree": "^1.0.5",
 				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.4",
+				"esrap": "^2.2.9",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",


### PR DESCRIPTION
Resolves the Dependabot alerts in the SvelteKit example (4 alerts).

## Changes
- **svelte** 5.55.1 → 5.56.0 — GHSA-f3cj-j4f6-wq85, GHSA-pr6f-5x2q-rwfp, GHSA-rcqx-6q8c-2c42 (#1619, #1622, #1625)
- **@sveltejs/kit** 2.55.0 → 2.61.1 — GHSA-hgv7-v322-mmgr (#1643)

Both move within their existing caret ranges (`^5.49.1`, `^2.50.1`), so this is a **lockfile-only** change — no `package.json` edits. Incidentally pulls svelte-closure deps `esrap` 2.2.9, `devalue` 5.8.1, and `@sveltejs/acorn-typescript` 1.0.10.

## Verification
`npm audit --package-lock-only` reports svelte and @sveltejs/kit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)