### PR TITLE
fix(arcjet-guard): detect and recycle silently dropped HTTP/2 connections

### DIFF
--- a/arcjet-guard/src/transport-bun.ts
+++ b/arcjet-guard/src/transport-bun.ts
@@ -31,7 +31,7 @@ export function createTransport(baseUrl: string): Transport {
 
   // No proxy: connect directly over HTTP/2.
   if (proxyUrl === undefined) {
-    return createHttp2Transport(baseUrl);
+    return createHttp2Transport(baseUrl).transport;
   }
 
   // Proxy: Bun's native `fetch` honors the proxy environment variables. The

--- a/arcjet-guard/src/transport-http2.ts
+++ b/arcjet-guard/src/transport-http2.ts
@@ -14,20 +14,56 @@
 import type { Transport } from "@connectrpc/connect";
 import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
 
+import { withConnectionRecycling } from "./transport-recycle.ts";
+
+/**
+ * A direct HTTP/2 transport plus the session manager that owns its connection.
+ *
+ * The session manager is exposed so callers (and tests) can tear the
+ * connection down deterministically.
+ */
+export interface Http2TransportHandle {
+  transport: Transport;
+  sessionManager: Http2SessionManager;
+}
+
 /**
  * Create a direct HTTP/2 Connect transport, optimistically pre-connecting.
  *
  * The session is pre-connected so the first `.guard()` call doesn't pay the
- * full TCP + TLS setup cost.
+ * full TCP + TLS setup cost. PING keep-alive and deadline-based connection
+ * recycling detect a silently dropped connection (an intermediary expiring an
+ * idle flow without notifying either end) and replace it, instead of letting a
+ * dead session fail every call until the process restarts.
  *
  * @param baseUrl Base URL for the Arcjet API.
- * @returns A Connect transport that talks HTTP/2 directly to `baseUrl`.
+ * @returns The transport and its session manager.
  */
-export function createHttp2Transport(baseUrl: string): Transport {
+export function createHttp2Transport(baseUrl: string): Http2TransportHandle {
   const sessionManager = new Http2SessionManager(baseUrl, {
-    // AWS Global Accelerator doesn't support PING so we use a very high idle
-    // timeout. Ref:
-    // https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout
+    // Detect and survive silently dropped connections:
+    //
+    // - `pingIntervalMs` sends PING frames on connections with in-flight
+    //   streams and, crucially, verifies a connection with a PING before
+    //   reusing it after `pingIntervalMs` of inactivity — transparently
+    //   dialing a fresh connection when the old one is dead.
+    // - `pingIdleConnection` extends the pings to idle connections, keeping
+    //   NAT/conntrack entries on the path alive (AWS NAT gateways expire idle
+    //   flows at 350s, Global Accelerator at 340s). Global Accelerator's idle
+    //   timeout is not reset by dataless TCP keepalive packets, but HTTP/2
+    //   PING frames are stream data, which does reset it. Ref:
+    //   https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout
+    //   Idle connections and the ping timers are unref'd by connect-es, so
+    //   this does not keep a quiescent process from exiting.
+    // - `pingTimeoutMs` bounds how long a dead connection lingers once a PING
+    //   goes unanswered; the default of 15s is slow next to typical guard
+    //   call timeouts of 1-2s.
+    // - `idleConnectionTimeoutMs` still closes a connection nothing has used
+    //   for a while; the pre-request verification above makes the subsequent
+    //   re-dial transparent.
+    pingIntervalMs: 55 * 1000,
+    pingTimeoutMs: 5 * 1000,
+    pingIdleConnection: true,
     idleConnectionTimeoutMs: 340 * 1000,
   });
 
@@ -35,9 +71,14 @@ export function createHttp2Transport(baseUrl: string): Transport {
   // call will retry the connection anyway.
   void sessionManager.connect().catch(() => {});
 
-  return createConnectTransport({
-    baseUrl,
-    httpVersion: "2",
+  const transport = withConnectionRecycling(
+    createConnectTransport({
+      baseUrl,
+      httpVersion: "2",
+      sessionManager,
+    }),
     sessionManager,
-  });
+  );
+
+  return { transport, sessionManager };
 }

--- a/arcjet-guard/src/transport-node.ts
+++ b/arcjet-guard/src/transport-node.ts
@@ -40,7 +40,7 @@ export function createTransport(baseUrl: string): Transport {
 
   // No proxy: connect directly over HTTP/2.
   if (proxyUrl === undefined) {
-    return createHttp2Transport(baseUrl);
+    return createHttp2Transport(baseUrl).transport;
   }
 
   // Proxy: route through it over HTTP/1.1 using the agent's built-in proxy

--- a/arcjet-guard/src/transport-recycle.test.ts
+++ b/arcjet-guard/src/transport-recycle.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for deadline-based connection recycling.
+ *
+ * Uses the in-memory Connect router transport as the inner transport so the
+ * wrapper is exercised through real RPC machinery — no network I/O.
+ */
+
+import assert from "node:assert/strict";
+import { describe, mock, test } from "node:test";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient, createRouterTransport } from "@connectrpc/connect";
+import type { Client } from "@connectrpc/connect";
+
+import { DecideService, GuardResponseSchema } from "./proto/proto/decide/v2/decide_pb.js";
+import {
+  withConnectionRecycling,
+  RECYCLE_AFTER_CONSECUTIVE_DEADLINES,
+} from "./transport-recycle.ts";
+import type { RecyclableSession } from "./transport-recycle.ts";
+
+/** Per-call outcome for the scripted inner transport. */
+type Outcome = "ok" | "deadline" | "canceled" | "internal";
+
+/** A `RecyclableSession` that records calls instead of managing a connection. */
+function fakeSession(): RecyclableSession & { aborts: number; connects: number } {
+  return {
+    aborts: 0,
+    connects: 0,
+    abort() {
+      this.aborts += 1;
+    },
+    connect() {
+      this.connects += 1;
+      return Promise.resolve("open");
+    },
+  };
+}
+
+/** Build a client whose calls play back `outcomes` in order, then a session spy. */
+function scriptedClient(outcomes: Outcome[]): {
+  client: Client<typeof DecideService>;
+  session: ReturnType<typeof fakeSession>;
+} {
+  let call = 0;
+  const inner = createRouterTransport(({ service }) => {
+    service(DecideService, {
+      guard() {
+        const outcome = outcomes[call] ?? "ok";
+        call += 1;
+        switch (outcome) {
+          case "deadline":
+            throw new ConnectError("deadline", Code.DeadlineExceeded);
+          case "canceled":
+            throw new ConnectError("canceled", Code.Canceled);
+          case "internal":
+            throw new ConnectError("internal", Code.Internal);
+          case "ok":
+            return create(GuardResponseSchema, {});
+        }
+      },
+    });
+  });
+  const session = fakeSession();
+  const client = createClient(DecideService, withConnectionRecycling(inner, session));
+  return { client, session };
+}
+
+/** Call `guard` and swallow the expected rejection. */
+async function callIgnoringError(client: Client<typeof DecideService>): Promise<void> {
+  await client.guard({}).catch(() => {});
+}
+
+describe("withConnectionRecycling", () => {
+  test("recycles after consecutive deadline failures, not before", async () => {
+    const { client, session } = scriptedClient(["deadline", "deadline", "deadline"]);
+
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES - 1; index++) {
+      await callIgnoringError(client);
+      assert.equal(session.aborts, 0);
+    }
+
+    await callIgnoringError(client);
+    assert.equal(session.aborts, 1);
+    assert.equal(session.connects, 1);
+  });
+
+  test("a success resets the run", async () => {
+    const { client, session } = scriptedClient([
+      "deadline",
+      "deadline",
+      "ok",
+      "deadline",
+      "deadline",
+    ]);
+
+    for (let index = 0; index < 5; index++) {
+      await callIgnoringError(client);
+    }
+
+    assert.equal(session.aborts, 0);
+  });
+
+  test("non-deadline errors neither count nor reset the run", async () => {
+    const { client, session } = scriptedClient(["deadline", "deadline", "internal", "deadline"]);
+
+    for (let index = 0; index < 3; index++) {
+      await callIgnoringError(client);
+    }
+    assert.equal(session.aborts, 0, "an internal error must not count as a deadline");
+
+    await callIgnoringError(client);
+    assert.equal(session.aborts, 1, "an internal error must not reset the run");
+  });
+
+  test("caller cancellation does not count toward the threshold", async () => {
+    const outcomes: Outcome[] = [];
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES; index++) {
+      outcomes.push("canceled");
+    }
+    const { client, session } = scriptedClient(outcomes);
+
+    for (let index = 0; index < outcomes.length; index++) {
+      await callIgnoringError(client);
+    }
+
+    assert.equal(session.aborts, 0);
+  });
+
+  test("the run restarts after a recycle", async () => {
+    const outcomes: Outcome[] = [];
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES * 2; index++) {
+      outcomes.push("deadline");
+    }
+    const { client, session } = scriptedClient(outcomes);
+
+    for (let index = 0; index < outcomes.length; index++) {
+      await callIgnoringError(client);
+    }
+
+    assert.equal(session.aborts, 2);
+  });
+
+  test("responses and errors pass through unchanged", async () => {
+    const { client } = scriptedClient(["ok", "deadline"]);
+
+    await client.guard({});
+
+    await assert.rejects(
+      () => client.guard({}),
+      (error: unknown) => ConnectError.from(error).code === Code.DeadlineExceeded,
+    );
+  });
+
+  test("recycling logs only when ARCJET_LOG_LEVEL requests it", async (t) => {
+    const outcomes: Outcome[] = [];
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES; index++) {
+      outcomes.push("deadline");
+    }
+    const warn = mock.method(console, "warn", () => {});
+    t.after(() => {
+      warn.mock.restore();
+    });
+
+    const previousLevel = process.env.ARCJET_LOG_LEVEL;
+    try {
+      delete process.env.ARCJET_LOG_LEVEL;
+      const quiet = scriptedClient(outcomes);
+      for (let index = 0; index < outcomes.length; index++) {
+        await callIgnoringError(quiet.client);
+      }
+      assert.equal(warn.mock.callCount(), 0, "silent when the level is unset");
+
+      process.env.ARCJET_LOG_LEVEL = "warn";
+      const loud = scriptedClient(outcomes);
+      for (let index = 0; index < outcomes.length; index++) {
+        await callIgnoringError(loud.client);
+      }
+      assert.equal(warn.mock.callCount(), 1, "logs when the level includes warn");
+    } finally {
+      if (previousLevel === undefined) {
+        delete process.env.ARCJET_LOG_LEVEL;
+      } else {
+        process.env.ARCJET_LOG_LEVEL = previousLevel;
+      }
+    }
+  });
+});

--- a/arcjet-guard/src/transport-recycle.ts
+++ b/arcjet-guard/src/transport-recycle.ts
@@ -1,0 +1,114 @@
+/**
+ * Dead-connection recovery for the guard HTTP/2 transport.
+ *
+ * A long-lived HTTP/2 session can die silently: an intermediary (NAT gateway,
+ * L4 load balancer, connection-tracking table) can drop the connection state
+ * during an idle period without sending a FIN or RST to either end. The client
+ * then holds a session that looks open but black-holes every write, so every
+ * RPC times out — and keeps timing out until TCP retransmission gives up many
+ * minutes later, because nothing else tears the session down.
+ *
+ * The PING keep-alive configured in `transport-http2.ts` detects most of this,
+ * but as a backstop this wrapper watches RPC outcomes: after a run of
+ * consecutive deadline failures with no success in between, it aborts the
+ * managed session so the next call dials a fresh connection.
+ *
+ * @packageDocumentation
+ */
+
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
+
+/**
+ * Consecutive deadline failures after which the connection is recycled.
+ *
+ * High enough that a couple of genuinely slow responses don't kill a healthy
+ * connection (aborting also kills any concurrent in-flight streams), low
+ * enough that a dead session costs only a few failed-open calls.
+ */
+export const RECYCLE_AFTER_CONSECUTIVE_DEADLINES = 3;
+
+/**
+ * The subset of `Http2SessionManager` the wrapper needs.
+ *
+ * Narrowed so tests can inject a fake.
+ */
+export interface RecyclableSession {
+  abort(reason?: Error): void;
+  connect(): Promise<unknown>;
+}
+
+/**
+ * Wrap a transport so consecutive deadline failures recycle the connection.
+ *
+ * Only `Code.DeadlineExceeded` failures count: a dead-but-open session
+ * manifests as every call timing out. Caller-initiated aborts surface as
+ * `Code.Canceled`, and connection-level failures (refused, reset) already put
+ * the session manager into its error state, from which it re-dials on its own.
+ * Other errors neither count nor reset the run — only a success proves the
+ * connection is alive.
+ *
+ * @param transport Transport whose unary calls should be watched.
+ * @param session Session manager to abort when the threshold is reached.
+ * @returns A transport with the same behavior plus connection recycling.
+ */
+export function withConnectionRecycling(
+  transport: Transport,
+  session: RecyclableSession,
+): Transport {
+  let consecutiveDeadlines = 0;
+
+  return {
+    async unary(method, signal, timeoutMs, header, input, contextValues) {
+      try {
+        const response = await transport.unary(
+          method,
+          signal,
+          timeoutMs,
+          header,
+          input,
+          contextValues,
+        );
+        consecutiveDeadlines = 0;
+        return response;
+      } catch (error: unknown) {
+        if (ConnectError.from(error).code === Code.DeadlineExceeded) {
+          consecutiveDeadlines += 1;
+          if (consecutiveDeadlines >= RECYCLE_AFTER_CONSECUTIVE_DEADLINES) {
+            consecutiveDeadlines = 0;
+            recycle(session);
+          }
+        }
+        throw error;
+      }
+    },
+    // Guard is unary-only; pass streaming calls through untouched.
+    stream(method, signal, timeoutMs, header, input, contextValues) {
+      return transport.stream(method, signal, timeoutMs, header, input, contextValues);
+    },
+  };
+}
+
+/**
+ * Abort the session and optimistically re-dial in the background.
+ *
+ * @param session Session manager holding the suspect connection.
+ */
+function recycle(session: RecyclableSession): void {
+  // Mirror the edge-safe, `ARCJET_LOG_LEVEL`-gated logging pattern of
+  // `detect-proxy.ts`: this event is the SDK healing a broken network path,
+  // which is worth surfacing during an incident, but stays quiet by default.
+  const level = globalThis.process?.env?.["ARCJET_LOG_LEVEL"];
+  if (level === "debug" || level === "info" || level === "warn") {
+    console.warn(
+      "Arcjet: consecutive timeouts talking to the Arcjet API; recycling the connection",
+    );
+  }
+
+  session.abort(
+    new ConnectError("connection recycled after consecutive deadline failures", Code.Unavailable),
+  );
+  // Optimistic background re-dial so the next call doesn't pay the full
+  // connection setup cost. Failures are ignored; the next RPC retries anyway.
+  void session.connect().catch(() => {});
+}

--- a/arcjet-guard/test/runtime/node.test.ts
+++ b/arcjet-guard/test/runtime/node.test.ts
@@ -26,6 +26,8 @@ import {
 } from "@arcjet/guard";
 import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
 
+import { createHttp2Transport } from "../../src/transport-http2.ts";
+import type { Http2TransportHandle } from "../../src/transport-http2.ts";
 import { cases } from "../_shared/cases.ts";
 import type { GuardSurface } from "../_shared/cases.ts";
 import {
@@ -138,6 +140,48 @@ describe("Runtime: Node.js HTTP/2 over TLS (self-signed)", () => {
     // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated hasError()
     assert.equal(decision.hasError(), false);
 
+    const result = input.result(decision);
+    assert.ok(result);
+    assert.equal(result.remainingTokens, 95);
+  });
+});
+
+describe("Runtime: guard HTTP/2 transport factory (keep-alive + recycling)", () => {
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+  let handle: Http2TransportHandle | undefined;
+
+  before(async () => {
+    ({ baseUrl, close: closeServer } = await startH2Server());
+  });
+
+  after(async () => {
+    if (handle !== undefined) handle.sessionManager.abort();
+    await closeServer();
+  });
+
+  test("guard call succeeds through the production transport factory", async () => {
+    // Exercises `createHttp2Transport` itself — PING keep-alive options and
+    // the connection-recycling wrapper — against a real HTTP/2 server, unlike
+    // the transports above, which are assembled by hand.
+    handle = createHttp2Transport(baseUrl);
+    const arcjet = launchArcjetWithTransport({
+      key: "ajkey_dummy",
+      transport: handle.transport,
+    });
+    const limit = tokenBucket({
+      refillRate: 10,
+      intervalSeconds: 60,
+      maxTokens: 100,
+    });
+    const input = limit({ key: "user_1" });
+
+    const decision = await arcjet.guard({
+      label: "test.h2.factory",
+      rules: [input],
+    });
+
+    assert.equal(decision.conclusion, "ALLOW");
     const result = input.result(decision);
     assert.ok(result);
     assert.equal(result.remainingTokens, 95);


### PR DESCRIPTION
## Problem

The guard direct HTTP/2 transport holds one long-lived session with **no keep-alive probing**. If an intermediary (NAT gateway, L4 load balancer, conntrack) silently drops the connection state during an idle period, the SDK holds a session that looks open but black-holes every write: **every guard call times out and fails open, indefinitely, until the process restarts**. This is the leading hypothesis for a production incident (traffic to the Arcjet API stopping entirely after a burst of timeouts, while the app keeps running).

PINGs were originally disabled citing AWS Global Accelerator's idle-timeout docs. That was a misreading: GA ignores **dataless TCP keepalive packets**, but HTTP/2 PING frames are stream data, which *does* reset its idle timer ([ref](https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout)).

## Changes

Two layers of defense in `createHttp2Transport`:

1. **PING keep-alive** (`pingIntervalMs: 55s`, `pingTimeoutMs: 5s`, `pingIdleConnection: true`):
   - verifies a connection with a PING before reusing it after inactivity, transparently re-dialing if it's dead;
   - tears down a dead connection within 5s once a PING goes unanswered (the 15s default is slow next to 1–2s guard timeouts);
   - keeps NAT/conntrack entries alive (AWS NAT gateways expire idle flows at 350s, GA at 340s; 55s clears both plus more aggressive middleboxes).
   - connect-es `unref()`s idle connections and all ping timers, so this does not keep a quiescent process from exiting (verified in the connect-node source).

2. **Connection recycling backstop** (`transport-recycle.ts`): after 3 consecutive `DeadlineExceeded` failures with no success in between, abort the session and optimistically re-dial. Only deadline failures count — caller cancellation (`Canceled`) and connection-level errors (which already put the session manager in its error state) don't. A recycle logs a warning when `ARCJET_LOG_LEVEL` requests it, following the `detect-proxy.ts` edge-safe logging pattern.

`createHttp2Transport` now returns `{ transport, sessionManager }` (internal API) so callers and tests can tear connections down deterministically.

## Not in scope (follow-ups from the same investigation)

- Defaulting the proxy path to HTTP/2-over-CONNECT (`proxyHttpVersion: "2"`)
- Runtime feature-detection of the Node agent `proxyEnv` option (silently ignored on Node < 22.x backport)
- Mirroring these options in `@arcjet/transport` for the main SDK

## Testing

- 7 new unit tests for the recycling wrapper via the in-memory Connect router transport (threshold, reset-on-success, non-deadline errors neither count nor reset, caller cancellation excluded, run restarts after recycle, pass-through, log gating).
- New runtime test driving `createHttp2Transport` itself against a real HTTP/2 server (previous runtime tests hand-assembled their transports and never exercised the factory).
- Full guard suite: 310 unit + 28 Node runtime + 26 Bun runtime tests pass; build, oxlint, tsgo, oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)