### PR TITLE
feat(nosecone-next): add nonce API to get the CSP nonce

### DIFF
--- a/nosecone-next/README.md
+++ b/nosecone-next/README.md
@@ -80,6 +80,33 @@ export default createMiddleware();
  }
 ```
 
+### Accessing the nonce
+
+When the `Content-Security-Policy` is enabled, Nosecone generates a unique
+nonce for every request. Next.js applies it to the scripts it renders
+automatically, but third-party scripts that don't use the Next.js `<Script>`
+component need the nonce passed in manually. For example,
+[PostHog](https://posthog.com/docs/libraries/next-js) requires the nonce in its
+`init` call.
+
+Use the `nonce` function to read the nonce for the current request from a Server
+Component, Route Handler, or anywhere else `next/headers` is available:
+
+```tsx
+import { nonce } from "@nosecone/next";
+
+export default async function Page() {
+  const cspNonce = await nonce();
+
+  return <script nonce={cspNonce}>{`/* ... */`}</script>;
+}
+```
+
+The page must be dynamically rendered for the nonce to be available, which is
+the same requirement as applying the nonce to Next.js scripts (see the `app/layout.tsx`
+example above). `nonce` returns `undefined` if the `Content-Security-Policy` is
+disabled or doesn't contain a nonce.
+
 ## License
 
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]

--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -52,7 +52,7 @@ function nextScriptSrc() {
 // capturing the value without the surrounding `'nonce-'` and `'` syntax. This
 // mirrors how Next.js extracts the nonce from the header so that the value
 // returned by `nonce` is the same one Next.js applies to its own scripts. See:
-// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/get-script-nonce-from-header.tsx
+// https://github.com/vercel/next.js/blob/647d923a3f140f9f484415406feee05aae9fd179/packages/next/src/server/app-render/get-script-nonce-from-header.tsx
 const nonceSourceRegex = /^'nonce-([A-Za-z0-9+/_-]+={0,2})'$/;
 
 /**

--- a/nosecone-next/index.ts
+++ b/nosecone-next/index.ts
@@ -37,15 +37,94 @@ export { nosecone };
  */
 export default nosecone;
 
-function nonce() {
+function createNonce() {
   return `'nonce-${btoa(crypto.randomUUID())}'` as const;
 }
 
 function nextScriptSrc() {
   return process.env.NODE_ENV === "development"
     ? // Next.js hot reloading relies on `eval` so we enable it in development
-      ([nonce, "'unsafe-eval'"] as const)
-    : ([nonce] as const);
+      ([createNonce, "'unsafe-eval'"] as const)
+    : ([createNonce] as const);
+}
+
+// Matches a `Content-Security-Policy` nonce source such as `'nonce-abc123'`,
+// capturing the value without the surrounding `'nonce-'` and `'` syntax. This
+// mirrors how Next.js extracts the nonce from the header so that the value
+// returned by `nonce` is the same one Next.js applies to its own scripts. See:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/get-script-nonce-from-header.tsx
+const nonceSourceRegex = /^'nonce-([A-Za-z0-9+/_-]+={0,2})'$/;
+
+/**
+ * Extract the nonce from a `Content-Security-Policy` header value.
+ *
+ * @param value
+ *   Value of the `Content-Security-Policy` header.
+ * @returns
+ *   The nonce, or `undefined` if there is no nonce in the header.
+ */
+function nonceFromContentSecurityPolicy(value: string): string | undefined {
+  const directives = value
+    // Directives are split by `;`.
+    .split(";")
+    .map((directive) => directive.trim());
+
+  // First try to find the `script-src` directive, otherwise fall back to
+  // `default-src`, matching the directives Next.js inspects.
+  const directive =
+    directives.find((directive) => directive.startsWith("script-src")) ??
+    directives.find((directive) => directive.startsWith("default-src"));
+
+  if (!directive) {
+    return undefined;
+  }
+
+  // Skip the directive name (the first token) and return the first nonce.
+  for (const source of directive.split(/\s+/).slice(1)) {
+    const match = source.trim().match(nonceSourceRegex);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Get the `Content-Security-Policy` nonce for the current request.
+ *
+ * Nosecone generates a unique nonce for every request when the
+ * `Content-Security-Policy` is configured with our defaults. Next.js applies
+ * that nonce to the scripts it renders automatically, but third-party scripts
+ * that do not use the Next.js `<Script>` component need the value passed in
+ * manually. For example, PostHog requires the nonce in its `init` call.
+ *
+ * Call this from a Server Component, Route Handler, or anywhere else
+ * `next/headers` is available. The page must be dynamically rendered for the
+ * nonce to be available — see the example in the `README`.
+ *
+ * @returns
+ *   The nonce for the current request, or `undefined` if the
+ *   `Content-Security-Policy` is disabled or does not contain a nonce.
+ */
+export async function nonce(): Promise<string | undefined> {
+  // Imported dynamically so that `next/headers`, which is server-only, is not
+  // pulled into the Edge middleware bundle when `createMiddleware` is imported.
+  const { headers } = await import("next/headers");
+  const headerList = await headers();
+
+  // Next.js copies the `Content-Security-Policy` response header set by our
+  // middleware onto the request headers, so we can read the per-request nonce
+  // back out of it here.
+  const contentSecurityPolicy =
+    headerList.get("content-security-policy") ??
+    headerList.get("content-security-policy-report-only");
+
+  if (typeof contentSecurityPolicy !== "string") {
+    return undefined;
+  }
+
+  return nonceFromContentSecurityPolicy(contentSecurityPolicy);
 }
 
 function nextStyleSrc() {

--- a/nosecone-next/test/index.test.ts
+++ b/nosecone-next/test/index.test.ts
@@ -8,6 +8,7 @@ test("@nosecone/next", async function (t) {
       "default",
       // TODO(@wooorm-arcjet): use a clearer name: defaults for what, function to generate them?
       "defaults",
+      "nonce",
       "nosecone",
       "withVercelToolbar",
     ]);


### PR DESCRIPTION
## What

Adds a `nonce` export to `@nosecone/next` that returns the Content-Security-Policy nonce for the current request, so developers can pass it to third-party scripts that don't integrate with the Next.js `<Script>` component (e.g. PostHog, which requires the nonce in its `init` call).

```tsx
import { nonce } from "@nosecone/next";

export default async function Page() {
  const cspNonce = await nonce();
  return <script nonce={cspNonce}>{`/* ... */`}</script>;
}
```

## How

Nosecone's middleware sets a `Content-Security-Policy` response header containing a per-request nonce. Next.js copies that header onto the request headers and reads the nonce back out to apply it to its own rendered scripts. `nonce` reads the same request CSP header (via `next/headers`) and extracts the nonce using the same parsing Next.js uses — guaranteeing the returned value matches the nonce Next.js applies to its scripts. No middleware changes were needed.

Notable decisions:
- `next/headers` is imported dynamically inside `nonce()` so the server-only module isn't pulled into the Edge middleware bundle when `createMiddleware` is imported from the same entry point.
- Returns the bare nonce value (not `'nonce-...'`), matching what `nonce=""` attributes and libraries like PostHog expect, and mirroring Next.js's own extraction.
- The private nonce generator was renamed `nonce` → `createNonce` to free up the public name.

This is scoped to `@nosecone/next`. The base `nosecone` package generates no nonce by default and has no request context to read from; the SvelteKit adapter delegates nonce handling to SvelteKit's native CSP (`%sveltekit.nonce%`).

## Testing

- `npm run build`, `npm run lint`, and `npm test` pass for `nosecone-next`.
- Updated the public-API surface test to include `nonce`.

Closes #3133

🤖 Generated with [Claude Code](https://claude.com/claude-code)