### PR TITLE
test(arcjet): force test runner to exit; add CI test-job timeouts

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -11,6 +11,9 @@ env:
 jobs:
   bun-test:
     name: Bun
+    # Tests normally finish in a few minutes; cap well above that so a hung
+    # process fails fast instead of running to the 6h GitHub default.
+    timeout-minutes: 15
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -37,6 +40,7 @@ jobs:
         working-directory: arcjet-bun
   deno-test:
     name: Deno
+    timeout-minutes: 15
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -68,6 +72,7 @@ jobs:
   node-test:
     name: "Run tests (OS: ${{matrix.os}}, Node: ${{ matrix.node }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -118,6 +123,7 @@ jobs:
   transport-runtime:
     name: "@arcjet/transport proxy (${{ matrix.runtime }} ${{ matrix.bun-version || matrix.deno-version }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -48,8 +48,8 @@
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
-    "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=95 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=95 -- test/*.test.js",
+    "test-api": "node --test --test-force-exit -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit --test-coverage-branches=95 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=95 -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## What

On Node 26 the `arcjet` package's `node --test` run **completed** (all tests passed and the coverage report printed) but the process never exited, hanging the `Run tests (Node: 26)` job until GitHub's 6h default. Because the run finishes before hanging, a stray ref'd handle is keeping the event loop alive *after* the runner is done — only surfaced in the CI sandbox (Node 22 limped through in ~9.5m; Node 26 hung and was cancelled).

## Changes

- Add `--test-force-exit` to the `arcjet` package's `test-coverage` / `test-api` scripts so the runner exits promptly once tests and reporters finish. This does not mask failures — pass/fail is determined before exit.
- Add `timeout-minutes: 15` to the reusable test jobs (`node-test`, `bun-test`, `deno-test`, `transport-runtime`) as a safety net so any future hang fails fast instead of running for hours.

## Verification

- Locally on Node 26.4.0 the `arcjet` coverage run passes and exits cleanly with the flag.
- `actionlint` and `zizmor` pass on the workflow.
- The Node 26 `Run tests` job on this PR is the real confirmation that the hang is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)