### PR TITLE
ci: stop release-please self-triggering loop on its own branch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,12 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    # Only run Release Please on `main`. It pushes to
+    # `release-please--branches--main` using a GitHub App token, and App token
+    # pushes (unlike `GITHUB_TOKEN`) re-trigger workflows — so running this job
+    # on that branch makes it force-push and re-trigger itself in an infinite
+    # loop. The `test` and `examples` jobs still run on the release branch.
+    if: github.ref == 'refs/heads/main'
     # Release Please is very fast, so we set a tiny timeout
     timeout-minutes: 2
     # The GitHub App token handles write permissions for contents and


### PR DESCRIPTION
## Problem

The `arcjet-arcjet-js-release-please[bot]` has been stuck in a **self-triggering loop**, force-pushing a fresh `chore: Release 1.6.0` commit to `release-please--branches--main` roughly once a minute for ~9 hours — hundreds of cancelled `Push` workflow runs.

## Root cause

Two individually-reasonable changes are fatal together:

- **#5998** added `release-please--branches--main` to `push.yml`'s `branches:` trigger.
- **#6019** switched the token from `GITHUB_TOKEN` to a GitHub App installation token.

Pushes made with `GITHUB_TOKEN` do **not** re-trigger workflows (GitHub's loop guard), but **App-token pushes do**. So:

```
release-please force-pushes release branch (App token)
  → push event on release-please--branches--main
    → push.yml runs the `release` job again
      → release-please regenerates the commit + force-pushes (new SHA)
        → push event again → ∞
```

This stayed dormant after #6019 (May 5) until the 1.6.0 release cycle opened a release PR for the loop to thrash against.

## Fix

Gate the `release` job to `main` only — it never needs to run when its own PR branch is pushed. This preserves both prior intents: the `test` and `examples` jobs still run on the release branch (#5998), and the App token still authors the release (#6019).

Once merged, the push to `main` runs the release job once normally, then any further push to the release branch skips it → loop broken.

> [!NOTE]
> The loop is still running. Until this lands, consider disabling the `Push` workflow or closing the 1.6.0 release PR to stop burning Actions minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)