### PR TITLE
fix: classify phone numbers with Rampart model

### DIFF
--- a/sensitive-info-rampart/README.md
+++ b/sensitive-info-rampart/README.md
@@ -73,9 +73,10 @@ The model detects: `GIVEN_NAME`, `SURNAME`, `EMAIL`, `PHONE_NUMBER`, `URL`,
 `CITY`, `STATE`, and `ZIP_CODE`.
 
 Deterministic recognizers additionally detect the structured, validatable types
-`EMAIL`, `URL`, `IP_ADDRESS`, `PHONE_NUMBER`, `SSN`, and `CREDIT_CARD_NUMBER`
-(Luhn-validated), mirroring Rampart's deterministic redaction layer. On
-overlapping text the recognizer result wins over the model.
+`EMAIL`, `URL`, `IP_ADDRESS`, `SSN`, and `CREDIT_CARD_NUMBER` (Luhn-validated),
+mirroring Rampart's deterministic redaction layer. Phone numbers are left to
+the model because their digit shape overlaps with financial and government
+identifiers. On overlapping text the recognizer result wins over the model.
 
 The full set is exported as `rampartEntities`:
 

--- a/sensitive-info-rampart/src/index.ts
+++ b/sensitive-info-rampart/src/index.ts
@@ -30,10 +30,10 @@ export interface RampartOptions extends ModelOptions {
    * {@linkcode defaultRecognizers}).
    *
    * These handle structured, validatable types — email addresses, URLs, IP
-   * addresses, phone numbers, SSNs, and Luhn-valid card numbers — which are more
-   * reliable with patterns than with the model. They are also the supported
-   * extension point for custom detection with this backend: add a recognizer to
-   * detect additional spans.
+   * addresses, SSNs, and Luhn-valid card numbers — which are more reliable with
+   * patterns than with the model. They are also the supported extension point
+   * for custom detection with this backend: add a recognizer to detect
+   * additional spans.
    *
    * Pass `[]` to disable deterministic recognition and rely on the model alone.
    */
@@ -122,7 +122,6 @@ function mergeSpans(groups: ReadonlyArray<ReadonlyArray<DetectedSpan>>): Detecte
  * - `"EMAIL"`
  * - `"URL"`
  * - `"IP_ADDRESS"`
- * - `"PHONE_NUMBER"`
  * - `"SSN"`
  * - `"CREDIT_CARD_NUMBER"`
  *

--- a/sensitive-info-rampart/src/recognizers.ts
+++ b/sensitive-info-rampart/src/recognizers.ts
@@ -142,10 +142,9 @@ export const creditCardRecognizer: Recognizer = (value) =>
  * deterministic redaction layer. Structured, validatable types are handled here
  * rather than by the model, which is more reliable for them.
  *
- * They are ordered most-specific first. Overlap resolution happens later in the
- * backend (longer spans win; equal-length ties keep the earlier-listed
- * recognizer), so this order only breaks ties — for example a Luhn-valid card
- * over the looser phone matcher when they match the same text.
+ * Phone numbers are intentionally left to the NER model because their digit
+ * shape overlaps with bank accounts, routing numbers, and other identifiers.
+ * A pattern cannot validate which semantic type the digits represent.
  */
 export const defaultRecognizers: ReadonlyArray<Recognizer> = [
   creditCardRecognizer,
@@ -153,7 +152,6 @@ export const defaultRecognizers: ReadonlyArray<Recognizer> = [
   emailRecognizer,
   urlRecognizer,
   ipAddressRecognizer,
-  phoneRecognizer,
 ];
 
 /**

--- a/sensitive-info-rampart/test/index.test.ts
+++ b/sensitive-info-rampart/test/index.test.ts
@@ -159,10 +159,18 @@ test("native types use their analyze tag, others are custom", async function () 
 
 test("maps each native type to its analyze tag", async function () {
   const { context } = fakeContext();
-  // One recognizer per native type, so every native branch of the
-  // string -> tagged-union conversion is exercised.
   const value = "192.168.1.1 +1 (415) 555-2671 a@b.com 4111 1111 1111 1111";
-  const backend = rampart({ runModel: stubModel([]) });
+  const phone = "+1 (415) 555-2671";
+  const phoneStart = value.indexOf(phone);
+  const backend = rampart({
+    runModel: stubModel([
+      {
+        start: phoneStart,
+        end: phoneStart + phone.length,
+        type: "PHONE_NUMBER",
+      },
+    ]),
+  });
 
   const result = await backend.detect(
     context,

--- a/sensitive-info-rampart/test/integration.test.ts
+++ b/sensitive-info-rampart/test/integration.test.ts
@@ -67,6 +67,75 @@ test("detects names, address, SSN and email with correct offsets", async functio
   assert.equal(found.get("STREET_NAME"), "Main Street");
 });
 
+test("model distinguishes bank accounts and routing numbers from phones", async function (t) {
+  const value =
+    "Details on file: name: Alex Morgan; email: alex.morgan@client-corp.example; " +
+    "ssn: 431-55-9928; bank_account: 0123456789; routing_number: 022000020";
+  const entities = {
+    tag: "deny" as const,
+    val: [
+      { tag: "phone-number" } as const,
+      { tag: "custom", val: "BANK_ACCOUNT" } as const,
+      { tag: "custom", val: "ROUTING_NUMBER" } as const,
+    ],
+  };
+
+  let result;
+  try {
+    result = await tryDetect(value, entities);
+  } catch (error) {
+    t.skip(`model unavailable: ${(error as Error).message}`);
+    return;
+  }
+
+  const found = result.denied.map((entity) => ({
+    type:
+      entity.identifiedType.tag === "custom"
+        ? entity.identifiedType.val
+        : entity.identifiedType.tag,
+    value: value.slice(entity.start, entity.end),
+  }));
+  assert.equal(
+    found
+      .filter(({ type }) => type === "BANK_ACCOUNT")
+      .map(({ value }) => value)
+      .join(""),
+    "0123456789",
+  );
+  assert.equal(
+    found
+      .filter(({ type }) => type === "ROUTING_NUMBER")
+      .map(({ value }) => value)
+      .join(""),
+    "022000020",
+  );
+  assert.ok(!found.some(({ type }) => type === "phone-number"));
+});
+
+test("model detects a formatted phone without a phone recognizer", async function (t) {
+  const value = "Call me at +1 (415) 555-2671.";
+  const entities = {
+    tag: "deny" as const,
+    val: [{ tag: "phone-number" } as const],
+  };
+
+  let result;
+  try {
+    result = await tryDetect(value, entities);
+  } catch (error) {
+    t.skip(`model unavailable: ${(error as Error).message}`);
+    return;
+  }
+
+  assert.ok(
+    result.denied.some(
+      (entity) =>
+        entity.identifiedType.tag === "phone-number" &&
+        value.slice(entity.start, entity.end).includes("555-2671"),
+    ),
+  );
+});
+
 test("handles input longer than the model's token window via chunking", async function (t) {
   // A body well past the 512-token limit, with a name only at the very end.
   // Before chunking this threw an onnxruntime broadcast error.

--- a/sensitive-info-rampart/test/recognizers.test.ts
+++ b/sensitive-info-rampart/test/recognizers.test.ts
@@ -104,5 +104,7 @@ test("runRecognizers accepts a custom recognizer list", function () {
 });
 
 test("defaultRecognizers covers the structured types", function () {
-  assert.equal(defaultRecognizers.length, 6);
+  assert.equal(defaultRecognizers.length, 5);
+  assert.ok(!defaultRecognizers.includes(phoneRecognizer));
+  assert.deepEqual(runRecognizers("bank account 0123456789"), []);
 });


### PR DESCRIPTION
Remove the shape-only phone recognizer from Rampart defaults so contextual NER can distinguish phone numbers from bank accounts and routing numbers. Keep structurally validated recognizers authoritative and add real-model regressions for financial identifiers and formatted phones.

ADR: https://github.com/arcjet/arcjet/pull/8679