### PR TITLE
deps: migrate from @typescript/native-preview to stable typescript@7

### DIFF
--- a/analyze-wasm/package.json
+++ b/analyze-wasm/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "build:jco": "jco transpile --instantiation async --no-wasi-shim --out-dir src/wasm/ -- src/wasm/arcjet_analyze_js_req.component.wasm",
     "build": "npm run build:jco && tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -66,7 +66,7 @@
     "@bytecodealliance/jco": "1.5.0",
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/analyze/package.json
+++ b/analyze/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -57,7 +57,7 @@
     "@bytecodealliance/jco": "1.5.0",
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/arcjet-astro/package.json
+++ b/arcjet-astro/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -74,7 +74,7 @@
   "devDependencies": {
     "astro": "7.0.9",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "astro": "^5.9.3 || ^6.0.0 || ^7.0.0"

--- a/arcjet-bun/package.json
+++ b/arcjet-bun/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "npm run build"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
   "devDependencies": {
     "bun-types": "1.3.14",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3",
+    "typescript": "7.0.2",
     "undici-types": "7.28.0"
   },
   "engines": {}

--- a/arcjet-deno/package.json
+++ b/arcjet-deno/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "npm run build"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "@arcjet/cache": "1.9.1",
     "@types/deno": "2.7.0",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {}
 }

--- a/arcjet-fastify/package.json
+++ b/arcjet-fastify/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=80 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=90 -- test/*.test.ts",
@@ -76,7 +76,7 @@
     "@types/node": "22.20.1",
     "fastify": "5.10.0",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "fastify": ">=5"

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -69,7 +69,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit && tsgo --project tsconfig.lint.json --noEmit",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.lint.json --noEmit",
     "lint": "oxlint --tsconfig=tsconfig.lint.json",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
@@ -90,10 +90,10 @@
   },
   "devDependencies": {
     "@types/node": "22.20.1",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "miniflare": "4.20260708.1",
     "oxlint-tsgolint": "0.23.0",
-    "tsdown": "0.22.7"
+    "tsdown": "0.22.7",
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/arcjet-nest/package.json
+++ b/arcjet-nest/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test": "npm run build && npm run test-api"
   },
@@ -75,7 +75,7 @@
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^10 || ^11",

--- a/arcjet-next/package.json
+++ b/arcjet-next/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test": "npm run build && npm run test-api"
   },
@@ -75,7 +75,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "next": ">=13"

--- a/arcjet-node/package.json
+++ b/arcjet-node/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=75 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=90 --test-coverage-lines=75 -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -74,7 +74,7 @@
     "@arcjet/cache": "1.9.1",
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/arcjet-nuxt/package.json
+++ b/arcjet-nuxt/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "prepack": "npm run build",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
@@ -74,7 +74,7 @@
     "@nuxt/kit": "4.4.8",
     "@nuxt/schema": "4.4.8",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "@nuxt/kit": ">=4",

--- a/arcjet-react-router/package.json
+++ b/arcjet-react-router/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=75 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=90 --test-coverage-lines=65 -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -74,7 +74,7 @@
     "@arcjet/cache": "1.9.1",
     "react-router": "7.18.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "react-router": ">=7"

--- a/arcjet-remix/package.json
+++ b/arcjet-remix/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test": "npm run build && npm run test-api"
   },
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {}
 }

--- a/arcjet-sveltekit/package.json
+++ b/arcjet-sveltekit/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test": "npm run build && npm run test-api"
   },
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-0"

--- a/arcjet/package.json
+++ b/arcjet/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-runtime-cloudflare": "npm run build && node --test test/runtime/cloudflare/cloudflare.test.ts",
     "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=95 --test-coverage-exclude \"../{analyze-wasm,analyze,arcjet,cache,duration,env,headers,ip,logger,protocol,runtime,sprintf,stable-hash,transport}/**/*.{js,ts}\" --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=95 -- test/*.test.ts",
@@ -77,7 +77,7 @@
     "miniflare": "4.20260708.1",
     "rolldown": "1.1.5",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/body/package.json
+++ b/body/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "pretest": "npm run build",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/cache/package.json
+++ b/cache/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -50,7 +50,7 @@
   "dependencies": {},
   "devDependencies": {
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/decorate/package.json
+++ b/decorate/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/duration/package.json
+++ b/duration/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/env/package.json
+++ b/env/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -50,7 +50,7 @@
   "dependencies": {},
   "devDependencies": {
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/headers/package.json
+++ b/headers/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/inspect/package.json
+++ b/inspect/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/ip/package.json
+++ b/ip/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "generate": "npm run build && node scripts/verify-ranges.ts --write",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test --test-coverage-branches=100 --test-coverage-exclude \"test/**/*.{js,ts}\" --test-coverage-functions=100 --test-coverage-lines=100 -- test/*.test.ts",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/logger/package.json
+++ b/logger/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/nosecone-next/package.json
+++ b/nosecone-next/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -65,7 +65,7 @@
     "@types/node": "22.20.1",
     "next": "16.2.10",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "next": ">=14"

--- a/nosecone-sveltekit/package.json
+++ b/nosecone-sveltekit/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"

--- a/nosecone/package.json
+++ b/nosecone/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "*"
       ],
       "devDependencies": {
-        "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "oxfmt": "0.55.0",
         "oxlint": "1.70.0",
         "turbo": "2.10.5"
@@ -33,7 +32,7 @@
         "@bytecodealliance/jco": "1.5.0",
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -47,7 +46,7 @@
         "@bytecodealliance/jco": "1.5.0",
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -108,7 +107,7 @@
         "miniflare": "4.20260708.1",
         "rolldown": "1.1.5",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -131,7 +130,7 @@
       "devDependencies": {
         "astro": "7.0.9",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "peerDependencies": {
         "astro": "^5.9.3 || ^6.0.0 || ^7.0.0"
@@ -154,7 +153,7 @@
       "devDependencies": {
         "bun-types": "1.3.14",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3",
+        "typescript": "7.0.2",
         "undici-types": "7.28.0"
       }
     },
@@ -176,7 +175,7 @@
         "@arcjet/cache": "1.9.1",
         "@types/deno": "2.7.0",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       }
     },
     "arcjet-fastify": {
@@ -197,7 +196,7 @@
         "@types/node": "22.20.1",
         "fastify": "5.10.0",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -236,10 +235,10 @@
       },
       "devDependencies": {
         "@types/node": "22.20.1",
-        "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "miniflare": "4.20260708.1",
         "oxlint-tsgolint": "0.23.0",
-        "tsdown": "0.22.7"
+        "tsdown": "0.22.7",
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -282,7 +281,7 @@
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.2",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -329,7 +328,7 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -373,7 +372,7 @@
         "@arcjet/cache": "1.9.1",
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -414,7 +413,7 @@
         "@nuxt/kit": "4.4.8",
         "@nuxt/schema": "4.4.8",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "peerDependencies": {
         "@nuxt/kit": ">=4",
@@ -439,7 +438,7 @@
         "@arcjet/cache": "1.9.1",
         "react-router": "7.18.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "peerDependencies": {
         "react-router": ">=7"
@@ -461,7 +460,7 @@
       },
       "devDependencies": {
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       }
     },
     "arcjet-sveltekit": {
@@ -481,7 +480,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -507,273 +506,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "arcjet/node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.2.tgz",
-      "integrity": "sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.2.tgz",
-      "integrity": "sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.2.tgz",
-      "integrity": "sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.2.tgz",
-      "integrity": "sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.2.tgz",
-      "integrity": "sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.2.tgz",
-      "integrity": "sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.2.tgz",
-      "integrity": "sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.2.tgz",
-      "integrity": "sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.2.tgz",
-      "integrity": "sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.2.tgz",
-      "integrity": "sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.2.tgz",
-      "integrity": "sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.2.tgz",
-      "integrity": "sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.2.tgz",
-      "integrity": "sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.5"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.2.tgz",
-      "integrity": "sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "arcjet/node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.2.tgz",
-      "integrity": "sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "arcjet/node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -782,40 +514,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "arcjet/node_modules/rolldown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
-      "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.137.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.2",
-        "@rolldown/binding-darwin-arm64": "1.1.2",
-        "@rolldown/binding-darwin-x64": "1.1.2",
-        "@rolldown/binding-freebsd-x64": "1.1.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.2",
-        "@rolldown/binding-linux-arm64-musl": "1.1.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.2",
-        "@rolldown/binding-linux-x64-gnu": "1.1.2",
-        "@rolldown/binding-linux-x64-musl": "1.1.2",
-        "@rolldown/binding-openharmony-arm64": "1.1.2",
-        "@rolldown/binding-wasm32-wasi": "1.1.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.2",
-        "@rolldown/binding-win32-x64-msvc": "1.1.2"
       }
     },
     "arcjet/node_modules/undici-types": {
@@ -832,7 +530,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -861,7 +559,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -878,7 +576,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -908,7 +606,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -937,7 +635,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -950,7 +648,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -983,7 +681,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -1013,7 +711,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -1046,7 +744,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -4600,32 +4298,27 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==",
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsgo": "bin/tsgo"
-      },
+      "optional": true,
+      "os": [
+        "aix"
+      ],
       "engines": {
         "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2"
       }
     },
-    "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==",
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
       "cpu": [
         "arm64"
       ],
@@ -4639,10 +4332,10 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==",
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
       "cpu": [
         "x64"
       ],
@@ -4656,10 +4349,44 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==",
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
       "cpu": [
         "arm"
       ],
@@ -4673,10 +4400,10 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==",
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
       "cpu": [
         "arm64"
       ],
@@ -4690,10 +4417,95 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==",
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
       "cpu": [
         "x64"
       ],
@@ -4707,10 +4519,95 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==",
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
       "cpu": [
         "arm64"
       ],
@@ -4724,10 +4621,10 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260707.2",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260707.2.tgz",
-      "integrity": "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==",
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
       "cpu": [
         "x64"
       ],
@@ -9922,17 +9819,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/ufo": {
@@ -10634,7 +10552,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10651,7 +10569,7 @@
         "@types/node": "22.20.1",
         "next": "16.2.10",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10710,6 +10628,20 @@
         "undici-types": "~6.21.0"
       }
     },
+    "nosecone-sveltekit/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "nosecone-sveltekit/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -10746,7 +10678,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10779,7 +10711,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10793,7 +10725,7 @@
         "@bytecodealliance/jco": "1.5.0",
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10839,7 +10771,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10857,7 +10789,7 @@
         "@types/node": "22.20.1",
         "arcjet": "1.9.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10899,7 +10831,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10929,7 +10861,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"
@@ -10967,7 +10899,7 @@
       "devDependencies": {
         "@types/node": "22.20.1",
         "tsdown": "0.22.7",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.21.0 <23 || >=24.5.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "oxfmt": "0.55.0",
     "oxlint": "1.70.0",
     "turbo": "2.10.5"
@@ -28,6 +27,9 @@
     },
     "fast-uri": "3.1.4",
     "postcss": "^8.5.10",
+    "rolldown-plugin-dts": {
+      "typescript": "7.0.2"
+    },
     "rollup": "npm:@rollup/wasm-node",
     "svgo": "4.0.2"
   },

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -88,7 +88,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/redact-wasm/package.json
+++ b/redact-wasm/package.json
@@ -54,7 +54,7 @@
   "scripts": {
     "build:jco": "jco transpile --instantiation async --no-wasi-shim --out-dir src/wasm/ -- src/wasm/arcjet_analyze_bindings_redact.component.wasm",
     "build": "npm run build:jco && tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -64,7 +64,7 @@
     "@bytecodealliance/jco": "1.5.0",
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/redact/package.json
+++ b/redact/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --experimental-vm-modules --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --experimental-vm-modules --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -57,7 +57,7 @@
   "dependencies": {},
   "devDependencies": {
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/sensitive-info-rampart/package.json
+++ b/sensitive-info-rampart/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -59,7 +59,7 @@
     "@types/node": "22.20.1",
     "arcjet": "1.9.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "@arcjet/analyze": "1.9.1",

--- a/sprintf/package.json
+++ b/sprintf/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/stable-hash/package.json
+++ b/stable-hash/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test": "npm run build && npm run test-coverage"
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"

--- a/transport/package.json
+++ b/transport/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "test-api": "node --test -- test/*.test.ts",
     "test-coverage": "node --experimental-test-coverage --test -- test/*.test.ts",
     "test-runtime-bun": "npm run build && HTTPS_PROXY=http://127.0.0.1:49219 bun test test/runtime/proxy.bun.test.ts",
@@ -78,7 +78,7 @@
   "devDependencies": {
     "@types/node": "22.20.1",
     "tsdown": "0.22.7",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=22.21.0 <23 || >=24.5.0"


### PR DESCRIPTION
TypeScript 7's native (Go-ported) compiler is now GA as the regular typescript package (7.0.2, released 2026-07-08), shipping its compiler under the standard tsc binary instead of the preview package's tsgo. Every package's typecheck script changes from `tsgo --noEmit` to `tsc --noEmit` (arcjet-guard keeps its second invocation against tsconfig.lint.json); the plain `typescript` devDependency each package already carried for tsdown's declaration emission is bumped from 6.0.3 straight to 7.0.2, replacing the need for a separate native-preview package entirely. Root's @typescript/native-preview devDependency (previously the only thing making `tsgo` resolvable via hoisting) is removed.

tsdown's own dependency, rolldown-plugin-dts, added typescript@7 support in 0.27.9; the resolved 0.27.12 already supports it and correctly emits declarations via the native compiler even for packages using the classic (non-oxc) path.

One exception: nosecone-sveltekit stays on typescript@6.0.3. @sveltejs/kit's peerDependency (typescript@"^5.3.3 || ^6.0.0", even on its latest release) doesn't yet include TS7, and declaring typescript@7.0.2 as a root project devDependency turned that peer mismatch into a hard ERESOLVE failure. Resolved by not declaring typescript at the root at all, and instead scoping an override to rolldown-plugin-dts's own resolution so it can still find TS7 without forcing a workspace-wide peer conflict; nosecone-sveltekit's own build and typecheck fall back to its local typescript@6.0.3.

Verified: full lint/format/build/typecheck/test suite green, plus the ONNX model test and the Cloudflare Workers/miniflare runtime test explicitly re-run with real (non-skipped) assertions.