### PR TITLE
fix(ci): force node --test to exit for all coverage packages (Node 26 hang)

### DIFF
--- a/analyze-wasm/package.json
+++ b/analyze-wasm/package.json
@@ -56,7 +56,7 @@
     "build": "npm run build:jco && npm run build:rollup",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -40,7 +40,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/arcjet-astro/package.json
+++ b/arcjet-astro/package.json
@@ -54,7 +54,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/arcjet-fastify/package.json
+++ b/arcjet-fastify/package.json
@@ -52,7 +52,7 @@
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=80 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=90 -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit --test-coverage-branches=80 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=90 -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -75,7 +75,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage --test-coverage-include=src/** --test-coverage-exclude=src/**/*.test.ts src/**/*.test.ts",
+    "test-unit": "node --test --test-force-exit --experimental-test-coverage --test-coverage-include=src/** --test-coverage-exclude=src/**/*.test.ts src/**/*.test.ts",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
     "test-runtime-deno": "npm run build && deno test --no-check --allow-all test/runtime/deno.test.ts",

--- a/arcjet-node/package.json
+++ b/arcjet-node/package.json
@@ -51,7 +51,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=75 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=90 --test-coverage-lines=75 -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit --test-coverage-branches=75 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=90 --test-coverage-lines=75 -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/arcjet-nuxt/package.json
+++ b/arcjet-nuxt/package.json
@@ -73,7 +73,7 @@
     "lint": "eslint .",
     "prepack": "npm run build",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "type": "module",

--- a/arcjet-react-router/package.json
+++ b/arcjet-react-router/package.json
@@ -70,7 +70,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=75 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=90 --test-coverage-lines=65 -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit --test-coverage-branches=75 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=90 --test-coverage-lines=65 -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "type": "module",

--- a/body/package.json
+++ b/body/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint .",
     "pretest": "npm run build",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/cache/package.json
+++ b/cache/package.json
@@ -38,7 +38,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/decorate/package.json
+++ b/decorate/package.json
@@ -38,7 +38,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/duration/package.json
+++ b/duration/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/env/package.json
+++ b/env/package.json
@@ -38,7 +38,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/headers/package.json
+++ b/headers/package.json
@@ -38,7 +38,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/ip/package.json
+++ b/ip/package.json
@@ -41,7 +41,7 @@
     "generate": "npm run build && node scripts/verify-ranges.ts --write",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=100 --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=100 -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit --test-coverage-branches=100 --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=100 -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage",
     "verify-ranges": "npm run build && node scripts/verify-ranges.ts"
   },

--- a/logger/package.json
+++ b/logger/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/nosecone-next/package.json
+++ b/nosecone-next/package.json
@@ -50,7 +50,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -50,7 +50,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/nosecone/package.json
+++ b/nosecone/package.json
@@ -48,7 +48,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -45,7 +45,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/redact-wasm/package.json
+++ b/redact-wasm/package.json
@@ -52,7 +52,7 @@
     "build": "npm run build:jco && npm run build:rollup",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/redact/package.json
+++ b/redact/package.json
@@ -38,7 +38,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {

--- a/sprintf/package.json
+++ b/sprintf/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/stable-hash/package.json
+++ b/stable-hash/package.json
@@ -49,7 +49,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test": "npm run build && npm run lint && npm run test-coverage"
   },
   "dependencies": {},

--- a/transport/package.json
+++ b/transport/package.json
@@ -57,7 +57,7 @@
     "build": "rollup --config rollup.config.js",
     "lint": "eslint .",
     "test-api": "node --test -- test/*.test.js",
-    "test-coverage": "node --experimental-test-coverage --test -- test/*.test.js",
+    "test-coverage": "node --experimental-test-coverage --test --test-force-exit -- test/*.test.js",
     "test-runtime-bun": "npm run build && HTTPS_PROXY=http://127.0.0.1:49219 bun test test/runtime/proxy.bun.test.ts",
     "test-runtime-deno": "npm run build && HTTPS_PROXY=http://127.0.0.1:49219 deno test --allow-all --no-check test/runtime/proxy.deno.test.ts",
     "test": "npm run build && npm run lint && npm run test-coverage"


### PR DESCRIPTION
## What

Follow-up to #6108 (which fixed only `arcjet` core + added job timeouts). After that merged, the Node 26 job still hung — turbo just stalled at the *next* coverage package.

## Root cause

`@arcjet/transport`'s `createHttp2Transport` does an optimistic pre-connect (`sessionManager.connect()`), leaving a ref'd connecting socket. Under CI's harden-runner `egress-policy: block`, packets to non-allowlisted hosts are **dropped**, so that socket stays in the `connecting` state indefinitely and keeps the event loop alive — the test run completes (all tests pass, coverage prints) but the process never exits. Node 22 idle-closed it after ~340s (its ~9.5m runs); Node 26 doesn't.

Reproduced locally by pointing the transport at a blackholed RFC5737 address (`192.0.2.1`): the run finishes, then the process hangs on a `ConnectWrap`/`TCPSocketWrap` until killed. Verified `--test-force-exit` makes the same scenario exit `0`.

The affected packages are exactly those whose coverage tests exercise the transport (`transport`, `guard`, and the `node`/`fastify`/`astro`/`nuxt`/`react-router` adapters), so the flag is applied uniformly to all `node --test --experimental-test-coverage` scripts.

## Change

Add `--test-force-exit` to all remaining coverage test scripts. It exits the runner once tests and reporters finish; it does not mask failures (pass/fail is decided before exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)