### PR TITLE
fix(transport): make HTTP/2-over-CONNECT-proxy work on Node >= 26

### DIFF
--- a/transport/proxy-tunnel.ts
+++ b/transport/proxy-tunnel.ts
@@ -145,8 +145,49 @@ export function createTunnelingConnection(
       }
 
       // Splice: proxy -> bridge, so origin bytes become readable by the client.
-      proxySocket.on("data", (data: Buffer) => bridge.push(data));
-      proxySocket.on("end", () => bridge.push(null));
+      //
+      // For a cleartext (h2c) origin the bridge *is* the HTTP/2 socket, so these
+      // bytes are HTTP/2 frames. A proxy can coalesce a whole response
+      // (HEADERS + DATA + END_STREAM) into one chunk; delivered as a single
+      // synchronous read, the HTTP/2 client surfaces the DATA and the stream end
+      // in one turn, which races `@connectrpc/connect-node`'s async-iterator
+      // response reader and intermittently throws `ERR_STREAM_PREMATURE_CLOSE`
+      // on Node >= 26 (a real or TLS-wrapped socket avoids this — it delivers
+      // frames across separate reads). So for h2c we split the stream on HTTP/2
+      // frame boundaries and push one frame per tick, preserving order; the
+      // client then reads the DATA before observing END_STREAM. For an HTTPS
+      // origin the bytes are TLS records (the origin TLS socket reframes them),
+      // so we forward them unchanged.
+      if (originIsHttps) {
+        proxySocket.on("data", (data: Buffer) => bridge.push(data));
+      } else {
+        let inbound = Buffer.alloc(0);
+        proxySocket.on("data", (data: Buffer) => {
+          inbound = Buffer.concat([inbound, data]);
+          // An HTTP/2 frame is a 9-byte header (24-bit length, then type, flags,
+          // and stream id) followed by `length` bytes of payload.
+          while (inbound.length >= 9) {
+            const frameLength = 9 + inbound.readUIntBE(0, 3);
+            if (inbound.length < frameLength) {
+              break; // Wait for the rest of this frame.
+            }
+            const frame = inbound.subarray(0, frameLength);
+            inbound = inbound.subarray(frameLength);
+            setImmediate(() => {
+              if (!bridge.destroyed) {
+                bridge.push(frame);
+              }
+            });
+          }
+        });
+      }
+      proxySocket.on("end", () =>
+        setImmediate(() => {
+          if (!bridge.destroyed) {
+            bridge.push(null);
+          }
+        }),
+      );
 
       // Flush whatever the client buffered while the tunnel was establishing.
       tunnelReady = true;
@@ -173,11 +214,34 @@ export function createTunnelingConnection(
       return bridge;
     }
 
-    return tls.connect({
-      ...options,
-      socket: bridge,
-      servername: authority.hostname,
-      ALPNProtocols: ["h2"],
-    });
+    try {
+      return tls.connect({
+        ...options,
+        socket: bridge,
+        // Validate the certificate against the origin host. For a hostname this
+        // is also sent as SNI below; for an IP it is the identity to match
+        // (since SNI is omitted), so the cert's IP SAN is still checked.
+        host: authority.hostname,
+        // RFC 6066 §3 forbids IP literals in the TLS SNI `servername`: it must
+        // be a DNS hostname. When the origin is addressed by IP we therefore
+        // omit SNI entirely (the certificate is still validated against the IP
+        // via `host` above). Node historically tolerated an IP here with a
+        // deprecation warning, but Node >= 26 enforces the RFC and throws
+        // `ERR_INVALID_ARG_VALUE`.
+        servername:
+          net.isIP(authority.hostname) === 0 ? authority.hostname : undefined,
+        ALPNProtocols: ["h2"],
+      });
+    } catch (error) {
+      // Constructing the origin TLS connection can throw *synchronously* (for
+      // example, Node >= 26 rejects an IP-literal `servername` per RFC 6066).
+      // We have already opened `proxySocket`; if we let the throw escape we
+      // strand that open handle, which keeps the event loop — and the whole
+      // process — alive (this is what hung CI). Tear both sides down before
+      // rethrowing so a failed setup fails fast and cleanly.
+      proxySocket.destroy();
+      bridge.destroy(error as Error);
+      throw error;
+    }
   };
 }

--- a/transport/proxy-tunnel.ts
+++ b/transport/proxy-tunnel.ts
@@ -161,13 +161,26 @@ export function createTunnelingConnection(
       if (originIsHttps) {
         proxySocket.on("data", (data: Buffer) => bridge.push(data));
       } else {
+        // HTTP/2's default `SETTINGS_MAX_FRAME_SIZE` is 16 KiB and we never raise
+        // it, so any frame larger than this generous cap is already a protocol
+        // violation. Bounding the buffer keeps a malicious or broken peer from
+        // using the 24-bit length field (up to ~16 MiB) to make us buffer an
+        // oversized frame before forwarding anything.
+        const maxFramePayload = 2 ** 20; // 1 MiB
         let inbound = Buffer.alloc(0);
         proxySocket.on("data", (data: Buffer) => {
           inbound = Buffer.concat([inbound, data]);
           // An HTTP/2 frame is a 9-byte header (24-bit length, then type, flags,
           // and stream id) followed by `length` bytes of payload.
           while (inbound.length >= 9) {
-            const frameLength = 9 + inbound.readUIntBE(0, 3);
+            const payloadLength = inbound.readUIntBE(0, 3);
+            if (payloadLength > maxFramePayload) {
+              bridge.destroy(
+                new Error("Proxy tunnel received an oversized HTTP/2 frame"),
+              );
+              return;
+            }
+            const frameLength = 9 + payloadLength;
             if (inbound.length < frameLength) {
               break; // Wait for the rest of this frame.
             }
@@ -214,6 +227,16 @@ export function createTunnelingConnection(
       return bridge;
     }
 
+    // `URL.hostname` wraps an IPv6 literal in brackets (e.g. `[::1]`), which
+    // `net.isIP` does not recognise. Strip them so an IPv6 origin is detected as
+    // an IP (and so the certificate is matched against the bare address — an IP
+    // SAN has no brackets).
+    const bareHostname =
+      authority.hostname.startsWith("[") && authority.hostname.endsWith("]")
+        ? authority.hostname.slice(1, -1)
+        : authority.hostname;
+    const originIsIpLiteral = net.isIP(bareHostname) !== 0;
+
     try {
       return tls.connect({
         ...options,
@@ -221,15 +244,13 @@ export function createTunnelingConnection(
         // Validate the certificate against the origin host. For a hostname this
         // is also sent as SNI below; for an IP it is the identity to match
         // (since SNI is omitted), so the cert's IP SAN is still checked.
-        host: authority.hostname,
-        // RFC 6066 §3 forbids IP literals in the TLS SNI `servername`: it must
-        // be a DNS hostname. When the origin is addressed by IP we therefore
-        // omit SNI entirely (the certificate is still validated against the IP
-        // via `host` above). Node historically tolerated an IP here with a
-        // deprecation warning, but Node >= 26 enforces the RFC and throws
-        // `ERR_INVALID_ARG_VALUE`.
-        servername:
-          net.isIP(authority.hostname) === 0 ? authority.hostname : undefined,
+        host: bareHostname,
+        // RFC 6066 §3 forbids an IP literal in the TLS SNI `servername` — it must
+        // be a DNS hostname — so we omit SNI for an IP origin (IPv4 or IPv6) and
+        // rely on `host` above for certificate validation. Node <= 24 tolerated
+        // an IP here (deprecation warning); Node >= 26 enforces the RFC and
+        // throws `ERR_INVALID_ARG_VALUE`.
+        servername: originIsIpLiteral ? undefined : bareHostname,
         ALPNProtocols: ["h2"],
       });
     } catch (error) {

--- a/transport/test/index.test.ts
+++ b/transport/test/index.test.ts
@@ -19,22 +19,9 @@ import {
   createProxy,
   generateSelfSignedCert,
   listen,
+  trackHttp2Sessions,
   withHttpProxyEnvironment,
 } from "./proxy.js";
-
-// Node >= 26 changed HTTP/2 + TLS behavior in ways that break the two
-// HTTP/2-over-CONNECT-tunnel round-trip tests below: the h2c-through-tunnel
-// case surfaces `ERR_STREAM_PREMATURE_CLOSE`, and the ALPN-over-tunnel case
-// rejects the TLS `servername` because it is an IP literal (`127.0.0.1`),
-// which Node 26 no longer permits (SNI must be a hostname). When those tests
-// fail mid-handshake they also leave the tunnel socket open, which keeps the
-// test process alive and hangs the runner. Skip them on Node >= 26 until the
-// proxy-tunnel path is updated for the new behavior; they still run on 22/24.
-const nodeMajorVersion = Number.parseInt(process.versions.node, 10);
-const skipOnNode26 =
-  nodeMajorVersion >= 26
-    ? "skipped on Node >= 26: HTTP/2-over-CONNECT-tunnel behavior changed (premature close / IP-literal SNI rejected)"
-    : false;
 
 function elizaRoutes() {
   return connectNodeAdapter({
@@ -91,7 +78,7 @@ async function withHttpOrigin(
   try {
     await fn("http://localhost:" + port);
   } finally {
-    await server.close();
+    await close(server);
   }
 }
 
@@ -114,7 +101,7 @@ test("@arcjet/transport", async function (t) {
     const port = uniquePort++;
     const url = "http://localhost:" + port;
 
-    const server = http2.createServer(elizaRoutes());
+    const server = trackHttp2Sessions(http2.createServer(elizaRoutes()));
 
     await new Promise(function (resolve) {
       server.listen({ port }, function () {
@@ -125,7 +112,7 @@ test("@arcjet/transport", async function (t) {
     const client = createClient(ElizaService, createTransport(url));
     const result = await client.say({ sentence: "Hi!" });
 
-    await server.close();
+    await close(server);
 
     assert.equal(result.sentence, "You said `Hi!`");
   });
@@ -206,12 +193,11 @@ test("@arcjet/transport", async function (t) {
 
   await t.test(
     "should preserve HTTP/2 through a proxy when `proxyHttpVersion` is `2`",
-    { skip: skipOnNode26 },
     async function () {
       // A cleartext HTTP/2 (h2c) origin lets us drive a real round trip through
       // the tunnel without certificates: the `CONNECT` proxy tunnels TCP and
       // the transport speaks HTTP/2 over it end-to-end.
-      const origin = http2.createServer(elizaRoutes());
+      const origin = trackHttp2Sessions(http2.createServer(elizaRoutes()));
       const originUrl = await listen(origin);
       const authority = new URL(originUrl).host;
 
@@ -246,7 +232,6 @@ test("@arcjet/transport", async function (t) {
 
   await t.test(
     "should negotiate HTTP/2 (ALPN `h2`) end-to-end through a CONNECT proxy",
-    { skip: skipOnNode26 },
     async function () {
       // The production API is HTTPS, where HTTP/2 is selected by ALPN during the
       // TLS handshake. That handshake happens directly with the origin inside
@@ -254,6 +239,14 @@ test("@arcjet/transport", async function (t) {
       // certificate here (via `ca`) so the handshake completes and we can assert
       // the negotiated protocol — exercising the tunnel helper the way the
       // transport uses it.
+      //
+      // This origin is addressed by IP (`127.0.0.1`). RFC 6066 §3 forbids an IP
+      // literal in the TLS SNI, so the tunnel must NOT send SNI here (the cert is
+      // validated against the IP instead). This test originally failed because
+      // the tunnel set the SNI to the origin host unconditionally: an IP origin
+      // therefore produced a non-compliant IP-literal SNI, which Node <= 24
+      // tolerated (with a deprecation warning) but Node >= 26 rejects outright.
+      // The hostname companion test below covers the case where SNI *is* sent.
       const { key, cert } = generateSelfSignedCert();
       const origin = http2.createSecureServer({ key, cert });
       origin.on("stream", function (stream) {
@@ -269,19 +262,27 @@ test("@arcjet/transport", async function (t) {
       });
       const proxyUrl = await listen(proxy);
 
-      const session = http2.connect(originUrl, {
-        ca: cert,
-        createConnection: createTunnelingConnection(proxyUrl),
-      });
-
+      // `http2.connect` calls `createConnection` synchronously, so if the
+      // tunnel helper throws while setting up the connection (for example, on
+      // Node >= 26 with an IP-literal SNI) the throw surfaces from this call.
+      // Keep it inside the `try` and track the session in an outer binding so
+      // the `finally` always tears down the proxy and origin, even when the
+      // session was never created.
+      let session: http2.ClientHttp2Session | undefined;
       try {
+        const connected = http2.connect(originUrl, {
+          ca: cert,
+          createConnection: createTunnelingConnection(proxyUrl),
+        });
+        session = connected;
+
         await new Promise<void>(function (resolve, reject) {
-          session.once("connect", () => resolve());
-          session.once("error", reject);
+          connected.once("connect", () => resolve());
+          connected.once("error", reject);
         });
 
         assert.equal(
-          session.alpnProtocol,
+          connected.alpnProtocol,
           "h2",
           "expected HTTP/2 to be negotiated with the origin through the tunnel",
         );
@@ -289,7 +290,7 @@ test("@arcjet/transport", async function (t) {
         // A round trip proves the tunnel carries real HTTP/2 frames, not just a
         // completed handshake.
         const body = await new Promise<string>(function (resolve, reject) {
-          const request = session.request({ ":path": "/" });
+          const request = connected.request({ ":path": "/" });
           let data = "";
           request.setEncoding("utf8");
           request.on("data", (chunk) => (data += chunk));
@@ -299,7 +300,81 @@ test("@arcjet/transport", async function (t) {
         });
         assert.equal(body, "ok");
       } finally {
-        session.close();
+        session?.close();
+        await close(proxy);
+        await close(origin);
+      }
+
+      assert.ok(
+        connectRequests >= 1,
+        "expected the request to be tunneled through the proxy via CONNECT",
+      );
+    },
+  );
+
+  await t.test(
+    "should negotiate HTTP/2 (ALPN `h2`) to a hostname origin through a CONNECT proxy",
+    async function () {
+      // Companion to the IP test above and the production-realistic case: a
+      // hostname origin, where the tunnel *does* send SNI and the certificate is
+      // validated against it. The origin still listens on the loopback IP and the
+      // proxy dials that IP, so the tunnel stays on IPv4 regardless of how
+      // `localhost` resolves; only the SNI, `:authority`, and certificate use the
+      // hostname.
+      const hostname = "localhost";
+      const { key, cert } = generateSelfSignedCert(hostname);
+      const origin = trackHttp2Sessions(http2.createSecureServer({ key, cert }));
+      origin.on("stream", function (stream) {
+        stream.respond({ ":status": 200 });
+        stream.end("ok");
+      });
+      const loopbackUrl = await listen(origin, "https");
+      const port = new URL(loopbackUrl).port;
+      const originUrl = `https://${hostname}:${port}`;
+      const authority = new URL(originUrl).host;
+
+      let connectRequests = 0;
+      const proxy = createConnectProxy(
+        authority,
+        () => {
+          connectRequests++;
+        },
+        // Dial the loopback origin even though the authority is a hostname.
+        "127.0.0.1",
+      );
+      const proxyUrl = await listen(proxy);
+
+      let session: http2.ClientHttp2Session | undefined;
+      try {
+        const connected = http2.connect(originUrl, {
+          ca: cert,
+          createConnection: createTunnelingConnection(proxyUrl),
+        });
+        session = connected;
+
+        await new Promise<void>(function (resolve, reject) {
+          connected.once("connect", () => resolve());
+          connected.once("error", reject);
+        });
+
+        assert.equal(
+          connected.alpnProtocol,
+          "h2",
+          "expected HTTP/2 to be negotiated with the origin through the tunnel",
+        );
+
+        const body = await new Promise<string>(function (resolve, reject) {
+          const request = connected.request({ ":path": "/" });
+          let data = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk) => (data += chunk));
+          request.on("end", () => resolve(data));
+          request.on("error", reject);
+          request.end();
+        });
+        assert.equal(body, "ok");
+      } finally {
+        session?.close();
         await close(proxy);
         await close(origin);
       }
@@ -317,7 +392,7 @@ test("@arcjet/transport", async function (t) {
       const port = uniquePort++;
       const url = "http://localhost:" + port;
 
-      const server = http2.createServer(elizaRoutes());
+      const server = trackHttp2Sessions(http2.createServer(elizaRoutes()));
 
       await new Promise(function (resolve) {
         server.listen({ port }, function () {
@@ -344,7 +419,7 @@ test("@arcjet/transport", async function (t) {
         const result = await client.say({ sentence: "Hi!" });
         assert.equal(result.sentence, "You said `Hi!`");
       } finally {
-        await server.close();
+        await close(server);
       }
 
       // The proxy was bypassed, so nothing should have been logged.
@@ -384,7 +459,7 @@ test("@arcjet/transport", async function (t) {
     const port = uniquePort++;
     const url = "http://localhost:" + port;
 
-    const server = http2.createServer(elizaRoutes());
+    const server = trackHttp2Sessions(http2.createServer(elizaRoutes()));
 
     await new Promise(function (resolve) {
       server.listen({ port }, function () {
@@ -403,7 +478,7 @@ test("@arcjet/transport", async function (t) {
       const result = await client.say({ sentence: "Hi!" });
       assert.equal(result.sentence, "You said `Hi!`");
     } finally {
-      await server.close();
+      await close(server);
     }
   });
 

--- a/transport/test/proxy.ts
+++ b/transport/test/proxy.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync } from "node:fs";
 import http from "node:http";
+import http2 from "node:http2";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -27,6 +28,43 @@ const proxyEnvironmentKeys = [
  * `close()` to let the server shut down.
  */
 const tunnelSockets = new WeakMap<net.Server, Set<net.Socket>>();
+
+/**
+ * Open server-side HTTP/2 sessions per origin server.
+ *
+ * The client's `Http2SessionManager` keeps its session — and the underlying
+ * socket — alive for reuse with a long idle timeout, so a direct HTTP/2 origin's
+ * `server.close()` would wait on that idle connection (hanging the runner on
+ * some Node versions; `closeAllConnections()` doesn't tear down an HTTP/2
+ * *session*). We track sessions per server via {@linkcode trackHttp2Sessions}
+ * and destroy them in {@linkcode close} to release the client connection.
+ */
+const http2Sessions = new WeakMap<
+  net.Server,
+  Set<http2.ServerHttp2Session>
+>();
+
+/**
+ * Track the HTTP/2 sessions a server accepts so {@linkcode close} can destroy
+ * them. Use this for direct HTTP/2 origins (those reached without a `CONNECT`
+ * tunnel, whose teardown otherwise closes the client connection).
+ *
+ * @param server
+ *   HTTP/2 server to track sessions for.
+ * @returns
+ *   The same server, for chaining with `http2.createServer(...)`.
+ */
+export function trackHttp2Sessions<
+  T extends http2.Http2Server | http2.Http2SecureServer,
+>(server: T): T {
+  const sessions = new Set<http2.ServerHttp2Session>();
+  server.on("session", (session) => {
+    sessions.add(session);
+    session.on("close", () => sessions.delete(session));
+  });
+  http2Sessions.set(server, sessions);
+  return server;
+}
 
 /**
  * Start listening on a random port on the loopback interface.
@@ -85,6 +123,15 @@ export async function close(server: net.Server): Promise<void> {
     if (sockets) {
       for (const socket of sockets) {
         socket.destroy();
+      }
+    }
+    // Destroy any tracked HTTP/2 sessions so a client holding an idle session
+    // (see `http2Sessions`) doesn't keep `server.close()` — and the process —
+    // waiting on its idle timeout.
+    const sessions = http2Sessions.get(server);
+    if (sessions) {
+      for (const session of sessions) {
+        session.destroy();
       }
     }
   });
@@ -206,15 +253,21 @@ export async function withHttpProxyEnvironment<T>(
  *   `host:port` the proxy expects to tunnel to.
  * @param onConnect
  *   Called for every `CONNECT` request the proxy receives.
+ * @param connectHost
+ *   Host to actually open the upstream connection to (optional). Defaults to the
+ *   host in `expectedAuthority`. Pass `127.0.0.1` when the authority uses a
+ *   hostname (e.g. to exercise SNI) but the origin listens on the loopback IP,
+ *   so the tunnel stays on IPv4 regardless of how `localhost` resolves.
  * @returns
  *   Proxy server.
  */
 export function createConnectProxy(
   expectedAuthority: string,
   onConnect: () => void,
+  connectHost?: string,
 ): net.Server {
   const separator = expectedAuthority.lastIndexOf(":");
-  const host = expectedAuthority.slice(0, separator);
+  const host = connectHost ?? expectedAuthority.slice(0, separator);
   const port = Number(expectedAuthority.slice(separator + 1));
 
   const sockets = new Set<net.Socket>();
@@ -260,22 +313,29 @@ export function createConnectProxy(
 }
 
 /**
- * Generate a throwaway self-signed certificate for `127.0.0.1`.
+ * Generate a throwaway self-signed certificate for an origin.
  *
  * Used to stand up a real HTTPS origin so the HTTPS-through-proxy (`CONNECT`)
- * path can be exercised. The client deliberately doesn't trust this
- * certificate — `createTransport`'s agent exposes no `ca` option and disabling
- * TLS verification is a security anti-pattern — so the handshake over the
- * tunnel is expected to fail; the test verifies routing via the proxy
- * receiving the `CONNECT`.
+ * path can be exercised. Depending on the test, the client either trusts the
+ * certificate (via `ca`) to complete the handshake and assert the negotiated
+ * protocol, or deliberately doesn't trust it (so the handshake fails and the
+ * test only verifies routing via the proxy receiving the `CONNECT`).
  *
+ * @param host
+ *   Host the certificate identifies (defaults to `127.0.0.1`). An IP literal is
+ *   added as an `IP` subjectAltName; a hostname as a `DNS` subjectAltName (which
+ *   is what a real TLS client validates against the SNI it sends).
  * @returns
  *   PEM-encoded private key and certificate.
  */
-export function generateSelfSignedCert(): { key: string; cert: string } {
+export function generateSelfSignedCert(host = "127.0.0.1"): {
+  key: string;
+  cert: string;
+} {
   const directory = mkdtempSync(join(tmpdir(), "arcjet-transport-cert-"));
   const keyFile = join(directory, "key.pem");
   const certFile = join(directory, "cert.pem");
+  const subjectAltName = net.isIP(host) ? `IP:${host}` : `DNS:${host}`;
 
   execFileSync(
     "openssl",
@@ -292,9 +352,9 @@ export function generateSelfSignedCert(): { key: string; cert: string } {
       "-days",
       "1",
       "-subj",
-      "/CN=127.0.0.1",
+      `/CN=${host}`,
       "-addext",
-      "subjectAltName=IP:127.0.0.1",
+      `subjectAltName=${subjectAltName}`,
     ],
     { stdio: "ignore" },
   );


### PR DESCRIPTION
## Summary

Re-enables the two `@arcjet/transport` proxy tests that #6112 skipped on Node 26, and fixes the three distinct issues that surface when the proxy-tunnel tests run on Node 26 (and the latest Node 22). Verified locally on Node **22.23.1, 24.18.0, and 26.4.0** (26.4.0 is the version that was hanging); the CI run on this PR is the real confirmation.

Closes #6113.

## The three issues

### 1. IP-literal SNI — the #6113 "category error"

`proxy-tunnel.ts` set the TLS `servername` to the origin host unconditionally. For an origin addressed by IP that puts an IP literal in the SNI, which RFC 6066 §3 forbids. Node ≤ 24 tolerated it (deprecation warning); Node ≥ 26 throws `ERR_INVALID_ARG_VALUE` synchronously — and, left unhandled, that throw also stranded the tunnel socket and hung the runner.

The invalid value originated in the test connecting to a `127.0.0.1` origin, but the durable defect is in the library: a correct TLS client must omit SNI for an IP destination (a real caller using an IP origin would hit the same crash). Fix: omit SNI for IP origins and validate the certificate against the IP via `host`.

### 2. Flaky `ERR_STREAM_PREMATURE_CLOSE` on the cleartext (h2c) path — a separate bug

A proxy can coalesce a whole response (HEADERS + DATA + END_STREAM) into a single read. Our `Duplex` bridge pushed those bytes **synchronously**, unlike a real socket, which surfaces them asynchronously and across reads. On Node 26 that synchronous, coalesced delivery raced `@connectrpc/connect-node`'s async-iterator response reader and dropped the body (~33% of runs).

Where the fix belongs: raw `node:http2` reading the same bridge was unaffected (0/40), and connect-node over a real or TLS-wrapped socket is fine — so the fix is in how the bridge delivers bytes. For the cleartext path we now split the stream on HTTP/2 frame boundaries and push one frame per tick (order preserved), so the client reads DATA before observing END_STREAM, matching real-socket delivery. The HTTPS path forwards bytes unchanged (they're TLS records, reframed by the origin TLS socket).

### 3. Node 22.23.1 hang — pre-existing, tests pass but the process won't exit

Independent of the above and already present on `main`: a client `Http2SessionManager` keeps an idle session (and its socket) alive with a 340s idle timeout, which `server.close()` waits on. On Node 22.23.1 three such sockets leaked and the suite hung even though every test passed (Node 24/26 happened to release them). Fix is in the test helper: track and destroy server-side HTTP/2 sessions on teardown.

## Also

- **Fail-fast teardown:** the tunnel destroys its proxy socket if the origin TLS setup throws, so a failed handshake errors immediately instead of hanging.
- **New `localhost` ALPN test** exercising the SNI-is-sent path (kept on IPv4 by having the proxy dial the loopback origin), alongside the existing IP test for the no-SNI path.
- The `timeout-minutes` CI safety net from #6108 is untouched.

## Verification

Full transport suite, repeated runs on raw Node binaries:

| Node | result |
| --- | --- |
| 22.23.1 | 23/23 pass, clean exit, 0 hangs |
| 24.18.0 | 23/23 pass, clean exit, 0 hangs |
| 26.4.0 | 23/23 pass, clean exit, 0 hangs (20× — the version that was hanging) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
