### PR TITLE
fix(arcjet-guard): make connection recycling single-flight per session generation

### DIFF
--- a/arcjet-guard/src/transport-recycle.test.ts
+++ b/arcjet-guard/src/transport-recycle.test.ts
@@ -171,9 +171,11 @@ describe("withConnectionRecycling", () => {
     assert.equal(session.aborts, 1);
   });
 
-  test("a stale success does not reset the run for the current session", async () => {
-    // The first call is held until after a recycle, so its success reports on
-    // the old session; it must not reset the deadline run of the new one.
+  test("a success from a call started before a recycle still resets the run", async () => {
+    // The first call is held until after a recycle and a partial deadline
+    // run against the replacement connection. Its success must reset that
+    // run: a mistaken reset only delays a needed recycle, while a discarded
+    // success risks tearing down a healthy connection.
     let releaseFirst: (() => void) | undefined;
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
@@ -205,8 +207,13 @@ describe("withConnectionRecycling", () => {
     releaseFirst?.();
     await held;
 
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES - 1; index++) {
+      await callIgnoringError(client);
+    }
+    assert.equal(session.aborts, 1, "the success must have reset the run");
+
     await callIgnoringError(client);
-    assert.equal(session.aborts, 2, "the stale success must not have reset the run");
+    assert.equal(session.aborts, 2, "counting must continue after the reset");
   });
 
   test("responses and errors pass through unchanged", async () => {

--- a/arcjet-guard/src/transport-recycle.test.ts
+++ b/arcjet-guard/src/transport-recycle.test.ts
@@ -13,6 +13,7 @@ import { Code, ConnectError, createClient, createRouterTransport } from "@connec
 import type { Client } from "@connectrpc/connect";
 
 import { DecideService, GuardResponseSchema } from "./proto/proto/decide/v2/decide_pb.js";
+import type { GuardResponse } from "./proto/proto/decide/v2/decide_pb.js";
 import {
   withConnectionRecycling,
   RECYCLE_AFTER_CONSECUTIVE_DEADLINES,
@@ -139,6 +140,73 @@ describe("withConnectionRecycling", () => {
     }
 
     assert.equal(session.aborts, 2);
+  });
+
+  test("a burst of concurrent timeouts triggers at most one recycle", async () => {
+    // Hold every call on a shared gate so they all start against the same
+    // session generation, then fail them together: the first three failures
+    // recycle, the stragglers from the old generation must not recycle again.
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inner = createRouterTransport(({ service }) => {
+      service(DecideService, {
+        async guard(): Promise<never> {
+          await gate;
+          throw new ConnectError("deadline", Code.DeadlineExceeded);
+        },
+      });
+    });
+    const session = fakeSession();
+    const client = createClient(DecideService, withConnectionRecycling(inner, session));
+
+    const calls: Promise<void>[] = [];
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES * 2; index++) {
+      calls.push(callIgnoringError(client));
+    }
+    release?.();
+    await Promise.all(calls);
+
+    assert.equal(session.aborts, 1);
+  });
+
+  test("a stale success does not reset the run for the current session", async () => {
+    // The first call is held until after a recycle, so its success reports on
+    // the old session; it must not reset the deadline run of the new one.
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const inner = createRouterTransport(({ service }) => {
+      service(DecideService, {
+        async guard(): Promise<GuardResponse> {
+          if (call++ === 0) {
+            await firstGate;
+            return create(GuardResponseSchema, {});
+          }
+          throw new ConnectError("deadline", Code.DeadlineExceeded);
+        },
+      });
+    });
+    const session = fakeSession();
+    const client = createClient(DecideService, withConnectionRecycling(inner, session));
+
+    const held = client.guard({});
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES; index++) {
+      await callIgnoringError(client);
+    }
+    assert.equal(session.aborts, 1);
+
+    for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES - 1; index++) {
+      await callIgnoringError(client);
+    }
+    releaseFirst?.();
+    await held;
+
+    await callIgnoringError(client);
+    assert.equal(session.aborts, 2, "the stale success must not have reset the run");
   });
 
   test("responses and errors pass through unchanged", async () => {

--- a/arcjet-guard/src/transport-recycle.ts
+++ b/arcjet-guard/src/transport-recycle.ts
@@ -48,12 +48,24 @@ export interface RecyclableSession {
  * Other errors neither count nor reset the run — only a success proves the
  * connection is alive.
  *
- * Recycling is single-flight per suspect session: each call is stamped with
- * the generation it started under, and outcomes from an older generation are
- * ignored. Without this, a burst of concurrent timeouts on one dead session
- * could cross the threshold repeatedly — the first three trigger a recycle,
- * then three stragglers from the same old session complete and abort the
- * freshly dialed replacement.
+ * All RPCs share one HTTP/2 session, so when that session dies silently,
+ * every RPC in flight on it times out — not just the three that reach the
+ * threshold. Each RPC therefore records `generation` (the count of recycles
+ * so far) when it starts, and deadline failures from before the latest
+ * recycle are discarded: they describe the connection that was already
+ * destroyed, not its replacement. Without this, a burst of concurrent
+ * timeouts would tear down the replacement connection (and its successor)
+ * before ever sending a request on it. Successes are not filtered this way:
+ * a mistaken counter reset only delays a needed recycle by a few calls,
+ * whereas a discarded success risks tearing down a healthy connection.
+ *
+ * The generation only advances on recycles performed here. The session
+ * manager also replaces the connection on its own (failed PING verification,
+ * idle timeout), and those swaps are invisible to this counter — so a
+ * timeout run can, rarely, straddle two physical connections and retire a
+ * healthy one early. That costs one redundant re-dial and is accepted as the
+ * price of staying at the transport layer, which sees RPC outcomes but not
+ * connection identity.
  *
  * @param transport Transport whose unary calls should be watched.
  * @param session Session manager to abort when the threshold is reached.
@@ -78,11 +90,9 @@ export function withConnectionRecycling(
           input,
           contextValues,
         );
-        // A stale success says nothing about the current session's health, so
-        // it must not reset the run either.
-        if (callGeneration === generation) {
-          consecutiveDeadlines = 0;
-        }
+        // Deliberately not generation-filtered; see the note above on why
+        // successes always reset the run.
+        consecutiveDeadlines = 0;
         return response;
       } catch (error: unknown) {
         if (

--- a/arcjet-guard/src/transport-recycle.ts
+++ b/arcjet-guard/src/transport-recycle.ts
@@ -48,6 +48,13 @@ export interface RecyclableSession {
  * Other errors neither count nor reset the run — only a success proves the
  * connection is alive.
  *
+ * Recycling is single-flight per suspect session: each call is stamped with
+ * the generation it started under, and outcomes from an older generation are
+ * ignored. Without this, a burst of concurrent timeouts on one dead session
+ * could cross the threshold repeatedly — the first three trigger a recycle,
+ * then three stragglers from the same old session complete and abort the
+ * freshly dialed replacement.
+ *
  * @param transport Transport whose unary calls should be watched.
  * @param session Session manager to abort when the threshold is reached.
  * @returns A transport with the same behavior plus connection recycling.
@@ -56,10 +63,12 @@ export function withConnectionRecycling(
   transport: Transport,
   session: RecyclableSession,
 ): Transport {
+  let generation = 0;
   let consecutiveDeadlines = 0;
 
   return {
     async unary(method, signal, timeoutMs, header, input, contextValues) {
+      const callGeneration = generation;
       try {
         const response = await transport.unary(
           method,
@@ -69,12 +78,20 @@ export function withConnectionRecycling(
           input,
           contextValues,
         );
-        consecutiveDeadlines = 0;
+        // A stale success says nothing about the current session's health, so
+        // it must not reset the run either.
+        if (callGeneration === generation) {
+          consecutiveDeadlines = 0;
+        }
         return response;
       } catch (error: unknown) {
-        if (ConnectError.from(error).code === Code.DeadlineExceeded) {
+        if (
+          callGeneration === generation &&
+          ConnectError.from(error).code === Code.DeadlineExceeded
+        ) {
           consecutiveDeadlines += 1;
           if (consecutiveDeadlines >= RECYCLE_AFTER_CONSECUTIVE_DEADLINES) {
+            generation += 1;
             consecutiveDeadlines = 0;
             recycle(session);
           }


### PR DESCRIPTION
## Problem

Follow-up to #6137, addressing [David's review comment](https://github.com/arcjet/arcjet-js/pull/6137#issuecomment-4975176041):

> One concern with the recycling logic: the deadline counter is shared across all requests and isn't tied to a particular session. If many requests time out concurrently, the first three can trigger a reconnect, then later completions from that old session can cross the threshold again and abort the newly established session. Could we make recycling single-flight and associate failures with a session generation, so each suspect session can trigger at most one recycle?

## Changes

`withConnectionRecycling` now keeps a generation counter alongside the deadline run:

- Each unary call is stamped with the generation (count of recycles so far) when it starts.
- Deadline failures from before the latest recycle are discarded: they describe the connection that was already destroyed, not its replacement. A burst of concurrent timeouts on one dead session therefore tears it down at most once — stragglers can't also tear down the freshly dialed replacement.
- Successes are deliberately **not** generation-filtered: a mistaken counter reset only delays a needed recycle by a few calls, whereas a discarded success risks tearing down a healthy connection, so any success resets the run (as before this PR).
- Failures on the new generation still count from zero, so a replacement session that is also dead gets recycled as before (covered by the existing "run restarts after a recycle" test, which passes unchanged).

The doc comment also now states the mechanism's known limit: the generation only advances on recycles performed by the wrapper, so connection replacements the session manager performs on its own (failed PING verification, idle timeout) are invisible to the counter. A timeout run can therefore, rarely, straddle two physical connections and retire a healthy one early — one redundant re-dial, accepted as the price of staying at the transport layer, which sees RPC outcomes but not connection identity.

## Testing

Two new unit tests, both verified to fail against the implementation they guard against:

- **Concurrent burst**: 6 calls start against one session and all time out together; asserts exactly one recycle (previously two — the second aborting the new session).
- **Pre-recycle success**: a call held from before a recycle completes successfully after a partial deadline run against the replacement; asserts it resets that run (fails if the reset is generation-gated) and that counting continues afterwards.

Full guard suite: 312 unit + 28 Node runtime tests pass; build, oxlint, tsgo, and oxfmt clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
