### PR TITLE
feat(guard): add optional client registration and a test client

### DIFF
--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -474,14 +474,24 @@ if (decision.hasFailedOpen()) {
 }
 ```
 
-`capture()` drops the event, and `flush()` resolves immediately. Both report
-`AJ3005` locally. This is the one failure the SDK cannot report well: with no
-client there is no configured logger either, so it can only reach the default
-sink.
+`capture()` drops the event silently, and `flush()` resolves immediately.
+Nothing is logged: the client that would have carried a logger is the thing
+that is missing, so the only available sink would be an unconfigurable console
+warning on a request path — noise an application cannot turn off. The decision
+returned by `guard()` is the observable signal, and making the `capture()` case
+observable is planned as an opt-in on the call itself.
 
 ### Registering twice, and unregistering
 
-Registration is guarded. A second client does not displace the first — the
+Registration is version-checked. The slot is shared by every copy of
+`@arcjet/guard` in the process, so a registration is only used by the exact
+build that wrote it — the stored value is a live object whose internals are
+guaranteed within one build and not across them. A copy that finds a
+registration from another version leaves it alone and fails open, exactly as if
+nothing were registered, and reports `AJ3006` on its own logger. Two versions
+in one process therefore do not share a client.
+
+Registration is also guarded. A second client does not displace the first — the
 attempt is reported as `AJ3004` on the **incumbent's** logger, so a library or a
 stray second `launchArcjet()` cannot quietly redirect an application's telemetry
 to a different key. Registering the client that is already registered is a
@@ -537,9 +547,15 @@ The client also implements `Symbol.dispose`, so `using` replaces the `finally`:
 using arcjet = registerTestClient();
 ```
 
-Note that the `using` *syntax* needs Node.js 24 or compilation through
-TypeScript; Node.js 22 defines `Symbol.dispose` but cannot parse `using`. Call
-`unregister()` directly if you are targeting Node.js 22 without a compile step.
+`unregister()` and `[Symbol.dispose]` are the same function under two names, so
+neither can drift from the other.
+
+Two caveats, both on the consuming project rather than on this package. The
+`using` *syntax* needs Node.js 24 to run natively or compilation through
+TypeScript — Node.js 22 defines `Symbol.dispose` but cannot parse `using`. And
+because `[Symbol.dispose]` appears in the published types, a project compiling
+with `skipLibCheck: false` needs `esnext.disposable` in its `lib` even if it
+never writes `using`; `unregister()` is unaffected either way.
 
 `guard()` on the test client records the call and returns a fail-open `ALLOW`,
 because no rule actually ran. It is not a mock server and does not let you stub

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -427,6 +427,126 @@ cannot encode is reported locally as `AJ1017` and also travels with that event i
 `local_warnings`. A queue-full event or failed batch never reaches the server, so
 those drops can only be reported locally.
 
+## Registering a client (optional)
+
+Passing the client explicitly is the recommended path, and everything above does
+exactly that. Registration is a shortcut for the case it cannot cover: code too
+deep in an application to be handed a client, where `capture()` is often most
+useful.
+
+`launchArcjet()` never touches global state. Registering is always a separate,
+explicit call:
+
+```ts
+// instrumentation.ts, or whatever runs at startup
+import { launchArcjet, registerArcjet } from "@arcjet/guard";
+
+const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+
+registerArcjet(arcjet); // now, and only now, something is global
+```
+
+`guard()`, `capture()` and `flush()` are then importable on their own, and reach
+the registered client:
+
+```ts
+// deep in application code — nothing was passed down here
+import { capture } from "@arcjet/guard";
+
+export async function refund(id: string): Promise<void> {
+  await issueRefund(id);
+  capture({ action: "refund.issued", metadata: { invoice: id } });
+}
+```
+
+### What happens with nothing registered
+
+`guard()` returns a fail-open `ALLOW` carrying an error result, so
+`decision.hasFailedOpen()` is `true`. It does not throw — these functions behave
+exactly like the client methods they forward to, and the never-throw contract
+holds.
+
+```ts
+const decision = await guard({ label: "refund", rules: [limit(input)] });
+
+if (decision.hasFailedOpen()) {
+  // No rule was evaluated. Treat this as "policy did not run", not as a pass.
+}
+```
+
+`capture()` drops the event, and `flush()` resolves immediately. Both report
+`AJ3005` locally. This is the one failure the SDK cannot report well: with no
+client there is no configured logger either, so it can only reach the default
+sink.
+
+### Registering twice, and unregistering
+
+Registration is guarded. A second client does not displace the first — the
+attempt is reported as `AJ3004` on the **incumbent's** logger, so a library or a
+stray second `launchArcjet()` cannot quietly redirect an application's telemetry
+to a different key. Registering the client that is already registered is a
+silent no-op.
+
+```ts
+registerArcjet(a); // registered: a
+registerArcjet(b); // warns; a stays registered
+unregisterArcjet(); // nothing registered
+```
+
+`unregisterArcjet()` takes no argument and clears whatever is there. That
+asymmetry is deliberate: requiring the client back would mean every teardown has
+to keep hold of it, which is the problem registration exists to avoid. The cost
+is that anything calling it clears the application's client and every free call
+afterwards fails open — so **libraries should not call it**. Libraries take a
+client explicitly. That is a convention, not something the SDK enforces.
+
+An explicitly passed client always wins; the registered one is only consulted
+when none was passed.
+
+### Testing
+
+`@arcjet/guard/testing` registers an in-memory client that records calls and
+talks to nothing:
+
+```ts
+import { registerTestClient } from "@arcjet/guard/testing";
+import { refund } from "./refund.ts";
+
+test("refund captures an event", () => {
+  const arcjet = registerTestClient();
+  try {
+    refund("inv_1");
+
+    assert.equal(arcjet.captures[0]?.action, "refund.issued");
+  } finally {
+    arcjet.unregister();
+  }
+});
+```
+
+It throws if a client is already registered, which surfaces a leak from an
+earlier test rather than letting this one assert against the wrong recorder.
+
+Captures are recorded synchronously, so assertions need no waiting, and they go
+through the same validation and metadata encoding as a real `capture()` — a call
+the real client would drop is not recorded here either.
+
+The client also implements `Symbol.dispose`, so `using` replaces the `finally`:
+
+```ts
+using arcjet = registerTestClient();
+```
+
+Note that the `using` *syntax* needs Node.js 24 or compilation through
+TypeScript; Node.js 22 defines `Symbol.dispose` but cannot parse `using`. Call
+`unregister()` directly if you are targeting Node.js 22 without a compile step.
+
+`guard()` on the test client records the call and returns a fail-open `ALLOW`,
+because no rule actually ran. It is not a mock server and does not let you stub
+per-rule verdicts. One consequence worth knowing: helpers that fail closed on a
+failed-open decision — `guardTool`, `guardAction` — will therefore **deny**
+against this client.
+
 ## Metadata
 
 `guard()` and every rule accept `metadata`: an object of string keys mapped to
@@ -614,7 +734,8 @@ Methods available on both `RuleWithConfig` and `RuleWithInput`:
 
 ## SDK namespaces: core and integrations
 
-`@arcjet/guard` exposes two import layers:
+`@arcjet/guard` exposes two import layers, plus `@arcjet/guard/testing` for the
+in-memory test client:
 
 ### Core guard (`@arcjet/guard`)
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -522,10 +522,32 @@ talks to nothing:
 import { registerTestClient } from "@arcjet/guard/testing";
 import { refund } from "./refund.ts";
 
-test("refund captures an event", () => {
+test("refund captures an event", async () => {
+  using arcjet = registerTestClient();
+
+  await refund("inv_1");
+
+  assert.equal(arcjet.captures[0]?.action, "refund.issued");
+});
+```
+
+`using` unregisters the client at the end of the block, including when the test
+fails part-way through. Note the `await`: the capture happens wherever the code
+under test reaches it, so a test that forgets to await an async function asserts
+before the event exists.
+
+<details>
+<summary>Without <code>using</code> — Node.js 22, or no TypeScript compile step</summary>
+
+The `using` *syntax* needs Node.js 24 to run natively, or compilation through
+TypeScript. Node.js 22 defines `Symbol.dispose` but cannot parse `using`. Call
+`unregister()` from a `finally` instead:
+
+```ts
+test("refund captures an event", async () => {
   const arcjet = registerTestClient();
   try {
-    refund("inv_1");
+    await refund("inv_1");
 
     assert.equal(arcjet.captures[0]?.action, "refund.issued");
   } finally {
@@ -534,28 +556,23 @@ test("refund captures an event", () => {
 });
 ```
 
+`unregister()` and `[Symbol.dispose]` are the same function under two names, so
+neither can drift from the other. It is safe to call twice, so it also works
+from an `afterEach`.
+
+One related caveat: because `[Symbol.dispose]` appears in the published types, a
+project compiling with `skipLibCheck: false` needs `esnext.disposable` in its
+`lib` even if it never writes `using`. `unregister()` is unaffected either way.
+
+</details>
+
 It throws if a client is already registered, which surfaces a leak from an
 earlier test rather than letting this one assert against the wrong recorder.
 
-Captures are recorded synchronously, so assertions need no waiting, and they go
-through the same validation and metadata encoding as a real `capture()` — a call
-the real client would drop is not recorded here either.
-
-The client also implements `Symbol.dispose`, so `using` replaces the `finally`:
-
-```ts
-using arcjet = registerTestClient();
-```
-
-`unregister()` and `[Symbol.dispose]` are the same function under two names, so
-neither can drift from the other.
-
-Two caveats, both on the consuming project rather than on this package. The
-`using` *syntax* needs Node.js 24 to run natively or compilation through
-TypeScript — Node.js 22 defines `Symbol.dispose` but cannot parse `using`. And
-because `[Symbol.dispose]` appears in the published types, a project compiling
-with `skipLibCheck: false` needs `esnext.disposable` in its `lib` even if it
-never writes `using`; `unregister()` is unaffected either way.
+Each recorded capture goes through the same validation and metadata encoding as
+a real `capture()`, so a call the real client would drop is not recorded here
+either. Recording itself is synchronous — once the code under test reaches
+`capture()`, the event is there with no flushing or waiting.
 
 `guard()` on the test client records the call and returns a fail-open `ALLOW`,
 because no rule actually ran. It is not a mock server and does not let you stub

--- a/arcjet-guard/jsr.json
+++ b/arcjet-guard/jsr.json
@@ -5,7 +5,8 @@
   "exports": {
     ".": "./src/fetch.ts",
     "./node": "./src/node.ts",
-    "./fetch": "./src/fetch.ts"
+    "./fetch": "./src/fetch.ts",
+    "./testing": "./src/testing.ts"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.js", "package.json", "LICENSE", "README.md"]

--- a/arcjet-guard/jsr.json
+++ b/arcjet-guard/jsr.json
@@ -6,7 +6,7 @@
     ".": "./src/fetch.ts",
     "./node": "./src/node.ts",
     "./fetch": "./src/fetch.ts",
-    "./testing": "./src/testing.ts"
+    "./testing": "./src/testing/index.ts"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.js", "package.json", "LICENSE", "README.md"]

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -64,6 +64,10 @@
       "types": "./dist/fetch.d.ts",
       "import": "./dist/fetch.js"
     },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js"
+    },
     "./vercel-ai/v7": {
       "types": "./dist/vercel-ai/v7/index.d.ts",
       "import": "./dist/vercel-ai/v7/index.js"

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -65,8 +65,8 @@
       "import": "./dist/fetch.js"
     },
     "./testing": {
-      "types": "./dist/testing.d.ts",
-      "import": "./dist/testing.js"
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
     },
     "./vercel-ai/v7": {
       "types": "./dist/vercel-ai/v7/index.d.ts",

--- a/arcjet-guard/src/bun.ts
+++ b/arcjet-guard/src/bun.ts
@@ -120,6 +120,13 @@ export {
   // Transport-agnostic factory
   launchArcjetWithTransport,
 
+  // Optional registration, and the free calls it enables
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
+  flush,
+
   // Internal
   _launchWithTransportFactory,
 } from "./index.ts";

--- a/arcjet-guard/src/client.ts
+++ b/arcjet-guard/src/client.ts
@@ -20,7 +20,12 @@ import {
   type WaitUntil,
 } from "./capture-delivery.ts";
 import { ruleToProto, decisionFromProto, decisionMembers } from "./convert.ts";
-import { createDiagnosticHandler, type DiagnosticLogger } from "./diagnostics.ts";
+import {
+  createDiagnosticHandler,
+  symbolArcjetDiagnostics,
+  type DiagnosticHandler,
+  type DiagnosticLogger,
+} from "./diagnostics.ts";
 import {
   type ArcjetMetadata,
   type LocalWarning,
@@ -29,6 +34,7 @@ import {
 } from "./metadata.ts";
 import {
   DecideService,
+  type CaptureEvent,
   CaptureEventSchema,
   CaptureRequestSchema,
   GuardRequestSchema,
@@ -91,6 +97,8 @@ export function createGuardClient(options: GuardClientOptions): {
   guard(opts: GuardOptions): Promise<Decision>;
   capture(opts: CaptureOptions): void;
   flush(timeoutMs?: number): Promise<void>;
+  /** @internal The client's diagnostics channel, for the registry. */
+  [symbolArcjetDiagnostics]: DiagnosticHandler;
 } {
   const { key, transport, userAgent = defaultUserAgent() } = options;
 
@@ -252,45 +260,10 @@ export function createGuardClient(options: GuardClientOptions): {
       // are inspected, so the entire normalization path stays inside this
       // boundary.
       try {
-        const normalized = normalizeCaptureOptions(opts);
-        if (normalized === undefined) {
-          diagnose({
-            code: "AJ3000",
-            message: "Capture input was invalid; the event was dropped",
-            count: 1,
-          });
+        const event = normalizeCaptureEvent(opts, diagnose);
+        if (event === undefined) {
           return;
         }
-
-        const occurredAtUnixMs =
-          normalized.occurredAt === undefined
-            ? BigInt(Date.now())
-            : BigInt(normalized.occurredAt.getTime());
-        const encoded = encodeMetadata(normalized.metadata);
-        const warnings = [
-          ...normalized.localWarnings,
-          ...encoded.localWarnings,
-          ...enforceMetadataBudget([encoded.metadataJson]),
-        ];
-        for (const warning of warnings) {
-          diagnose(warning);
-        }
-
-        const event = create(CaptureEventSchema, {
-          occurredAtUnixMs,
-          correlationId: normalized.correlationId ?? "",
-          decisionId: normalized.decisionId ?? "",
-          action: normalized.action,
-          metadataJson: encoded.metadataJson,
-          localWarnings: warnings.map((warning) => create(WarningSchema, warning)),
-          // Where the event came from. This method is the explicit-call path, so
-          // it is always "sdk"; a future span-conversion path sets "otlp". Not a
-          // caller option on purpose — the producer decides, not the caller.
-          //
-          // The server never defaults this, so sending nothing would leave the
-          // event's origin unknown rather than merely unstated.
-          source: CAPTURE_SOURCE_SDK,
-        });
 
         // Read outside the normalization above so a throwing getter costs the
         // delivery hint rather than the whole event.
@@ -311,7 +284,80 @@ export function createGuardClient(options: GuardClientOptions): {
       // burst of drops that stops reports only its first event.
       diagnose.drain();
     },
+
+    [symbolArcjetDiagnostics]: diagnose,
   };
+}
+
+/**
+ * Build the wire event for a `capture()` call, reporting anything dropped.
+ *
+ * Shared by the real client and the test client so a test asserts against the
+ * event that would actually have been sent — same validation, same metadata
+ * encoding, same warnings — rather than against the caller's raw input. A test
+ * client that recorded the input instead would pass on a `capture()` the real
+ * client drops.
+ *
+ * Returns `undefined` when the event is unusable, having already diagnosed it.
+ * Never throws: the whole path runs inside the boundary, because plain
+ * JavaScript callers can bypass the types and getters can throw while values
+ * are read.
+ *
+ * @internal Not part of the public API. Unreachable outside the package: the
+ * `exports` map lists no path that resolves here.
+ */
+export function normalizeCaptureEvent(
+  value: unknown,
+  diagnose: DiagnosticHandler,
+): CaptureEvent | undefined {
+  try {
+    const normalized = normalizeCaptureOptions(value);
+    if (normalized === undefined) {
+      diagnose({
+        code: "AJ3000",
+        message: "Capture input was invalid; the event was dropped",
+        count: 1,
+      });
+      return;
+    }
+
+    const occurredAtUnixMs =
+      normalized.occurredAt === undefined
+        ? BigInt(Date.now())
+        : BigInt(normalized.occurredAt.getTime());
+    const encoded = encodeMetadata(normalized.metadata);
+    const warnings = [
+      ...normalized.localWarnings,
+      ...encoded.localWarnings,
+      ...enforceMetadataBudget([encoded.metadataJson]),
+    ];
+    for (const warning of warnings) {
+      diagnose(warning);
+    }
+
+    return create(CaptureEventSchema, {
+      occurredAtUnixMs,
+      correlationId: normalized.correlationId ?? "",
+      decisionId: normalized.decisionId ?? "",
+      action: normalized.action,
+      metadataJson: encoded.metadataJson,
+      localWarnings: warnings.map((warning) => create(WarningSchema, warning)),
+      // Where the event came from. This is the explicit-call path, so it is
+      // always "sdk"; a future span-conversion path sets "otlp". Not a caller
+      // option on purpose — the producer decides, not the caller.
+      //
+      // The server never defaults this, so sending nothing would leave the
+      // event's origin unknown rather than merely unstated.
+      source: CAPTURE_SOURCE_SDK,
+    });
+  } catch {
+    diagnose({
+      code: "AJ3000",
+      message: "Capture input was invalid; the event was dropped",
+      count: 1,
+    });
+    return undefined;
+  }
 }
 
 /**
@@ -466,6 +512,25 @@ function toWarnings(localWarnings: readonly LocalWarning[]): readonly Warning[] 
     code: warning.code,
     message: warning.message,
   }));
+}
+
+/**
+ * Synthesize the fail-open ALLOW returned when a guard could not be evaluated.
+ *
+ * Shared with the registry so `guard()` with nothing registered degrades the
+ * same way a transport failure does: an ALLOW carrying an error result, so
+ * `hasFailedOpen()` reports true. Returning a plain ALLOW instead would be a
+ * silent bypass — indistinguishable from a guard that ran and permitted the
+ * call.
+ *
+ * @internal Not part of the public API. Unreachable outside the package: the
+ * `exports` map lists no path that resolves here.
+ */
+export function createFailOpenDecision(
+  message: string,
+  warnings: readonly Warning[] = [],
+): Decision {
+  return failOpen(message, warnings);
 }
 
 function failOpen(message: string, warnings: readonly Warning[] = []): Decision {

--- a/arcjet-guard/src/diagnostics.ts
+++ b/arcjet-guard/src/diagnostics.ts
@@ -9,7 +9,7 @@ import { Logger } from "@arcjet/logger";
  */
 export type ArcjetDiagnostic = {
   /** Stable machine-readable code. */
-  code: "AJ1001" | "AJ1017" | "AJ3000" | "AJ3001" | "AJ3002" | "AJ3003";
+  code: "AJ1001" | "AJ1017" | "AJ3000" | "AJ3001" | "AJ3002" | "AJ3003" | "AJ3004" | "AJ3005";
   /** Static human-readable description. */
   message: string;
   /** Number of events affected, when relevant. */
@@ -20,6 +20,22 @@ export type ArcjetDiagnostic = {
 export type DiagnosticLogger = Pick<Logger, "warn">;
 
 export type DiagnosticHandler = (diagnostic: ArcjetDiagnostic) => void;
+
+/**
+ * Where a client keeps its diagnostics channel so the registry can reach it.
+ *
+ * A client's logger is captured inside `createGuardClient` and appears nowhere
+ * on the public `ArcjetGuard` surface. Registration needs it anyway: when a
+ * second client tries to register, the warning belongs to the application that
+ * registered *first*, on the logger it configured — not on whatever sink the
+ * late registrant brought with it.
+ *
+ * A symbol rather than a property so it stays invisible to `Object.keys` and
+ * cannot collide with anything on a caller-supplied object.
+ *
+ * @internal
+ */
+export const symbolArcjetDiagnostics: unique symbol = Symbol.for("arcjet.guard.diagnostics");
 
 /** A handler that holds counts back and can be asked to release them. */
 export type CoalescingDiagnosticHandler = DiagnosticHandler & {

--- a/arcjet-guard/src/diagnostics.ts
+++ b/arcjet-guard/src/diagnostics.ts
@@ -9,7 +9,7 @@ import { Logger } from "@arcjet/logger";
  */
 export type ArcjetDiagnostic = {
   /** Stable machine-readable code. */
-  code: "AJ1001" | "AJ1017" | "AJ3000" | "AJ3001" | "AJ3002" | "AJ3003" | "AJ3004" | "AJ3005";
+  code: "AJ1001" | "AJ1017" | "AJ3000" | "AJ3001" | "AJ3002" | "AJ3003" | "AJ3004" | "AJ3006";
   /** Static human-readable description. */
   message: string;
   /** Number of events affected, when relevant. */

--- a/arcjet-guard/src/fetch.ts
+++ b/arcjet-guard/src/fetch.ts
@@ -131,6 +131,13 @@ export {
   // Transport-agnostic factory
   launchArcjetWithTransport,
 
+  // Optional registration, and the free calls it enables
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
+  flush,
+
   // Internal
   _launchWithTransportFactory,
 } from "./index.ts";

--- a/arcjet-guard/src/index.test.ts
+++ b/arcjet-guard/src/index.test.ts
@@ -4,6 +4,8 @@ import { describe, test } from "node:test";
 import { create } from "@bufbuild/protobuf";
 import { createRouterTransport } from "@connectrpc/connect";
 
+import * as bunEntrypoint from "./bun.ts";
+import * as fetchEntrypoint from "./fetch.ts";
 import {
   launchArcjetWithTransport,
   _launchWithTransportFactory,
@@ -16,6 +18,7 @@ import {
   defineCustomRule,
 } from "./index.ts";
 import type { DiagnosticLogger } from "./index.ts";
+import * as nodeEntrypoint from "./node.ts";
 import {
   DecideService,
   GuardResponseSchema,
@@ -25,6 +28,18 @@ import {
   GuardConclusion,
   GuardRuleType,
 } from "./proto/proto/decide/v2/decide_pb.js";
+
+/**
+ * The three runtime entrypoints, spread so their exports can be probed by name.
+ *
+ * Imported statically rather than with `await import(specifier)`, which returns
+ * `any` and would make every lookup below an unchecked assignment.
+ */
+const entrypoints: readonly (readonly [string, Record<string, unknown>])[] = [
+  ["./node.ts", { ...nodeEntrypoint }],
+  ["./bun.ts", { ...bunEntrypoint }],
+  ["./fetch.ts", { ...fetchEntrypoint }],
+];
 
 describe("re-exports", () => {
   test("DiagnosticLogger is nameable by consumers", () => {
@@ -55,6 +70,38 @@ describe("re-exports", () => {
 
   test("launchArcjetWithTransport is exported", () => {
     assert.equal(typeof launchArcjetWithTransport, "function");
+  });
+
+  test("registration and the free calls are exported from every entrypoint", () => {
+    // The `exports` map resolves "." to one of these three by runtime
+    // condition, so a symbol missing from any one of them is missing from the
+    // package on that runtime.
+    for (const [specifier, entrypoint] of entrypoints) {
+      for (const name of ["registerArcjet", "unregisterArcjet", "guard", "capture", "flush"]) {
+        assert.equal(typeof entrypoint[name], "function", `${specifier} must export ${name}`);
+      }
+    }
+  });
+
+  test("the registry's internals stay off the public entrypoints", () => {
+    // These exist so `registry.ts` and `testing.ts` can share code with
+    // `client.ts`; they are `@internal` and no `exports` entry resolves to the
+    // modules that declare them. Re-exporting one here would publish it by
+    // accident, which no other check would catch.
+    const internals = [
+      "registerArcjetForTesting",
+      "registeredClient",
+      "createFailOpenDecision",
+      "normalizeCaptureEvent",
+      "symbolArcjetDiagnostics",
+      "symbolArcjetClient",
+    ];
+
+    for (const [specifier, entrypoint] of entrypoints) {
+      for (const name of internals) {
+        assert.equal(name in entrypoint, false, `${specifier} must not export ${name}`);
+      }
+    }
   });
 
   test("_launchWithTransportFactory is exported", () => {

--- a/arcjet-guard/src/index.ts
+++ b/arcjet-guard/src/index.ts
@@ -77,7 +77,11 @@
 import type { Transport } from "@connectrpc/connect";
 
 import { createGuardClient } from "./client.ts";
-import type { DiagnosticLogger } from "./diagnostics.ts";
+import {
+  symbolArcjetDiagnostics,
+  type DiagnosticHandler,
+  type DiagnosticLogger,
+} from "./diagnostics.ts";
 import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
 // The type of `LaunchOptions.logger`, so a consumer can name what they have
 // to implement. `ArcjetDiagnostic` is deliberately not exported: it is the
@@ -155,6 +159,11 @@ export {
   localDetectSensitiveInfo,
   defineCustomRule,
 } from "./rules.ts";
+
+// Optional registration, and the free calls it enables. Nothing here takes
+// effect until an application calls `registerArcjet()` — `launchArcjet()`
+// itself touches no global state.
+export { registerArcjet, unregisterArcjet, guard, capture, flush } from "./registry.ts";
 
 /**
  * Options for `launchArcjet()`.
@@ -240,7 +249,10 @@ export function launchArcjetWithTransport(
     ...(options.logger === undefined ? {} : { logger: options.logger }),
   });
 
-  return {
+  // The diagnostics channel rides along under a symbol so registration can
+  // report a second `registerArcjet()` on the logger this client was launched
+  // with. It stays off `ArcjetGuard`, so it is not public API.
+  const launched: ArcjetGuard & { [symbolArcjetDiagnostics]: DiagnosticHandler } = {
     guard(opts: GuardOptions): Promise<Decision> {
       return client.guard(opts);
     },
@@ -250,7 +262,10 @@ export function launchArcjetWithTransport(
     flush(timeoutMs?: number): Promise<void> {
       return client.flush(timeoutMs);
     },
+    [symbolArcjetDiagnostics]: client[symbolArcjetDiagnostics],
   };
+
+  return launched;
 }
 
 /**

--- a/arcjet-guard/src/node.ts
+++ b/arcjet-guard/src/node.ts
@@ -127,6 +127,13 @@ export {
   // Transport-agnostic factory
   launchArcjetWithTransport,
 
+  // Optional registration, and the free calls it enables
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
+  flush,
+
   // Internal
   _launchWithTransportFactory,
 } from "./index.ts";

--- a/arcjet-guard/src/registration-slot.test.ts
+++ b/arcjet-guard/src/registration-slot.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+
+import { recorder, recorderWithDiagnostics, writeSlot } from "../test/_shared/registry-recorder.ts";
+import { registeredClient } from "./registration-slot.ts";
+import { capture, guard, registerArcjet, unregisterArcjet } from "./registry.ts";
+import { symbolArcjetClient } from "./symbol.ts";
+import { VERSION } from "./version.ts";
+
+// Registration is process-wide, so a test that leaves a client behind changes
+// the meaning of every test after it.
+afterEach(() => {
+  unregisterArcjet();
+});
+
+describe("the global slot", () => {
+  test("is a Symbol.for slot two package copies can share", () => {
+    const client = recorder();
+    registerArcjet(client);
+
+    // Resolved independently of the module's own import, which is the whole
+    // point: a second copy of @arcjet/guard reaches the same slot.
+    const slot = Symbol.for("arcjet.guard.client");
+    assert.equal(symbolArcjetClient, slot);
+
+    const stored = (globalThis as Record<symbol, unknown>)[slot];
+    assert.deepEqual(stored, { version: VERSION, client });
+  });
+
+  test("holds the version alongside the client", () => {
+    const client = recorder();
+    registerArcjet(client);
+
+    assert.deepEqual((globalThis as Record<symbol, unknown>)[symbolArcjetClient], {
+      version: VERSION,
+      client,
+    });
+  });
+});
+
+describe("version checking", () => {
+  test("ignores a registration written by a different SDK version", () => {
+    writeSlot({ version: "0.0.0-other", client: recorder() });
+
+    // Exact match, not a range: the stored value is a live object whose
+    // internals are only guaranteed within one build.
+    assert.equal(registeredClient(), undefined);
+  });
+
+  test("a foreign-version registration makes the free calls fail open", async () => {
+    writeSlot({ version: "0.0.0-other", client: recorder() });
+
+    const decision = await guard({ label: "test", rules: [] });
+
+    assert.equal(decision.conclusion, "ALLOW");
+    assert.equal(decision.hasFailedOpen(), true);
+  });
+
+  test("a foreign-version incumbent is not displaced", () => {
+    const foreign = recorder();
+    writeSlot({ version: "0.0.0-other", client: foreign });
+
+    registerArcjet(recorderWithDiagnostics());
+
+    // Displacing it would break the other copy's free calls, so this copy
+    // degrades to failing open instead.
+    assert.deepEqual((globalThis as Record<symbol, unknown>)[symbolArcjetClient], {
+      version: "0.0.0-other",
+      client: foreign,
+    });
+    assert.equal(registeredClient(), undefined);
+  });
+
+  test("the version clash is reported on the registrant's own channel", () => {
+    writeSlot({ version: "0.0.0-other", client: recorder() });
+
+    const mine = recorderWithDiagnostics();
+    registerArcjet(mine);
+
+    // Not the incumbent's: it belongs to a build whose internals this one
+    // cannot verify, so calling into it is exactly what must not happen.
+    assert.equal(mine.diagnostics.length, 1);
+    assert.equal(mine.diagnostics[0]?.code, "AJ3006");
+  });
+});
+
+describe("reading a hostile slot", () => {
+  test("ignores anything malformed without throwing", () => {
+    for (const value of [null, 42, "nope", {}, { version: 1, client: recorder() }]) {
+      writeSlot(value);
+
+      assert.equal(registeredClient(), undefined);
+      assert.doesNotThrow(() => {
+        capture({ action: "test.done" });
+      });
+    }
+  });
+
+  test("ignores a registration whose client is not callable", () => {
+    writeSlot({ version: VERSION, client: { guard: "nope" } });
+
+    assert.equal(registeredClient(), undefined);
+    assert.doesNotThrow(() => {
+      capture({ action: "test.done" });
+    });
+  });
+});

--- a/arcjet-guard/src/registration-slot.ts
+++ b/arcjet-guard/src/registration-slot.ts
@@ -1,0 +1,152 @@
+/**
+ * The global slot a registered client lives in, and the checks guarding it.
+ *
+ * Split out from `registry.ts` so the test-only registration path can reach
+ * these primitives without `registry.ts` — which is in every production import
+ * graph — having to export anything only tests use.
+ *
+ * @packageDocumentation
+ * @internal
+ */
+
+import type { ArcjetGuard } from "./index.ts";
+import { symbolArcjetClient } from "./symbol.ts";
+import { VERSION } from "./version.ts";
+
+type GlobalWithArcjet = typeof globalThis & {
+  [symbolArcjetClient]?: unknown;
+};
+
+/**
+ * What actually goes in the global slot.
+ *
+ * The client is wrapped rather than stored bare so the version travels with it,
+ * and so registering never has to mutate an object the caller owns.
+ *
+ * @internal
+ */
+export type Registration = {
+  version: string;
+  client: ArcjetGuard;
+};
+
+/**
+ * Whether a registration was written by this exact build of the SDK.
+ *
+ * `Symbol.for` is realm-wide, so the slot is shared by every copy of
+ * `@arcjet/guard` in the process — including copies at other versions, which is
+ * the normal outcome of one dependency pinning a different range than another.
+ * What is stored is a live object, and its usable surface is more than the three
+ * public methods: the diagnostics symbol, the decision shape, and the internal
+ * symbols on it are only guaranteed within a single build.
+ *
+ * So the check is exact string equality, not a range. A copy that finds a
+ * registration it did not write treats it as absent and fails open, which is the
+ * same degradation as nothing being registered at all. The cost is that two
+ * versions in one process do not share a client — each keeps whatever it
+ * registered, and the one that lost the race fails open rather than calling into
+ * a shape it cannot verify.
+ *
+ * @internal
+ */
+export function isCurrentVersion(registration: Registration): boolean {
+  return registration.version === VERSION;
+}
+
+/**
+ * Read and validate whatever is in the global slot.
+ *
+ * Validated on the way out, not only on the way in. The slot lives on
+ * `globalThis` under a well-known symbol, so anything in the process can write
+ * to it — a `null`, a half-built value, or a record from a version whose shape
+ * this build cannot vouch for. Any of those reaching a call site would surface
+ * as a TypeError thrown from `capture()` deep in application code, which is what
+ * the never-throw contract exists to prevent.
+ *
+ * Returns the record regardless of version so callers can tell "nothing is
+ * registered" from "another version registered", which need different handling:
+ * the first is a free slot, the second is somebody else's.
+ *
+ * @internal
+ */
+export function readRegistration(): Registration | undefined {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  const candidate = globalWithArcjet[symbolArcjetClient];
+
+  if (typeof candidate !== "object" || candidate === null) {
+    return undefined;
+  }
+
+  const registration = candidate as Partial<Registration>;
+  if (typeof registration.version !== "string" || !isClient(registration.client)) {
+    return undefined;
+  }
+
+  return { version: registration.version, client: registration.client };
+}
+
+/**
+ * The registered client, if this build wrote it.
+ *
+ * @internal
+ */
+export function registeredClient(): ArcjetGuard | undefined {
+  const registration = readRegistration();
+  if (registration === undefined || !isCurrentVersion(registration)) {
+    return undefined;
+  }
+
+  return registration.client;
+}
+
+/**
+ * Stamp a client with this build's version and put it in the slot.
+ *
+ * @internal
+ */
+export function writeRegistration(client: ArcjetGuard): void {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  globalWithArcjet[symbolArcjetClient] = { version: VERSION, client };
+}
+
+/** Empty the slot. @internal */
+export function clearRegistration(): void {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  // oxlint-disable-next-line typescript/no-dynamic-delete -- clearing the slot
+  delete globalWithArcjet[symbolArcjetClient];
+}
+
+/**
+ * Whether the slot holds anything at all, valid or not.
+ *
+ * Deliberately unvalidated, unlike {@link readRegistration}. The test-only
+ * registration uses this to detect a leak from an earlier test, and a record
+ * this build cannot parse is just as much a leak as one it can.
+ *
+ * @internal
+ */
+export function hasRegistration(): boolean {
+  return symbolArcjetClient in globalThis;
+}
+
+/**
+ * Whether a value can actually serve the free calls.
+ *
+ * Structural rather than an instance check, because the test client and
+ * hand-rolled fakes are legitimate registrations and none of them are built by
+ * `launchArcjet()`.
+ *
+ * @internal
+ */
+export function isClient(value: unknown): value is ArcjetGuard {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<ArcjetGuard>;
+  return (
+    typeof candidate.guard === "function" &&
+    typeof candidate.capture === "function" &&
+    typeof candidate.flush === "function"
+  );
+}

--- a/arcjet-guard/src/registry.test.ts
+++ b/arcjet-guard/src/registry.test.ts
@@ -1,70 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, test } from "node:test";
 
-import { createFailOpenDecision } from "./client.ts";
-import { symbolArcjetDiagnostics, type ArcjetDiagnostic } from "./diagnostics.ts";
+import { recorder, recorderWithDiagnostics } from "../test/_shared/registry-recorder.ts";
 import type { ArcjetGuard } from "./index.ts";
-import {
-  capture,
-  flush,
-  guard,
-  registerArcjet,
-  registerArcjetForTesting,
-  registeredClient,
-  unregisterArcjet,
-} from "./registry.ts";
-import { symbolArcjetClient } from "./symbol.ts";
-import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
-import { VERSION } from "./version.ts";
-
-type Recorder = ArcjetGuard & {
-  guards: GuardOptions[];
-  captures: CaptureOptions[];
-  flushes: (number | undefined)[];
-};
-
-function recorder(): Recorder {
-  const guards: GuardOptions[] = [];
-  const captures: CaptureOptions[] = [];
-  const flushes: (number | undefined)[] = [];
-  return {
-    guards,
-    captures,
-    flushes,
-    guard(options: GuardOptions): Promise<Decision> {
-      guards.push(options);
-      return Promise.resolve(createFailOpenDecision("stub"));
-    },
-    capture(options: CaptureOptions): void {
-      captures.push(options);
-    },
-    flush(timeoutMs?: number): Promise<void> {
-      flushes.push(timeoutMs);
-      return Promise.resolve();
-    },
-  };
-}
-
-/** A client that records what the registry reported to it. */
-function recorderWithDiagnostics(): Recorder & { diagnostics: ArcjetDiagnostic[] } {
-  const diagnostics: ArcjetDiagnostic[] = [];
-  return Object.assign(recorder(), {
-    diagnostics,
-    [symbolArcjetDiagnostics]: (diagnostic: ArcjetDiagnostic): void => {
-      diagnostics.push(diagnostic);
-    },
-  });
-}
-
-/** Put an arbitrary value in the global slot, bypassing `registerArcjet`. */
-function writeSlot(value: unknown): void {
-  Object.defineProperty(globalThis, symbolArcjetClient, {
-    configurable: true,
-    enumerable: false,
-    value,
-    writable: true,
-  });
-}
+import { registeredClient } from "./registration-slot.ts";
+import { capture, flush, guard, registerArcjet, unregisterArcjet } from "./registry.ts";
 
 // Registration is process-wide, so a test that leaves a client behind changes
 // the meaning of every test after it.
@@ -90,10 +30,9 @@ describe("registerArcjet", () => {
 
   test("keeps the incumbent when a second client registers", () => {
     const first = recorderWithDiagnostics();
-    const second = recorder();
 
     registerArcjet(first);
-    registerArcjet(second);
+    registerArcjet(recorder());
 
     assert.equal(registeredClient(), first);
   });
@@ -123,91 +62,21 @@ describe("registerArcjet", () => {
 
   test("a client with no diagnostics channel does not throw", () => {
     registerArcjet(recorder());
+
     assert.doesNotThrow(() => {
       registerArcjet(recorder());
     });
   });
 
-  test("registers under a Symbol.for slot two package copies can share", () => {
-    const client = recorder();
-    registerArcjet(client);
-
-    // Resolved independently of the module's own import, which is the whole
-    // point: a second copy of @arcjet/guard reaches the same slot.
-    const slot = Symbol.for("arcjet.guard.client");
-    assert.equal(symbolArcjetClient, slot);
-
-    const stored = (globalThis as Record<symbol, unknown>)[slot];
-    assert.deepEqual(stored, { version: VERSION, client });
-  });
-
   test("refuses a value that is not a client", () => {
     // Reachable from plain JavaScript, which bypasses the types entirely —
-    // which is the whole point, so the assertions here are deliberate.
+    // which is the point, so the assertions here are deliberate.
     // oxlint-disable typescript/no-unsafe-type-assertion -- simulating a plain-JS caller
     registerArcjet(null as unknown as ArcjetGuard);
     registerArcjet({ guard: "not a function" } as unknown as ArcjetGuard);
     // oxlint-enable typescript/no-unsafe-type-assertion
 
     assert.equal(registeredClient(), undefined);
-  });
-});
-
-describe("version checking", () => {
-  test("ignores a registration written by a different SDK version", () => {
-    writeSlot({ version: "0.0.0-other", client: recorder() });
-
-    // Exact match, not a range: the stored value is a live object whose
-    // internals are only guaranteed within one build.
-    assert.equal(registeredClient(), undefined);
-  });
-
-  test("a foreign-version registration makes the free calls fail open", async () => {
-    writeSlot({ version: "0.0.0-other", client: recorder() });
-
-    const decision = await guard({ label: "test", rules: [] });
-
-    assert.equal(decision.conclusion, "ALLOW");
-    assert.equal(decision.hasFailedOpen(), true);
-  });
-
-  test("a foreign-version incumbent is not displaced", () => {
-    const foreign = recorder();
-    writeSlot({ version: "0.0.0-other", client: foreign });
-
-    const mine = recorderWithDiagnostics();
-    registerArcjet(mine);
-
-    // Displacing it would break the other copy's free calls, so this copy
-    // degrades to failing open instead.
-    assert.deepEqual((globalThis as Record<symbol, unknown>)[symbolArcjetClient], {
-      version: "0.0.0-other",
-      client: foreign,
-    });
-    assert.equal(registeredClient(), undefined);
-  });
-
-  test("the version clash is reported on the registrant's own channel", () => {
-    writeSlot({ version: "0.0.0-other", client: recorder() });
-
-    const mine = recorderWithDiagnostics();
-    registerArcjet(mine);
-
-    // Not the incumbent's: it belongs to a build whose internals this one
-    // cannot verify, so calling into it is exactly what must not happen.
-    assert.equal(mine.diagnostics.length, 1);
-    assert.equal(mine.diagnostics[0]?.code, "AJ3006");
-  });
-
-  test("ignores a malformed slot without throwing", () => {
-    for (const value of [null, 42, "nope", {}, { version: 1, client: recorder() }]) {
-      writeSlot(value);
-
-      assert.equal(registeredClient(), undefined);
-      assert.doesNotThrow(() => {
-        capture({ action: "test.done" });
-      });
-    }
   });
 });
 
@@ -223,15 +92,6 @@ describe("unregisterArcjet", () => {
     assert.doesNotThrow(() => {
       unregisterArcjet();
     });
-  });
-
-  test("leaves the slot absent rather than set to undefined", () => {
-    registerArcjet(recorder());
-    unregisterArcjet();
-
-    // `in` rather than a value check: a lingering own property set to undefined
-    // would still read as "registered" to anything using `in`.
-    assert.equal(symbolArcjetClient in globalThis, false);
   });
 });
 
@@ -262,26 +122,5 @@ describe("with nothing registered", () => {
 
   test("flush() resolves", async () => {
     await assert.doesNotReject(flush());
-  });
-});
-
-describe("launch and register are separate", () => {
-  test("registerArcjetForTesting throws when something is registered", () => {
-    registerArcjet(recorder());
-
-    assert.throws(
-      () => {
-        registerArcjetForTesting(recorder());
-      },
-      /already registered/i,
-      "a leaked registration must fail loudly under test, not warn and continue",
-    );
-  });
-
-  test("registerArcjetForTesting registers when the slot is free", () => {
-    const client = recorder();
-    registerArcjetForTesting(client);
-
-    assert.equal(registeredClient(), client);
   });
 });

--- a/arcjet-guard/src/registry.test.ts
+++ b/arcjet-guard/src/registry.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./registry.ts";
 import { symbolArcjetClient } from "./symbol.ts";
 import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
+import { VERSION } from "./version.ts";
 
 type Recorder = ArcjetGuard & {
   guards: GuardOptions[];
@@ -52,6 +53,16 @@ function recorderWithDiagnostics(): Recorder & { diagnostics: ArcjetDiagnostic[]
     [symbolArcjetDiagnostics]: (diagnostic: ArcjetDiagnostic): void => {
       diagnostics.push(diagnostic);
     },
+  });
+}
+
+/** Put an arbitrary value in the global slot, bypassing `registerArcjet`. */
+function writeSlot(value: unknown): void {
+  Object.defineProperty(globalThis, symbolArcjetClient, {
+    configurable: true,
+    enumerable: false,
+    value,
+    writable: true,
   });
 }
 
@@ -125,7 +136,78 @@ describe("registerArcjet", () => {
     // point: a second copy of @arcjet/guard reaches the same slot.
     const slot = Symbol.for("arcjet.guard.client");
     assert.equal(symbolArcjetClient, slot);
-    assert.equal((globalThis as Record<symbol, unknown>)[slot], client);
+
+    const stored = (globalThis as Record<symbol, unknown>)[slot];
+    assert.deepEqual(stored, { version: VERSION, client });
+  });
+
+  test("refuses a value that is not a client", () => {
+    // Reachable from plain JavaScript, which bypasses the types entirely —
+    // which is the whole point, so the assertions here are deliberate.
+    // oxlint-disable typescript/no-unsafe-type-assertion -- simulating a plain-JS caller
+    registerArcjet(null as unknown as ArcjetGuard);
+    registerArcjet({ guard: "not a function" } as unknown as ArcjetGuard);
+    // oxlint-enable typescript/no-unsafe-type-assertion
+
+    assert.equal(registeredClient(), undefined);
+  });
+});
+
+describe("version checking", () => {
+  test("ignores a registration written by a different SDK version", () => {
+    writeSlot({ version: "0.0.0-other", client: recorder() });
+
+    // Exact match, not a range: the stored value is a live object whose
+    // internals are only guaranteed within one build.
+    assert.equal(registeredClient(), undefined);
+  });
+
+  test("a foreign-version registration makes the free calls fail open", async () => {
+    writeSlot({ version: "0.0.0-other", client: recorder() });
+
+    const decision = await guard({ label: "test", rules: [] });
+
+    assert.equal(decision.conclusion, "ALLOW");
+    assert.equal(decision.hasFailedOpen(), true);
+  });
+
+  test("a foreign-version incumbent is not displaced", () => {
+    const foreign = recorder();
+    writeSlot({ version: "0.0.0-other", client: foreign });
+
+    const mine = recorderWithDiagnostics();
+    registerArcjet(mine);
+
+    // Displacing it would break the other copy's free calls, so this copy
+    // degrades to failing open instead.
+    assert.deepEqual((globalThis as Record<symbol, unknown>)[symbolArcjetClient], {
+      version: "0.0.0-other",
+      client: foreign,
+    });
+    assert.equal(registeredClient(), undefined);
+  });
+
+  test("the version clash is reported on the registrant's own channel", () => {
+    writeSlot({ version: "0.0.0-other", client: recorder() });
+
+    const mine = recorderWithDiagnostics();
+    registerArcjet(mine);
+
+    // Not the incumbent's: it belongs to a build whose internals this one
+    // cannot verify, so calling into it is exactly what must not happen.
+    assert.equal(mine.diagnostics.length, 1);
+    assert.equal(mine.diagnostics[0]?.code, "AJ3006");
+  });
+
+  test("ignores a malformed slot without throwing", () => {
+    for (const value of [null, 42, "nope", {}, { version: 1, client: recorder() }]) {
+      writeSlot(value);
+
+      assert.equal(registeredClient(), undefined);
+      assert.doesNotThrow(() => {
+        capture({ action: "test.done" });
+      });
+    }
   });
 });
 

--- a/arcjet-guard/src/registry.test.ts
+++ b/arcjet-guard/src/registry.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+
+import { createFailOpenDecision } from "./client.ts";
+import { symbolArcjetDiagnostics, type ArcjetDiagnostic } from "./diagnostics.ts";
+import type { ArcjetGuard } from "./index.ts";
+import {
+  capture,
+  flush,
+  guard,
+  registerArcjet,
+  registerArcjetForTesting,
+  registeredClient,
+  unregisterArcjet,
+} from "./registry.ts";
+import { symbolArcjetClient } from "./symbol.ts";
+import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
+
+type Recorder = ArcjetGuard & {
+  guards: GuardOptions[];
+  captures: CaptureOptions[];
+  flushes: (number | undefined)[];
+};
+
+function recorder(): Recorder {
+  const guards: GuardOptions[] = [];
+  const captures: CaptureOptions[] = [];
+  const flushes: (number | undefined)[] = [];
+  return {
+    guards,
+    captures,
+    flushes,
+    guard(options: GuardOptions): Promise<Decision> {
+      guards.push(options);
+      return Promise.resolve(createFailOpenDecision("stub"));
+    },
+    capture(options: CaptureOptions): void {
+      captures.push(options);
+    },
+    flush(timeoutMs?: number): Promise<void> {
+      flushes.push(timeoutMs);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A client that records what the registry reported to it. */
+function recorderWithDiagnostics(): Recorder & { diagnostics: ArcjetDiagnostic[] } {
+  const diagnostics: ArcjetDiagnostic[] = [];
+  return Object.assign(recorder(), {
+    diagnostics,
+    [symbolArcjetDiagnostics]: (diagnostic: ArcjetDiagnostic): void => {
+      diagnostics.push(diagnostic);
+    },
+  });
+}
+
+// Registration is process-wide, so a test that leaves a client behind changes
+// the meaning of every test after it.
+afterEach(() => {
+  unregisterArcjet();
+});
+
+describe("registerArcjet", () => {
+  test("routes the free calls to the registered client", async () => {
+    const client = recorder();
+    registerArcjet(client);
+
+    await guard({ label: "test", rules: [] });
+    capture({ action: "test.done" });
+    await flush(50);
+
+    assert.equal(client.guards.length, 1);
+    assert.equal(client.guards[0]?.label, "test");
+    assert.equal(client.captures.length, 1);
+    assert.equal(client.captures[0]?.action, "test.done");
+    assert.deepEqual(client.flushes, [50]);
+  });
+
+  test("keeps the incumbent when a second client registers", () => {
+    const first = recorderWithDiagnostics();
+    const second = recorder();
+
+    registerArcjet(first);
+    registerArcjet(second);
+
+    assert.equal(registeredClient(), first);
+  });
+
+  test("reports the refused registration on the incumbent's channel", () => {
+    const first = recorderWithDiagnostics();
+
+    registerArcjet(first);
+    registerArcjet(recorder());
+
+    // The warning belongs to whoever registered first: it is their telemetry a
+    // silent takeover would have redirected.
+    assert.equal(first.diagnostics.length, 1);
+    assert.equal(first.diagnostics[0]?.code, "AJ3004");
+  });
+
+  test("re-registering the same client is silent", () => {
+    const client = recorderWithDiagnostics();
+
+    registerArcjet(client);
+    registerArcjet(client);
+
+    assert.equal(registeredClient(), client);
+    // A module evaluated twice must not look like a takeover attempt.
+    assert.deepEqual(client.diagnostics, []);
+  });
+
+  test("a client with no diagnostics channel does not throw", () => {
+    registerArcjet(recorder());
+    assert.doesNotThrow(() => {
+      registerArcjet(recorder());
+    });
+  });
+
+  test("registers under a Symbol.for slot two package copies can share", () => {
+    const client = recorder();
+    registerArcjet(client);
+
+    // Resolved independently of the module's own import, which is the whole
+    // point: a second copy of @arcjet/guard reaches the same slot.
+    const slot = Symbol.for("arcjet.guard.client");
+    assert.equal(symbolArcjetClient, slot);
+    assert.equal((globalThis as Record<symbol, unknown>)[slot], client);
+  });
+});
+
+describe("unregisterArcjet", () => {
+  test("clears the registration", () => {
+    registerArcjet(recorder());
+    unregisterArcjet();
+
+    assert.equal(registeredClient(), undefined);
+  });
+
+  test("is safe to call with nothing registered", () => {
+    assert.doesNotThrow(() => {
+      unregisterArcjet();
+    });
+  });
+
+  test("leaves the slot absent rather than set to undefined", () => {
+    registerArcjet(recorder());
+    unregisterArcjet();
+
+    // `in` rather than a value check: a lingering own property set to undefined
+    // would still read as "registered" to anything using `in`.
+    assert.equal(symbolArcjetClient in globalThis, false);
+  });
+});
+
+describe("with nothing registered", () => {
+  test("guard() fails open rather than throwing", async () => {
+    const decision = await guard({ label: "test", rules: [] });
+
+    // Both halves matter. A plain ALLOW would also satisfy the first
+    // assertion, and that is the actual bug worth catching: a silent bypass
+    // that looks exactly like a guard which ran and permitted the call.
+    assert.equal(decision.conclusion, "ALLOW");
+    assert.equal(decision.hasFailedOpen(), true);
+  });
+
+  test("the fail-open decision carries an error result", async () => {
+    const decision = await guard({ label: "test", rules: [] });
+
+    const errors = decision.errorResults();
+    assert.equal(errors.length, 1);
+    assert.match(errors[0]?.message ?? "", /no registered Arcjet client/i);
+  });
+
+  test("capture() drops the event without throwing", () => {
+    assert.doesNotThrow(() => {
+      capture({ action: "test.done" });
+    });
+  });
+
+  test("flush() resolves", async () => {
+    await assert.doesNotReject(flush());
+  });
+});
+
+describe("launch and register are separate", () => {
+  test("registerArcjetForTesting throws when something is registered", () => {
+    registerArcjet(recorder());
+
+    assert.throws(
+      () => {
+        registerArcjetForTesting(recorder());
+      },
+      /already registered/i,
+      "a leaked registration must fail loudly under test, not warn and continue",
+    );
+  });
+
+  test("registerArcjetForTesting registers when the slot is free", () => {
+    const client = recorder();
+    registerArcjetForTesting(client);
+
+    assert.equal(registeredClient(), client);
+  });
+});

--- a/arcjet-guard/src/registry.ts
+++ b/arcjet-guard/src/registry.ts
@@ -1,0 +1,241 @@
+/**
+ * Optional process-wide registration for an Arcjet client.
+ *
+ * Registering exists for one reason: so code that cannot reach a client handle
+ * can still call `guard()` and `capture()`. Passing a client explicitly always
+ * works and is the recommended path — this is the shortcut, not the default.
+ *
+ * Nothing here runs unless an application calls {@link registerArcjet}.
+ * `launchArcjet()` has no global side effects.
+ *
+ * @packageDocumentation
+ */
+
+import { createFailOpenDecision } from "./client.ts";
+import {
+  createDiagnosticHandler,
+  symbolArcjetDiagnostics,
+  type ArcjetDiagnostic,
+  type DiagnosticHandler,
+} from "./diagnostics.ts";
+import type { ArcjetGuard } from "./index.ts";
+import { symbolArcjetClient } from "./symbol.ts";
+import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
+
+type GlobalWithArcjet = typeof globalThis & {
+  [symbolArcjetClient]?: ArcjetGuard;
+};
+
+type ClientWithDiagnostics = ArcjetGuard & {
+  [symbolArcjetDiagnostics]: DiagnosticHandler;
+};
+
+/**
+ * Where a diagnostic goes when no registered client can take it.
+ *
+ * Module-scoped so it coalesces across calls: `capture()` sits on request
+ * paths, and an application that forgot to register would otherwise emit a
+ * line per event.
+ */
+const fallbackDiagnostics = createDiagnosticHandler();
+
+/**
+ * Register a client for the free {@link guard}, {@link capture} and
+ * {@link flush} functions.
+ *
+ * Guarded on purpose. If something tries to register a second client the first
+ * one stays and the attempt is reported, so a library — or a stray second
+ * `launchArcjet()` — cannot quietly redirect an application's telemetry to a
+ * different key. Registering the client that is already registered is a no-op
+ * rather than a warning, so a module evaluated twice stays silent.
+ *
+ * @example
+ * ```ts
+ * // instrumentation.ts, or whatever runs at startup
+ * import { launchArcjet, registerArcjet } from "@arcjet/guard";
+ *
+ * registerArcjet(launchArcjet({ key: process.env.ARCJET_KEY! }));
+ * ```
+ */
+export function registerArcjet(client: ArcjetGuard): void {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  const incumbent = globalWithArcjet[symbolArcjetClient];
+
+  if (incumbent === undefined) {
+    globalWithArcjet[symbolArcjetClient] = client;
+    return;
+  }
+
+  if (incumbent === client) {
+    return;
+  }
+
+  // Reported on the incumbent's logger, not the late registrant's: the
+  // application that registered first configured that sink, and it is the one
+  // whose telemetry an unnoticed second registration would have redirected.
+  diagnose(incumbent, {
+    code: "AJ3004",
+    message: "An Arcjet client is already registered; the existing one was kept",
+  });
+}
+
+/**
+ * Clear the registered client, if any.
+ *
+ * Takes no argument and clears whatever is there. That asymmetry with
+ * {@link registerArcjet} is deliberate: requiring the client back would mean
+ * every teardown has to keep hold of it, which is the exact problem
+ * registration exists to avoid.
+ *
+ * The cost is that anything calling this clears the application's client, and
+ * every free call after it fails open. Libraries should not call it — they take
+ * a client explicitly. That is a convention, not something enforced here.
+ */
+export function unregisterArcjet(): void {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  // oxlint-disable-next-line typescript/no-dynamic-delete -- clearing the slot
+  delete globalWithArcjet[symbolArcjetClient];
+}
+
+/**
+ * Evaluate guard rules through the registered client.
+ *
+ * With nothing registered this returns a fail-open ALLOW carrying an error
+ * result, so `decision.hasFailedOpen()` is true. It does not throw: these
+ * functions behave exactly like the client methods they forward to, and the
+ * never-throw contract holds.
+ *
+ * @example
+ * ```ts
+ * import { guard, detectPromptInjection } from "@arcjet/guard";
+ *
+ * const decision = await guard({
+ *   label: "support.reply",
+ *   rules: [detectPromptInjection()(userMessage)],
+ * });
+ * ```
+ */
+export function guard(options: GuardOptions): Promise<Decision> {
+  const client = registeredClient();
+  if (client !== undefined) {
+    return client.guard(options);
+  }
+
+  diagnoseMissingClient();
+  return Promise.resolve(
+    createFailOpenDecision("guard() was called with no registered Arcjet client"),
+  );
+}
+
+/**
+ * Record a fact about what the application did, through the registered client.
+ *
+ * With nothing registered the event is dropped and diagnosed. Capture is
+ * best-effort telemetry, which is what makes dropping acceptable — the
+ * diagnostic is the only way to hear about it, since a dropped event never
+ * reaches the server and so has no response to carry a warning back on.
+ *
+ * @example
+ * ```ts
+ * // deep in application code — nothing was passed down here
+ * import { capture } from "@arcjet/guard";
+ *
+ * export async function refund(id: string): Promise<void> {
+ *   await issueRefund(id);
+ *   capture({ action: "refund.issued", metadata: { invoice: id } });
+ * }
+ * ```
+ */
+export function capture(options: CaptureOptions): void {
+  const client = registeredClient();
+  if (client !== undefined) {
+    client.capture(options);
+    return;
+  }
+
+  diagnoseMissingClient();
+}
+
+/**
+ * Drain the registered client's buffered capture events within a deadline.
+ *
+ * Resolves immediately with nothing registered — there is no queue to drain.
+ */
+export function flush(timeoutMs?: number): Promise<void> {
+  const client = registeredClient();
+  if (client !== undefined) {
+    return client.flush(timeoutMs);
+  }
+
+  diagnoseMissingClient();
+  return Promise.resolve();
+}
+
+/**
+ * Register a client, refusing to displace or silently share with an incumbent.
+ *
+ * The test client uses this instead of {@link registerArcjet} because the
+ * failure modes invert under test. In an application a second registration
+ * should be survivable, so it warns and carries on. In a test suite a client
+ * left registered by an earlier test is a leak that makes the current test
+ * assert against the wrong recorder — quietly, and usually somewhere else. So
+ * this throws.
+ *
+ * @internal Not part of the public API. Unreachable outside the package: the
+ * `exports` map lists no path that resolves here.
+ */
+export function registerArcjetForTesting(client: ArcjetGuard): void {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  if (globalWithArcjet[symbolArcjetClient] !== undefined) {
+    throw new Error(
+      "An Arcjet client is already registered. Call unregisterArcjet() first — " +
+        "an earlier test probably left one behind.",
+    );
+  }
+
+  globalWithArcjet[symbolArcjetClient] = client;
+}
+
+/**
+ * The currently registered client, if any.
+ *
+ * @internal Not part of the public API. Unreachable outside the package: the
+ * `exports` map lists no path that resolves here.
+ */
+export function registeredClient(): ArcjetGuard | undefined {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  return globalWithArcjet[symbolArcjetClient];
+}
+
+/**
+ * Report that a free call found nothing registered.
+ *
+ * This is the one failure the SDK cannot report well: with no client there is
+ * no configured logger either, so it can only reach the coalescing fallback.
+ */
+function diagnoseMissingClient(): void {
+  fallbackDiagnostics({
+    code: "AJ3005",
+    message: "No Arcjet client is registered; the call failed open",
+  });
+}
+
+function diagnose(client: ArcjetGuard, diagnostic: ArcjetDiagnostic): void {
+  if (hasDiagnostics(client)) {
+    client[symbolArcjetDiagnostics](diagnostic);
+    return;
+  }
+
+  fallbackDiagnostics(diagnostic);
+}
+
+/**
+ * Whether a client carries a diagnostics channel.
+ *
+ * Anything can be registered — the test client is not built by
+ * `launchArcjet()`, and neither is a hand-rolled fake — so the channel is
+ * checked for rather than assumed.
+ */
+function hasDiagnostics(client: ArcjetGuard): client is ClientWithDiagnostics {
+  return symbolArcjetDiagnostics in client && typeof client[symbolArcjetDiagnostics] === "function";
+}

--- a/arcjet-guard/src/registry.ts
+++ b/arcjet-guard/src/registry.ts
@@ -18,49 +18,19 @@ import {
   type DiagnosticHandler,
 } from "./diagnostics.ts";
 import type { ArcjetGuard } from "./index.ts";
-import { symbolArcjetClient } from "./symbol.ts";
+import {
+  clearRegistration,
+  isClient,
+  isCurrentVersion,
+  readRegistration,
+  registeredClient,
+  writeRegistration,
+} from "./registration-slot.ts";
 import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
-import { VERSION } from "./version.ts";
-
-type GlobalWithArcjet = typeof globalThis & {
-  [symbolArcjetClient]?: unknown;
-};
 
 type ClientWithDiagnostics = ArcjetGuard & {
   [symbolArcjetDiagnostics]: DiagnosticHandler;
 };
-
-/**
- * What actually goes in the global slot.
- *
- * The client is wrapped rather than stored bare so the version travels with
- * it, and so registering never has to mutate an object the caller owns.
- */
-type Registration = {
-  version: string;
-  client: ArcjetGuard;
-};
-
-/**
- * Whether a registration was written by this exact build of the SDK.
- *
- * `Symbol.for` is realm-wide, so the slot is shared by every copy of
- * `@arcjet/guard` in the process — including copies at other versions, which
- * is the normal outcome of one dependency pinning a different range than
- * another. What is stored is a live object, and its usable surface is more
- * than the three public methods: the diagnostics symbol, the decision shape,
- * and the internal symbols on it are only guaranteed within a single build.
- *
- * So the check is exact string equality, not a range. A copy that finds a
- * registration it did not write treats it as absent and fails open, which is
- * the same degradation as nothing being registered at all. The cost is that
- * two versions in one process do not share a client — each keeps whatever it
- * registered, and the one that lost the race fails open rather than calling
- * into a shape it cannot verify.
- */
-function isCurrentVersion(registration: Registration): boolean {
-  return registration.version === VERSION;
-}
 
 /**
  * Register a client for the free {@link guard}, {@link capture} and
@@ -89,11 +59,10 @@ export function registerArcjet(client: ArcjetGuard): void {
     return;
   }
 
-  const globalWithArcjet: GlobalWithArcjet = globalThis;
   const existing = readRegistration();
 
   if (existing === undefined) {
-    globalWithArcjet[symbolArcjetClient] = { version: VERSION, client };
+    writeRegistration(client);
     return;
   }
 
@@ -139,9 +108,7 @@ export function registerArcjet(client: ArcjetGuard): void {
  * a client explicitly. That is a convention, not something enforced here.
  */
 export function unregisterArcjet(): void {
-  const globalWithArcjet: GlobalWithArcjet = globalThis;
-  // oxlint-disable-next-line typescript/no-dynamic-delete -- clearing the slot
-  delete globalWithArcjet[symbolArcjetClient];
+  clearRegistration();
 }
 
 /**
@@ -219,99 +186,6 @@ export function flush(timeoutMs?: number): Promise<void> {
   }
 
   return Promise.resolve();
-}
-
-/**
- * Register a client, refusing to displace or silently share with an incumbent.
- *
- * The test client uses this instead of {@link registerArcjet} because the
- * failure modes invert under test. In an application a second registration
- * should be survivable, so it warns and carries on. In a test suite a client
- * left registered by an earlier test is a leak that makes the current test
- * assert against the wrong recorder — quietly, and usually somewhere else. So
- * this throws.
- *
- * @internal Not part of the public API. Unreachable outside the package: the
- * `exports` map lists no path that resolves here.
- */
-export function registerArcjetForTesting(client: ArcjetGuard): void {
-  const globalWithArcjet: GlobalWithArcjet = globalThis;
-  // `in` rather than a validated read: anything at all in the slot — including
-  // a record this build cannot parse — means an earlier test left something
-  // behind, which is what this is here to catch.
-  if (symbolArcjetClient in globalWithArcjet) {
-    throw new Error(
-      "An Arcjet client is already registered. Call unregisterArcjet() first — " +
-        "an earlier test probably left one behind.",
-    );
-  }
-
-  globalWithArcjet[symbolArcjetClient] = { version: VERSION, client };
-}
-
-/**
- * The currently registered client, if any.
- *
- * @internal Not part of the public API. Unreachable outside the package: the
- * `exports` map lists no path that resolves here.
- */
-export function registeredClient(): ArcjetGuard | undefined {
-  const registration = readRegistration();
-  if (registration === undefined || !isCurrentVersion(registration)) {
-    return undefined;
-  }
-
-  return registration.client;
-}
-
-/**
- * Read and validate whatever is in the global slot.
- *
- * Validated on the way out, not only on the way in. The slot lives on
- * `globalThis` under a well-known symbol, so anything in the process can write
- * to it — a `null`, a half-built value, or a record from a version whose shape
- * this build cannot vouch for. Any of those reaching a call site would surface
- * as a TypeError thrown from `capture()` deep in application code, which is
- * what the never-throw contract exists to prevent.
- *
- * Returns the record regardless of version so callers can tell "nothing is
- * registered" from "another version registered", which need different
- * handling: the first is a free slot, the second is somebody else's.
- */
-function readRegistration(): Registration | undefined {
-  const globalWithArcjet: GlobalWithArcjet = globalThis;
-  const candidate = globalWithArcjet[symbolArcjetClient];
-
-  if (typeof candidate !== "object" || candidate === null) {
-    return undefined;
-  }
-
-  const registration = candidate as Partial<Registration>;
-  if (typeof registration.version !== "string" || !isClient(registration.client)) {
-    return undefined;
-  }
-
-  return { version: registration.version, client: registration.client };
-}
-
-/**
- * Whether a value can actually serve the free calls.
- *
- * Structural rather than an instance check, because the test client and
- * hand-rolled fakes are legitimate registrations and none of them are built by
- * `launchArcjet()`.
- */
-function isClient(value: unknown): value is ArcjetGuard {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const candidate = value as Partial<ArcjetGuard>;
-  return (
-    typeof candidate.guard === "function" &&
-    typeof candidate.capture === "function" &&
-    typeof candidate.flush === "function"
-  );
 }
 
 /**

--- a/arcjet-guard/src/registry.ts
+++ b/arcjet-guard/src/registry.ts
@@ -13,7 +13,6 @@
 
 import { createFailOpenDecision } from "./client.ts";
 import {
-  createDiagnosticHandler,
   symbolArcjetDiagnostics,
   type ArcjetDiagnostic,
   type DiagnosticHandler,
@@ -21,9 +20,10 @@ import {
 import type { ArcjetGuard } from "./index.ts";
 import { symbolArcjetClient } from "./symbol.ts";
 import type { CaptureOptions, Decision, GuardOptions } from "./types.ts";
+import { VERSION } from "./version.ts";
 
 type GlobalWithArcjet = typeof globalThis & {
-  [symbolArcjetClient]?: ArcjetGuard;
+  [symbolArcjetClient]?: unknown;
 };
 
 type ClientWithDiagnostics = ArcjetGuard & {
@@ -31,13 +31,36 @@ type ClientWithDiagnostics = ArcjetGuard & {
 };
 
 /**
- * Where a diagnostic goes when no registered client can take it.
+ * What actually goes in the global slot.
  *
- * Module-scoped so it coalesces across calls: `capture()` sits on request
- * paths, and an application that forgot to register would otherwise emit a
- * line per event.
+ * The client is wrapped rather than stored bare so the version travels with
+ * it, and so registering never has to mutate an object the caller owns.
  */
-const fallbackDiagnostics = createDiagnosticHandler();
+type Registration = {
+  version: string;
+  client: ArcjetGuard;
+};
+
+/**
+ * Whether a registration was written by this exact build of the SDK.
+ *
+ * `Symbol.for` is realm-wide, so the slot is shared by every copy of
+ * `@arcjet/guard` in the process — including copies at other versions, which
+ * is the normal outcome of one dependency pinning a different range than
+ * another. What is stored is a live object, and its usable surface is more
+ * than the three public methods: the diagnostics symbol, the decision shape,
+ * and the internal symbols on it are only guaranteed within a single build.
+ *
+ * So the check is exact string equality, not a range. A copy that finds a
+ * registration it did not write treats it as absent and fails open, which is
+ * the same degradation as nothing being registered at all. The cost is that
+ * two versions in one process do not share a client — each keeps whatever it
+ * registered, and the one that lost the race fails open rather than calling
+ * into a shape it cannot verify.
+ */
+function isCurrentVersion(registration: Registration): boolean {
+  return registration.version === VERSION;
+}
 
 /**
  * Register a client for the free {@link guard}, {@link capture} and
@@ -58,22 +81,46 @@ const fallbackDiagnostics = createDiagnosticHandler();
  * ```
  */
 export function registerArcjet(client: ArcjetGuard): void {
-  const globalWithArcjet: GlobalWithArcjet = globalThis;
-  const incumbent = globalWithArcjet[symbolArcjetClient];
-
-  if (incumbent === undefined) {
-    globalWithArcjet[symbolArcjetClient] = client;
+  // Plain JavaScript callers can bypass the types, and a value that is not a
+  // client would turn every later free call into a TypeError thrown into
+  // application code. Refusing it here keeps the slot holding only things the
+  // free calls can actually invoke.
+  if (!isClient(client)) {
     return;
   }
 
-  if (incumbent === client) {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  const existing = readRegistration();
+
+  if (existing === undefined) {
+    globalWithArcjet[symbolArcjetClient] = { version: VERSION, client };
+    return;
+  }
+
+  if (!isCurrentVersion(existing)) {
+    // A different build of the SDK owns the slot. Displacing it would break
+    // that copy's free calls, so the incumbent stays and this copy degrades to
+    // failing open — the same outcome as nothing being registered.
+    //
+    // Reported on the *registrant's* channel, unlike the same-version case
+    // below. The incumbent belongs to a build whose internals this one cannot
+    // verify, so its diagnostics channel is exactly what must not be called.
+    diagnose(client, {
+      code: "AJ3006",
+      message:
+        "An Arcjet client from a different SDK version is registered; the existing one was kept",
+    });
+    return;
+  }
+
+  if (existing.client === client) {
     return;
   }
 
   // Reported on the incumbent's logger, not the late registrant's: the
   // application that registered first configured that sink, and it is the one
   // whose telemetry an unnoticed second registration would have redirected.
-  diagnose(incumbent, {
+  diagnose(existing.client, {
     code: "AJ3004",
     message: "An Arcjet client is already registered; the existing one was kept",
   });
@@ -121,7 +168,9 @@ export function guard(options: GuardOptions): Promise<Decision> {
     return client.guard(options);
   }
 
-  diagnoseMissingClient();
+  // The decision is the report. It carries an error result, so
+  // `hasFailedOpen()` is true and a caller that inspects it sees that no policy
+  // ran — which is a better signal than a log line nobody configured.
   return Promise.resolve(
     createFailOpenDecision("guard() was called with no registered Arcjet client"),
   );
@@ -130,10 +179,15 @@ export function guard(options: GuardOptions): Promise<Decision> {
 /**
  * Record a fact about what the application did, through the registered client.
  *
- * With nothing registered the event is dropped and diagnosed. Capture is
- * best-effort telemetry, which is what makes dropping acceptable — the
- * diagnostic is the only way to hear about it, since a dropped event never
- * reaches the server and so has no response to carry a warning back on.
+ * With nothing registered the event is dropped silently. Capture is best-effort
+ * telemetry, which is what makes dropping acceptable, and this path has no
+ * configured logger to report to — the client that would have carried one is
+ * the thing that is missing.
+ *
+ * Silence is the deliberate choice over an unconfigurable console warning,
+ * which would be noise on a request path with no way to turn it off. Making
+ * this observable is a future opt-in on the call itself, so an application that
+ * wants to hear about it can ask.
  *
  * @example
  * ```ts
@@ -150,10 +204,7 @@ export function capture(options: CaptureOptions): void {
   const client = registeredClient();
   if (client !== undefined) {
     client.capture(options);
-    return;
   }
-
-  diagnoseMissingClient();
 }
 
 /**
@@ -167,7 +218,6 @@ export function flush(timeoutMs?: number): Promise<void> {
     return client.flush(timeoutMs);
   }
 
-  diagnoseMissingClient();
   return Promise.resolve();
 }
 
@@ -186,14 +236,17 @@ export function flush(timeoutMs?: number): Promise<void> {
  */
 export function registerArcjetForTesting(client: ArcjetGuard): void {
   const globalWithArcjet: GlobalWithArcjet = globalThis;
-  if (globalWithArcjet[symbolArcjetClient] !== undefined) {
+  // `in` rather than a validated read: anything at all in the slot — including
+  // a record this build cannot parse — means an earlier test left something
+  // behind, which is what this is here to catch.
+  if (symbolArcjetClient in globalWithArcjet) {
     throw new Error(
       "An Arcjet client is already registered. Call unregisterArcjet() first — " +
         "an earlier test probably left one behind.",
     );
   }
 
-  globalWithArcjet[symbolArcjetClient] = client;
+  globalWithArcjet[symbolArcjetClient] = { version: VERSION, client };
 }
 
 /**
@@ -203,30 +256,75 @@ export function registerArcjetForTesting(client: ArcjetGuard): void {
  * `exports` map lists no path that resolves here.
  */
 export function registeredClient(): ArcjetGuard | undefined {
-  const globalWithArcjet: GlobalWithArcjet = globalThis;
-  return globalWithArcjet[symbolArcjetClient];
+  const registration = readRegistration();
+  if (registration === undefined || !isCurrentVersion(registration)) {
+    return undefined;
+  }
+
+  return registration.client;
 }
 
 /**
- * Report that a free call found nothing registered.
+ * Read and validate whatever is in the global slot.
  *
- * This is the one failure the SDK cannot report well: with no client there is
- * no configured logger either, so it can only reach the coalescing fallback.
+ * Validated on the way out, not only on the way in. The slot lives on
+ * `globalThis` under a well-known symbol, so anything in the process can write
+ * to it — a `null`, a half-built value, or a record from a version whose shape
+ * this build cannot vouch for. Any of those reaching a call site would surface
+ * as a TypeError thrown from `capture()` deep in application code, which is
+ * what the never-throw contract exists to prevent.
+ *
+ * Returns the record regardless of version so callers can tell "nothing is
+ * registered" from "another version registered", which need different
+ * handling: the first is a free slot, the second is somebody else's.
  */
-function diagnoseMissingClient(): void {
-  fallbackDiagnostics({
-    code: "AJ3005",
-    message: "No Arcjet client is registered; the call failed open",
-  });
+function readRegistration(): Registration | undefined {
+  const globalWithArcjet: GlobalWithArcjet = globalThis;
+  const candidate = globalWithArcjet[symbolArcjetClient];
+
+  if (typeof candidate !== "object" || candidate === null) {
+    return undefined;
+  }
+
+  const registration = candidate as Partial<Registration>;
+  if (typeof registration.version !== "string" || !isClient(registration.client)) {
+    return undefined;
+  }
+
+  return { version: registration.version, client: registration.client };
 }
 
+/**
+ * Whether a value can actually serve the free calls.
+ *
+ * Structural rather than an instance check, because the test client and
+ * hand-rolled fakes are legitimate registrations and none of them are built by
+ * `launchArcjet()`.
+ */
+function isClient(value: unknown): value is ArcjetGuard {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<ArcjetGuard>;
+  return (
+    typeof candidate.guard === "function" &&
+    typeof candidate.capture === "function" &&
+    typeof candidate.flush === "function"
+  );
+}
+
+/**
+ * Report a diagnostic on a client's own channel.
+ *
+ * Drops it when the client has no channel. There is deliberately no fallback
+ * sink: an unconfigurable console warning is noise an application cannot turn
+ * off, and every client built by `launchArcjet()` carries a channel.
+ */
 function diagnose(client: ArcjetGuard, diagnostic: ArcjetDiagnostic): void {
   if (hasDiagnostics(client)) {
     client[symbolArcjetDiagnostics](diagnostic);
-    return;
   }
-
-  fallbackDiagnostics(diagnostic);
 }
 
 /**

--- a/arcjet-guard/src/symbol.ts
+++ b/arcjet-guard/src/symbol.ts
@@ -1,5 +1,5 @@
 /**
- * Internal symbol used for SDK bookkeeping.
+ * Internal symbols used for SDK bookkeeping.
  *
  * Symbol keys are hidden from JSON.stringify, Object.keys, and casual
  * property access, so consumers can't accidentally depend on — or
@@ -11,3 +11,21 @@
 
 /** @internal Single symbol key for correlation IDs. */
 export const symbolArcjetInternal: unique symbol = Symbol.for("arcjet.guard.internal");
+
+/**
+ * The `globalThis` slot holding the registered client.
+ *
+ * Registered under `Symbol.for` so two copies of `@arcjet/guard` in one realm —
+ * a direct dependency and a transitive one on a different version — resolve to
+ * the same slot, instead of each keeping a private registration the other
+ * cannot see.
+ *
+ * Namespaced under `guard` rather than taking a bare `arcjet.client` on
+ * purpose. Registration is scoped to the Guards SDK for now, and a client in
+ * this slot has `guard()`, `capture()` and `flush()` but no `protect()`.
+ * Claiming the unnamespaced key would leave the request SDK finding a client
+ * here that cannot satisfy the interface it expects.
+ *
+ * @internal
+ */
+export const symbolArcjetClient: unique symbol = Symbol.for("arcjet.guard.client");

--- a/arcjet-guard/src/testing.test.ts
+++ b/arcjet-guard/src/testing.test.ts
@@ -61,7 +61,7 @@ describe("registerTestClient", () => {
     const arcjet = registerTestClient();
 
     // Called directly rather than through `using`: Node.js 22 defines
-    // Symbol.dispose but does not parse the `using` syntax, and this suite runs
+    // Symbol.dispose but cannot parse the `using` syntax, and this suite runs
     // on the package's minimum Node.
     arcjet[Symbol.dispose]();
 

--- a/arcjet-guard/src/testing.test.ts
+++ b/arcjet-guard/src/testing.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, test } from "node:test";
+
+import { createFailOpenDecision } from "./client.ts";
+import type { ArcjetGuard } from "./index.ts";
+import { capture, guard, registerArcjet, registeredClient, unregisterArcjet } from "./registry.ts";
+import { registerTestClient } from "./testing.ts";
+import type { ArcjetMetadata, Decision } from "./types.ts";
+
+/** A client that does nothing, only to occupy the registration slot. */
+const occupant: ArcjetGuard = {
+  guard(): Promise<Decision> {
+    return Promise.resolve(createFailOpenDecision("occupant"));
+  },
+  capture(): void {},
+  flush(): Promise<void> {
+    return Promise.resolve();
+  },
+};
+
+afterEach(() => {
+  unregisterArcjet();
+});
+
+describe("registerTestClient", () => {
+  test("registers itself, so free calls reach it", () => {
+    const arcjet = registerTestClient();
+
+    assert.equal(registeredClient(), arcjet);
+  });
+
+  test("throws when a client is already registered", () => {
+    registerArcjet(occupant);
+
+    // A leak from an earlier test would otherwise have this test assert
+    // against the previous test's recorder.
+    assert.throws(() => registerTestClient(), /already registered/i);
+  });
+
+  test("unregister() clears the registration", () => {
+    const arcjet = registerTestClient();
+    arcjet.unregister();
+
+    assert.equal(registeredClient(), undefined);
+  });
+
+  test("unregister() is safe to call twice", () => {
+    const arcjet = registerTestClient();
+    arcjet.unregister();
+
+    // An `afterEach` runs after a failed test too, so a second call has to be
+    // survivable.
+    assert.doesNotThrow(() => {
+      arcjet.unregister();
+    });
+  });
+
+  test("Symbol.dispose unregisters", () => {
+    const arcjet = registerTestClient();
+
+    // Called directly rather than through `using`: Node.js 22 defines
+    // Symbol.dispose but does not parse the `using` syntax, and this suite runs
+    // on the package's minimum Node.
+    arcjet[Symbol.dispose]();
+
+    assert.equal(registeredClient(), undefined);
+  });
+});
+
+describe("recording captures", () => {
+  test("records a capture made through the free function", () => {
+    const arcjet = registerTestClient();
+
+    capture({ action: "refund.issued", metadata: { invoice: "inv_1" } });
+
+    assert.equal(arcjet.captures.length, 1);
+    assert.equal(arcjet.captures[0]?.action, "refund.issued");
+    assert.deepEqual(arcjet.captures[0]?.metadata, { invoice: "inv_1" });
+  });
+
+  test("records captures in call order", () => {
+    const arcjet = registerTestClient();
+
+    capture({ action: "first" });
+    capture({ action: "second" });
+
+    assert.deepEqual(
+      arcjet.captures.map((c) => c.action),
+      ["first", "second"],
+    );
+  });
+
+  test("preserves nested metadata through the wire encoding", () => {
+    const arcjet = registerTestClient();
+
+    capture({ action: "order.placed", metadata: { items: [1, 2], user: { id: "u1" } } });
+
+    assert.deepEqual(arcjet.captures[0]?.metadata, { items: [1, 2], user: { id: "u1" } });
+  });
+
+  test("keeps correlationId and decisionId only when supplied", () => {
+    const arcjet = registerTestClient();
+
+    capture({ action: "with", correlationId: "corr_1", decisionId: "dec_1" });
+    capture({ action: "without" });
+
+    assert.equal(arcjet.captures[0]?.correlationId, "corr_1");
+    assert.equal(arcjet.captures[0]?.decisionId, "dec_1");
+    assert.equal(arcjet.captures[1]?.correlationId, undefined);
+    assert.equal(arcjet.captures[1]?.decisionId, undefined);
+  });
+
+  test("records occurredAt when the call supplies one", () => {
+    const arcjet = registerTestClient();
+    const occurredAt = new Date("2026-08-04T12:00:00.000Z");
+
+    capture({ action: "backfilled", occurredAt });
+
+    assert.deepEqual(arcjet.captures[0]?.occurredAt, occurredAt);
+  });
+
+  test("drops an invalid event exactly as the real client would", () => {
+    const arcjet = registerTestClient();
+
+    // An empty `action` is rejected by the same validation the real client
+    // runs. Recording the raw input instead would let this test pass while the
+    // real client silently dropped the event in production.
+    capture({ action: "" });
+
+    assert.deepEqual(arcjet.captures, []);
+  });
+
+  test("surfaces encoding warnings on the recorded event", () => {
+    const arcjet = registerTestClient();
+
+    const circular: ArcjetMetadata = {};
+    circular.self = circular;
+    capture({ action: "lossy", metadata: { ok: "kept", bad: circular } });
+
+    const recorded = arcjet.captures[0];
+    assert.equal(recorded?.action, "lossy");
+    assert.deepEqual(recorded?.metadata, { ok: "kept" });
+    assert.ok((recorded?.warnings.length ?? 0) > 0, "the dropped key should be reported");
+  });
+
+  test("does not throw on metadata named __proto__", () => {
+    const arcjet = registerTestClient();
+
+    const metadata: ArcjetMetadata = {};
+    Object.defineProperty(metadata, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      value: { polluted: true },
+      writable: true,
+    });
+    capture({ action: "hostile", metadata });
+
+    const recorded = arcjet.captures[0];
+    assert.ok(recorded !== undefined);
+    // Recording the key must not have walked the prototype chain.
+    const probe: Record<string, unknown> = {};
+    assert.equal(probe.polluted, undefined);
+  });
+});
+
+function exportsMap(): Record<string, unknown> {
+  const packageJson: unknown = JSON.parse(
+    readFileSync(resolve(import.meta.dirname, "../package.json"), "utf8"),
+  );
+  assert.ok(packageJson !== null && typeof packageJson === "object");
+  const map = (packageJson as { exports?: Record<string, unknown> }).exports;
+  assert.ok(map !== undefined, "package.json must have an exports field");
+  return map;
+}
+
+describe("the ./testing subpath", () => {
+  test("is declared, and points at the built test client", () => {
+    assert.deepEqual(exportsMap()["./testing"], {
+      types: "./dist/testing.d.ts",
+      import: "./dist/testing.js",
+    });
+  });
+
+  test("no exports entry reaches the registry or the client", () => {
+    // Strict `exports` encapsulation is what keeps `registerArcjetForTesting`,
+    // `createFailOpenDecision` and `normalizeCaptureEvent` internal: nothing
+    // listed here resolves to the modules that declare them, so importing one
+    // throws ERR_PACKAGE_PATH_NOT_EXPORTED at the package boundary.
+    const targets = JSON.stringify(exportsMap());
+
+    assert.doesNotMatch(targets, /dist\/registry\./);
+    assert.doesNotMatch(targets, /dist\/client\./);
+    assert.doesNotMatch(targets, /dist\/diagnostics\./);
+    assert.doesNotMatch(targets, /dist\/symbol\./);
+  });
+});
+
+describe("recording guards", () => {
+  test("records the guard call and answers fail-open", async () => {
+    const arcjet = registerTestClient();
+
+    const decision = await guard({ label: "tools.weather", rules: [] });
+
+    assert.equal(arcjet.guards.length, 1);
+    assert.equal(arcjet.guards[0]?.label, "tools.weather");
+    // Fail-open rather than a plain ALLOW: no rule ran, and a plain ALLOW
+    // would claim policy was evaluated. Note that helpers which fail closed on
+    // a failed-open decision will therefore deny against this client.
+    assert.equal(decision.conclusion, "ALLOW");
+    assert.equal(decision.hasFailedOpen(), true);
+  });
+
+  test("flush resolves without a queue to drain", async () => {
+    const arcjet = registerTestClient();
+
+    await assert.doesNotReject(arcjet.flush());
+  });
+});

--- a/arcjet-guard/src/testing.ts
+++ b/arcjet-guard/src/testing.ts
@@ -1,0 +1,196 @@
+/**
+ * `@arcjet/guard/testing` — an in-memory client for application tests.
+ *
+ * Registers a client that records what was called and talks to nothing. It
+ * exists so a test can assert that application code captured the event it was
+ * supposed to, without a key, a network, or a running server.
+ *
+ * This is deliberately not a mock server. It records calls and answers guards
+ * uniformly; it does not let a test stub per-rule verdicts. Simulating real
+ * decisions is a much larger job — closer to MSW than to a stub — and is not
+ * what this is for.
+ *
+ * @packageDocumentation
+ */
+
+import { normalizeCaptureEvent, createFailOpenDecision } from "./client.ts";
+import { symbolArcjetDiagnostics, type DiagnosticHandler } from "./diagnostics.ts";
+import type { ArcjetGuard } from "./index.ts";
+import { registerArcjetForTesting, unregisterArcjet } from "./registry.ts";
+import type { ArcjetMetadata, CaptureOptions, Decision, GuardOptions, Warning } from "./types.ts";
+
+/**
+ * Diagnostics are dropped rather than logged.
+ *
+ * A test that captures something invalid asserts on the recorded event's
+ * `warnings`, which say the same thing in the place the test is already
+ * looking. Logging as well would put warnings in the output of every test that
+ * exercises a drop deliberately.
+ */
+const ignoreDiagnostic: DiagnosticHandler = () => {};
+
+/**
+ * Clear the registration.
+ *
+ * Unconditional, because `unregisterArcjet()` takes no argument and clears
+ * whatever is there — which is this client in every ordinary case. Safe to call
+ * twice, so an `afterEach` still works after a failed test.
+ */
+function unregisterTestClient(): void {
+  unregisterArcjet();
+}
+
+/** A capture event recorded by an {@link ArcjetTestClient}. */
+export type ArcjetTestCapture = {
+  /** What the application said it did. */
+  action: string;
+  /** Present only when the call supplied one. */
+  correlationId?: string;
+  /** Present only when the call supplied one. */
+  decisionId?: string;
+  /** The call's timestamp, or when it was recorded. */
+  occurredAt: Date;
+  /** Metadata as it would have been sent, decoded back from the wire. */
+  metadata: ArcjetMetadata;
+  /** Anything the SDK dropped or rewrote while encoding this event. */
+  warnings: readonly Warning[];
+};
+
+/** An in-memory Arcjet client that records calls instead of sending them. */
+export type ArcjetTestClient = ArcjetGuard & {
+  /** Captured events, in call order. */
+  readonly captures: readonly ArcjetTestCapture[];
+  /** Guard calls, in call order. */
+  readonly guards: readonly GuardOptions[];
+
+  /**
+   * Unregister the client.
+   *
+   * Safe to call twice, so it works in an `afterEach` that also runs after a
+   * failed test.
+   */
+  unregister(): void;
+
+  /**
+   * Unregister via `using`, on runtimes and TypeScript versions that support it.
+   *
+   * Node.js 22 defines `Symbol.dispose` but does not parse `using`, which only
+   * arrived in Node.js 24. On Node.js 22 either compile the `using` through
+   * TypeScript, or call {@link ArcjetTestClient.unregister} from a `finally`.
+   */
+  [Symbol.dispose](): void;
+};
+
+/**
+ * Register an in-memory client that records Guard and Capture calls.
+ *
+ * The one place launching and registering are a single act — a test that wanted
+ * them apart would use `launchArcjet()` directly.
+ *
+ * Throws if a client is already registered. In an application a second
+ * registration warns and carries on, because it should be survivable; in a test
+ * it means an earlier test leaked one, and every assertion here would silently
+ * read the wrong recorder.
+ *
+ * Captures are recorded as they happen, so assertions need no waiting. There is
+ * no transport and no queue, which is why unregistering is synchronous — there
+ * is nothing to drain.
+ *
+ * @example
+ * ```ts
+ * import { registerTestClient } from "@arcjet/guard/testing";
+ * import { refund } from "./refund.ts";
+ *
+ * test("refund captures an event", () => {
+ *   const arcjet = registerTestClient();
+ *   try {
+ *     refund("inv_1");
+ *
+ *     assert.equal(arcjet.captures[0]?.action, "refund.issued");
+ *   } finally {
+ *     arcjet.unregister();
+ *   }
+ * });
+ * ```
+ *
+ * @example On Node.js 24, or through TypeScript, `using` replaces the `finally`.
+ * ```ts
+ * test("refund captures an event", () => {
+ *   using arcjet = registerTestClient();
+ *
+ *   refund("inv_1");
+ *
+ *   assert.equal(arcjet.captures[0]?.action, "refund.issued");
+ * });
+ * ```
+ */
+export function registerTestClient(): ArcjetTestClient {
+  const captures: ArcjetTestCapture[] = [];
+  const guards: GuardOptions[] = [];
+
+  const client: ArcjetTestClient & { [symbolArcjetDiagnostics]: DiagnosticHandler } = {
+    captures,
+    guards,
+
+    guard(options: GuardOptions): Promise<Decision> {
+      guards.push(options);
+      // A fail-open ALLOW rather than a plain one, because no rule was
+      // evaluated and a plain ALLOW would claim otherwise. Note this means
+      // `hasFailedOpen()` is true, and helpers that fail closed on a
+      // failed-open decision — `guardTool`, `guardAction` — will DENY against
+      // this client.
+      return Promise.resolve(
+        createFailOpenDecision("guard() was called on the Arcjet test client; no rules ran"),
+      );
+    },
+
+    capture(options: CaptureOptions): void {
+      // Normalized through the same path the real client uses, so a test fails
+      // on a `capture()` the real client would have dropped instead of quietly
+      // recording the raw input.
+      const event = normalizeCaptureEvent(options, ignoreDiagnostic);
+      if (event === undefined) {
+        return;
+      }
+
+      const metadata: ArcjetMetadata = {};
+      for (const [key, value] of Object.entries(event.metadataJson)) {
+        // defineProperty rather than assignment: a key such as `__proto__`
+        // would otherwise mutate the prototype instead of landing on the
+        // object, and dropping it would hide exactly the metadata a test about
+        // hostile input is asserting on.
+        Object.defineProperty(metadata, key, {
+          configurable: true,
+          enumerable: true,
+          value: JSON.parse(value) as ArcjetMetadata[string],
+          writable: true,
+        });
+      }
+
+      captures.push({
+        action: event.action,
+        ...(event.correlationId === "" ? {} : { correlationId: event.correlationId }),
+        ...(event.decisionId === "" ? {} : { decisionId: event.decisionId }),
+        occurredAt: new Date(Number(event.occurredAtUnixMs)),
+        metadata,
+        warnings: event.localWarnings.map((warning) => ({
+          code: warning.code,
+          message: warning.message,
+        })),
+      });
+    },
+
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+
+    unregister: unregisterTestClient,
+
+    [Symbol.dispose]: unregisterTestClient,
+
+    [symbolArcjetDiagnostics]: ignoreDiagnostic,
+  };
+
+  registerArcjetForTesting(client);
+  return client;
+}

--- a/arcjet-guard/src/testing.ts
+++ b/arcjet-guard/src/testing.ts
@@ -66,17 +66,26 @@ export type ArcjetTestClient = ArcjetGuard & {
   /**
    * Unregister the client.
    *
+   * The very same function as `[Symbol.dispose]`, not a wrapper around it —
+   * one reference under two names, so the two cannot drift and either one
+   * survives being destructured off the client.
+   *
    * Safe to call twice, so it works in an `afterEach` that also runs after a
-   * failed test.
+   * failed test. This is the form every toolchain accepts; prefer `using`
+   * where yours supports it.
    */
   unregister(): void;
 
   /**
-   * Unregister via `using`, on runtimes and TypeScript versions that support it.
+   * Unregister via `using`.
    *
-   * Node.js 22 defines `Symbol.dispose` but does not parse `using`, which only
-   * arrived in Node.js 24. On Node.js 22 either compile the `using` through
-   * TypeScript, or call {@link ArcjetTestClient.unregister} from a `finally`.
+   * Two requirements come with this, both on the consumer rather than here.
+   * The `using` *syntax* needs Node.js 24 to parse natively, or compilation
+   * through TypeScript; Node.js 22 defines `Symbol.dispose` but cannot parse
+   * `using`. And because this member appears in the published `.d.ts`, a
+   * consumer compiling with `skipLibCheck: false` needs `esnext.disposable` in
+   * their `lib` even if they never write `using` — {@link
+   * ArcjetTestClient.unregister} is the way out for them.
    */
   [Symbol.dispose](): void;
 };
@@ -113,16 +122,6 @@ export type ArcjetTestClient = ArcjetGuard & {
  * });
  * ```
  *
- * @example On Node.js 24, or through TypeScript, `using` replaces the `finally`.
- * ```ts
- * test("refund captures an event", () => {
- *   using arcjet = registerTestClient();
- *
- *   refund("inv_1");
- *
- *   assert.equal(arcjet.captures[0]?.action, "refund.issued");
- * });
- * ```
  */
 export function registerTestClient(): ArcjetTestClient {
   const captures: ArcjetTestCapture[] = [];

--- a/arcjet-guard/src/testing/index.test.ts
+++ b/arcjet-guard/src/testing/index.test.ts
@@ -3,11 +3,12 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, test } from "node:test";
 
-import { createFailOpenDecision } from "./client.ts";
-import type { ArcjetGuard } from "./index.ts";
-import { capture, guard, registerArcjet, registeredClient, unregisterArcjet } from "./registry.ts";
-import { registerTestClient } from "./testing.ts";
-import type { ArcjetMetadata, Decision } from "./types.ts";
+import { createFailOpenDecision } from "../client.ts";
+import type { ArcjetGuard } from "../index.ts";
+import { registeredClient } from "../registration-slot.ts";
+import { capture, guard, registerArcjet, unregisterArcjet } from "../registry.ts";
+import type { ArcjetMetadata, Decision } from "../types.ts";
+import { registerTestClient } from "./index.ts";
 
 /** A client that does nothing, only to occupy the registration slot. */
 const occupant: ArcjetGuard = {
@@ -167,7 +168,7 @@ describe("recording captures", () => {
 
 function exportsMap(): Record<string, unknown> {
   const packageJson: unknown = JSON.parse(
-    readFileSync(resolve(import.meta.dirname, "../package.json"), "utf8"),
+    readFileSync(resolve(import.meta.dirname, "../../package.json"), "utf8"),
   );
   assert.ok(packageJson !== null && typeof packageJson === "object");
   const map = (packageJson as { exports?: Record<string, unknown> }).exports;
@@ -178,8 +179,8 @@ function exportsMap(): Record<string, unknown> {
 describe("the ./testing subpath", () => {
   test("is declared, and points at the built test client", () => {
     assert.deepEqual(exportsMap()["./testing"], {
-      types: "./dist/testing.d.ts",
-      import: "./dist/testing.js",
+      types: "./dist/testing/index.d.ts",
+      import: "./dist/testing/index.js",
     });
   });
 
@@ -191,6 +192,8 @@ describe("the ./testing subpath", () => {
     const targets = JSON.stringify(exportsMap());
 
     assert.doesNotMatch(targets, /dist\/registry\./);
+    assert.doesNotMatch(targets, /dist\/registration-slot\./);
+    assert.doesNotMatch(targets, /dist\/testing\/register\./);
     assert.doesNotMatch(targets, /dist\/client\./);
     assert.doesNotMatch(targets, /dist\/diagnostics\./);
     assert.doesNotMatch(targets, /dist\/symbol\./);

--- a/arcjet-guard/src/testing/index.ts
+++ b/arcjet-guard/src/testing/index.ts
@@ -13,11 +13,12 @@
  * @packageDocumentation
  */
 
-import { normalizeCaptureEvent, createFailOpenDecision } from "./client.ts";
-import { symbolArcjetDiagnostics, type DiagnosticHandler } from "./diagnostics.ts";
-import type { ArcjetGuard } from "./index.ts";
-import { registerArcjetForTesting, unregisterArcjet } from "./registry.ts";
-import type { ArcjetMetadata, CaptureOptions, Decision, GuardOptions, Warning } from "./types.ts";
+import { normalizeCaptureEvent, createFailOpenDecision } from "../client.ts";
+import { symbolArcjetDiagnostics, type DiagnosticHandler } from "../diagnostics.ts";
+import type { ArcjetGuard } from "../index.ts";
+import { unregisterArcjet } from "../registry.ts";
+import type { ArcjetMetadata, CaptureOptions, Decision, GuardOptions, Warning } from "../types.ts";
+import { registerArcjetForTesting } from "./register.ts";
 
 /**
  * Diagnostics are dropped rather than logged.

--- a/arcjet-guard/src/testing/register.test.ts
+++ b/arcjet-guard/src/testing/register.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+
+import { recorder } from "../../test/_shared/registry-recorder.ts";
+import { registeredClient } from "../registration-slot.ts";
+import { registerArcjet, unregisterArcjet } from "../registry.ts";
+import { registerArcjetForTesting } from "./register.ts";
+
+afterEach(() => {
+  unregisterArcjet();
+});
+
+describe("registerArcjetForTesting", () => {
+  test("throws when something is already registered", () => {
+    registerArcjet(recorder());
+
+    assert.throws(
+      () => {
+        registerArcjetForTesting(recorder());
+      },
+      /already registered/i,
+      "a leaked registration must fail loudly under test, not warn and continue",
+    );
+  });
+
+  test("registers when the slot is free", () => {
+    const client = recorder();
+    registerArcjetForTesting(client);
+
+    assert.equal(registeredClient(), client);
+  });
+
+  test("throws on a foreign-version incumbent too", () => {
+    // `registeredClient()` reports this as absent, but it is still a leak: an
+    // unvalidated check is what makes that distinction, and the leak is what
+    // matters here.
+    registerArcjetForTesting(recorder());
+
+    assert.throws(() => {
+      registerArcjetForTesting(recorder());
+    }, /already registered/i);
+  });
+});

--- a/arcjet-guard/src/testing/register.ts
+++ b/arcjet-guard/src/testing/register.ts
@@ -1,0 +1,39 @@
+/**
+ * The test-only registration path.
+ *
+ * Lives under `testing/` rather than in `registry.ts` so nothing only tests use
+ * sits in a module every production import graph pulls in.
+ *
+ * @packageDocumentation
+ * @internal
+ */
+
+import type { ArcjetGuard } from "../index.ts";
+import { hasRegistration, writeRegistration } from "../registration-slot.ts";
+
+/**
+ * Register a client, refusing to displace or share with an incumbent.
+ *
+ * The test client uses this instead of `registerArcjet()` because the failure
+ * modes invert under test. In an application a second registration should be
+ * survivable, so it warns and carries on. In a test suite a client left
+ * registered by an earlier test is a leak that makes the current test assert
+ * against the wrong recorder — quietly, and usually somewhere else. So this
+ * throws.
+ *
+ * The check is deliberately unvalidated: anything in the slot is a leak,
+ * including a record written by another version of the SDK, which
+ * `registeredClient()` would report as absent.
+ *
+ * @internal
+ */
+export function registerArcjetForTesting(client: ArcjetGuard): void {
+  if (hasRegistration()) {
+    throw new Error(
+      "An Arcjet client is already registered. Call unregisterArcjet() first — " +
+        "an earlier test probably left one behind.",
+    );
+  }
+
+  writeRegistration(client);
+}

--- a/arcjet-guard/src/vercel-ai/v7/index.test.ts
+++ b/arcjet-guard/src/vercel-ai/v7/index.test.ts
@@ -167,7 +167,10 @@ test("AC1.1: root export map keys and runtime conditions unchanged", () => {
   assert.ok(exportsMap, "package.json must have an exports field");
 
   const exportKeys = sortedKeys(exportsMap);
-  const expectedRootKeys = [".", "./bun", "./fetch", "./node", "./vercel-ai/v7"];
+  // "./testing" is the in-memory client for application tests. Deliberately a
+  // single entry rather than a runtime-conditional one: it has no transport, so
+  // there is nothing for a condition to select.
+  const expectedRootKeys = [".", "./bun", "./fetch", "./node", "./testing", "./vercel-ai/v7"];
 
   assert.deepEqual(
     exportKeys,

--- a/arcjet-guard/test/_shared/cases.ts
+++ b/arcjet-guard/test/_shared/cases.ts
@@ -11,7 +11,14 @@
 
 import assert from "node:assert/strict";
 
-import type { ArcjetGuard, launchArcjetWithTransport } from "../../src/index.ts";
+import type {
+  ArcjetGuard,
+  capture as freeCapture,
+  guard as freeGuard,
+  launchArcjetWithTransport,
+  registerArcjet as register,
+  unregisterArcjet as unregister,
+} from "../../src/index.ts";
 import type {
   tokenBucket,
   fixedWindow,
@@ -47,6 +54,10 @@ export interface GuardSurface {
   detectPromptInjection: typeof detectPromptInjection;
   localDetectSensitiveInfo: typeof localDetectSensitiveInfo;
   defineCustomRule: typeof defineCustomRule;
+  registerArcjet: typeof register;
+  unregisterArcjet: typeof unregister;
+  guard: typeof freeGuard;
+  capture: typeof freeCapture;
 }
 
 /** A single test case. */
@@ -544,6 +555,56 @@ export const cases: TestCase[] = [
 
       assert.equal(capturedConfig["flag"], "on");
       assert.equal(capturedInput["value"], "test-value");
+    },
+  },
+  {
+    // Registration writes to a `Symbol.for` slot on `globalThis`, so this has
+    // to hold on every runtime rather than only on Node.
+    name: "registration routes the free calls to the registered client",
+    async run(s) {
+      const arcjet = guard(s, tokenBucketAllow);
+      const rule = s.tokenBucket({
+        bucket: "test",
+        refillRate: 10,
+        intervalSeconds: 60,
+        maxTokens: 100,
+      });
+
+      s.registerArcjet(arcjet);
+      try {
+        const decision = await s.guard({ label: "test", rules: [rule({ key: "user_1" })] });
+
+        assert.equal(decision.conclusion, "ALLOW");
+        assert.equal(decision.hasFailedOpen(), false);
+        // Never throws, even though nothing here can observe delivery.
+        s.capture({ action: "runtime.checked" });
+      } finally {
+        s.unregisterArcjet();
+      }
+    },
+  },
+  {
+    name: "the free guard() fails open when nothing is registered",
+    async run(s) {
+      s.unregisterArcjet();
+
+      const decision = await s.guard({ label: "test", rules: [] });
+
+      // Both halves matter: a plain ALLOW would pass the first assertion while
+      // being a silent bypass.
+      assert.equal(decision.conclusion, "ALLOW");
+      assert.equal(decision.hasFailedOpen(), true);
+    },
+  },
+  {
+    name: "launching a client registers nothing",
+    async run(s) {
+      s.unregisterArcjet();
+      guard(s, tokenBucketAllow);
+
+      const decision = await s.guard({ label: "test", rules: [] });
+
+      assert.equal(decision.hasFailedOpen(), true);
     },
   },
 ];

--- a/arcjet-guard/test/_shared/registry-recorder.ts
+++ b/arcjet-guard/test/_shared/registry-recorder.ts
@@ -1,0 +1,74 @@
+/**
+ * Recording client doubles shared by the registration tests.
+ *
+ * Lives under `test/` rather than `src/` because the build globs
+ * `src/**\/*.ts` minus `*.test.ts`, so a helper here would otherwise be emitted
+ * into `dist/`.
+ *
+ * @packageDocumentation
+ */
+
+import { createFailOpenDecision } from "../../src/client.ts";
+import { symbolArcjetDiagnostics, type ArcjetDiagnostic } from "../../src/diagnostics.ts";
+import type { ArcjetGuard } from "../../src/index.ts";
+import { symbolArcjetClient } from "../../src/symbol.ts";
+import type { CaptureOptions, Decision, GuardOptions } from "../../src/types.ts";
+
+/** A client that records every call made through it. */
+export type Recorder = ArcjetGuard & {
+  guards: GuardOptions[];
+  captures: CaptureOptions[];
+  flushes: (number | undefined)[];
+};
+
+/** A {@link Recorder} that also records what the registry reported to it. */
+export type RecorderWithDiagnostics = Recorder & { diagnostics: ArcjetDiagnostic[] };
+
+/** Build a recording client. */
+export function recorder(): Recorder {
+  const guards: GuardOptions[] = [];
+  const captures: CaptureOptions[] = [];
+  const flushes: (number | undefined)[] = [];
+  return {
+    guards,
+    captures,
+    flushes,
+    guard(options: GuardOptions): Promise<Decision> {
+      guards.push(options);
+      return Promise.resolve(createFailOpenDecision("stub"));
+    },
+    capture(options: CaptureOptions): void {
+      captures.push(options);
+    },
+    flush(timeoutMs?: number): Promise<void> {
+      flushes.push(timeoutMs);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** Build a recording client carrying a diagnostics channel. */
+export function recorderWithDiagnostics(): RecorderWithDiagnostics {
+  const diagnostics: ArcjetDiagnostic[] = [];
+  return Object.assign(recorder(), {
+    diagnostics,
+    [symbolArcjetDiagnostics]: (diagnostic: ArcjetDiagnostic): void => {
+      diagnostics.push(diagnostic);
+    },
+  });
+}
+
+/**
+ * Put an arbitrary value in the global slot, bypassing `registerArcjet`.
+ *
+ * Used to simulate what another copy of the SDK — or anything else in the
+ * process — could leave there.
+ */
+export function writeSlot(value: unknown): void {
+  Object.defineProperty(globalThis, symbolArcjetClient, {
+    configurable: true,
+    enumerable: false,
+    value,
+    writable: true,
+  });
+}

--- a/arcjet-guard/test/runtime/bun.test.ts
+++ b/arcjet-guard/test/runtime/bun.test.ts
@@ -22,6 +22,10 @@ import {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 } from "@arcjet/guard";
 import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
 
@@ -37,6 +41,10 @@ const surface: GuardSurface = {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 };
 
 describe("In-memory shared cases (Bun entrypoint)", () => {

--- a/arcjet-guard/test/runtime/cloudflare/worker.ts
+++ b/arcjet-guard/test/runtime/cloudflare/worker.ts
@@ -15,6 +15,10 @@ import {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 } from "../../../src/fetch.ts";
 import { cases } from "../../_shared/cases.ts";
 import type { GuardSurface } from "../../_shared/cases.ts";
@@ -31,6 +35,10 @@ const surface: GuardSurface = {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 };
 
 interface TestResult {

--- a/arcjet-guard/test/runtime/deno.test.ts
+++ b/arcjet-guard/test/runtime/deno.test.ts
@@ -21,6 +21,10 @@ import {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 } from "../../src/index.ts";
 import { userAgent } from "../../src/version.ts";
 import { cases } from "../_shared/cases.ts";
@@ -34,6 +38,10 @@ const surface: GuardSurface = {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 };
 
 // Run all shared in-memory cases

--- a/arcjet-guard/test/runtime/fetch.test.ts
+++ b/arcjet-guard/test/runtime/fetch.test.ts
@@ -38,6 +38,10 @@ import {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 } from "@arcjet/guard/fetch";
 
 import { cases } from "../_shared/cases.ts";
@@ -52,6 +56,10 @@ const surface: GuardSurface = {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 };
 
 describe("In-memory shared cases (Fetch entrypoint)", () => {

--- a/arcjet-guard/test/runtime/node.test.ts
+++ b/arcjet-guard/test/runtime/node.test.ts
@@ -23,6 +23,10 @@ import {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 } from "@arcjet/guard";
 import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
 
@@ -44,6 +48,10 @@ const surface: GuardSurface = {
   detectPromptInjection,
   localDetectSensitiveInfo,
   defineCustomRule,
+  registerArcjet,
+  unregisterArcjet,
+  guard,
+  capture,
 };
 
 describe("In-memory shared cases (Node entrypoint)", () => {
@@ -185,5 +193,50 @@ describe("Runtime: guard HTTP/2 transport factory (keep-alive + recycling)", () 
     const result = input.result(decision);
     assert.ok(result);
     assert.equal(result.remainingTokens, 95);
+  });
+});
+
+describe("Package boundary: the exports map is the public API", () => {
+  test("@arcjet/guard/testing resolves to the test client", async () => {
+    const testing: Record<string, unknown> = await import("@arcjet/guard/testing");
+
+    assert.equal(typeof testing.registerTestClient, "function");
+  });
+
+  test("the registered test client receives the free calls", async () => {
+    const { registerTestClient } = await import("@arcjet/guard/testing");
+    const { capture: freeCapture } = await import("@arcjet/guard");
+
+    const arcjet = registerTestClient();
+    try {
+      freeCapture({ action: "runtime.checked" });
+
+      assert.equal(arcjet.captures[0]?.action, "runtime.checked");
+    } finally {
+      arcjet.unregister();
+    }
+  });
+
+  test("internal modules are unreachable through the package boundary", async () => {
+    // The seams the registry and test client share with the client — the
+    // fail-open decision, capture normalization, the diagnostics symbol — are
+    // `@internal`. `stripInternal` is not enabled, so the tag alone documents
+    // rather than enforces; encapsulation is what actually holds, and this is
+    // the check that proves it against the built package.
+    for (const specifier of [
+      "@arcjet/guard/registry",
+      "@arcjet/guard/client",
+      "@arcjet/guard/diagnostics",
+      "@arcjet/guard/symbol",
+    ]) {
+      await assert.rejects(
+        () => import(specifier),
+        (error: NodeJS.ErrnoException) => {
+          assert.equal(error.code, "ERR_PACKAGE_PATH_NOT_EXPORTED");
+          return true;
+        },
+        `${specifier} must not resolve`,
+      );
+    }
   });
 });

--- a/arcjet-guard/tsconfig.json
+++ b/arcjet-guard/tsconfig.json
@@ -12,9 +12,9 @@
     "isolatedDeclarations": true,
     "isolatedModules": true,
     // `esnext.disposable` types `Symbol.dispose`, which the test client
-    // implements. Types only: it changes no emit and raises no runtime floor.
-    // Node.js 22.21 already defines `Symbol.dispose` — it is the `using`
-    // *syntax* that needs Node.js 24, and nothing in this package uses it.
+    // implements so `using` works. Types only: no emit change, no runtime
+    // floor change. Node.js 22.21 defines `Symbol.dispose` already — it is the
+    // `using` syntax that needs Node.js 24.
     "lib": ["es2023", "esnext.disposable", "webworker"],
     "module": "es2022",
     "moduleDetection": "force",

--- a/arcjet-guard/tsconfig.json
+++ b/arcjet-guard/tsconfig.json
@@ -11,7 +11,11 @@
     "incremental": false,
     "isolatedDeclarations": true,
     "isolatedModules": true,
-    "lib": ["es2023", "webworker"],
+    // `esnext.disposable` types `Symbol.dispose`, which the test client
+    // implements. Types only: it changes no emit and raises no runtime floor.
+    // Node.js 22.21 already defines `Symbol.dispose` — it is the `using`
+    // *syntax* that needs Node.js 24, and nothing in this package uses it.
+    "lib": ["es2023", "esnext.disposable", "webworker"],
     "module": "es2022",
     "moduleDetection": "force",
     "moduleResolution": "bundler",


### PR DESCRIPTION
See ADR: https://github.com/arcjet/arcjet/blob/main/docs/adrs/2026-07-24-unified-arcjet-client-registration-and-lifecycle.md

Note: It is only added to Guard here as having a single client is happening elsewhere

```ts
import { launchArcjet, registerArcjet } from "@arcjet/guard";

const arcjet = launchArcjet(/* ... */);

// Stored on globalThis
registerArcjet(arcjet);
```

```ts
import { capture, guard } from "@arcjet/guard";

// ... later

cature(/* ... */) // Pulls client off globalThis
```

```ts
import { registerTestClient } from "@arcjet/guard/testing";
import { refund } from "./refund.ts";

test("refund captures an event", async () => {
  using arcjet = registerTestClient();

  await refund("inv_1");

  assert.equal(arcjet.captures[0]?.action, "refund.issued");
});
```