### PR TITLE
fix: emit Windows-compatible Wasm paths

### DIFF
--- a/analyze-wasm/test/index.test.ts
+++ b/analyze-wasm/test/index.test.ts
@@ -52,9 +52,10 @@ test("@arcjet/analyze-wasm", async function (t) {
 
   await t.test("should emit Windows-compatible paths", async function () {
     const paths = await fs.readdir(new URL("../dist/", import.meta.url), { recursive: true });
-    assert.ok(
-      paths.every((path) => path.split(/[\\/]/).every((segment) => !segment.endsWith("."))),
+    const invalidPaths = paths.filter((path) =>
+      path.split(/[\\/]/).some((segment) => segment.endsWith(".")),
     );
+    assert.deepEqual(invalidPaths, [], `Windows-invalid paths: ${invalidPaths.join(", ")}`);
   });
 
   await t.test("should expose the public api on `wasm`", async function () {

--- a/analyze-wasm/test/index.test.ts
+++ b/analyze-wasm/test/index.test.ts
@@ -2,6 +2,7 @@
 // See `analyze/test/analyze.test.ts`.
 // The tests here are more minimal: basic functionality.
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 import test from "node:test";
 
 import { initializeWasm } from "../dist/index.js";
@@ -47,6 +48,13 @@ assert.ok(wasm);
 test("@arcjet/analyze-wasm", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../dist/index.js")).sort(), ["initializeWasm"]);
+  });
+
+  await t.test("should emit Windows-compatible paths", async function () {
+    const paths = await fs.readdir(new URL("../dist/", import.meta.url), { recursive: true });
+    assert.ok(
+      paths.every((path) => path.split(/[\\/]/).every((segment) => !segment.endsWith("."))),
+    );
   });
 
   await t.test("should expose the public api on `wasm`", async function () {

--- a/analyze-wasm/wasm-plugins.js
+++ b/analyze-wasm/wasm-plugins.js
@@ -62,8 +62,9 @@ export function base64Wasm() {
           ? path.resolve(path.dirname(importer), clean)
           : path.resolve(clean);
         // Keep the virtual id relative so the emitted chunk name does not leak
-        // an absolute build path into published output.
-        const id = `\0${clean.replace(/\.wasm$/, ".js")}`;
+        // an absolute build path into published output. Strip the leading `./`
+        // because rolldown emits it as a Windows-invalid `_.` path segment.
+        const id = `\0${clean.replace(/^\.\//, "").replace(/\.wasm$/, ".js")}`;
         idToWasmPath.set(id, absWasm);
         return id;
       }

--- a/redact-wasm/test/index.test.ts
+++ b/redact-wasm/test/index.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 import test from "node:test";
 
 import { initializeWasm } from "../dist/index.js";
@@ -9,6 +10,13 @@ assert.ok(wasm);
 test("@arcjet/redact-wasm", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../dist/index.js")).sort(), ["initializeWasm"]);
+  });
+
+  await t.test("should emit Windows-compatible paths", async function () {
+    const paths = await fs.readdir(new URL("../dist/", import.meta.url), { recursive: true });
+    assert.ok(
+      paths.every((path) => path.split(/[\\/]/).every((segment) => !segment.endsWith("."))),
+    );
   });
 });
 

--- a/redact-wasm/test/index.test.ts
+++ b/redact-wasm/test/index.test.ts
@@ -14,9 +14,10 @@ test("@arcjet/redact-wasm", async function (t) {
 
   await t.test("should emit Windows-compatible paths", async function () {
     const paths = await fs.readdir(new URL("../dist/", import.meta.url), { recursive: true });
-    assert.ok(
-      paths.every((path) => path.split(/[\\/]/).every((segment) => !segment.endsWith("."))),
+    const invalidPaths = paths.filter((path) =>
+      path.split(/[\\/]/).some((segment) => segment.endsWith(".")),
     );
+    assert.deepEqual(invalidPaths, [], `Windows-invalid paths: ${invalidPaths.join(", ")}`);
   });
 });
 

--- a/redact-wasm/wasm-plugins.js
+++ b/redact-wasm/wasm-plugins.js
@@ -62,8 +62,9 @@ export function base64Wasm() {
           ? path.resolve(path.dirname(importer), clean)
           : path.resolve(clean);
         // Keep the virtual id relative so the emitted chunk name does not leak
-        // an absolute build path into published output.
-        const id = `\0${clean.replace(/\.wasm$/, ".js")}`;
+        // an absolute build path into published output. Strip the leading `./`
+        // because rolldown emits it as a Windows-invalid `_.` path segment.
+        const id = `\0${clean.replace(/^\.\//, "").replace(/\.wasm$/, ".js")}`;
         idToWasmPath.set(id, absWasm);
         return id;
       }


### PR DESCRIPTION
## Summary

Strip the leading `./` from virtual Wasm module IDs so Rolldown no longer emits the Windows-invalid `_.` path segment. Apply the same correction to both analyze and redact Wasm builds, with regression coverage for generated paths.

Fixes #6136