### PR TITLE
feat(guard): error/warning decision model with hasFailedOpen() gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,8 +847,10 @@ const decision = await arcjet.guard({ label: "tools.weather", rules: [...] });
 decision.conclusion;   // "ALLOW" or "DENY"
 decision.reason;       // "RATE_LIMIT", "PROMPT_INJECTION", "SENSITIVE_INFO", "CUSTOM", "ERROR", etc.
 
-// Layer 2: error detection
-decision.hasError();   // true if any rule errored or the server reported diagnostics
+// Layer 2: error/warning detection
+decision.hasFailedOpen(); // true if ALLOW only because a rule/decision could not be processed (fail-closed gate)
+decision.errorResults();  // results that errored (rules or the decision that could not be processed)
+decision.warnings;        // decision-level diagnostics (e.g. an invalid metadata key that was stripped)
 
 // Layer 3: per-rule results (see "Per-rule results" above)
 for (const result of decision.results) {

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -114,9 +114,17 @@ if (decision.conclusion === "DENY") {
   throw new Error("Request denied");
 }
 
-// Check for errors (fail-open — errors don't cause denials)
-if (decision.hasError()) {
-  console.warn("At least one rule errored");
+// Check for failures (fail-open — errors don't cause denials). hasFailedOpen()
+// is true only when the conclusion is ALLOW because a rule or the decision
+// could not be processed — gate a fail-closed policy on it.
+if (decision.hasFailedOpen()) {
+  console.warn("Allowed only because evaluation failed open", decision.errorResults());
+}
+
+// Decision-level diagnostics (e.g. an invalid metadata key that was stripped).
+// Warnings never change the conclusion.
+for (const warning of decision.warnings) {
+  console.warn(`${warning.code}: ${warning.message}`);
 }
 
 // From a RuleWithInput — result for this specific submission
@@ -311,8 +319,10 @@ const decision = await arcjet.guard({
 decision.conclusion; // "ALLOW" | "DENY"
 decision.reason; // "RATE_LIMIT" | "PROMPT_INJECTION" | ... (only on DENY)
 
-// Error check (fail-open — errors don't cause denials)
-decision.hasError(); // true if any rule errored
+// Failure check (fail-open — errors don't cause denials)
+decision.hasFailedOpen(); // true if ALLOW only because a rule/decision could not be processed
+decision.errorResults(); // the results that errored
+decision.warnings; // decision-level request-validation diagnostics
 
 // Per-rule results — iterate all
 for (const result of decision.results) {
@@ -387,15 +397,22 @@ Methods available on both `RuleWithConfig` and `RuleWithInput`:
   });
   ```
 
-- **Handle errors explicitly.** Check `decision.hasError()` to detect rules
-  that errored during evaluation. The SDK fails open — an errored rule does
-  not cause a denial:
+- **Handle failures explicitly.** The SDK fails open — an errored rule does not
+  cause a denial. Check `decision.hasFailedOpen()` to detect when a decision
+  returned `ALLOW` only because a rule or the decision could not be processed,
+  and inspect `decision.errorResults()` for the details. Gate a fail-closed
+  policy on it:
 
   ```ts
-  if (decision.hasError()) {
-    console.error("Guard error — proceeding with caution");
+  if (decision.hasFailedOpen()) {
+    // Evaluation degraded — decide whether to proceed or deny.
+    console.error("Guard failed open", decision.errorResults());
   }
   ```
+
+  `decision.hasError()` still works but is deprecated: it conflated request
+  diagnostics with errors. Use `decision.warnings` for diagnostics and
+  `decision.errorResults()` / `decision.hasFailedOpen()` for errors.
 
 - **Use labels** to identify protection boundaries. Labels appear in the
   Arcjet dashboard and help correlate decisions with specific tool calls or

--- a/arcjet-guard/src/client.test.ts
+++ b/arcjet-guard/src/client.test.ts
@@ -117,6 +117,7 @@ describe("In-memory server: token bucket", () => {
     assert.equal(decision.id, "gdec_allow_tb");
     assert.equal(decision.results.length, 1);
     assert.equal(decision.results[0].type, "TOKEN_BUCKET");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     const result = input.result(decision);
@@ -599,6 +600,7 @@ describe("In-memory server: sensitive info", () => {
     });
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
   });
 });
@@ -884,6 +886,7 @@ describe("In-memory server: multi-rule", () => {
 
     assert.equal(decision.conclusion, "ALLOW");
     assert.equal(decision.results.length, 2);
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     const rlResult = rl.result(decision);
@@ -1193,7 +1196,13 @@ describe("In-memory server: error handling", () => {
 
     const decision = await arcjet.guard({ label: "test", rules: [] });
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
+    // No rules means a synthetic error result: the decision failed open.
+    assert.equal(decision.hasFailedOpen(), true);
+    assert.equal(decision.errorResults().length, 1);
+    // No request-level diagnostics.
+    assert.equal(decision.warnings.length, 0);
   });
 
   test("server error returns fail-open ALLOW with error result", async () => {
@@ -1211,9 +1220,16 @@ describe("In-memory server: error handling", () => {
 
     const decision = await arcjet.guard({ label: "test", rules: [input] });
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
     assert.equal(decision.results.length, 1);
     assert.equal(decision.results[0]?.type, "RULE_ERROR");
+    // A transport failure is a decision-level error: ALLOW only because the
+    // request could not be processed.
+    assert.equal(decision.hasFailedOpen(), true);
+    assert.equal(decision.errorResults().length, 1);
+    assert.equal(decision.errorResults()[0].code, "TRANSPORT_ERROR");
+    assert.equal(decision.warnings.length, 0);
     if (decision.results[0]?.type === "RULE_ERROR") {
       assert.ok(decision.results[0].message.includes("service unavailable"));
     }
@@ -1259,6 +1275,7 @@ describe("In-memory server: error handling", () => {
     });
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
     assert.equal(decision.results[0].type, "RULE_ERROR");
   });

--- a/arcjet-guard/src/client.ts
+++ b/arcjet-guard/src/client.ts
@@ -14,7 +14,7 @@ import {
   createClient as createConnectClient,
 } from "@connectrpc/connect";
 
-import { ruleToProto, decisionFromProto } from "./convert.ts";
+import { ruleToProto, decisionFromProto, decisionMembers } from "./convert.ts";
 import {
   DecideService,
   GuardRequestSchema,
@@ -149,16 +149,20 @@ function failOpen(message: string): Decision {
     conclusion: "ALLOW",
     reason: "ERROR",
     type: "RULE_ERROR",
+    warnings: [],
     message,
     code: "TRANSPORT_ERROR",
     [symbolArcjetInternal]: { configId: "", inputId: "" },
   };
+  const results = [errorResult];
   const d: InternalDecision = {
     conclusion: "ALLOW" as const,
     id: "",
-    results: [errorResult],
-    hasError: () => true,
-    [symbolArcjetInternal]: { results: [errorResult] },
+    results,
+    // A transport failure is an error (the request could not be processed),
+    // carried as the error result above — not a warning.
+    ...decisionMembers("ALLOW", results, []),
+    [symbolArcjetInternal]: { results },
   };
   return d;
 }

--- a/arcjet-guard/src/convert.test.ts
+++ b/arcjet-guard/src/convert.test.ts
@@ -775,6 +775,7 @@ describe("decisionFromProto", () => {
     assert.equal(decision.id, "gdec_test123");
     assert.equal(decision.results.length, 1);
     assert.equal(decision.results[0].type, "TOKEN_BUCKET");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     const result = input.result(decision);
@@ -982,7 +983,18 @@ describe("decisionFromProto", () => {
     const decision = decisionFromProto(response, [input]);
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
+    // An errored rule is a rule-level error: it fails open to ALLOW, so the
+    // decision did fail open, and the errored result is inspectable.
+    assert.equal(decision.hasFailedOpen(), true);
+    assert.equal(decision.errorResults().length, 1);
+    assert.equal(decision.errorResults()[0].code, "TIMEOUT");
+    assert.equal(decision.errorResults()[0].message, "evaluator timeout");
+    // No request-level diagnostics on this response.
+    assert.equal(decision.warnings.length, 0);
+    // Per-rule warnings channel is empty until the service populates it.
+    assert.equal(decision.results[0].warnings.length, 0);
     assert.equal(decision.results[0].type, "RULE_ERROR");
     if (decision.results[0].type === "RULE_ERROR") {
       assert.equal(decision.results[0].message, "evaluator timeout");
@@ -1022,7 +1034,13 @@ describe("decisionFromProto", () => {
     const decision = decisionFromProto(response, []);
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
+    // A missing decision is a decision-level error: fail-open ALLOW with a
+    // single synthetic error result the caller can detect.
+    assert.equal(decision.hasFailedOpen(), true);
+    assert.equal(decision.errorResults().length, 1);
+    assert.equal(decision.errorResults()[0].code, "NO_DECISION");
   });
 
   test("unrecognized result case maps to UNKNOWN", () => {
@@ -1054,7 +1072,156 @@ describe("decisionFromProto", () => {
 
     assert.equal(decision.conclusion, "ALLOW");
     assert.equal(decision.results.length, 0);
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
+    // Clean ALLOW: no errored results, so it did not fail open.
+    assert.equal(decision.hasFailedOpen(), false);
+    assert.equal(decision.errorResults().length, 0);
+    assert.equal(decision.warnings.length, 0);
+  });
+
+  test("response errors surface as decision-level warnings", () => {
+    // The proto's `GuardResponse.errors` carries non-fatal request-validation
+    // diagnostics. The SDK surfaces them as warnings instead of dropping them.
+    const response = create(GuardResponseSchema, {
+      errors: [
+        create(ResultErrorSchema, { code: "AJ1100", message: "stripped invalid metadata key" }),
+      ],
+      decision: create(GuardDecisionSchema, {
+        id: "gdec_test123",
+        conclusion: GuardConclusion.ALLOW,
+        reason: GuardReason.UNSPECIFIED,
+        ruleResults: [],
+      }),
+    });
+
+    const decision = decisionFromProto(response, []);
+
+    // The decision is still valid (ALLOW, nothing errored) — it did NOT fail
+    // open. The diagnostic is a warning.
+    assert.equal(decision.conclusion, "ALLOW");
+    assert.equal(decision.hasFailedOpen(), false);
+    assert.equal(decision.errorResults().length, 0);
+    assert.equal(decision.warnings.length, 1);
+    assert.equal(decision.warnings[0].code, "AJ1100");
+    assert.equal(decision.warnings[0].message, "stripped invalid metadata key");
+    // The deprecated union still fires on warnings (back-compat).
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
+    assert.equal(decision.hasError(), true);
+  });
+
+  test("DENY with an errored rule does not fail open", () => {
+    // Another rule denied, so the ALLOW masking an error did not happen —
+    // hasFailedOpen() must be false even though a rule errored.
+    const rule = tokenBucket({
+      bucket: "test",
+      refillRate: 10,
+      intervalSeconds: 60,
+      maxTokens: 100,
+    });
+    const input = rule({ key: "user_1" });
+
+    const response = makeResponse(GuardConclusion.DENY, [
+      {
+        resultId: "gres_test1",
+        configId: input[symbolArcjetInternal].configId,
+        inputId: input[symbolArcjetInternal].inputId,
+        type: GuardRuleType.TOKEN_BUCKET,
+        result: {
+          case: "error",
+          value: create(ResultErrorSchema, { message: "evaluator timeout", code: "TIMEOUT" }),
+        },
+      },
+    ]);
+
+    const decision = decisionFromProto(response, [input]);
+
+    assert.equal(decision.conclusion, "DENY");
+    assert.equal(decision.hasFailedOpen(), false);
+    // The errored result is still inspectable.
+    assert.equal(decision.errorResults().length, 1);
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
+    assert.equal(decision.hasError(), true);
+  });
+
+  test("combined decision warning and rule error keep severity separate", () => {
+    // The four-channel cell: a decision-level warning AND a rule-level error
+    // on the same decision. Severity is carried by channel, not inferred.
+    const rule = tokenBucket({
+      bucket: "test",
+      refillRate: 10,
+      intervalSeconds: 60,
+      maxTokens: 100,
+    });
+    const input = rule({ key: "user_1" });
+
+    const response = create(GuardResponseSchema, {
+      errors: [
+        create(ResultErrorSchema, { code: "AJ1100", message: "stripped invalid metadata key" }),
+      ],
+      decision: create(GuardDecisionSchema, {
+        id: "gdec_test123",
+        conclusion: GuardConclusion.ALLOW,
+        reason: GuardReason.UNSPECIFIED,
+        ruleResults: [
+          create(GuardRuleResultSchema, {
+            resultId: "gres_test1",
+            configId: input[symbolArcjetInternal].configId,
+            inputId: input[symbolArcjetInternal].inputId,
+            type: GuardRuleType.TOKEN_BUCKET,
+            result: {
+              case: "error",
+              value: create(ResultErrorSchema, { message: "evaluator timeout", code: "TIMEOUT" }),
+            },
+          }),
+        ],
+      }),
+    });
+
+    const decision = decisionFromProto(response, [input]);
+
+    // Warning channel.
+    assert.equal(decision.warnings.length, 1);
+    assert.equal(decision.warnings[0].code, "AJ1100");
+    // Error channel.
+    assert.equal(decision.errorResults().length, 1);
+    assert.equal(decision.errorResults()[0].code, "TIMEOUT");
+    // ALLOW masking an error → failed open.
+    assert.equal(decision.hasFailedOpen(), true);
+    // Deprecated union fires on both.
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
+    assert.equal(decision.hasError(), true);
+  });
+
+  test("malformed warning fields are coerced at the boundary", () => {
+    // Connect-JSON on the wire can deliver a non-string where a string is
+    // expected (a malformed or proxied response). The SDK validates at the
+    // boundary rather than trusting the wire shape. Build a valid response via
+    // `create()`, then inject non-string values through a widening view of the
+    // error element (no narrowing assertion on the response itself).
+    const response = create(GuardResponseSchema, {
+      errors: [
+        create(ResultErrorSchema, { code: "ok", message: "ok" }),
+      ],
+      decision: {
+        id: "gdec_test123",
+        conclusion: GuardConclusion.ALLOW,
+        reason: GuardReason.UNSPECIFIED,
+        ruleResults: [],
+      },
+    });
+    // Inject non-string values through a widening view of the error element.
+    const malformed: { code: unknown; message: unknown } = response.errors[0];
+    malformed.code = 42;
+    malformed.message = null;
+
+    const decision = decisionFromProto(response, []);
+
+    assert.equal(decision.warnings.length, 1);
+    // Non-string code/message fall back to defaults rather than surfacing the
+    // raw wire values.
+    assert.equal(decision.warnings[0].code, "UNKNOWN");
+    assert.equal(decision.warnings[0].message, "Unknown warning");
   });
 
   test("multi-rule correlation — results and deniedResult", () => {

--- a/arcjet-guard/src/convert.ts
+++ b/arcjet-guard/src/convert.ts
@@ -44,7 +44,9 @@ import type {
   InternalResult,
   Reason,
   RuleResult,
+  RuleResultError,
   RuleWithInput,
+  Warning,
 } from "./types.ts";
 
 /** Hash a string with SHA-256 and return the hex digest. */
@@ -187,12 +189,16 @@ export function reasonFromProto(r: GuardReason): Reason {
  * @internal
  */
 export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
+  // Per-rule warnings have no data source yet — the Decide service does not
+  // emit per-rule diagnostics. Always empty until then.
+  const warnings: readonly Warning[] = [];
   switch (pr.result.case) {
     case undefined: {
       return {
         conclusion: "ALLOW" as const,
         reason: "UNKNOWN",
         type: "UNKNOWN",
+        warnings,
       };
     }
     case "tokenBucket": {
@@ -201,6 +207,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(v.conclusion),
         reason: "RATE_LIMIT",
         type: "TOKEN_BUCKET",
+        warnings,
         remainingTokens: v.remainingTokens,
         maxTokens: v.maxTokens,
         resetAtUnixSeconds: v.resetAtUnixSeconds,
@@ -214,6 +221,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(v.conclusion),
         reason: "RATE_LIMIT",
         type: "FIXED_WINDOW",
+        warnings,
         remainingRequests: v.remainingRequests,
         maxRequests: v.maxRequests,
         resetAtUnixSeconds: v.resetAtUnixSeconds,
@@ -226,6 +234,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(v.conclusion),
         reason: "RATE_LIMIT",
         type: "SLIDING_WINDOW",
+        warnings,
         remainingRequests: v.remainingRequests,
         maxRequests: v.maxRequests,
         resetAtUnixSeconds: v.resetAtUnixSeconds,
@@ -237,6 +246,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(pr.result.value.conclusion),
         reason: "PROMPT_INJECTION",
         type: "PROMPT_INJECTION",
+        warnings,
       };
     }
     case "moderateContent": {
@@ -244,6 +254,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(pr.result.value.conclusion),
         reason: "MODERATE_CONTENT",
         type: "MODERATE_CONTENT",
+        warnings,
         detected: pr.result.value.detected,
       };
     }
@@ -253,6 +264,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(v.conclusion),
         reason: "SENSITIVE_INFO",
         type: "SENSITIVE_INFO",
+        warnings,
         detectedEntityTypes: v.detectedEntityTypes,
       };
     }
@@ -262,6 +274,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: conclusionFromProto(v.conclusion),
         reason: "CUSTOM",
         type: "CUSTOM",
+        warnings,
         data: Object.fromEntries(Object.entries(v.data)),
       };
     }
@@ -271,6 +284,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: "ALLOW" as const,
         reason: "ERROR",
         type: "RULE_ERROR",
+        warnings,
         message: v.message || "Unknown error",
         code: v.code || "UNKNOWN",
       };
@@ -280,6 +294,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: "ALLOW" as const,
         reason: "NOT_RUN",
         type: "NOT_RUN",
+        warnings,
       };
     }
     default: {
@@ -287,6 +302,7 @@ export function resultFromProto(pr: ProtoGuardRuleResult): RuleResult {
         conclusion: "ALLOW" as const,
         reason: "UNKNOWN",
         type: "UNKNOWN",
+        warnings,
       };
     }
   }
@@ -519,6 +535,65 @@ async function ruleBodyToProto(rule: RuleWithInput, signal?: AbortSignal): Promi
 }
 
 /**
+ * Coerce a value to a string with a fallback. Network data is untrusted — the
+ * proto's `ResultError` fields arrive over Connect-JSON, where a malformed
+ * response can put a non-string where a string is expected.
+ */
+function toStringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+/**
+ * Convert the proto `GuardResponse.errors` payload (non-fatal request
+ * validation diagnostics) into decision-level {@link Warning}s, validating
+ * each entry at the SDK boundary.
+ */
+function warningsFromProto(
+  errors: readonly { code: unknown; message: unknown }[],
+): readonly Warning[] {
+  return errors.map((e) => ({
+    code: toStringOr(e.code, "UNKNOWN"),
+    message: toStringOr(e.message, "Unknown warning"),
+  }));
+}
+
+/**
+ * Build the shared diagnostic members every decision carries — `warnings` plus
+ * the derived `errorResults()` / `hasFailedOpen()` / `hasError()` helpers — from
+ * a conclusion, its results, and any decision-level warnings.
+ *
+ * `errorResults()` scans `results` for `RuleResultError` (which includes the
+ * synthetic error result used when a request could not be processed). It is
+ * computed once and closed over so `hasFailedOpen()` and `errorResults()` share
+ * a single scan rather than re-filtering on each call. `hasError()` is the
+ * deprecated conflated union (warnings ∪ errors).
+ *
+ * @internal
+ */
+export function decisionMembers(
+  conclusion: Conclusion,
+  results: readonly RuleResult[],
+  warnings: readonly Warning[],
+): {
+  warnings: readonly Warning[];
+  errorResults: () => readonly RuleResultError[];
+  hasFailedOpen: () => boolean;
+  hasError: () => boolean;
+} {
+  // Compute once; both accessors close over the same array.
+  const errored = results.filter(
+    (r): r is RuleResultError => r.type === "RULE_ERROR",
+  );
+  const errorResults = (): readonly RuleResultError[] => errored;
+  return {
+    warnings,
+    errorResults,
+    hasFailedOpen: (): boolean => conclusion === "ALLOW" && errored.length > 0,
+    hasError: (): boolean => warnings.length > 0 || errored.length > 0,
+  };
+}
+
+/**
  * Convert a proto `GuardResponse` to the SDK `Decision`.
  *
  * Correlates proto results back to SDK rule instances using
@@ -528,23 +603,29 @@ export function decisionFromProto(
   response: ProtoGuardResponse,
   _rules: readonly RuleWithInput[],
 ): Decision {
+  // Top-level diagnostics are decision-level warnings; present whether or not a
+  // decision came back.
+  const warnings = warningsFromProto(response.errors);
   const proto = response.decision;
   if (!proto) {
-    // No decision in response — synthesize an ALLOW with error.
+    // No usable decision — synthesize a fail-open ALLOW carrying an error
+    // result so `hasFailedOpen()` / `errorResults()` see the failure.
     const errorResult: InternalResult = {
       conclusion: "ALLOW",
       reason: "ERROR",
       type: "RULE_ERROR",
+      warnings: [],
       message: "No decision in response",
       code: "NO_DECISION",
       [symbolArcjetInternal]: { configId: "", inputId: "" },
     };
+    const results = [errorResult];
     const d: InternalDecision = {
       conclusion: "ALLOW" as const,
       id: "",
-      results: [errorResult],
-      hasError: () => true,
-      [symbolArcjetInternal]: { results: [errorResult] },
+      results,
+      ...decisionMembers("ALLOW", results, warnings),
+      [symbolArcjetInternal]: { results },
     };
     return d;
   }
@@ -564,9 +645,6 @@ export function decisionFromProto(
 
   const results: readonly RuleResult[] = internalResults;
 
-  const hasResponseErrors = response.errors.length > 0;
-  const hasError = (): boolean => hasResponseErrors || results.some((r) => r.type === "RULE_ERROR");
-
   const conclusion = conclusionFromProto(proto.conclusion);
   const reason = reasonFromProto(proto.reason);
 
@@ -576,7 +654,7 @@ export function decisionFromProto(
       reason,
       id: proto.id,
       results,
-      hasError,
+      ...decisionMembers("DENY", results, warnings),
       [symbolArcjetInternal]: { results: internalResults },
     };
     return d;
@@ -586,7 +664,7 @@ export function decisionFromProto(
     conclusion: "ALLOW" as const,
     id: proto.id,
     results,
-    hasError,
+    ...decisionMembers("ALLOW", results, warnings),
     [symbolArcjetInternal]: { results: internalResults },
   };
   return d;

--- a/arcjet-guard/src/custom-rules.test.ts
+++ b/arcjet-guard/src/custom-rules.test.ts
@@ -465,6 +465,9 @@ function emptyDecision(): Decision {
     id: "gdec_test",
     results: [],
     hasError: (): boolean => false,
+    warnings: [],
+    errorResults: (): never[] => [],
+    hasFailedOpen: (): boolean => false,
   };
 }
 
@@ -504,6 +507,9 @@ function decisionWithMultiple(
     id: "gdec_test",
     results: ruleResults,
     hasError: (): boolean => false,
+    warnings: [],
+    errorResults: (): never[] => [],
+    hasFailedOpen: (): boolean => false,
     [symbolArcjetInternal]: { results: ruleResults },
   };
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test helper building a mock Decision

--- a/arcjet-guard/src/fetch.ts
+++ b/arcjet-guard/src/fetch.ts
@@ -35,9 +35,14 @@
  *   console.log(decision.reason); // "RATE_LIMIT", "PROMPT_INJECTION", etc.
  * }
  *
- * // Check for errors (fail-open — errors don't cause denials)
- * if (decision.hasError()) {
- *   console.warn("At least one rule errored");
+ * // Fail open by default; opt in to fail closed when a rule could not run.
+ * if (decision.hasFailedOpen()) {
+ *   console.warn("a rule could not be evaluated", decision.errorResults());
+ * }
+ *
+ * // Request diagnostics — the decision is still valid.
+ * for (const warning of decision.warnings) {
+ *   console.warn(warning.code, warning.message);
  * }
  *
  * // Per-rule results
@@ -163,9 +168,14 @@ import { createTransport } from "./transport-fetch.ts";
  *   console.log(decision.reason); // "RATE_LIMIT", "PROMPT_INJECTION", etc.
  * }
  *
- * // Check for errors (fail-open — errors don't cause denials)
- * if (decision.hasError()) {
- *   console.warn("At least one rule errored");
+ * // Fail open by default; opt in to fail closed when a rule could not run.
+ * if (decision.hasFailedOpen()) {
+ *   console.warn("a rule could not be evaluated", decision.errorResults());
+ * }
+ *
+ * // Request diagnostics — the decision is still valid.
+ * for (const warning of decision.warnings) {
+ *   console.warn(warning.code, warning.message);
  * }
  *
  * // Per-rule results

--- a/arcjet-guard/src/guard.test.ts
+++ b/arcjet-guard/src/guard.test.ts
@@ -359,6 +359,7 @@ describe("decisionFromProto", () => {
     assert.equal(decision.id, "gdec_test123");
     assert.equal(decision.results.length, 1);
     assert.equal(decision.results[0].type, "TOKEN_BUCKET");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     // Layer 3 — rule.result()
@@ -568,6 +569,7 @@ describe("decisionFromProto", () => {
     const decision = decisionFromProto(response, [input]);
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
     assert.equal(decision.results[0].type, "RULE_ERROR");
     if (decision.results[0].type === "RULE_ERROR") {
@@ -620,6 +622,7 @@ describe("decisionFromProto", () => {
     const decision = decisionFromProto(response, [input]);
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
   });
 
@@ -730,13 +733,16 @@ describe("Three-layer decision inspection", () => {
     assert.equal(decision.results.length, 3);
   });
 
+  // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
   test("Layer 2: decision.hasError() is false when no errors", () => {
     const { response, rl1, rl2, pi } = multiRuleResponse();
     const decision = decisionFromProto(response, [rl1, rl2, pi]);
 
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
   });
 
+  // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
   test("Layer 2: decision.hasError() is true when a rule errored", () => {
     const rule = tokenBucket({
       bucket: "test",
@@ -763,6 +769,7 @@ describe("Three-layer decision inspection", () => {
     ]);
 
     const decision = decisionFromProto(response, [input]);
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
   });
 
@@ -869,6 +876,7 @@ describe("Edge cases", () => {
 
     assert.equal(decision.conclusion, "ALLOW");
     assert.equal(decision.results.length, 0);
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
   });
 
@@ -902,6 +910,7 @@ describe("Edge cases", () => {
     ]);
 
     const decision = decisionFromProto(response, [i1, i2]);
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
   });
 
@@ -999,6 +1008,7 @@ describe("Edge cases", () => {
 
     const decision = decisionFromProto(response, [i1, i2]);
     assert.equal(decision.conclusion, "DENY");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), true);
   });
 });

--- a/arcjet-guard/src/index.ts
+++ b/arcjet-guard/src/index.ts
@@ -35,9 +35,14 @@
  *   console.log(decision.reason); // "RATE_LIMIT", "PROMPT_INJECTION", etc.
  * }
  *
- * // Check for errors (fail-open — errors don't cause denials)
- * if (decision.hasError()) {
- *   console.warn("At least one rule errored");
+ * // Fail open by default; opt in to fail closed when a rule could not run.
+ * if (decision.hasFailedOpen()) {
+ *   console.warn("a rule could not be evaluated", decision.errorResults());
+ * }
+ *
+ * // Request diagnostics — the decision is still valid.
+ * for (const warning of decision.warnings) {
+ *   console.warn(warning.code, warning.message);
  * }
  *
  * // Per-rule results
@@ -77,6 +82,7 @@ export type {
   Conclusion,
   Reason,
   Mode,
+  Warning,
   RuleResult,
   RuleResultTokenBucket,
   RuleResultFixedWindow,

--- a/arcjet-guard/src/node.ts
+++ b/arcjet-guard/src/node.ts
@@ -31,9 +31,14 @@
  *   console.log(decision.reason); // "RATE_LIMIT", "PROMPT_INJECTION", etc.
  * }
  *
- * // Check for errors (fail-open — errors don't cause denials)
- * if (decision.hasError()) {
- *   console.warn("At least one rule errored");
+ * // Fail open by default; opt in to fail closed when a rule could not run.
+ * if (decision.hasFailedOpen()) {
+ *   console.warn("a rule could not be evaluated", decision.errorResults());
+ * }
+ *
+ * // Request diagnostics — the decision is still valid.
+ * for (const warning of decision.warnings) {
+ *   console.warn(warning.code, warning.message);
  * }
  *
  * // Per-rule results
@@ -158,9 +163,14 @@ import { createTransport } from "./transport-node.ts";
  *   console.log(decision.reason); // "RATE_LIMIT", "PROMPT_INJECTION", etc.
  * }
  *
- * // Check for errors (fail-open — errors don't cause denials)
- * if (decision.hasError()) {
- *   console.warn("At least one rule errored");
+ * // Fail open by default; opt in to fail closed when a rule could not run.
+ * if (decision.hasFailedOpen()) {
+ *   console.warn("a rule could not be evaluated", decision.errorResults());
+ * }
+ *
+ * // Request diagnostics — the decision is still valid.
+ * for (const warning of decision.warnings) {
+ *   console.warn(warning.code, warning.message);
  * }
  *
  * // Per-rule results

--- a/arcjet-guard/src/rules.test.ts
+++ b/arcjet-guard/src/rules.test.ts
@@ -354,6 +354,9 @@ describe("result() and deniedResult() with no decision data", () => {
       id: "gdec_test",
       results: [],
       hasError: (): boolean => false,
+      warnings: [],
+      errorResults: (): never[] => [],
+      hasFailedOpen: (): boolean => false,
     };
 
     assert.equal(input.result(decision), null);
@@ -373,6 +376,9 @@ describe("result() and deniedResult() with no decision data", () => {
       id: "gdec_test",
       results: [],
       hasError: (): boolean => false,
+      warnings: [],
+      errorResults: (): never[] => [],
+      hasFailedOpen: (): boolean => false,
     };
 
     assert.equal(input.deniedResult(decision), null);
@@ -391,6 +397,9 @@ describe("result() and deniedResult() with no decision data", () => {
       id: "gdec_test",
       results: [],
       hasError: (): boolean => false,
+      warnings: [],
+      errorResults: (): never[] => [],
+      hasFailedOpen: (): boolean => false,
     };
 
     assert.deepEqual(rule.results(decision), []);
@@ -409,6 +418,9 @@ describe("result() and deniedResult() with no decision data", () => {
       id: "gdec_test",
       results: [],
       hasError: (): boolean => false,
+      warnings: [],
+      errorResults: (): never[] => [],
+      hasFailedOpen: (): boolean => false,
     };
 
     assert.equal(rule.deniedResult(decision), null);
@@ -506,6 +518,9 @@ describe("defineCustomRule", () => {
       id: "gdec_test",
       results: [],
       hasError: (): boolean => false,
+      warnings: [],
+      errorResults: (): never[] => [],
+      hasFailedOpen: (): boolean => false,
     };
 
     assert.equal(input.result(decision), null);

--- a/arcjet-guard/src/rules.ts
+++ b/arcjet-guard/src/rules.ts
@@ -367,9 +367,10 @@ export function detectPromptInjection(
  *
  * **Experimental.** The rule name and result shape may change. This
  * functionality may not be available yet, so while this rule is experimental
- * a call may simply return an error result. Errors are fail open, so
- * `decision.hasError()` reports `true` while the conclusion stays `"ALLOW"`.
- * Check the latest version of this SDK to see whether the rule is now stable.
+ * a call may simply return an error result. Errors are fail open, so the
+ * conclusion stays `"ALLOW"` and `decision.hasFailedOpen()` reports `true`
+ * (inspect the errored result with `decision.errorResults()`). Check the
+ * latest version of this SDK to see whether the rule is now stable.
  *
  * @example
  * ```ts

--- a/arcjet-guard/src/types.ts
+++ b/arcjet-guard/src/types.ts
@@ -26,6 +26,21 @@ export type Reason =
 export type Mode = "LIVE" | "DRY_RUN";
 
 /**
+ * A warning means the decision (or a single rule result) was processed
+ * correctly — the result is trustworthy — but something should be fixed, e.g.
+ * an invalid metadata key that was stripped or an invalid label.
+ *
+ * Contrast with an errored result ({@link RuleResultError}), which means a rule
+ * or the decision _could not_ be processed and the security signal is degraded.
+ */
+export type Warning = {
+  /** Machine-readable code (e.g. `"AJ1100"`). */
+  readonly code: string;
+  /** Human-readable description. */
+  readonly message: string;
+};
+
+/**
  * Built-in sensitive information entity types supported by the WASM
  * analyzer. Custom entity types are not supported in `@arcjet/guard` —
  * use a custom rule instead.
@@ -49,6 +64,13 @@ export type RuleResultTokenBucket = {
   readonly reason: "RATE_LIMIT";
   /** Discriminant — always `"TOKEN_BUCKET"`. */
   readonly type: "TOKEN_BUCKET";
+  /**
+   * Per-rule warnings — this rule was processed correctly (the result is
+   * trustworthy) but something about it should be fixed. Informational; never
+   * changes the rule's conclusion. Empty until the Decide service emits
+   * per-rule diagnostics.
+   */
+  readonly warnings: readonly Warning[];
   /** Number of tokens remaining in the bucket after this evaluation. */
   readonly remainingTokens: number;
   /** Maximum capacity of the token bucket. */
@@ -69,6 +91,8 @@ export type RuleResultFixedWindow = {
   readonly reason: "RATE_LIMIT";
   /** Discriminant — always `"FIXED_WINDOW"`. */
   readonly type: "FIXED_WINDOW";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
   /** Number of requests remaining in the current window. */
   readonly remainingRequests: number;
   /** Maximum requests allowed per window. */
@@ -87,6 +111,8 @@ export type RuleResultSlidingWindow = {
   readonly reason: "RATE_LIMIT";
   /** Discriminant — always `"SLIDING_WINDOW"`. */
   readonly type: "SLIDING_WINDOW";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
   /** Number of requests remaining in the current sliding interval. */
   readonly remainingRequests: number;
   /** Maximum requests allowed per sliding interval. */
@@ -105,6 +131,8 @@ export type RuleResultPromptInjection = {
   readonly reason: "PROMPT_INJECTION";
   /** Discriminant — always `"PROMPT_INJECTION"`. */
   readonly type: "PROMPT_INJECTION";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
 };
 
 /**
@@ -119,6 +147,8 @@ export type RuleResultModerateContent = {
   readonly reason: "MODERATE_CONTENT";
   /** Discriminant — always `"MODERATE_CONTENT"`. */
   readonly type: "MODERATE_CONTENT";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
   /** Whether harmful content was detected in the input text. */
   readonly detected: boolean;
 };
@@ -131,6 +161,8 @@ export type RuleResultSensitiveInfo = {
   readonly reason: "SENSITIVE_INFO";
   /** Discriminant — always `"SENSITIVE_INFO"`. */
   readonly type: "SENSITIVE_INFO";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
   /**
    * Entity types detected in the input (e.g. `"EMAIL"`, `"PHONE_NUMBER"`).
    *
@@ -152,6 +184,8 @@ export type RuleResultCustom<TData extends Record<string, string> = Record<strin
   readonly reason: "CUSTOM";
   /** Discriminant — always `"CUSTOM"`. */
   readonly type: "CUSTOM";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
   /** Key-value data returned by the custom rule's `evaluate` function. */
   readonly data: Readonly<TData>;
 };
@@ -164,6 +198,8 @@ export type RuleResultNotRun = {
   readonly reason: "NOT_RUN";
   /** Discriminant — always `"NOT_RUN"`. */
   readonly type: "NOT_RUN";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
 };
 
 /**
@@ -177,6 +213,8 @@ export type RuleResultError = {
   readonly reason: "ERROR";
   /** Discriminant — always `"RULE_ERROR"`. */
   readonly type: "RULE_ERROR";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
   /** Human-readable error description. */
   readonly message: string;
   /** Machine-readable error code */
@@ -191,6 +229,8 @@ export type RuleResultUnknown = {
   readonly reason: "UNKNOWN";
   /** Discriminant — always `"UNKNOWN"`. */
   readonly type: "UNKNOWN";
+  /** Per-rule warnings. Informational; never changes the conclusion. */
+  readonly warnings: readonly Warning[];
 };
 
 /** Union of all possible rule result types. */
@@ -212,7 +252,32 @@ export type DecisionBase = {
   readonly results: readonly RuleResult[];
   /** Server-generated unique identifier (TypeID, prefix `"gdec"`). */
   readonly id: string;
-  /** True if any rule errored during evaluation (layer 2 helper). */
+  /**
+   * Decision-level warnings — diagnostics from request validation (e.g. an
+   * invalid metadata key that was stripped). The decision is still valid; these
+   * are informational and never change the conclusion.
+   */
+  readonly warnings: readonly Warning[];
+  /**
+   * The results that errored — rules (or the decision itself) that _could not
+   * be processed_. Empty when nothing errored. Each entry carries a `code` and
+   * `message`; correlate one to a specific rule with `rule.result(decision)`.
+   */
+  errorResults(): readonly RuleResultError[];
+  /**
+   * True when this decision returned `ALLOW` only because a rule or the
+   * decision could not be processed — i.e. it failed open. Gate a fail-closed
+   * policy on this: `if (decision.hasFailedOpen()) return deny()`. "Failed open"
+   * describes an outcome of _this decision_, not the policy configuration.
+   */
+  hasFailedOpen(): boolean;
+  /**
+   * True if there is any warning or any errored rule (the old conflated union).
+   *
+   * @deprecated Use {@link DecisionBase.warnings} for request diagnostics and
+   *   {@link DecisionBase.errorResults} / {@link DecisionBase.hasFailedOpen} for
+   *   errors. Removed in the next major.
+   */
   hasError(): boolean;
 };
 

--- a/arcjet-guard/test/_shared/cases.ts
+++ b/arcjet-guard/test/_shared/cases.ts
@@ -79,6 +79,7 @@ export const cases: TestCase[] = [
 
       assert.equal(decision.conclusion, "ALLOW");
       assert.equal(decision.id, "gdec_allow_tb");
+      // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
       assert.equal(decision.hasError(), false);
 
       const result = input.result(decision);
@@ -381,6 +382,7 @@ export const cases: TestCase[] = [
       const decision = await arcjet.guard({ label: "test", rules: [input] });
 
       assert.equal(decision.conclusion, "ALLOW");
+      // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
       assert.equal(decision.hasError(), true);
     },
   },
@@ -391,6 +393,7 @@ export const cases: TestCase[] = [
       const arcjet = guard(s, tokenBucketAllow);
       const decision = await arcjet.guard({ label: "test", rules: [] });
       assert.equal(decision.conclusion, "ALLOW");
+      // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
       assert.equal(decision.hasError(), true);
     },
   },

--- a/arcjet-guard/test/runtime/bun.test.ts
+++ b/arcjet-guard/test/runtime/bun.test.ts
@@ -81,6 +81,7 @@ describe("Bun: connect-node HTTP/2 over TLS (self-signed)", () => {
     });
 
     expect(decision.conclusion).toBe("ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     expect(decision.hasError()).toBe(false);
 
     const result = input.result(decision);

--- a/arcjet-guard/test/runtime/cloudflare/worker.ts
+++ b/arcjet-guard/test/runtime/cloudflare/worker.ts
@@ -83,6 +83,7 @@ export default {
 
       return Response.json({
         conclusion: decision.conclusion,
+        // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
         hasError: decision.hasError(),
         remainingTokens: result?.remainingTokens ?? null,
       });

--- a/arcjet-guard/test/runtime/deno.test.ts
+++ b/arcjet-guard/test/runtime/deno.test.ts
@@ -116,6 +116,7 @@ Deno.test("Deno: token bucket ALLOW over HTTPS HTTP/2 (fetch transport)", async 
     });
 
     assertEquals(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assertEquals(decision.hasError(), false);
 
     const result = input.result(decision);

--- a/arcjet-guard/test/runtime/fetch.test.ts
+++ b/arcjet-guard/test/runtime/fetch.test.ts
@@ -87,6 +87,7 @@ describe("Runtime: Fetch (connect-web) transport", () => {
     });
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     const result = input.result(decision);

--- a/arcjet-guard/test/runtime/node.test.ts
+++ b/arcjet-guard/test/runtime/node.test.ts
@@ -85,6 +85,7 @@ describe("Runtime: Node.js HTTP/2 transport", () => {
     });
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     const result = input.result(decision);
@@ -134,6 +135,7 @@ describe("Runtime: Node.js HTTP/2 over TLS (self-signed)", () => {
     });
 
     assert.equal(decision.conclusion, "ALLOW");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
     const result = input.result(decision);


### PR DESCRIPTION
Replace the single conflated `hasError()` boolean on a guard decision with a two-axis model — scope (decision vs. rule) × severity (error vs. warning) — consistent with the Python and Go SDKs. Severity is carried by channel, not inferred from placement: an error is a result (a rule or the decision could not be processed); a warning is a `warnings` entry (processed correctly, but fix it).

Surfaces:
- decision.warnings surfaces the GuardResponse.errors payload as decision-level warnings instead of reading it only to flip a boolean and dropping it. Validated at the SDK boundary (non-string code/message from a malformed Connect-JSON response fall back to defaults).
- result.warnings adds the per-rule warning channel, empty until the Decide service emits per-rule diagnostics.
- decision.errorResults() returns the results that could not be processed, including the synthetic decision-level error result. Replaces the "did any rule fail" boolean with the data.
- decision.hasFailedOpen() is the fail-closed gate: true when the conclusion is ALLOW only because a rule or the decision could not be processed.
- decision.hasError() is deprecated (still works; triggers on warnings or errors) for one release cycle.

guard() never throws for runtime degradation: transport, parse, and missing-decision failures all return a fail-open ALLOW carrying a single synthetic error result, so hasFailedOpen()/errorResults() see the failure.

errorResults() is computed once and shared by hasFailedOpen()/hasError() rather than re-filtering on each call.