### PR TITLE
chore: document publishing and fix sensitive-info-rampart peer deps

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -261,7 +261,8 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "merge": false
+      "merge": false,
+      "updatePeerDependencies": true
     },
     {
       "type": "linked-versions",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,10 @@ package.
 Each new adapter should come with an example application in this repository. See
 [Examples](#examples) for guidance on creating an example.
 
-New adapters must also be added to our Release Please configuration files so it
-can be included in the next release. The two files that must be updated are
-[.release-please-manifest.json](./.github/.release-please-manifest.json) and
-[release-please-config.json](./.github/release-please-config.json). We can help
-you make changes to these files if you need help.
+New adapters (and any other new package) must also be wired into our release and
+publish pipeline before they can ship. See [Adding a new
+package](#adding-a-new-package) for the full checklist. We can help you make
+these changes if you need it.
 
 ## Examples
 
@@ -58,18 +57,100 @@ the workflow file.
 
 ## Publish
 
-Publishing to npm is mostly automated but involves two bots and requires two
-people.
+Publishing to npm is mostly automated, gated behind a manual approval, and
+requires two people. Packages authenticate to npm with
+[trusted publishing](#npm-trusted-publishing) (OIDC) rather than long-lived
+tokens, and every package is published with provenance.
 
-It looks like this:
+The workflow is defined in
+[publish.yml](./.github/workflows/publish.yml). It runs in two jobs: a
+`preflight` job that validates the request (no approval needed) and a gated
+`publish` job that runs only after a second person approves the `npm-publish`
+GitHub environment.
 
-1. Release Please keeps a PR up to date with changelogs;
-   some landed PRs, notably dependency updates, do not trigger it to run,
-   so make sure to land something real after those.
-2. Person approves that PR and requests Trunk to merge it
-   When it lands, Release Please creates a tag and GitHub release notes.
-3. Person goes to Actions -> Publish -> Run workflow -> Tags, then selects
-   the tag to publish.
-4. Other team members are asked by GitHub to approve that run,
-   one person does, optionally with a comment.
-5. GitHub publishes to npm, which takes about 5 minutes.
+### Publishing a stable release
+
+1. [Release Please](https://github.com/googleapis/release-please) keeps a
+   release pull request up to date with changelogs and version bumps. Some
+   landed PRs, notably dependency updates, do not trigger it to run, so make
+   sure to land something real after those.
+2. A person approves and merges that release PR. When it lands, Release Please
+   creates the `vX.Y.Z` tag and GitHub release notes.
+3. A person goes to Actions -> Publish -> Run workflow, selects the release tag,
+   and chooses the `latest` dist-tag.
+4. The `preflight` job runs immediately (no approval) and writes a summary of
+   exactly what will be published. It fails the run early if the tag is not a
+   release tag, the package versions do not all match the tag, or a non-stable
+   version is being sent to `latest`.
+5. Another team member is asked by GitHub to approve the gated `publish` job,
+   and one person does, optionally with a comment.
+6. GitHub publishes to npm, which takes about 5 minutes.
+
+### Publishing a release candidate (rc)
+
+Release candidates are published to the `rc` dist-tag (never `latest`) so they
+can be validated in production without becoming the default install. Unlike a
+stable release, an rc is cut manually:
+
+1. Create a release branch, e.g. `release/1.10.0-rc`.
+2. On that branch, bump every workspace package to the rc version (e.g.
+   `1.10.0-rc.0`), keeping them in lockstep — all package versions, the internal
+   exact-pin dependencies, and the `x-release-please-version` constants tracked
+   as `extra-files` in
+   [release-please-config.json](./.github/release-please-config.json). The
+   `preflight` job asserts every package version equals the tag, so any package
+   left behind will fail the run.
+3. Tag the release commit `v1.10.0-rc.0` and push the branch and tag.
+4. Go to Actions -> Publish -> Run workflow, select the rc tag, and be sure to
+   choose the `rc` dist-tag.
+5. Approve the gated `publish` job as with a stable release.
+
+The release branch is throwaway — the stable release still comes from Release
+Please on `main`.
+
+### npm trusted publishing
+
+Each package trusts the GitHub Actions workflow to publish it via OIDC, so no
+npm tokens are stored anywhere. This is configured once per package on npm, at
+`https://www.npmjs.com/package/<package-name>/access` -> Trusted Publisher ->
+edit, with these values:
+
+- **Publisher:** GitHub Actions
+- **Organization or user:** `arcjet`
+- **Repository:** `arcjet-js`
+- **Workflow filename:** `publish.yml`
+- **Environment name:** `npm-publish`
+- **Allowed actions:** Allow `npm publish`
+
+The quickest way to get these right is to open an already-configured package
+(e.g. [arcjet](https://www.npmjs.com/package/arcjet/access)), hit edit, and copy
+the same values.
+
+> [!IMPORTANT]
+> A package must already exist on npm before a trusted publisher can be added to
+> it. A brand-new package therefore needs one **manual** first publish before
+> trusted publishing works — see [Adding a new
+> package](#adding-a-new-package).
+
+### Adding a new package
+
+When you add a new package (an adapter or otherwise), wire it into the release
+and publish pipeline. Miss one of these and the package will silently not be
+released, or a release run will fail:
+
+1. **Release Please config.** Add the package to both:
+   - [.release-please-manifest.json](./.github/.release-please-manifest.json) —
+     an entry with the current release version, so it stays in lockstep.
+   - [release-please-config.json](./.github/release-please-config.json) — a
+     `packages` entry (`component` set to the npm name, `skip-github-release:
+     true`, plus `extra-files` for any in-source version constants) **and** the
+     package's npm name in the `linked-versions` `components` list.
+2. **Publish workflow.** Add `--workspace @arcjet/<name>` to the correct
+   dependency level in [publish.yml](./.github/workflows/publish.yml). Levels
+   publish in dependency order, so the package must sit in a level after all of
+   its internal dependencies.
+3. **First publish is manual.** Because trusted publishing cannot be configured
+   until the package exists on npm, build the package and publish it once by
+   hand (`npm publish --workspace @arcjet/<name>`), then configure
+   [trusted publishing](#npm-trusted-publishing) for it.
+4. After that, it publishes automatically alongside everything else.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,6 +11682,14 @@
       "peerDependencies": {
         "@arcjet/analyze": "1.9.1",
         "arcjet": "1.9.1"
+      },
+      "peerDependenciesMeta": {
+        "@arcjet/analyze": {
+          "optional": true
+        },
+        "arcjet": {
+          "optional": true
+        }
       }
     },
     "sensitive-info-rampart/node_modules/@types/node": {

--- a/sensitive-info-rampart/package.json
+++ b/sensitive-info-rampart/package.json
@@ -62,8 +62,16 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "@arcjet/analyze": "1.8.0",
-    "arcjet": "1.8.0"
+    "@arcjet/analyze": "1.9.1",
+    "arcjet": "1.9.1"
+  },
+  "peerDependenciesMeta": {
+    "@arcjet/analyze": {
+      "optional": true
+    },
+    "arcjet": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"


### PR DESCRIPTION
Follow-ups from manually publishing the newly added `@arcjet/sensitive-info-rampart` package (1.9.0/1.9.1), which was released without being fully configured in the release pipeline.

## Docs (CONTRIBUTING.md)

- **npm trusted publishing** — documents the per-package OIDC config (GitHub Actions / `arcjet` / `arcjet-js` / `publish.yml` / `npm-publish` env / allow `npm publish`) and the tip to copy an existing package's settings.
- **Adding a new package** — a checklist covering the release-please manifest + config (component, `skip-github-release`, `extra-files`, `linked-versions`), the `publish.yml` dependency level, and the **manual first publish** required before trusted publishing can be configured.
- **Release candidate (rc) publishing** — the manual `release/X.Y.Z-rc` branch → `vX.Y.Z-rc.N` tag → dispatch Publish with the `rc` dist-tag flow.
- Reworked the stable-release steps around the current preflight/gated-approval workflow and **removed the outdated Trunk merge reference**.

## Release-please fix

- Enable `updatePeerDependencies` on the `node-workspace` plugin so peer dependency versions stay in lockstep across releases (they were previously skipped, which is how the `1.8.0` peer pins below went stale).

## sensitive-info-rampart peer deps

- `@arcjet/analyze` and `arcjet` are **type-only** imports (`import type` in every source file), so they're now `optional` peer dependencies via `peerDependenciesMeta`, and the stale `1.8.0` pins are corrected to `1.9.1` to match the rest of the workspace.

## Notes

- Committed as `chore:` to avoid triggering a full linked-version `1.9.2` bump, since the peer-dep fix already ships in the manual `1.9.1` publish. Re-type as `fix:` if a coordinated release is preferred.
- `package-lock.json` only gains the `peerDependenciesMeta` mirror for `sensitive-info-rampart`; unrelated lockfile churn from local npm-version drift was deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)