### PR TITLE
ci: allow mise attestation-verification endpoints in lint-workflows

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -39,10 +39,12 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            mise-versions.jdx.dev:443
             mise.jdx.dev:443
             mise.run:443
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

The `Lint workflows` job (`actionlint + zizmor`) has been failing on **every** run repo-wide — including the merge queue — since the gate was added. It is not a workflow-lint finding: `mise install` aborts in the **Harden Runner** step before any linting happens.

## Root cause

The job runs `step-security/harden-runner` with `egress-policy: block`, but the allow-list omits two endpoints that `mise` needs to **verify the GitHub artifact attestations** of the actionlint/zizmor binaries:

- `mise-versions.jdx.dev` — version metadata (only `mise.jdx.dev` was allowed; harden-runner matches exact hosts).
- `tuf-repo-cdn.sigstore.dev` — the Sigstore TUF root (`.../15.root.json`), which the attestation verification fetches.

The binaries download fine (via `objects.githubusercontent.com`), then verification can't reach Sigstore and `mise` errors with:

```
Failed to install tools: aqua:rhysd/actionlint, aqua:zizmorcore/zizmor
... TUF repository load failed: Failed to fetch https://tuf-repo-cdn.sigstore.dev/15.root.json
```

## Fix

Add the two endpoints to the harden-runner allow-list.

## Note (possible follow-up)

With egress fixed, **actionlint** should install and run. **zizmor** may still fail on a separate, pre-existing attestation **identity mismatch**:

```
Workflow verification failed: expected 'zizmorcore/zizmor/.github/workflows/release-binaries.yml',
found certificate identity: "https://dotcom.releases.github.com"
```

(zizmor moved to GitHub immutable releases, so the aqua registry's expected signer is stale.) If that surfaces after this merges, it needs an aqua/mise registry bump rather than an egress change — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
