### PR TITLE
fix(protocol): add typeid.js and typeid.d.ts to package files

### DIFF
--- a/protocol/package.json
+++ b/protocol/package.json
@@ -38,6 +38,8 @@
     "convert.js",
     "index.d.ts",
     "index.js",
+    "typeid.d.ts",
+    "typeid.js",
     "well-known-bots.d.ts",
     "well-known-bots.js"
   ],


### PR DESCRIPTION
## Summary

- `typeid.ts` was vendored in #6103 but its compiled outputs were omitted from the `files` array in `protocol/package.json`
- With `preserveModules: true`, rollup emits `typeid.js` as a separate file that `index.js` `import`s at runtime — consumers get `Module not found: Can't resolve './typeid.js'` (reproduces in Next.js builds against the published 1.5.0 package)
- Fix: add `typeid.d.ts` and `typeid.js` alongside the other compiled module outputs already listed in `files`

Fixes: `home:build: Module not found: Can't resolve './typeid.js'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)