### PR TITLE
feat: expose correlationId on protect() and guard()

### DIFF
--- a/arcjet-bun/index.ts
+++ b/arcjet-bun/index.ts
@@ -179,7 +179,7 @@ export interface ArcjetBun<Props extends PlainObject> {
    */
   protect(
     request: Request,
-    ...properties: MaybeProperties<Props>
+    ...properties: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -321,8 +321,11 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(request, props?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, (properties || {}) as Properties);
 
         const getBody = async () => {
           if (request.bodyUsed) {
@@ -351,7 +354,7 @@ export default function arcjet<
           return readBodyWeb(clonedRequest.body, { expectedLength });
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
       handler(fetch) {
         return async function (request, server) {

--- a/arcjet-deno/index.ts
+++ b/arcjet-deno/index.ts
@@ -177,7 +177,7 @@ export interface ArcjetDeno<Props extends PlainObject> {
    */
   protect(
     request: Request,
-    ...props: MaybeProperties<Props>
+    ...props: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -320,8 +320,11 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(request, props?): Promise<ArcjetDecision> {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, (properties || {}) as Properties);
 
         const getBody = async () => {
           const clonedRequest = request.clone();
@@ -346,7 +349,7 @@ export default function arcjet<
           return readBodyWeb(clonedRequest.body, { expectedLength });
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
       handler(fn) {
         return async function (request, info) {

--- a/arcjet-deno/test/index.test.ts
+++ b/arcjet-deno/test/index.test.ts
@@ -296,6 +296,7 @@ test("`arcjetDeno`", async function (t) {
 
       assert.deepEqual(cleanRequest, {
         cookies: "session=a",
+        correlationId: undefined,
         email: undefined,
         extra: {},
         headers: {

--- a/arcjet-fastify/index.ts
+++ b/arcjet-fastify/index.ts
@@ -169,7 +169,7 @@ export interface ArcjetFastify<Props> {
    */
   protect(
     request: ArcjetFastifyRequest,
-    ...properties: MaybeProperties<Props>
+    ...properties: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -254,15 +254,21 @@ export default function arcjet<
   ): ArcjetFastify<Properties> {
     const client: ArcjetFastify<Properties> = {
       async protect(fastifyRequest, properties?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...ruleProps } = properties ?? {};
         const arcjetRequest = toArcjetRequest(
           fastifyRequest,
           log,
           proxies,
           // Cast of `{}` because here we switch from `undefined` to `Properties`.
-          properties || ({} as Properties),
+          ruleProps as Properties,
         );
 
-        return arcjetCore.protect({ getBody }, arcjetRequest);
+        return arcjetCore.protect(
+          { getBody },
+          { ...arcjetRequest, correlationId },
+        );
 
         async function getBody() {
           if (

--- a/arcjet-fastify/test/index.test.ts
+++ b/arcjet-fastify/test/index.test.ts
@@ -285,6 +285,7 @@ test("`arcjetFastify`", async function (t) {
 
       assert.deepEqual(cleanRequest, {
         cookies: "session=a",
+        correlationId: undefined,
         email: undefined,
         extra: {},
         headers: {

--- a/arcjet-guard/src/client.test.ts
+++ b/arcjet-guard/src/client.test.ts
@@ -1032,7 +1032,7 @@ describe("In-memory server: auth header", () => {
   });
 });
 describe("In-memory server: request metadata", () => {
-  test("label and metadata are sent to the server", async () => {
+  test("label, metadata, and correlationId are sent to the server", async () => {
     const rule = tokenBucket({
       bucket: "test",
       refillRate: 10,
@@ -1043,10 +1043,12 @@ describe("In-memory server: request metadata", () => {
 
     let receivedLabel = "";
     let receivedMetadata: Record<string, string> = {};
+    let receivedCorrelationId = "";
 
     const arcjet = guardWithMock((req) => {
       receivedLabel = req.label;
       receivedMetadata = { ...req.metadata };
+      receivedCorrelationId = req.correlationId;
 
       const sub = req.ruleSubmissions[0];
       return create(GuardResponseSchema, {
@@ -1079,11 +1081,13 @@ describe("In-memory server: request metadata", () => {
     await arcjet.guard({
       label: "tools.weather",
       metadata: { region: "us-east-1", user_id: "u_abc" },
+      correlationId: "wf_abcdef",
       rules: [input],
     });
 
     assert.equal(receivedLabel, "tools.weather");
     assert.deepEqual(receivedMetadata, { region: "us-east-1", user_id: "u_abc" });
+    assert.equal(receivedCorrelationId, "wf_abcdef");
   });
 
   test("user-agent is sent in the request body", async () => {

--- a/arcjet-guard/src/client.ts
+++ b/arcjet-guard/src/client.ts
@@ -90,6 +90,7 @@ export function createGuardClient(options: GuardClientOptions): {
         label: opts.label,
         metadata: opts.metadata ?? {},
         ruleSubmissions: protoRules,
+        correlationId: opts.correlationId ?? "",
       });
 
       const timeoutMs =

--- a/arcjet-guard/src/types.ts
+++ b/arcjet-guard/src/types.ts
@@ -1365,6 +1365,29 @@ export interface GuardOptions {
    * ```
    */
   metadata?: Record<string, string>;
+  /**
+   * Optional, caller-supplied opaque identifier used to correlate this guard
+   * call with other `guard()` and `protect()` calls that belong to the same
+   * workflow, agent run, or multi-step task (for example a web request that
+   * kicks off a chain of tool calls).
+   *
+   * Unlike {@link GuardOptions.metadata}, this is a dedicated, indexable field
+   * with a stable name. It does not affect the decision; it is stored alongside
+   * the recorded decision so a chain of actions can be reconstructed.
+   *
+   * Bounded server-side to max 256 bytes of printable ASCII; values that exceed
+   * this are dropped, not truncated.
+   *
+   * @example
+   * ```ts
+   * arcjet.guard({
+   *   label: "tools.weather",
+   *   rules: [input],
+   *   correlationId: requestId,
+   * })
+   * ```
+   */
+  correlationId?: string;
   /** Maximum seconds to wait for the server response. */
   timeoutSeconds?: number;
   /** Cancellation signal. */

--- a/arcjet-nest/index.ts
+++ b/arcjet-nest/index.ts
@@ -288,7 +288,7 @@ export interface ArcjetNest<Props extends PlainObject = PlainObject> {
    */
   protect(
     request: ArcjetNestRequest,
-    ...props: MaybeProperties<Props>
+    ...props: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -442,8 +442,11 @@ function arcjet<
         return withClient(client);
       },
       async protect(request, props?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, (properties || {}) as Properties);
 
         const getBody = async () => {
           // Read the stream if the body is not present.
@@ -475,7 +478,7 @@ function arcjet<
           return JSON.stringify(request.body);
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
     };
 

--- a/arcjet-next/index.ts
+++ b/arcjet-next/index.ts
@@ -432,7 +432,7 @@ export interface ArcjetNext<Props extends PlainObject> {
    */
   protect(
     request: ArcjetNextRequest,
-    ...props: MaybeProperties<Props>
+    ...props: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -664,8 +664,11 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(request, props?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, (properties || {}) as Properties);
 
         const getBody = async () => {
           if (typeof request.clone === "function") {
@@ -706,7 +709,7 @@ export default function arcjet<
           return JSON.stringify(request.body);
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
     };
 

--- a/arcjet-node/index.ts
+++ b/arcjet-node/index.ts
@@ -296,7 +296,7 @@ export interface ArcjetNode<Props extends PlainObject> {
    */
   protect(
     request: ArcjetNodeRequest,
-    ...props: MaybeProperties<Props>
+    ...props: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -447,8 +447,11 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(request, props?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, (properties || {}) as Properties);
 
         const getBody = async () => {
           // Read the stream if the body is not present.
@@ -479,7 +482,7 @@ export default function arcjet<
           return JSON.stringify(request.body);
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
     };
 

--- a/arcjet-node/test/index.test.ts
+++ b/arcjet-node/test/index.test.ts
@@ -276,6 +276,7 @@ test("`arcjetNode`", async function (t) {
 
       assert.deepEqual(cleanRequest, {
         cookies: "session=a",
+        correlationId: undefined,
         email: undefined,
         extra: {},
         headers: {
@@ -295,6 +296,57 @@ test("`arcjetNode`", async function (t) {
         query: "?b",
       });
     });
+
+    await t.test(
+      "should forward a `correlationId` passed as an option",
+      async function () {
+        const restore = capture();
+
+        let request: ArcjetRequestDetails | undefined;
+
+        const arcjet = arcjetNode({
+          client: createLocalClient(),
+          key: exampleKey,
+          rules: [
+            [
+              {
+                mode: "LIVE",
+                priority: 1,
+                async protect(_context, details) {
+                  request = details;
+                  return new ArcjetRuleResult({
+                    conclusion: "ALLOW",
+                    fingerprint: "",
+                    reason: new ArcjetReason(),
+                    ruleId: "",
+                    state: "RUN",
+                    ttl: 0,
+                  });
+                },
+                validate() {},
+                version: 0,
+                type: "",
+              },
+            ],
+          ],
+        });
+
+        const { server, url } = await createSimpleServer({
+          decide: (req) => arcjet.protect(req, { correlationId: "wf_abcdef" }),
+        });
+
+        const response = await fetch(new URL("/a?b#c", url), {
+          headers: { cookie: "session=a", "user-agent": "Test" },
+        });
+
+        await server.close();
+        restore();
+
+        assert.equal(response.status, 200);
+        assert.ok(request);
+        assert.equal(request.correlationId, "wf_abcdef");
+      },
+    );
   });
 
   await t.test("`.withRule()`", async function (t) {

--- a/arcjet-react-router/index.ts
+++ b/arcjet-react-router/index.ts
@@ -120,7 +120,7 @@ export interface ArcjetReactRouter<
    */
   protect(
     details: ArcjetReactRouterRequest,
-    ...rest: MaybeProperties<Properties>
+    ...rest: MaybeProperties<Properties & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -231,14 +231,17 @@ export default function arcjet<
         const context: ArcjetAdapterContext = {
           getBody: createGetBody(state, details),
         };
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...ruleProps } = properties ?? {};
         const request = toArcjetRequest(
           state,
           details,
           // Cast of `{}` because here we switch from `undefined` to `Properties`.
-          properties ?? ({} as Properties),
+          ruleProps as Properties,
         );
 
-        return baseClient.protect(context, request);
+        return baseClient.protect(context, { ...request, correlationId });
       },
       withRule(rule) {
         return withClient(baseClient.withRule(rule));

--- a/arcjet-remix/index.ts
+++ b/arcjet-remix/index.ts
@@ -190,7 +190,7 @@ export interface ArcjetRemix<Props extends PlainObject> {
    */
   protect(
     request: ArcjetRemixRequest,
-    ...props: MaybeProperties<Props>
+    ...props: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -310,8 +310,11 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(details, props?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(details, props || ({} as Properties));
+        const req = toArcjetRequest(details, (properties || {}) as Properties);
 
         const getBody = async () => {
           const clonedRequest = details.request.clone();
@@ -337,7 +340,7 @@ export default function arcjet<
           return readBodyWeb(clonedRequest.body, { expectedLength });
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
     };
 

--- a/arcjet-sveltekit/index.ts
+++ b/arcjet-sveltekit/index.ts
@@ -230,7 +230,7 @@ export interface ArcjetSvelteKit<Props extends PlainObject> {
    */
   protect(
     event: ArcjetSvelteKitRequestEvent,
-    ...props: MaybeProperties<Props>
+    ...props: MaybeProperties<Props & { correlationId?: string }>
   ): Promise<ArcjetDecision>;
 
   /**
@@ -353,8 +353,11 @@ export default function arcjet<
         return withClient(client);
       },
       async protect(request, props?) {
+        // `correlationId` is a request-independent option, not a rule prop, so
+        // pull it out before building the request from the rule properties.
+        const { correlationId, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, (properties || {}) as Properties);
 
         const getBody = async () => {
           const clonedRequest = request.request.clone();
@@ -380,7 +383,7 @@ export default function arcjet<
           return readBodyWeb(clonedRequest.body, { expectedLength });
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, correlationId });
       },
     };
 

--- a/arcjet/index.ts
+++ b/arcjet/index.ts
@@ -140,6 +140,7 @@ const knownFields = [
   "email",
   "cookies",
   "query",
+  "correlationId",
 ];
 
 /**
@@ -320,8 +321,14 @@ function toAnalyzeRequest(request: ArcjetRequestDetails): AnalyzeRequest {
     }
   }
 
+  // The correlation ID is deliberately excluded from the analyze request so it
+  // never feeds the fingerprint (and therefore the decision cache key). Two
+  // requests that differ only by correlation ID must share state.
+  const { correlationId, ...rest } = request;
+  void correlationId;
+
   return {
-    ...request,
+    ...rest,
     headers,
   };
 }
@@ -530,7 +537,7 @@ function validateDetails(
       ...knownFields.map(function (key) {
         return {
           key,
-          required: key !== "body" && key !== "email",
+          required: key !== "body" && key !== "email" && key !== "correlationId",
           validate: key === "headers" ? validateHeaders : validateString,
         };
       }),
@@ -3513,6 +3520,10 @@ export default function arcjet<
       query: request.query,
       extra: extraProps(request),
       email: typeof request.email === "string" ? request.email : undefined,
+      correlationId:
+        typeof request.correlationId === "string"
+          ? request.correlationId
+          : undefined,
     });
 
     // Copy of the request details for remote use, which redacts sensitive fields.

--- a/arcjet/test/arcjet.test.ts
+++ b/arcjet/test/arcjet.test.ts
@@ -687,6 +687,8 @@ test("`arcjet`", async function (t) {
           path: "/bot-protection/quick-start",
           protocol: "http:",
           query: "",
+          // Known field: must stay top-level, not be moved onto `extra`.
+          correlationId: "wf_abcdef",
         });
 
         assert.deepEqual(requestAsJson(validateDetails), {
@@ -704,8 +706,46 @@ test("`arcjet`", async function (t) {
           path: "/bot-protection/quick-start",
           protocol: "http:",
           query: "",
+          correlationId: "wf_abcdef",
         });
         assert.equal(protectDetails, validateDetails);
+      },
+    );
+
+    await t.test(
+      "should forward `correlationId` to the client `decide` call",
+      async function () {
+        let decideDetails: unknown;
+        const instance = arcjet({
+          client: {
+            async decide(_context, details) {
+              decideDetails = details;
+              return new ArcjetAllowDecision({
+                reason: new ArcjetReason(),
+                results: [],
+                ttl: 0,
+              });
+            },
+            report() {},
+          },
+          key: exampleKey,
+          log: { ...console, debug() {} },
+          rules: [],
+        });
+
+        await instance.protect(createContext(), {
+          ...createRequest(),
+          correlationId: "wf_abcdef",
+        });
+
+        assert.ok(
+          decideDetails && typeof decideDetails === "object",
+          "expected `client.decide` to be called with details",
+        );
+        assert.equal(
+          (decideDetails as { correlationId?: string }).correlationId,
+          "wf_abcdef",
+        );
       },
     );
 

--- a/arcjet/test/fingerprint.test.ts
+++ b/arcjet/test/fingerprint.test.ts
@@ -335,6 +335,50 @@ test("Fingerprint", async function (t) {
       ]);
     },
   );
+
+  await t.test(
+    "should not fingerprint on `correlationId`",
+    async function () {
+      let fingerprint: unknown;
+      const instance = arcjet({
+        client: createLocalClient(),
+        key: exampleKey,
+        log: {
+          ...console,
+          debug($0, ...rest) {
+            if ($0 === "fingerprint (%s): %s") {
+              fingerprint = rest[1];
+              return;
+            }
+
+            if (typeof $0 === "string" && $0.startsWith("LATENCY")) return;
+
+            console.debug($0, ...rest);
+          },
+        },
+        rules: [],
+      });
+
+      const _1 = await instance.protect(createContext(), {
+        ...createFields(),
+        correlationId: "wf_aaaaaaaa",
+      });
+      const baseline = fingerprint;
+      const _2 = await instance.protect(createContext(), {
+        ...createFields(),
+        correlationId: "wf_bbbbbbbb",
+      });
+      const differentCorrelationId = fingerprint;
+      const _3 = await instance.protect(createContext(), createFields());
+      const noCorrelationId = fingerprint;
+
+      // Two calls differing only by correlation ID must share a fingerprint
+      // (and therefore the decision cache key); omitting it must not change it
+      // either.
+      assert.equal(baseline, differentCorrelationId);
+      assert.equal(baseline, noCorrelationId);
+    },
+  );
 });
 
 /**

--- a/protocol/client.ts
+++ b/protocol/client.ts
@@ -133,6 +133,7 @@ export function createClient(options: ClientOptions): Client {
         cookies: details.cookies,
         query: details.query,
         extra: details.extra,
+        correlationId: details.correlationId ?? "",
       };
 
       // Build the request object from the Protobuf generated class.
@@ -192,6 +193,7 @@ export function createClient(options: ClientOptions): Client {
         cookies: details.cookies,
         query: details.query,
         extra: details.extra,
+        correlationId: details.correlationId ?? "",
       };
 
       // Build the request object from the Protobuf generated class.

--- a/protocol/index.ts
+++ b/protocol/index.ts
@@ -1477,6 +1477,17 @@ export interface ArcjetRequestDetails {
    */
   // TODO: Consider moving email to `extra` map
   email?: string | undefined;
+
+  /**
+   * Optional, caller-supplied opaque identifier used to correlate this request
+   * with other `protect()` and `guard()` calls that belong to the same
+   * workflow, agent run, or multi-step task.
+   *
+   * It does not affect the decision and is excluded from the fingerprint (and
+   * therefore the decision cache key); it is stored alongside the recorded
+   * decision so a chain of actions can be reconstructed.
+   */
+  correlationId?: string | undefined;
 }
 
 /**

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -241,6 +241,76 @@ test("createClient", async (t) => {
     },
   );
 
+  await t.test(
+    "should send `correlationId` in the decide request",
+    async () => {
+      let seen: string | undefined;
+
+      const client = createClient({
+        ...exampleClientOptions,
+        transport: createRouterTransport(({ service }) => {
+          service(DecideService, {
+            decide(decideRequest) {
+              seen = decideRequest.details?.correlationId;
+
+              return create(DecideResponseSchema, {
+                decision: { conclusion: Conclusion.ALLOW },
+              });
+            },
+          });
+        }),
+      });
+
+      await client.decide(
+        exampleContext,
+        { ...exampleDetails, correlationId: "wf_abcdef" },
+        [],
+      );
+
+      assert.equal(seen, "wf_abcdef");
+    },
+  );
+
+  await t.test(
+    "should send `correlationId` in the report request",
+    async () => {
+      return new Promise((resolve, reject) => {
+        const client = createClient({
+          ...exampleClientOptions,
+          transport: createRouterTransport(({ service }) => {
+            service(DecideService, {
+              report(reportRequest) {
+                try {
+                  assert.equal(
+                    reportRequest.details?.correlationId,
+                    "wf_abcdef",
+                  );
+
+                  setTimeout(resolve);
+                } catch (error) {
+                  reject(error);
+                }
+
+                return create(ReportResponseSchema);
+              },
+            });
+          }),
+        });
+
+        client.report(
+          exampleContext,
+          { ...exampleDetails, correlationId: "wf_abcdef" },
+          new ArcjetDenyDecision({
+            reason: new ArcjetReason(),
+            results: [],
+            ttl: 0,
+          }),
+          [],
+        );
+      });
+    },
+  );
+
   await t.test("should support rules", async () => {
     let calls = 0;
 


### PR DESCRIPTION
Expose an optional, caller-supplied `correlationId` on the public entry points and map it to the protocol fields added in the proto regen:

- `protect()` (core `arcjet`): a new `correlationId` request field, mapped to `RequestDetails.correlation_id` (v1alpha1) and sent on both the decide and report paths.
- `guard()` (`@arcjet/guard`): a new `correlationId` option, mapped to `GuardRequest.correlation_id` (v2).

`correlationId` is treated as a known request field (so it is not funneled into the `extra` map) and is deliberately excluded from the fingerprint — and therefore the decision cache key — so two calls that differ only by correlation ID still share rate-limit state.

Server-side sanitization (max 256 bytes, printable ASCII; invalid values dropped, not truncated) remains authoritative; SDK-side validation can follow.