### PR TITLE
fix(guard): split errorResult() from result() so errors aren't up-cast

### DIFF
--- a/arcjet-guard/src/rules.test.ts
+++ b/arcjet-guard/src/rules.test.ts
@@ -11,6 +11,7 @@ import {
   defineCustomRule,
 } from "./rules.ts";
 import { symbolArcjetInternal } from "./symbol.ts";
+import type { Decision, InternalResult } from "./types.ts";
 
 describe("tokenBucket", () => {
   test("returns a callable with type discriminant", () => {
@@ -542,5 +543,184 @@ describe("defineCustomRule", () => {
     assert.deepEqual(rule.results(decision), []);
     assert.equal(rule.result(decision), null);
     assert.equal(rule.deniedResult(decision), null);
+  });
+});
+
+// Build an internal token bucket result carrying correlation IDs.
+function tokenBucketResult(
+  configId: string,
+  inputId: string,
+  conclusion: "ALLOW" | "DENY" = "ALLOW",
+): InternalResult {
+  return {
+    conclusion,
+    reason: "RATE_LIMIT",
+    type: "TOKEN_BUCKET",
+    warnings: [],
+    remainingTokens: 5,
+    maxTokens: 100,
+    resetAtUnixSeconds: 0,
+    refillRate: 10,
+    refillIntervalSeconds: 60,
+    [symbolArcjetInternal]: { configId, inputId },
+  } as InternalResult;
+}
+
+// Build an internal errored result carrying correlation IDs.
+function errorResult(
+  configId: string,
+  inputId: string,
+  code = "AJ1100",
+  message = "boom",
+): InternalResult {
+  return {
+    conclusion: "ALLOW",
+    reason: "ERROR",
+    type: "RULE_ERROR",
+    warnings: [],
+    message,
+    code,
+    [symbolArcjetInternal]: { configId, inputId },
+  } as InternalResult;
+}
+
+function decisionWith(results: InternalResult[]): Decision {
+  return {
+    conclusion: "ALLOW" as const,
+    id: "gdec_test",
+    results: results.map((r) => r),
+    hasError: (): boolean => results.some((r) => r.type === "RULE_ERROR"),
+    warnings: [],
+    errorResults: () => results.filter((r) => r.type === "RULE_ERROR"),
+    hasFailedOpen: (): boolean => false,
+    [symbolArcjetInternal]: { results },
+  } as Decision;
+}
+
+describe("errorResult() and the error/non-error split", () => {
+  const config = {
+    bucket: "test",
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 100,
+  };
+
+  test("RuleWithInput.errorResult() returns the errored result", () => {
+    const rule = tokenBucket(config);
+    const input = rule({ key: "user_1" });
+    const { configId } = rule[symbolArcjetInternal];
+    const { inputId } = input[symbolArcjetInternal];
+    const decision = decisionWith([errorResult(configId, inputId, "AJ1100")]);
+
+    const err = input.errorResult(decision);
+    assert.notEqual(err, null);
+    assert.equal(err?.type, "RULE_ERROR");
+    assert.equal(err?.reason, "ERROR");
+    assert.equal(err?.conclusion, "ALLOW"); // fail open
+    assert.equal(err?.code, "AJ1100");
+  });
+
+  test("RuleWithConfig.errorResult() returns the errored result", () => {
+    const rule = tokenBucket(config);
+    const input = rule({ key: "user_1" });
+    const { configId } = rule[symbolArcjetInternal];
+    const { inputId } = input[symbolArcjetInternal];
+    const decision = decisionWith([errorResult(configId, inputId, "AJ1200")]);
+
+    const err = rule.errorResult(decision);
+    assert.notEqual(err, null);
+    assert.equal(err?.code, "AJ1200");
+  });
+
+  test("result()/results()/deniedResult() never return an errored result", () => {
+    const rule = tokenBucket(config);
+    const input = rule({ key: "user_1" });
+    const { configId } = rule[symbolArcjetInternal];
+    const { inputId } = input[symbolArcjetInternal];
+    const decision = decisionWith([errorResult(configId, inputId)]);
+
+    // The whole point of the split: errors must not leak into non-error
+    // accessors (previously they were up-cast to e.g. RuleResultTokenBucket).
+    assert.equal(input.result(decision), null);
+    assert.deepEqual(input.results(decision), []);
+    assert.equal(input.deniedResult(decision), null);
+    assert.equal(rule.result(decision), null);
+    assert.deepEqual(rule.results(decision), []);
+    assert.equal(rule.deniedResult(decision), null);
+    // ...but errorResult surfaces it.
+    assert.notEqual(input.errorResult(decision), null);
+  });
+
+  test("errorResult() returns null for a non-error result", () => {
+    const rule = tokenBucket(config);
+    const input = rule({ key: "user_1" });
+    const { configId } = rule[symbolArcjetInternal];
+    const { inputId } = input[symbolArcjetInternal];
+    const decision = decisionWith([tokenBucketResult(configId, inputId)]);
+
+    assert.equal(input.errorResult(decision), null);
+    assert.equal(rule.errorResult(decision), null);
+    assert.notEqual(input.result(decision), null);
+  });
+
+  test("a DENY is a non-error result and is not dropped", () => {
+    const rule = tokenBucket(config);
+    const input = rule({ key: "user_1" });
+    const { configId } = rule[symbolArcjetInternal];
+    const { inputId } = input[symbolArcjetInternal];
+    const decision = decisionWith([
+      tokenBucketResult(configId, inputId, "DENY"),
+    ]);
+
+    const denied = input.deniedResult(decision);
+    assert.notEqual(denied, null);
+    assert.equal(denied?.conclusion, "DENY");
+    assert.equal(input.errorResult(decision), null); // a DENY is not an error
+  });
+
+  test("two invocations resolve distinct errors by identifier", () => {
+    const rule = tokenBucket(config);
+    const call1 = rule({ key: "first" });
+    const call2 = rule({ key: "second" });
+    const { configId } = rule[symbolArcjetInternal];
+    const id1 = call1[symbolArcjetInternal].inputId;
+    const id2 = call2[symbolArcjetInternal].inputId;
+    const decision = decisionWith([
+      errorResult(configId, id1, "AJ1001", "first failed"),
+      tokenBucketResult(configId, id2, "ALLOW"),
+    ]);
+
+    const err1 = call1.errorResult(decision);
+    assert.notEqual(err1, null);
+    assert.equal(err1?.code, "AJ1001");
+    // call2 did not error; its non-error result resolves cleanly.
+    assert.equal(call2.errorResult(decision), null);
+    assert.notEqual(call2.result(decision), null);
+  });
+
+  test("there is no plural errorResults() accessor on rules", () => {
+    const rule = tokenBucket(config);
+    const input = rule({ key: "user_1" });
+    assert.equal("errorResults" in rule, false);
+    assert.equal("errorResults" in input, false);
+  });
+
+  test("errorResult() is available across all rule types", () => {
+    const inputs = [
+      fixedWindow({ maxRequests: 100, windowSeconds: 60 })({ key: "u" }),
+      slidingWindow({ maxRequests: 100, intervalSeconds: 60 })({ key: "u" }),
+      detectPromptInjection()("text"),
+      experimental_moderateContent()("text"),
+      localDetectSensitiveInfo()("text"),
+      defineCustomRule({ evaluate: () => ({ conclusion: "ALLOW" as const }) })({
+        data: {},
+      })({ data: {} }),
+    ];
+    for (const input of inputs) {
+      const { configId, inputId } = input[symbolArcjetInternal];
+      const decision = decisionWith([errorResult(configId, inputId)]);
+      assert.notEqual(input.errorResult(decision), null);
+      assert.equal(input.result(decision), null);
+    }
   });
 });

--- a/arcjet-guard/src/rules.ts
+++ b/arcjet-guard/src/rules.ts
@@ -15,6 +15,7 @@ import type {
   InternalResult,
   RuleResult,
   RuleResultCustom,
+  RuleResultError,
   RuleResultFixedWindow,
   RuleResultPromptInjection,
   RuleResultModerateContent,
@@ -66,7 +67,13 @@ function getInternalResults(decision: Decision): readonly InternalResult[] {
   return isInternalDecision(decision) ? decision[symbolArcjetInternal].results : [];
 }
 
-/** Find a single result matching the given correlation IDs. */
+/**
+ * Find a single non-error result matching the given correlation IDs.
+ *
+ * Errored results ({@link RuleResultError}) are excluded — they are surfaced
+ * only via `errorResult()`. This is the error/non-error split: a non-error
+ * accessor must never return an errored result up-cast to the rule's own type.
+ */
 function findResult<T extends RuleResult>(
   decision: Decision,
   configId: string,
@@ -74,21 +81,23 @@ function findResult<T extends RuleResult>(
 ): T | null {
   const match = getInternalResults(decision).find(
     (r) =>
-      r[symbolArcjetInternal].configId === configId && r[symbolArcjetInternal].inputId === inputId,
+      r[symbolArcjetInternal].configId === configId &&
+      r[symbolArcjetInternal].inputId === inputId &&
+      r.type !== "RULE_ERROR",
   );
   if (!match) return null;
   const result: unknown = match;
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- server result matched by correlation IDs
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- non-error result matched by correlation IDs; RULE_ERROR excluded above
   return result as T;
 }
 
-/** Find all results for a given configId. */
+/** Find all non-error results for a given configId. */
 function findResults<T extends RuleResult>(decision: Decision, configId: string): T[] {
   return getInternalResults(decision)
-    .filter((r) => r[symbolArcjetInternal].configId === configId)
+    .filter((r) => r[symbolArcjetInternal].configId === configId && r.type !== "RULE_ERROR")
     .map((r): T => {
       const result: unknown = r;
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- server results matched by configId
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- non-error results matched by configId; RULE_ERROR excluded above
       return result as T;
     });
 }
@@ -96,6 +105,44 @@ function findResults<T extends RuleResult>(decision: Decision, configId: string)
 /** Find the first denied result for a given configId. */
 function findDeniedResult<T extends RuleResult>(decision: Decision, configId: string): T | null {
   return findResults<T>(decision, configId).find((r) => r.conclusion === "DENY") ?? null;
+}
+
+/**
+ * Find the errored result for one specific submission, matched by both
+ * correlation IDs. Returns only {@link RuleResultError} — never a non-error
+ * result.
+ */
+function findErrorResult(
+  decision: Decision,
+  configId: string,
+  inputId: string,
+): RuleResultError | null {
+  const match = getInternalResults(decision).find(
+    (r) =>
+      r[symbolArcjetInternal].configId === configId &&
+      r[symbolArcjetInternal].inputId === inputId &&
+      r.type === "RULE_ERROR",
+  );
+  if (!match) return null;
+  const result: unknown = match;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- matched on type === "RULE_ERROR" above
+  return result as RuleResultError;
+}
+
+/**
+ * Find the first errored result for a given configId. Mirrors
+ * {@link findDeniedResult}: if multiple invocations of the same rule errored,
+ * returns one arbitrarily. There is deliberately no `errorResults()` plural —
+ * retrieve per-submission via the bound input's `errorResult()`.
+ */
+function findErrorResultByConfig(decision: Decision, configId: string): RuleResultError | null {
+  const match = getInternalResults(decision).find(
+    (r) => r[symbolArcjetInternal].configId === configId && r.type === "RULE_ERROR",
+  );
+  if (!match) return null;
+  const result: unknown = match;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- matched on type === "RULE_ERROR" above
+  return result as RuleResultError;
 }
 
 /**
@@ -142,6 +189,9 @@ export function tokenBucket(config: TokenBucketConfig): RuleWithConfigTokenBucke
           const r = findResult<RuleResultTokenBucket>(decision, configId, inputId);
           return r === null ? [] : [r];
         },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResult(decision, configId, inputId);
+        },
       };
     },
     {
@@ -156,6 +206,9 @@ export function tokenBucket(config: TokenBucketConfig): RuleWithConfigTokenBucke
       },
       deniedResult(decision: Decision): RuleResultTokenBucket | null {
         return findDeniedResult<RuleResultTokenBucket>(decision, configId);
+      },
+      errorResult(decision: Decision): RuleResultError | null {
+        return findErrorResultByConfig(decision, configId);
       },
     },
   );
@@ -207,6 +260,9 @@ export function fixedWindow(config: FixedWindowConfig): RuleWithConfigFixedWindo
           const r = findResult<RuleResultFixedWindow>(decision, configId, inputId);
           return r === null ? [] : [r];
         },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResult(decision, configId, inputId);
+        },
       };
     },
     {
@@ -221,6 +277,9 @@ export function fixedWindow(config: FixedWindowConfig): RuleWithConfigFixedWindo
       },
       deniedResult(decision: Decision): RuleResultFixedWindow | null {
         return findDeniedResult<RuleResultFixedWindow>(decision, configId);
+      },
+      errorResult(decision: Decision): RuleResultError | null {
+        return findErrorResultByConfig(decision, configId);
       },
     },
   );
@@ -271,6 +330,9 @@ export function slidingWindow(config: SlidingWindowConfig): RuleWithConfigSlidin
           const r = findResult<RuleResultSlidingWindow>(decision, configId, inputId);
           return r === null ? [] : [r];
         },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResult(decision, configId, inputId);
+        },
       };
     },
     {
@@ -285,6 +347,9 @@ export function slidingWindow(config: SlidingWindowConfig): RuleWithConfigSlidin
       },
       deniedResult(decision: Decision): RuleResultSlidingWindow | null {
         return findDeniedResult<RuleResultSlidingWindow>(decision, configId);
+      },
+      errorResult(decision: Decision): RuleResultError | null {
+        return findErrorResultByConfig(decision, configId);
       },
     },
   );
@@ -338,6 +403,9 @@ export function detectPromptInjection(
           const r = findResult<RuleResultPromptInjection>(decision, configId, inputId);
           return r === null ? [] : [r];
         },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResult(decision, configId, inputId);
+        },
       };
     },
     {
@@ -352,6 +420,9 @@ export function detectPromptInjection(
       },
       deniedResult(decision: Decision): RuleResultPromptInjection | null {
         return findDeniedResult<RuleResultPromptInjection>(decision, configId);
+      },
+      errorResult(decision: Decision): RuleResultError | null {
+        return findErrorResultByConfig(decision, configId);
       },
     },
   );
@@ -424,6 +495,9 @@ export function experimental_moderateContent(
           const r = findResult<RuleResultModerateContent>(decision, configId, inputId);
           return r === null ? [] : [r];
         },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResult(decision, configId, inputId);
+        },
       };
     },
     {
@@ -438,6 +512,9 @@ export function experimental_moderateContent(
       },
       deniedResult(decision: Decision): RuleResultModerateContent | null {
         return findDeniedResult<RuleResultModerateContent>(decision, configId);
+      },
+      errorResult(decision: Decision): RuleResultError | null {
+        return findErrorResultByConfig(decision, configId);
       },
     },
   );
@@ -493,6 +570,9 @@ export function localDetectSensitiveInfo(
           const r = findResult<RuleResultSensitiveInfo>(decision, configId, inputId);
           return r === null ? [] : [r];
         },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResult(decision, configId, inputId);
+        },
       };
     },
     {
@@ -507,6 +587,9 @@ export function localDetectSensitiveInfo(
       },
       deniedResult(decision: Decision): RuleResultSensitiveInfo | null {
         return findDeniedResult<RuleResultSensitiveInfo>(decision, configId);
+      },
+      errorResult(decision: Decision): RuleResultError | null {
+        return findErrorResultByConfig(decision, configId);
       },
     },
   );
@@ -608,6 +691,9 @@ export function defineCustomRule<
             const r = findResult<RuleResultCustom<TData>>(decision, configId, inputId);
             return r === null ? [] : [r];
           },
+          errorResult(decision: Decision): RuleResultError | null {
+            return findErrorResult(decision, configId, inputId);
+          },
         };
       },
       {
@@ -622,6 +708,9 @@ export function defineCustomRule<
         },
         deniedResult(decision: Decision): RuleResultCustom<TData> | null {
           return findDeniedResult<RuleResultCustom<TData>>(decision, configId);
+        },
+        errorResult(decision: Decision): RuleResultError | null {
+          return findErrorResultByConfig(decision, configId);
         },
       },
     );

--- a/arcjet-guard/src/types.ts
+++ b/arcjet-guard/src/types.ts
@@ -1058,6 +1058,12 @@ export type RuleWithConfigTokenBucket = {
   result(decision: Decision): RuleResultTokenBucket | null;
   /** Return the first denied token bucket result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultTokenBucket | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A configured fixed window rule. */
@@ -1076,6 +1082,12 @@ export type RuleWithConfigFixedWindow = {
   result(decision: Decision): RuleResultFixedWindow | null;
   /** Return the first denied fixed window result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultFixedWindow | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A configured sliding window rule. */
@@ -1094,6 +1106,12 @@ export type RuleWithConfigSlidingWindow = {
   result(decision: Decision): RuleResultSlidingWindow | null;
   /** Return the first denied sliding window result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultSlidingWindow | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A configured prompt injection detection rule. */
@@ -1112,6 +1130,12 @@ export type RuleWithConfigPromptInjection = {
   result(decision: Decision): RuleResultPromptInjection | null;
   /** Return the first denied prompt injection result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultPromptInjection | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /**
@@ -1137,6 +1161,12 @@ export type RuleWithConfigModerateContent = {
   result(decision: Decision): RuleResultModerateContent | null;
   /** Return the first denied content moderation result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultModerateContent | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A configured sensitive info detection rule. */
@@ -1155,6 +1185,12 @@ export type RuleWithConfigSensitiveInfo = {
   result(decision: Decision): RuleResultSensitiveInfo | null;
   /** Return the first denied sensitive info result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultSensitiveInfo | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A configured custom rule. */
@@ -1176,6 +1212,12 @@ export type RuleWithConfigCustom<
   result(decision: Decision): RuleResultCustom<TData> | null;
   /** Return the first denied custom rule result, or `null` if none. */
   deniedResult(decision: Decision): RuleResultCustom<TData> | null;
+  /**
+   * Return the first errored result for this rule, or `null` if none errored.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** Union of all configured rule types. */
@@ -1204,6 +1246,12 @@ export type RuleWithInputTokenBucket = {
   result(decision: Decision): RuleResultTokenBucket | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultTokenBucket | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A fixed window rule with bound input. */
@@ -1222,6 +1270,12 @@ export type RuleWithInputFixedWindow = {
   result(decision: Decision): RuleResultFixedWindow | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultFixedWindow | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A sliding window rule with bound input. */
@@ -1240,6 +1294,12 @@ export type RuleWithInputSlidingWindow = {
   result(decision: Decision): RuleResultSlidingWindow | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultSlidingWindow | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A prompt injection rule with bound input. */
@@ -1258,6 +1318,12 @@ export type RuleWithInputPromptInjection = {
   result(decision: Decision): RuleResultPromptInjection | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultPromptInjection | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /**
@@ -1282,6 +1348,12 @@ export type RuleWithInputModerateContent = {
   result(decision: Decision): RuleResultModerateContent | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultModerateContent | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A sensitive info rule with bound input. */
@@ -1300,6 +1372,12 @@ export type RuleWithInputSensitiveInfo = {
   result(decision: Decision): RuleResultSensitiveInfo | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultSensitiveInfo | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** A custom rule with bound input. */
@@ -1320,6 +1398,12 @@ export type RuleWithInputCustom<TData extends Record<string, string> = Record<st
   result(decision: Decision): RuleResultCustom<TData> | null;
   /** Find this submission's denied result, or `null` if not denied. */
   deniedResult(decision: Decision): RuleResultCustom<TData> | null;
+  /**
+   * Find this submission's errored result, or `null` if it didn't error.
+   * Errors are excluded from {@link result}/{@link results}/{@link deniedResult};
+   * this is the only accessor that returns them.
+   */
+  errorResult(decision: Decision): RuleResultError | null;
 };
 
 /** Union of all rule-with-input types. */


### PR DESCRIPTION
findResult/findResults matched purely by correlation IDs and cast the match to the rule's non-error type, so an errored result was returned as e.g. RuleResultTokenBucket. Exclude RULE_ERROR from result()/results() and add a per-rule errorResult() that returns only RuleResultError.