### PR TITLE
deps: fix high severity Dependabot alerts (react-router, @remix-run)

### DIFF
--- a/examples/react-router-middleware/package-lock.json
+++ b/examples/react-router-middleware/package-lock.json
@@ -12,7 +12,7 @@
         "isbot": "^5.1.34",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router": "^7.13.0"
+        "react-router": "^7.15.0"
       },
       "devDependencies": {
         "@react-router/dev": "^7.13.0",
@@ -25,24 +25,24 @@
     },
     "../../arcjet-react-router": {
       "name": "@arcjet/react-router",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.4.0",
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
+        "@arcjet/cache": "1.5.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
         "eslint": "9.39.4",
-        "react-router": "7.13.2",
+        "react-router": "7.16.0",
         "typescript": "5.9.3"
       },
       "peerDependencies": {
@@ -1015,9 +1015,9 @@
       "license": "MIT"
     },
     "node_modules/@react-router/dev": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.13.2.tgz",
-      "integrity": "sha512-8Lgf+WCEIPDhp22YB3fyoiWnNyM39sjkfWnSxAwy+Sg83OHxnQFQg0OK1oPM9lm1n/hxJe4lLYOPNwDSyeGiog==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.17.0.tgz",
+      "integrity": "sha512-+ITMmv/1xUB+QF6ehCCOIVBNBDuKIEE+3JKCt+kTBvxDTk1s49qHbtCA4TzJYge41pNRGtFIiy5VAksLSVJheg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1028,7 +1028,7 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/traverse": "^7.27.7",
         "@babel/types": "^7.27.7",
-        "@react-router/node": "7.13.2",
+        "@react-router/node": "7.17.0",
         "@remix-run/node-fetch-server": "^0.13.0",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
@@ -1057,12 +1057,12 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.13.2",
-        "@vitejs/plugin-rsc": "~0.5.7",
-        "react-router": "^7.13.2",
+        "@react-router/serve": "^7.17.0",
+        "@vitejs/plugin-rsc": "~0.5.21",
+        "react-router": "^7.17.0",
         "react-server-dom-webpack": "^19.2.3",
-        "typescript": "^5.1.0",
-        "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",
+        "typescript": "^5.1.0 || ^6.0.0",
+        "vite": "^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "wrangler": "^3.28.2 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -1084,20 +1084,20 @@
       }
     },
     "node_modules/@react-router/express": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.13.2.tgz",
-      "integrity": "sha512-OuhenOg3LmCLT23+WA6CU/nIyhGv0/3kmyqpQuXxearj6Gbn1ufI+mkejFWPXsNJf+/y1ttY6P6XL8PzNX5E8w==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.17.0.tgz",
+      "integrity": "sha512-/onhRWlfCRTq0bI7t06d2KGRUr+Gy12+CHLZDaHkdtkHJxsUFPGlnfomBMQXQLIPW544I5ykKAY8Z2d/1J6+bQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/node": "7.13.2"
+        "@react-router/node": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "express": "^4.17.1 || ^5",
-        "react-router": "7.13.2",
-        "typescript": "^5.1.0"
+        "react-router": "7.17.0",
+        "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@react-router/node": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.13.2.tgz",
-      "integrity": "sha512-1q0v1gclPga2mNQ7Q+MLuLdEPRpDefAmz25jOlrEz+jSyYkaFt9qbSdkTUPw/QIg/DDnnT3QV8lhgr6r5iIAOA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.17.0.tgz",
+      "integrity": "sha512-RYR47qM9gJ8zV8Ntial5Rkgcst2YnwWXt0Ai34FezzkDK6AILpxpVatEzFEhNRwbSh6JO6iweY7XhfM4/K5dBA==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0"
@@ -1117,8 +1117,8 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.13.2",
-        "typescript": "^5.1.0"
+        "react-router": "7.17.0",
+        "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1127,14 +1127,14 @@
       }
     },
     "node_modules/@react-router/serve": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.13.2.tgz",
-      "integrity": "sha512-H/clM2tMw7daRd7bTM0kYYim4ZLrcWd30DY+R/xu8h2t2YvdfLAfHD0GfqGu3Ds8yAOrWFqH5Ly7BM7jk7fvCg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.17.0.tgz",
+      "integrity": "sha512-cjVz/HiZbkZe4urdImO6V+KFYDIGJk59DJXGnJ5XeDoltRi+buba0K6oTHIh0G0uoYJMm3gKqHKSiCN/a0dhJw==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
-        "@react-router/express": "7.13.2",
-        "@react-router/node": "7.13.2",
+        "@react-router/express": "7.17.0",
+        "@react-router/node": "7.17.0",
         "compression": "^1.8.1",
         "express": "^4.19.2",
         "get-port": "5.1.1",
@@ -1148,7 +1148,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.17.0"
       }
     },
     "node_modules/@remix-run/node-fetch-server": {
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/examples/react-router-middleware/package.json
+++ b/examples/react-router-middleware/package.json
@@ -6,7 +6,7 @@
     "isbot": "^5.1.34",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "^7.13.0"
+    "react-router": "^7.15.0"
   },
   "devDependencies": {
     "@react-router/dev": "^7.13.0",

--- a/examples/react-router/package-lock.json
+++ b/examples/react-router/package-lock.json
@@ -12,7 +12,7 @@
         "isbot": "^5.1.34",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router": "^7.13.0"
+        "react-router": "^7.15.0"
       },
       "devDependencies": {
         "@react-router/dev": "^7.13.0",
@@ -25,24 +25,24 @@
     },
     "../../arcjet-react-router": {
       "name": "@arcjet/react-router",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/cache": "1.4.0",
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
+        "@arcjet/cache": "1.5.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
         "eslint": "9.39.4",
-        "react-router": "7.13.2",
+        "react-router": "7.16.0",
         "typescript": "5.9.3"
       },
       "peerDependencies": {
@@ -1015,9 +1015,9 @@
       "license": "MIT"
     },
     "node_modules/@react-router/dev": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.13.2.tgz",
-      "integrity": "sha512-8Lgf+WCEIPDhp22YB3fyoiWnNyM39sjkfWnSxAwy+Sg83OHxnQFQg0OK1oPM9lm1n/hxJe4lLYOPNwDSyeGiog==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.17.0.tgz",
+      "integrity": "sha512-+ITMmv/1xUB+QF6ehCCOIVBNBDuKIEE+3JKCt+kTBvxDTk1s49qHbtCA4TzJYge41pNRGtFIiy5VAksLSVJheg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1028,7 +1028,7 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/traverse": "^7.27.7",
         "@babel/types": "^7.27.7",
-        "@react-router/node": "7.13.2",
+        "@react-router/node": "7.17.0",
         "@remix-run/node-fetch-server": "^0.13.0",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
@@ -1057,12 +1057,12 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.13.2",
-        "@vitejs/plugin-rsc": "~0.5.7",
-        "react-router": "^7.13.2",
+        "@react-router/serve": "^7.17.0",
+        "@vitejs/plugin-rsc": "~0.5.21",
+        "react-router": "^7.17.0",
         "react-server-dom-webpack": "^19.2.3",
-        "typescript": "^5.1.0",
-        "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",
+        "typescript": "^5.1.0 || ^6.0.0",
+        "vite": "^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "wrangler": "^3.28.2 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -1084,20 +1084,20 @@
       }
     },
     "node_modules/@react-router/express": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.13.2.tgz",
-      "integrity": "sha512-OuhenOg3LmCLT23+WA6CU/nIyhGv0/3kmyqpQuXxearj6Gbn1ufI+mkejFWPXsNJf+/y1ttY6P6XL8PzNX5E8w==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.17.0.tgz",
+      "integrity": "sha512-/onhRWlfCRTq0bI7t06d2KGRUr+Gy12+CHLZDaHkdtkHJxsUFPGlnfomBMQXQLIPW544I5ykKAY8Z2d/1J6+bQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/node": "7.13.2"
+        "@react-router/node": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "express": "^4.17.1 || ^5",
-        "react-router": "7.13.2",
-        "typescript": "^5.1.0"
+        "react-router": "7.17.0",
+        "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@react-router/node": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.13.2.tgz",
-      "integrity": "sha512-1q0v1gclPga2mNQ7Q+MLuLdEPRpDefAmz25jOlrEz+jSyYkaFt9qbSdkTUPw/QIg/DDnnT3QV8lhgr6r5iIAOA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.17.0.tgz",
+      "integrity": "sha512-RYR47qM9gJ8zV8Ntial5Rkgcst2YnwWXt0Ai34FezzkDK6AILpxpVatEzFEhNRwbSh6JO6iweY7XhfM4/K5dBA==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0"
@@ -1117,8 +1117,8 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.13.2",
-        "typescript": "^5.1.0"
+        "react-router": "7.17.0",
+        "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1127,14 +1127,14 @@
       }
     },
     "node_modules/@react-router/serve": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.13.2.tgz",
-      "integrity": "sha512-H/clM2tMw7daRd7bTM0kYYim4ZLrcWd30DY+R/xu8h2t2YvdfLAfHD0GfqGu3Ds8yAOrWFqH5Ly7BM7jk7fvCg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.17.0.tgz",
+      "integrity": "sha512-cjVz/HiZbkZe4urdImO6V+KFYDIGJk59DJXGnJ5XeDoltRi+buba0K6oTHIh0G0uoYJMm3gKqHKSiCN/a0dhJw==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
-        "@react-router/express": "7.13.2",
-        "@react-router/node": "7.13.2",
+        "@react-router/express": "7.17.0",
+        "@react-router/node": "7.17.0",
         "compression": "^1.8.1",
         "express": "^4.19.2",
         "get-port": "5.1.1",
@@ -1148,7 +1148,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.17.0"
       }
     },
     "node_modules/@remix-run/node-fetch-server": {
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -6,7 +6,7 @@
     "isbot": "^5.1.34",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "^7.13.0"
+    "react-router": "^7.15.0"
   },
   "devDependencies": {
     "@react-router/dev": "^7.13.0",

--- a/examples/remix-express/package-lock.json
+++ b/examples/remix-express/package-lock.json
@@ -44,22 +44,22 @@
     },
     "../../arcjet-remix": {
       "name": "@arcjet/remix",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
         "eslint": "9.39.4",
         "typescript": "5.9.3"
       }
@@ -1519,9 +1519,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.4.tgz",
-      "integrity": "sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.5.tgz",
+      "integrity": "sha512-yEDrKcIICHnaJdUOdBAXQTNXoehB0J3FBcZr4CnK6Alic6cVJGGBGMtJdIO7DUwNySwoYvkUTS3qnXuk2zGYZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1535,9 +1535,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.17.4",
-        "@remix-run/router": "1.23.2",
-        "@remix-run/server-runtime": "2.17.4",
+        "@remix-run/node": "2.17.5",
+        "@remix-run/router": "1.23.3",
+        "@remix-run/server-runtime": "2.17.5",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -1611,12 +1611,12 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.17.4.tgz",
-      "integrity": "sha512-4zZs0L7v2pvAq896zHRLNMhoOKIPXM9qnYdHLbz4mpZUMbNAgQacGazArIrUV3M4g0gRMY0dLrt5CqMNrlBeYg==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.17.5.tgz",
+      "integrity": "sha512-R4G22lXN4oRWusxdTsdnDYfjmnVaNUkWU6zg1OQZD15EJ5gZlx8psO62Tv77vXKN5XMhJ6YdODQ8179isvkNpw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/node": "2.17.4"
+        "@remix-run/node": "2.17.5"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1632,12 +1632,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
-      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.5.tgz",
+      "integrity": "sha512-CwOUCDJqh9o8r/n5N1l+vz4Jh7DFU52/jo7MN56+OL9gM+14aQKdq1aLAh+4V6GuI/qtki9PPk02GmULimmDkw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.17.4",
+        "@remix-run/server-runtime": "2.17.5",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -1658,15 +1658,15 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.4.tgz",
-      "integrity": "sha512-MeXHacIBoohr9jzec5j/Rmk57xk34korkPDDb0OPHgkdvh20lO5fJoSAcnZfjTIOH+Vsq1ZRQlmvG5PRQ/64Sw==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.5.tgz",
+      "integrity": "sha512-ya6OQ+T9yS4u8www75f4dH11NIYeK8K0eMrei+q4BTp6NrY2lqLTBfHqVlc23ZsUnWqdLUII4hzySVv+AJbTWA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "@remix-run/server-runtime": "2.17.4",
-        "react-router": "6.30.3",
-        "react-router-dom": "6.30.3",
+        "@remix-run/router": "1.23.3",
+        "@remix-run/server-runtime": "2.17.5",
+        "react-router": "6.30.4",
+        "react-router-dom": "6.30.4",
         "turbo-stream": "2.4.1"
       },
       "engines": {
@@ -1684,21 +1684,21 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
-      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.5.tgz",
+      "integrity": "sha512-SyJ5n2pQyo4ERGvjjLvL2PpRWBzlC2qzO5KkkOE2ygOiNcgOu9WQnnom9GI8KgsTRCO8JnIeLHFRcmxZnVBjfw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
+        "@remix-run/router": "1.23.3",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.7.2",
@@ -10186,12 +10186,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -10201,13 +10201,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"


### PR DESCRIPTION
Addresses the open **high severity** Dependabot alerts. After the first attempt, CI surfaced that the esbuild "fix" was both unnecessary and build-breaking (see below), so this PR is scoped to the genuinely-applicable fixes.

## Fixed

| Package | Fix | Location | Alerts |
|---|---|---|---|
| **react-router** | 7.x family → `7.17.0` (dep range `^7.15.0`) | `react-router`, `react-router-middleware` | #1682 #1681 #1676 #1675 #1668 #1667 |
| **@remix-run/server-runtime** | `@remix-run` 2.x → `2.17.5` (lockfile only) | `remix-express` | #1666 |

## Intentionally not changed

**esbuild (7 alerts: #1698 #1697 #1696 #1695 #1694 #1693 #1692)** — The advisory [GHSA-gv7w-rqvm-qjhr](https://github.com/advisories/GHSA-gv7w-rqvm-qjhr) is specific to esbuild's **Deno** module (`lib/deno/mod.ts`), which downloads its native binary *without integrity verification*. The Node.js install path (`lib/npm/node-install.ts`) used by these npm-based examples performs a SHA-256 `binaryIntegrityCheck()`, so **these examples are not affected**. Forcing `esbuild >= 0.28.1` also **breaks the Vite/Svelte builds** — esbuild 0.28 refuses to transform Svelte 5's private-field destructuring (`for (const [k, v] of this.#batches)`) down to the examples' legacy browser targets (`es2020`/`chrome87`…). Recommend dismissing these alerts as *not affected*.

**turbo-stream (#1680, remix-express)** — Patched only in **turbo-stream 3.0.0**, whose API is incompatible with Remix v2's `@remix-run/server-runtime@2.17.5` (removed `postPlugins`, `ReadableStream<Uint8Array>`→`<string>`, changed `decode` return shape). No patched 2.x exists. Fixing requires migrating the example off Remix v2 to React Router 7. Left open per maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)