### PR TITLE
chore: seed release-please manifest for sensitive-info-rampart

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -31,6 +31,7 @@
   "redact": "1.8.0",
   "redact-wasm": "1.8.0",
   "runtime": "1.8.0",
+  "sensitive-info-rampart": "1.8.0",
   "sprintf": "1.8.0",
   "stable-hash": "1.8.0",
   "transport": "1.8.0"


### PR DESCRIPTION
## What

Adds the missing `.github/.release-please-manifest.json` entry for `sensitive-info-rampart`:

```json
"sensitive-info-rampart": "1.8.0",
```

## Why

`@arcjet/sensitive-info-rampart` was added to `.github/release-please-config.json` in #6141 but never seeded in the release-please manifest. release-please maintains existing manifest entries but does not create one for a brand-new package, so it logged `⚠ No version for path sensitive-info-rampart` and could not manage the package's version.

As a result its own version and its `@arcjet/analyze` / `arcjet` dependency pins stayed at `1.8.0` while every other package moved to `1.9.0`. That left the release branch's `package.json` and `package-lock.json` out of sync, so `npm ci` failed across CI on the 1.9.0 release PR (#6134) — Lint, Run tests, and Build examples all failed at the install step.

Seeding the manifest gives release-please a baseline. Once this lands on `main`, the push re-triggers release-please, which will bump `sensitive-info-rampart` to `1.9.0`, rewrite its dependency pins, refresh the lockfile, and force-push #6134 so its checks go green.

Refs #6134

🤖 Generated with [Claude Code](https://claude.com/claude-code)