### PR TITLE
test(arcjet): verify protect() runs on Cloudflare Workers

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -177,3 +177,35 @@ jobs:
       # (`@arcjet/env`, `@arcjet/logger`) are available to the runtime test.
       - run: npm ci && npm run build
       - run: npm run ${{ matrix.script }} --workspace=@arcjet/transport
+
+  arcjet-runtime:
+    name: arcjet protect() (Cloudflare Workers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          # The runtime test runs against a local mock DecideService server via
+          # miniflare's bundled workerd, so no external decide endpoint is hit.
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+          disable-sudo-and-containers: true
+          egress-policy: block
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 24
+      # Build the whole workspace first so the SDK's dependencies (including the
+      # `workerd` entries of `@arcjet/transport` and `@arcjet/analyze-wasm`) are
+      # available to the runtime test.
+      - run: npm ci && npm run build
+      - run: npm run test-runtime-cloudflare --workspace=arcjet

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -187,8 +187,10 @@ jobs:
     steps:
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
-          # The runtime test runs against a local mock DecideService server via
-          # miniflare's bundled workerd, so no external decide endpoint is hit.
+          # The runtime test calls a local mock DecideService server, so the
+          # Arcjet decide endpoint is never hit. `workers.cloudflare.com` is
+          # contacted by miniflare's bundled workerd on startup (not by the
+          # test) and must be allowed so harden-runner doesn't block it.
           allowed-endpoints: >
             api.github.com:443
             github.com:443
@@ -196,6 +198,7 @@ jobs:
             objects.githubusercontent.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            workers.cloudflare.com:443
           disable-sudo-and-containers: true
           egress-policy: block
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -49,6 +49,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
+    "test-runtime-cloudflare": "npm run build && node --test test/runtime/cloudflare/cloudflare.test.ts",
     "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=95 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=95 -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
@@ -64,9 +65,15 @@
   "devDependencies": {
     "@arcjet/eslint-config": "1.5.0",
     "@arcjet/rollup-config": "1.5.0",
+    "@arcjet/transport": "1.5.0",
+    "@bufbuild/protobuf": "2.12.0",
+    "@connectrpc/connect": "2.1.2",
+    "@connectrpc/connect-node": "2.1.2",
     "@rollup/wasm-node": "4.62.2",
     "@types/node": "22.19.21",
     "eslint": "9.39.4",
+    "miniflare": "4.20260617.1",
+    "rolldown": "1.1.2",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/arcjet/test/runtime/cloudflare/cloudflare.test.ts
+++ b/arcjet/test/runtime/cloudflare/cloudflare.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Runtime test: core `arcjet` SDK `protect()` on Cloudflare Workers via
+ * miniflare.
+ *
+ * 1. Starts a real HTTP/1.1 mock DecideService server on localhost
+ * 2. Bundles the Worker in memory with rolldown, resolving the `workerd`
+ *    export conditions (so `@arcjet/transport` and `@arcjet/analyze-wasm`
+ *    pick their `workerd` entries)
+ * 3. Supplies the local-fingerprinting WASM as `CompiledWasm` modules — the
+ *    same module shape wrangler produces from the `.wasm` imports on a real
+ *    deploy
+ * 4. Starts miniflare and dispatches a request, which runs `protect()` inside
+ *    the Worker against the real mock server
+ * 5. Assertions run here in Node from the Worker's JSON response
+ *
+ * Uses HTTP/1.1 because Workers' `fetch()` doesn't control the outbound HTTP
+ * version — Cloudflare's edge negotiates the protocol transparently.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test, before, after } from "node:test";
+
+import { Miniflare } from "miniflare";
+import { rolldown } from "rolldown";
+import type { Plugin } from "rolldown";
+
+import {
+  startHttpServer,
+  getDecideCalls,
+  getLastDecideRequest,
+} from "./mock-server.ts";
+
+const WORKER_ENTRY = new URL("./worker.ts", import.meta.url).pathname;
+const WASM_DIR = new URL("../../../../analyze-wasm/wasm/", import.meta.url)
+  .pathname;
+
+describe("Runtime: core arcjet protect() on Cloudflare Workers (miniflare)", () => {
+  let mf: Miniflare;
+  let closeServer: () => Promise<void>;
+
+  before(async () => {
+    // Start a real mock server the Worker will call
+    const server = await startHttpServer();
+    closeServer = server.close;
+
+    // Keep the `.wasm` imports external under a bare basename so the bundle
+    // emits `import x from "<name>.wasm"`, which miniflare resolves to a
+    // `CompiledWasm` module we supply alongside the worker (mirroring wrangler).
+    const wasmBasenames = new Set<string>();
+    const wasmExternalPlugin: Plugin = {
+      name: "wasm-external",
+      resolveId(id) {
+        if (id.includes(".wasm")) {
+          const clean = id.replace(/\?.*$/, "");
+          const base = clean.slice(clean.lastIndexOf("/") + 1);
+          wasmBasenames.add(base);
+          return { id: base, external: true };
+        }
+        return null;
+      },
+    };
+
+    // Bundle the Worker in memory
+    const build = await rolldown({
+      input: WORKER_ENTRY,
+      platform: "neutral",
+      plugins: [wasmExternalPlugin],
+      resolve: {
+        extensions: [".ts", ".js", ".json"],
+        conditionNames: ["workerd", "browser", "import", "default"],
+      },
+    });
+    const { output } = await build.generate({ format: "esm" });
+    await build.close();
+
+    const modules = [
+      {
+        type: "ESModule" as const,
+        path: "worker.js",
+        contents: output[0].code,
+      },
+      ...[...wasmBasenames].map((base) => ({
+        type: "CompiledWasm" as const,
+        path: base,
+        contents: readFileSync(WASM_DIR + base),
+      })),
+    ];
+
+    mf = new Miniflare({
+      modules,
+      modulesRoot: "",
+      compatibilityDate: "2025-09-01",
+      compatibilityFlags: ["nodejs_compat"],
+      bindings: { ARCJET_BASE_URL: server.baseUrl },
+    });
+    await mf.ready;
+  });
+
+  after(async () => {
+    if (mf !== undefined) await mf.dispose();
+    if (closeServer !== undefined) await closeServer();
+  });
+
+  test("protect() returns ALLOW through real server from Workers", async () => {
+    const response = await mf.dispatchFetch("http://localhost/");
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- response.json() returns unknown
+    const json = (await response.json()) as {
+      conclusion?: string;
+      isErrored?: boolean;
+      error?: string;
+      stack?: string;
+    };
+
+    if (!response.ok) {
+      console.error(`  Worker error: ${json.error}\n${json.stack ?? ""}`);
+    }
+
+    assert.equal(response.ok, true, `Worker responded ${response.status}`);
+    assert.equal(json.conclusion, "ALLOW");
+    assert.equal(json.isErrored, false);
+
+    // Prove the request actually left the Worker via the workerd transport and
+    // reached the DecideService over the network (not a local short-circuit).
+    assert.equal(getDecideCalls(), 1, "expected exactly one decide() call");
+    const decideRequest = getLastDecideRequest();
+    assert.ok(decideRequest !== null);
+    assert.equal(decideRequest.sdkVersion, "test");
+    assert.equal(
+      decideRequest.ruleCount,
+      1,
+      "expected the token bucket rule to be sent",
+    );
+  });
+});

--- a/arcjet/test/runtime/cloudflare/mock-server.ts
+++ b/arcjet/test/runtime/cloudflare/mock-server.ts
@@ -1,0 +1,81 @@
+/**
+ * Mock Connect RPC server implementing the v1alpha1 `DecideService` that the
+ * core `arcjet` SDK calls from `protect()`.
+ *
+ * Uses HTTP/1.1 because Workers' `fetch()` doesn't control the outbound HTTP
+ * version — Cloudflare's edge negotiates the protocol transparently — so the
+ * Worker-side smoke test must reach a plain HTTP/1.1 origin.
+ *
+ * @packageDocumentation
+ */
+import http from "node:http";
+
+import { create } from "@bufbuild/protobuf";
+import { connectNodeAdapter } from "@connectrpc/connect-node";
+import type { ConnectRouter } from "@connectrpc/connect";
+import {
+  Conclusion,
+  DecideResponseSchema,
+  DecideService,
+  ReportResponseSchema,
+} from "@arcjet/protocol/proto/decide/v1alpha1/decide_pb.js";
+
+let decideCalls = 0;
+let lastDecideRequest: {
+  sdkVersion: string;
+  ruleCount: number;
+} | null = null;
+
+/** Number of `decide` RPCs the mock server has received. */
+export function getDecideCalls(): number {
+  return decideCalls;
+}
+
+/** Fields captured from the last `decide` RPC, or `null` if none received. */
+export function getLastDecideRequest(): typeof lastDecideRequest {
+  return lastDecideRequest;
+}
+
+function routes(router: ConnectRouter): void {
+  router.service(DecideService, {
+    decide(request) {
+      decideCalls++;
+      lastDecideRequest = {
+        sdkVersion: request.sdkVersion,
+        ruleCount: request.rules.length,
+      };
+      return create(DecideResponseSchema, {
+        decision: { conclusion: Conclusion.ALLOW },
+      });
+    },
+    report() {
+      return create(ReportResponseSchema, {});
+    },
+  });
+}
+
+/** Start an HTTP/1.1 server with the mock handler. Returns `{ baseUrl, close }`. */
+export async function startHttpServer(
+  port = 0,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  // Reset captured state so each server start is independent and the suite is
+  // not order-dependent.
+  decideCalls = 0;
+  lastDecideRequest = null;
+
+  const server = http.createServer(connectNodeAdapter({ routes }));
+  await new Promise<void>((resolve) =>
+    server.listen(port, "127.0.0.1", resolve),
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- always AddressInfo after listen()
+  const addr = server.address() as import("node:net").AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      }),
+  };
+}

--- a/arcjet/test/runtime/cloudflare/worker.ts
+++ b/arcjet/test/runtime/cloudflare/worker.ts
@@ -1,0 +1,73 @@
+/**
+ * Cloudflare Worker that exercises the core `arcjet` SDK `protect()` call.
+ *
+ * It wires the SDK the same way a Cloudflare adapter would:
+ *
+ * - `@arcjet/protocol/client.js` `createClient`
+ * - `@arcjet/transport` `createTransport`, which resolves to the `workerd`
+ *   export condition on Cloudflare
+ *
+ * then runs a remote rule (token bucket) through `protect()` against the mock
+ * `DecideService` server passed in via the `ARCJET_BASE_URL` binding.
+ */
+import { createClient } from "@arcjet/protocol/client.js";
+import { createTransport } from "@arcjet/transport";
+
+import arcjet, { tokenBucket } from "../../../index.js";
+
+interface Env {
+  ARCJET_BASE_URL: string;
+}
+
+// Minimal no-op logger matching the SDK's logger interface.
+const log = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+export default {
+  async fetch(_request: Request, env: Env): Promise<Response> {
+    try {
+      const client = createClient({
+        baseUrl: env.ARCJET_BASE_URL,
+        timeout: 5000,
+        sdkStack: "NODEJS",
+        sdkVersion: "test",
+        transport: createTransport(env.ARCJET_BASE_URL),
+      });
+
+      const aj = arcjet({
+        key: "ajkey_dummy",
+        rules: [tokenBucket({ refillRate: 10, interval: 60, capacity: 100 })],
+        client,
+        log,
+      });
+
+      const decision = await aj.protect(
+        { getBody: async () => "" },
+        {
+          ip: "1.2.3.4",
+          method: "GET",
+          protocol: "http",
+          host: "localhost",
+          path: "/",
+          headers: { "user-agent": "test" },
+          cookies: "",
+          query: "",
+          requested: 1,
+        },
+      );
+
+      return Response.json({
+        conclusion: decision.conclusion,
+        isErrored: decision.isErrored(),
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const stack = err instanceof Error ? err.stack : undefined;
+      return Response.json({ error: message, stack }, { status: 500 });
+    }
+  },
+};

--- a/arcjet/tsconfig.json
+++ b/arcjet/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../tsconfig.base.json"
+  "extends": "../tsconfig.base.json",
+  // The Cloudflare Workers runtime test uses miniflare/rolldown and worker
+  // globals that aren't part of the Node build, so it is excluded from
+  // type-checking here and run directly via `node --test`.
+  "exclude": ["node_modules/", "test/runtime/**"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,9 +105,15 @@
       "devDependencies": {
         "@arcjet/eslint-config": "1.5.0",
         "@arcjet/rollup-config": "1.5.0",
+        "@arcjet/transport": "1.5.0",
+        "@bufbuild/protobuf": "2.12.0",
+        "@connectrpc/connect": "2.1.2",
+        "@connectrpc/connect-node": "2.1.2",
         "@rollup/wasm-node": "4.62.2",
         "@types/node": "22.19.21",
         "eslint": "9.39.4",
+        "miniflare": "4.20260617.1",
+        "rolldown": "1.1.2",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -499,6 +505,307 @@
       "dev": true,
       "license": "MIT"
     },
+    "arcjet/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "arcjet/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "arcjet/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "arcjet/node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.2.tgz",
+      "integrity": "sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.2.tgz",
+      "integrity": "sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.2.tgz",
+      "integrity": "sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.2.tgz",
+      "integrity": "sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.2.tgz",
+      "integrity": "sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.2.tgz",
+      "integrity": "sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.2.tgz",
+      "integrity": "sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.2.tgz",
+      "integrity": "sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.2.tgz",
+      "integrity": "sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.2.tgz",
+      "integrity": "sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.2.tgz",
+      "integrity": "sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.2.tgz",
+      "integrity": "sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.2.tgz",
+      "integrity": "sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.5"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.2.tgz",
+      "integrity": "sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "arcjet/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.2.tgz",
+      "integrity": "sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "arcjet/node_modules/@types/node": {
       "version": "22.19.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
@@ -507,6 +814,40 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "arcjet/node_modules/rolldown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
+      "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.2",
+        "@rolldown/binding-darwin-arm64": "1.1.2",
+        "@rolldown/binding-darwin-x64": "1.1.2",
+        "@rolldown/binding-freebsd-x64": "1.1.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.2",
+        "@rolldown/binding-linux-arm64-musl": "1.1.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.2",
+        "@rolldown/binding-linux-x64-gnu": "1.1.2",
+        "@rolldown/binding-linux-x64-musl": "1.1.2",
+        "@rolldown/binding-openharmony-arm64": "1.1.2",
+        "@rolldown/binding-wasm32-wasi": "1.1.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.2",
+        "@rolldown/binding-win32-x64-msvc": "1.1.2"
       }
     },
     "arcjet/node_modules/undici-types": {
@@ -1621,6 +1962,137 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -1993,7 +2465,6 @@
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2826,6 +3297,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -3293,6 +3806,26 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5324,6 +5857,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/errx": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
@@ -7098,6 +7641,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/miniflare": {
+      "version": "4.20260617.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
+      "integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260617.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -8238,7 +8802,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -8941,6 +9504,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -9771,6 +10344,49 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
+      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260617.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+        "@cloudflare/workerd-linux-64": "1.20260617.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
+        "@cloudflare/workerd-windows-64": "1.20260617.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -9799,6 +10415,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/zimmerframe": {
@@ -10113,15 +10768,6 @@
         "node": ">=22.21.0 <23 || >=24.5.0"
       }
     },
-    "protocol/node_modules/@connectrpc/connect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
-      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0"
-      }
-    },
     "protocol/node_modules/@types/node": {
       "version": "22.19.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
@@ -10351,28 +10997,6 @@
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
-      }
-    },
-    "transport/node_modules/@connectrpc/connect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
-      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0"
-      }
-    },
-    "transport/node_modules/@connectrpc/connect-node": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
-      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2"
       }
     },
     "transport/node_modules/@connectrpc/connect-web": {


### PR DESCRIPTION
## Summary

Adds a miniflare runtime test proving the core `arcjet` SDK `protect()` call works on Cloudflare Workers. `guard()` already had a Cloudflare Workers runtime test ([`arcjet-guard/test/runtime/cloudflare`](https://github.com/arcjet/arcjet-js/tree/main/arcjet-guard/test/runtime/cloudflare)), but the core SDK `protect()` path did not — this closes that gap for #759.

The test wires the SDK exactly as a Cloudflare adapter would:

- bundles a Worker (rolldown) that imports the core SDK, resolving the `workerd` export conditions so `@arcjet/transport` and `@arcjet/analyze-wasm` pick their `workerd` entries;
- supplies the local-fingerprinting WASM to miniflare as `CompiledWasm` modules — the same module shape wrangler produces from the `.wasm` imports on a real deploy;
- runs `protect()` with a `tokenBucket` rule against a real mock `DecideService` server over HTTP, and asserts the decision plus that exactly one `decide()` call reached the server (i.e. it went through the transport, not a local short-circuit).

## Changes

- New `arcjet/test/runtime/cloudflare/` — `cloudflare.test.ts`, `worker.ts`, `mock-server.ts`
- New `test-runtime-cloudflare` npm script + `miniflare`/`rolldown`/`@connectrpc`/`@bufbuild/protobuf` devDependencies (connect/protobuf pinned to the versions already used by `@arcjet/protocol` and `@arcjet/transport` to avoid dual-version type breaks)
- Exclude `test/runtime/**` from the build type-check in `arcjet/tsconfig.json` (mirrors the `@arcjet/transport` package convention)
- New `arcjet-runtime` CI job in `reusable-test.yml`, mirroring the existing `transport-runtime` job

## Test plan

- `npm run test-runtime-cloudflare --workspace=arcjet` passes locally
- `npm run build` (full workspace) and `eslint` are clean

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)