### PR TITLE
fix(publish): include @arcjet/sensitive-info-rampart in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,6 +229,7 @@ jobs:
             --workspace @arcjet/nuxt \
             --workspace @arcjet/react-router \
             --workspace @arcjet/remix \
+            --workspace @arcjet/sensitive-info-rampart \
             --workspace @arcjet/sveltekit
       - name: Verify dist-tags
         # Nothing was published on a dry run, so there is nothing to verify.


### PR DESCRIPTION
## Summary

- `@arcjet/sensitive-info-rampart` was seeded into the release-please manifest in 39ec65f5 but never added to the hard-coded workspace list in `.github/workflows/publish.yml`, so the v1.9.0 release built and tested it but never uploaded it to npm.
- The "Verify dist-tags" step correctly caught the omission (failed [run](https://github.com/arcjet/arcjet-js/actions/runs/29453490346/job/87481368535)): `@arcjet/sensitive-info-rampart dist-tag 'latest' is '<none>', expected '1.9.0'.`
- Adds the package to Level 4. Its peer deps (`arcjet`, `@arcjet/analyze`) are published by Levels 2–3, so Level 4 is dependency-safe.

Note: this does not retroactively publish `1.9.0`. That version is a gap on npm; the fix lets the next release publish the package for the first time. Follow-up needed on the release-please side to decide how to handle the missing `1.9.0`.

## Test plan

- [ ] Next release-please dispatch of the Publish workflow publishes `@arcjet/sensitive-info-rampart` alongside the Level 4 framework integrations
- [ ] Verify dist-tags step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)