### PR TITLE
deps(remix-express): drop redundant cookie override

### DIFF
--- a/examples/remix-express/package-lock.json
+++ b/examples/remix-express/package-lock.json
@@ -4375,9 +4375,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/examples/remix-express/package.json
+++ b/examples/remix-express/package.json
@@ -45,7 +45,6 @@
   },
   "overrides": {
     "@vanilla-extract/integration": ">=8.0.1",
-    "cookie": "0.7.1",
     "esbuild": ">=0.25.0",
     "qs": "6.15.2",
     "tar": ">=7.5.7",


### PR DESCRIPTION
Small cleanup found while auditing whether the repo's `overrides` are still needed.

The `cookie: "0.7.1"` override in `examples/remix-express` pins cookie to an exact version that's one patch **behind** what the dependency tree resolves on its own. Removing it lets npm resolve **cookie 0.7.2** — newer, and still above the `GHSA-pxg6-pf52-xh8x` fix (0.7.0) — so the pin no longer does anything useful.

## Verification
Removed the override and re-locked: `cookie` resolves to `0.7.2` with **no other dependency changes**.

The example's other overrides (`@vanilla-extract/integration`, `esbuild`, `qs`, `tar`, `vite-node`) were each checked and are **still required** — removing any of them re-resolves a lower, vulnerable version, so they're left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)