### PR TITLE
ci(publish): pass dist-tag via --tag and drop publishConfig.tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,10 +51,10 @@ jobs:
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
           # The web form enforces the choice list, but API dispatches do not:
-          # a missing input arrives as an empty string, and an empty
-          # npm_config_tag would fall back to npm's default tag - latest.
-          # Validating both inputs here also means the later steps (including
-          # the approval-facing summary) only ever see known values.
+          # a missing input arrives as an empty string, and an empty dist-tag
+          # would publish `--tag ""`. Validating both inputs here also means
+          # the later steps (including the approval-facing summary) only ever
+          # see known values.
           case "$DIST_TAG" in
             latest|rc) ;;
             *)
@@ -161,11 +161,16 @@ jobs:
         run: npm test
       - name: Publish packages
         env:
-          # npm reads config from the environment; this step only runs
-          # publish commands, so these apply to all of them.
-          npm_config_tag: ${{ inputs['dist-tag'] }}
+          DIST_TAG: ${{ inputs['dist-tag'] }}
+          # dry-run is a boolean with no publishConfig equivalent, so passing
+          # it via the environment is safe and applies to every publish below.
           npm_config_dry_run: ${{ inputs.dry-run }}
         run: |
+          # Pass the dist-tag with --tag on each publish rather than the
+          # npm_config_tag environment variable. A command-line --tag outranks
+          # a package's publishConfig.tag; the environment variable does not,
+          # so publishConfig.tag would silently win and route the publish to
+          # its tag (e.g. latest) instead of the requested one.
           # npm publish --workspaces publishes in alphabetical directory order,
           # NOT dependency order. This means packages like @arcjet/astro get
           # published before their dependencies (e.g. @arcjet/body, @arcjet/env)
@@ -178,7 +183,7 @@ jobs:
           # If you add a new package, insert it in the correct level.
 
           # Level 0: no internal dependencies
-          npm publish \
+          npm publish --tag "$DIST_TAG" \
             --workspace @arcjet/analyze-wasm \
             --workspace @arcjet/body \
             --workspace @arcjet/cache \
@@ -194,7 +199,7 @@ jobs:
             --workspace nosecone
 
           # Level 1: depend on level 0
-          npm publish \
+          npm publish --tag "$DIST_TAG" \
             --workspace @arcjet/logger \
             --workspace @arcjet/protocol \
             --workspace @arcjet/redact \
@@ -202,18 +207,18 @@ jobs:
             --workspace @nosecone/sveltekit
 
           # Level 2: depend on levels 0-1
-          npm publish \
+          npm publish --tag "$DIST_TAG" \
             --workspace @arcjet/analyze \
             --workspace @arcjet/decorate \
             --workspace @arcjet/inspect
 
           # Level 3: core SDK + guard (depend on @arcjet/analyze from Level 2)
-          npm publish \
+          npm publish --tag "$DIST_TAG" \
             --workspace arcjet \
             --workspace @arcjet/guard
 
           # Level 4: public framework integrations
-          npm publish \
+          npm publish --tag "$DIST_TAG" \
             --workspace @arcjet/astro \
             --workspace @arcjet/bun \
             --workspace @arcjet/deno \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -230,3 +230,41 @@ jobs:
             --workspace @arcjet/react-router \
             --workspace @arcjet/remix \
             --workspace @arcjet/sveltekit
+      - name: Verify dist-tags
+        # Nothing was published on a dry run, so there is nothing to verify.
+        if: ${{ !inputs.dry-run }}
+        env:
+          DIST_TAG: ${{ inputs['dist-tag'] }}
+          EXPECTED: ${{ github.ref_name }}
+        run: |
+          # `npm publish` reports the requested tag but can silently write a
+          # different dist-tag while still exiting 0 - a package's
+          # publishConfig.tag once won over the requested tag, publishing a
+          # pre-release to `latest` and leaving `rc` unmoved, with a green
+          # run. Confirm every published package's requested dist-tag now
+          # resolves to this version so that failure mode fails the job.
+          version="${EXPECTED#v}"
+          # `.[]` yields the name value regardless of how npm keys the object.
+          names="$(npm pkg get name --workspaces | jq -r '.[]')"
+          failed=""
+          for pkg in $names; do
+            # A just-written dist-tag can briefly lag the publish call, so
+            # revalidate against the registry a few times before giving up.
+            actual=""
+            for attempt in 1 2 3 4 5 6; do
+              actual="$(npm view --prefer-online "$pkg" "dist-tags.$DIST_TAG" 2>/dev/null || true)"
+              [ "$actual" = "$version" ] && break
+              [ "$attempt" -lt 6 ] && sleep 5
+            done
+            if [ "$actual" = "$version" ]; then
+              echo "ok: $pkg $DIST_TAG -> $version"
+            else
+              echo "::error::$pkg dist-tag '$DIST_TAG' is '${actual:-<none>}', expected '$version'."
+              failed="$failed $pkg"
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::dist-tag verification failed for:$failed"
+            exit 1
+          fi
+          echo "Verified $DIST_TAG -> $version for all published packages."

--- a/analyze-wasm/package.json
+++ b/analyze-wasm/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build:jco": "jco transpile --instantiation async --no-wasi-shim --out-dir src/wasm/ -- src/wasm/arcjet_analyze_js_req.component.wasm",

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -40,8 +40,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-astro/package.json
+++ b/arcjet-astro/package.json
@@ -52,8 +52,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-bun/package.json
+++ b/arcjet-bun/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-deno/package.json
+++ b/arcjet-deno/package.json
@@ -50,8 +50,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-fastify/package.json
+++ b/arcjet-fastify/package.json
@@ -52,8 +52,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -65,8 +65,7 @@
     }
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-nest/package.json
+++ b/arcjet-nest/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-next/package.json
+++ b/arcjet-next/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-node/package.json
+++ b/arcjet-node/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-nuxt/package.json
+++ b/arcjet-nuxt/package.json
@@ -50,8 +50,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-react-router/package.json
+++ b/arcjet-react-router/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-remix/package.json
+++ b/arcjet-remix/package.json
@@ -50,8 +50,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet-sveltekit/package.json
+++ b/arcjet-sveltekit/package.json
@@ -51,8 +51,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -49,8 +49,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/body/package.json
+++ b/body/package.json
@@ -39,8 +39,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/cache/package.json
+++ b/cache/package.json
@@ -38,8 +38,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/decorate/package.json
+++ b/decorate/package.json
@@ -38,8 +38,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/duration/package.json
+++ b/duration/package.json
@@ -39,8 +39,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/env/package.json
+++ b/env/package.json
@@ -38,8 +38,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/headers/package.json
+++ b/headers/package.json
@@ -38,8 +38,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -39,8 +39,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/ip/package.json
+++ b/ip/package.json
@@ -46,8 +46,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/logger/package.json
+++ b/logger/package.json
@@ -39,8 +39,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/nosecone-next/package.json
+++ b/nosecone-next/package.json
@@ -49,8 +49,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -49,8 +49,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/nosecone/package.json
+++ b/nosecone/package.json
@@ -47,8 +47,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -71,8 +71,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/redact-wasm/package.json
+++ b/redact-wasm/package.json
@@ -49,8 +49,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build:jco": "jco transpile --instantiation async --no-wasi-shim --out-dir src/wasm/ -- src/wasm/arcjet_analyze_bindings_redact.component.wasm",

--- a/redact/package.json
+++ b/redact/package.json
@@ -38,8 +38,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -45,8 +45,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/sprintf/package.json
+++ b/sprintf/package.json
@@ -39,8 +39,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/stable-hash/package.json
+++ b/stable-hash/package.json
@@ -48,8 +48,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/transport/package.json
+++ b/transport/package.json
@@ -56,8 +56,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "latest"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
## What

- Pass the dist-tag with `--tag "$DIST_TAG"` on each `npm publish` in the publish workflow, instead of the `npm_config_tag` environment variable.
- Remove the redundant `publishConfig.tag: "latest"` from every published package (34 packages, incl. `@arcjet/guard`). `access: "public"` is kept.
- Add a post-publish `Verify dist-tags` step that asserts each package's requested dist-tag actually resolved to the published version, failing the job otherwise.

## Why

On the `1.8.0-rc.0` publish, the workflow requested the `rc` dist-tag via the `npm_config_tag` env var, and npm even logged `Publishing … with tag rc` — yet `1.8.0-rc.0` landed on `latest` and the `rc` tag was never advanced (it stayed at `1.7.0-rc.0`). Every package installing `@arcjet/*` at `latest` would have pulled a prerelease.

Root cause: every package hardcodes `publishConfig.tag: "latest"`. A **command-line `--tag`** outranks `publishConfig.tag`, but an **environment variable** (`npm_config_tag`) does not — so `publishConfig.tag: "latest"` silently won and routed every publish to `latest`. The previous workflow used `npm publish --tag "$TAG"` and worked correctly; the recent rewrite (#6130) switched to `npm_config_tag`, which exposed the trap.

`publishConfig.tag: "latest"` provided no benefit to remove:
- It only restated npm's default tag.
- It created the precedence trap above.
- It suppressed [npm 11's own guard](https://github.com/npm/cli/releases/tag/v11.0.0) that refuses to publish a prerelease under the default `latest` tag (an explicitly-set `latest` satisfies the guard).

## Fix from both ends

`--tag` on the command line makes the requested tag authoritative regardless of manifest config, and dropping `publishConfig.tag` removes the trap entirely. Belt and suspenders.

Note: `npm_config_dry_run` is intentionally left as an env var — it's a boolean with no `publishConfig` equivalent, so it has no analogous precedence issue.

## Safety net: verify dist-tags after publishing

The failure above shipped **green** — `npm publish` reports the requested tag but can silently write a different one while exiting 0. The new `Verify dist-tags` step closes that gap:

- Derives the published package list from `npm pkg get name --workspaces` (the same source preflight uses — no hardcoded list to drift), then reads `dist-tags.<requested-tag>` from the registry for each and asserts it equals the just-published version.
- Fails the job with `::error::` annotations naming any package whose tag didn't resolve.
- Skipped on dry runs (`if: ${{ !inputs.dry-run }}`).
- Retries a few times with backoff per package to absorb brief registry propagation lag (avoids flaky false failures).

Validated against live registry data: it passes on the current correct state (`latest=1.8.0`) and **reproduces a failure on the incident signature** (`rc` stuck at `1.7.0-rc.0` while expecting the published version) — i.e. had it existed, the bad publish would have failed loudly instead of shipping.

## Verification

- All 34 `package.json` files still parse and retain `access: "public"`; only the `tag` key was removed (`+1/-2` per file).
- Workflow YAML validated; 5 publish levels all carry `--tag "$DIST_TAG"`; no live `npm_config_tag` remains (only an explanatory comment). The `Verify dist-tags` run script is shellcheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)