### PR TITLE
deps: bump js-yaml to 4.2.0 to fix Dependabot alerts

### DIFF
--- a/examples/nestjs/package-lock.json
+++ b/examples/nestjs/package-lock.json
@@ -34,24 +34,24 @@
     },
     "../../arcjet-nest": {
       "name": "@arcjet/nest",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
         "@nestjs/common": "11.1.17",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.2",
@@ -3606,10 +3606,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-app-dir-rate-limit/package-lock.json
+++ b/examples/nextjs-app-dir-rate-limit/package-lock.json
@@ -30,23 +30,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -4395,10 +4395,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-app-dir-validate-email/package-lock.json
+++ b/examples/nextjs-app-dir-validate-email/package-lock.json
@@ -30,23 +30,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -62,16 +62,16 @@
     },
     "../../nosecone-next": {
       "name": "@nosecone/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nosecone": "1.4.0"
+        "nosecone": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "typescript": "5.9.3"
@@ -4407,10 +4407,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-bot-categories/package-lock.json
+++ b/examples/nextjs-bot-categories/package-lock.json
@@ -29,23 +29,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -4379,10 +4379,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-decorate/package-lock.json
+++ b/examples/nextjs-decorate/package-lock.json
@@ -30,23 +30,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -62,17 +62,17 @@
     },
     "../../decorate": {
       "name": "@arcjet/decorate",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/sprintf": "1.4.0"
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/sprintf": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
@@ -4404,10 +4404,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-ip-details/package-lock.json
+++ b/examples/nextjs-ip-details/package-lock.json
@@ -30,23 +30,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -62,13 +62,13 @@
     },
     "../../ip": {
       "name": "@arcjet/ip",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "typescript": "5.9.3"
       },
@@ -4400,10 +4400,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-pages-wrap/package-lock.json
+++ b/examples/nextjs-pages-wrap/package-lock.json
@@ -29,23 +29,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -4379,10 +4379,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-react-hook-form/package-lock.json
+++ b/examples/nextjs-react-hook-form/package-lock.json
@@ -41,23 +41,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -4285,10 +4285,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/nextjs-server-actions/package-lock.json
+++ b/examples/nextjs-server-actions/package-lock.json
@@ -26,23 +26,23 @@
     },
     "../../arcjet-next": {
       "name": "@arcjet/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/body": "1.4.0",
-        "@arcjet/env": "1.4.0",
-        "@arcjet/headers": "1.4.0",
-        "@arcjet/ip": "1.4.0",
-        "@arcjet/logger": "1.4.0",
-        "@arcjet/protocol": "1.4.0",
-        "@arcjet/transport": "1.4.0",
-        "arcjet": "1.4.0"
+        "@arcjet/body": "1.5.0",
+        "@arcjet/env": "1.5.0",
+        "@arcjet/headers": "1.5.0",
+        "@arcjet/ip": "1.5.0",
+        "@arcjet/logger": "1.5.0",
+        "@arcjet/protocol": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "arcjet": "1.5.0"
       },
       "devDependencies": {
-        "@arcjet/eslint-config": "1.4.0",
-        "@arcjet/rollup-config": "1.4.0",
-        "@rollup/wasm-node": "4.60.0",
-        "@types/node": "24.12.0",
+        "@arcjet/eslint-config": "1.5.0",
+        "@arcjet/rollup-config": "1.5.0",
+        "@rollup/wasm-node": "4.61.0",
+        "@types/node": "24.12.4",
         "eslint": "9.39.4",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -3820,10 +3820,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/examples/remix-express/package-lock.json
+++ b/examples/remix-express/package-lock.json
@@ -7273,10 +7273,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
Resolves all open **js-yaml** Dependabot alerts ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), medium) by bumping the transitive `js-yaml` dependency from `4.1.1` → `4.2.0`.

The advisory: js-yaml does not escape/quote special characters in keys when dumping, which can produce invalid or ambiguous YAML output.

## Fixed (10 alerts)

`js-yaml` bumped to `4.2.0` in these example lockfiles:

| Example | Alert |
|---|---|
| nestjs | #1703 |
| nextjs-app-dir-rate-limit | #1704 |
| nextjs-app-dir-validate-email | #1705 |
| nextjs-bot-categories | #1706 |
| nextjs-decorate | #1707 |
| nextjs-ip-details | #1708 |
| nextjs-pages-wrap | #1709 |
| nextjs-react-hook-form | #1710 |
| nextjs-server-actions | #1712 |
| remix-express | #1723 |

Lockfile re-lock only — no `package.json` changes. The only incidental diff is local workspace `file:` dependency references syncing from `1.4.0` to the current `1.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)