### PR TITLE
fix(guard): pin @connectrpc/* and @bufbuild/protobuf to exact versions

### DIFF
--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -83,10 +83,10 @@
   },
   "dependencies": {
     "@arcjet/analyze": "1.9.1",
-    "@bufbuild/protobuf": "^2.0.0",
-    "@connectrpc/connect": "^2.0.0",
-    "@connectrpc/connect-node": "^2.0.0",
-    "@connectrpc/connect-web": "^2.0.0"
+    "@bufbuild/protobuf": "2.12.1",
+    "@connectrpc/connect": "2.1.2",
+    "@connectrpc/connect-node": "2.1.2",
+    "@connectrpc/connect-web": "2.1.2"
   },
   "devDependencies": {
     "@types/node": "22.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "arcjet": "1.9.1"
       },
       "devDependencies": {
-        "astro": "^7.1.0",
+        "astro": "7.1.0",
         "tsdown": "0.22.7",
         "typescript": "7.0.2"
       },
@@ -177,10 +177,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@arcjet/analyze": "1.9.1",
-        "@bufbuild/protobuf": "^2.0.0",
-        "@connectrpc/connect": "^2.0.0",
-        "@connectrpc/connect-node": "^2.0.0",
-        "@connectrpc/connect-web": "^2.0.0"
+        "@bufbuild/protobuf": "2.12.1",
+        "@connectrpc/connect": "2.1.2",
+        "@connectrpc/connect-node": "2.1.2",
+        "@connectrpc/connect-web": "2.1.2"
       },
       "devDependencies": {
         "@types/node": "22.20.1",


### PR DESCRIPTION
`@arcjet/guard` declared the connectrpc family (`@connectrpc/connect`, `-node`, `-web`) and `@bufbuild/protobuf` at `^2.0.0`, while every other package that uses them — `@arcjet/transport`, `@arcjet/protocol`, `arcjet` — pins them **exactly** (`2.1.2` / `2.12.1`).

In a consumer's install, npm satisfies guard's `^2.0.0` with an older patch (`2.1.1`) while the exact pins get `2.1.2`, so **two copies of `@connectrpc/connect` land in `node_modules`** and their `Transport` types are structurally incompatible to TypeScript (`TS2322` / `TS2345`).

It surfaced downstream in the arcjet monorepo's `apps/decide-service` typecheck under npm 12 (npm 11 happened to hoist the duplicate compatibly, masking it). arcjet/arcjet#8634 dedupes it in the monorepo lockfile as a stopgap; **this is the upstream fix** so the skew can't recur on the next full re-resolve.

**Change:** align `@arcjet/guard`'s pins with the rest of the SDK (exact `2.1.2` / `2.12.1`). No resolution change within arcjet-js itself (it already deduped to 2.1.2); this corrects the *published* range that consumers see.

**Validation:** `@arcjet/guard` builds and typechecks clean (`turbo run build typecheck --filter=@arcjet/guard` → 6/6 successful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
