### PR TITLE
fix(ip): update verify-ranges script paths for src/dist layout

### DIFF
--- a/ip/scripts/verify-ranges.ts
+++ b/ip/scripts/verify-ranges.ts
@@ -12,18 +12,13 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import {
-  cloudflareIpv4Ranges,
-  cloudflareIpv6Ranges,
-} from "../dist/cloudflare.js";
+import { cloudflareIpv4Ranges, cloudflareIpv6Ranges } from "../dist/cloudflare.js";
 import { parseProxy } from "../dist/index.js";
 
 const IPV4_URL = "https://www.cloudflare.com/ips-v4/";
 const IPV6_URL = "https://www.cloudflare.com/ips-v6/";
 
-const sourcePath = fileURLToPath(
-  new URL("../src/cloudflare.ts", import.meta.url),
-);
+const sourcePath = fileURLToPath(new URL("../src/cloudflare.ts", import.meta.url));
 
 async function fetchRanges(url: string): Promise<Array<string>> {
   const response = await fetch(url);
@@ -75,16 +70,10 @@ function formatArray(entries: ReadonlyArray<string>): string {
   return `[\n${entries.map((entry) => `  "${entry}",`).join("\n")}\n]`;
 }
 
-function replaceArray(
-  source: string,
-  name: string,
-  entries: ReadonlyArray<string>,
-): string {
+function replaceArray(source: string, name: string, entries: ReadonlyArray<string>): string {
   // Match `export const <name>: ReadonlyArray<string> = [ ... ];`. The list
   // never contains `]`, so a non-greedy character class is sufficient.
-  const pattern = new RegExp(
-    `(export const ${name}: ReadonlyArray<string> = )\\[[^\\]]*\\]`,
-  );
+  const pattern = new RegExp(`(export const ${name}: ReadonlyArray<string> = )\\[[^\\]]*\\]`);
   if (!pattern.test(source)) {
     throw new Error(`Could not find array \`${name}\` in cloudflare.ts`);
   }
@@ -99,10 +88,7 @@ function today(): string {
 async function main() {
   const write = process.argv.includes("--write");
 
-  const [liveIpv4, liveIpv6] = await Promise.all([
-    fetchRanges(IPV4_URL),
-    fetchRanges(IPV6_URL),
-  ]);
+  const [liveIpv4, liveIpv6] = await Promise.all([fetchRanges(IPV4_URL), fetchRanges(IPV6_URL)]);
 
   const ipv4Diff = diff(cloudflareIpv4Ranges, liveIpv4);
   const ipv6Diff = diff(cloudflareIpv6Ranges, liveIpv6);
@@ -132,10 +118,7 @@ async function main() {
     let source = readFileSync(sourcePath, "utf8");
     source = replaceArray(source, "cloudflareIpv4Ranges", liveIpv4);
     source = replaceArray(source, "cloudflareIpv6Ranges", liveIpv6);
-    source = source.replace(
-      /(\/\/ last verified: )\d{4}-\d{2}-\d{2}/,
-      `$1${today()}`,
-    );
+    source = source.replace(/(\/\/ last verified: )\d{4}-\d{2}-\d{2}/, `$1${today()}`);
     writeFileSync(sourcePath, source);
     console.log("Updated cloudflare.ts with current Cloudflare IP ranges:");
     report("IPv4", ipv4Diff);

--- a/ip/scripts/verify-ranges.ts
+++ b/ip/scripts/verify-ranges.ts
@@ -1,24 +1,29 @@
 // Verify (or regenerate) the bundled Cloudflare IP ranges against the lists
 // Cloudflare publishes. Run on a schedule in CI so we notice when they change.
 //
-// Prefer the package scripts, which build first so the `../index.ts` import
-// (which re-exports the generated `./cloudflare.js`) resolves:
+// Use the package scripts, which build first so the `../dist/*.js` imports
+// resolve:
 //
 //   npm run verify-ranges -w @arcjet/ip   # check, exit non-zero on drift
-//   npm run generate -w @arcjet/ip        # rewrite cloudflare.ts in place
+//   npm run generate -w @arcjet/ip        # rewrite src/cloudflare.ts in place
 //
 // Runs with a Node version that strips TypeScript types (the repo uses Node 24).
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { cloudflareIpv4Ranges, cloudflareIpv6Ranges } from "../cloudflare.ts";
-import { parseProxy } from "../index.ts";
+import {
+  cloudflareIpv4Ranges,
+  cloudflareIpv6Ranges,
+} from "../dist/cloudflare.js";
+import { parseProxy } from "../dist/index.js";
 
 const IPV4_URL = "https://www.cloudflare.com/ips-v4/";
 const IPV6_URL = "https://www.cloudflare.com/ips-v6/";
 
-const sourcePath = fileURLToPath(new URL("../cloudflare.ts", import.meta.url));
+const sourcePath = fileURLToPath(
+  new URL("../src/cloudflare.ts", import.meta.url),
+);
 
 async function fetchRanges(url: string): Promise<Array<string>> {
   const response = await fetch(url);
@@ -70,10 +75,16 @@ function formatArray(entries: ReadonlyArray<string>): string {
   return `[\n${entries.map((entry) => `  "${entry}",`).join("\n")}\n]`;
 }
 
-function replaceArray(source: string, name: string, entries: ReadonlyArray<string>): string {
+function replaceArray(
+  source: string,
+  name: string,
+  entries: ReadonlyArray<string>,
+): string {
   // Match `export const <name>: ReadonlyArray<string> = [ ... ];`. The list
   // never contains `]`, so a non-greedy character class is sufficient.
-  const pattern = new RegExp(`(export const ${name}: ReadonlyArray<string> = )\\[[^\\]]*\\]`);
+  const pattern = new RegExp(
+    `(export const ${name}: ReadonlyArray<string> = )\\[[^\\]]*\\]`,
+  );
   if (!pattern.test(source)) {
     throw new Error(`Could not find array \`${name}\` in cloudflare.ts`);
   }
@@ -88,7 +99,10 @@ function today(): string {
 async function main() {
   const write = process.argv.includes("--write");
 
-  const [liveIpv4, liveIpv6] = await Promise.all([fetchRanges(IPV4_URL), fetchRanges(IPV6_URL)]);
+  const [liveIpv4, liveIpv6] = await Promise.all([
+    fetchRanges(IPV4_URL),
+    fetchRanges(IPV6_URL),
+  ]);
 
   const ipv4Diff = diff(cloudflareIpv4Ranges, liveIpv4);
   const ipv6Diff = diff(cloudflareIpv6Ranges, liveIpv6);
@@ -118,7 +132,10 @@ async function main() {
     let source = readFileSync(sourcePath, "utf8");
     source = replaceArray(source, "cloudflareIpv4Ranges", liveIpv4);
     source = replaceArray(source, "cloudflareIpv6Ranges", liveIpv6);
-    source = source.replace(/(\/\/ last verified: )\d{4}-\d{2}-\d{2}/, `$1${today()}`);
+    source = source.replace(
+      /(\/\/ last verified: )\d{4}-\d{2}-\d{2}/,
+      `$1${today()}`,
+    );
     writeFileSync(sourcePath, source);
     console.log("Updated cloudflare.ts with current Cloudflare IP ranges:");
     report("IPv4", ipv4Diff);


### PR DESCRIPTION
## Summary
- The scheduled "Verify Cloudflare IP ranges" workflow has been failing since #6093 with `ERR_MODULE_NOT_FOUND` (example run: https://github.com/arcjet/arcjet-js/actions/runs/29450938767/job/87472951397).
- That commit moved `ip/` sources into `ip/src/` and build output into `ip/dist/`, but `ip/scripts/verify-ranges.ts` still imported `../cloudflare.ts` and `../index.ts` from the (now empty) package root.
- Point runtime imports at `../dist/cloudflare.js` and `../dist/index.js` (matching what `ip/test/*.test.ts` do; the npm script builds first). Point the write target at `../src/cloudflare.ts`, the real source.

Importing from `../src/*.ts` isn't an option — `src/index.ts` re-exports `./cloudflare.js` at runtime and Node's TS-strip mode doesn't rewrite `.js` → `.ts`, so the resolver would `ERR_MODULE_NOT_FOUND` on `src/cloudflare.js`.

## Test plan
- [x] `npm run verify-ranges -w @arcjet/ip` locally prints `Cloudflare IP ranges are up to date.`
- [x] Re-run the "Verify Cloudflare IP ranges" workflow on this branch and confirm it passes > https://github.com/arcjet/arcjet-js/actions/runs/29452420605

🤖 Generated with [Claude Code](https://claude.com/claude-code)