### PR TITLE
ci: detect vendor SDK version skew and cover node-guard-policy

### DIFF
--- a/.github/scripts/check-sdk-version-alignment.mjs
+++ b/.github/scripts/check-sdk-version-alignment.mjs
@@ -1,0 +1,94 @@
+/**
+ * Fail when a vendor SDK resolves to more than one version across the
+ * repository.
+ *
+ * The examples install separately from the workspace root and pin their own
+ * lockfiles, while `@arcjet/guard` reaches them by path — so TypeScript resolves
+ * the SDK for guard's declarations from the root and for an example's own code
+ * from that example. Two copies are two nominally distinct declarations of the
+ * same type, and every value passed across the boundary stops assigning. The
+ * install succeeds and the failure surfaces much later as an unrelated-looking
+ * type error, which is why this is worth a dedicated check.
+ *
+ * The watched set is `@arcjet/guard`'s peer dependencies. Those are exactly the
+ * packages whose types cross that boundary, and deriving the set means a new
+ * vendor namespace is covered the day its peer is declared rather than whenever
+ * someone remembers to update this file.
+ *
+ * Reads lockfiles rather than `node_modules` so it needs no install and can run
+ * in the lint job.
+ */
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const GUARD_MANIFEST = "arcjet-guard/package.json";
+
+/** Every resolved version of `name` recorded in one lockfile, including nested copies. */
+function versionsIn(lockfilePath, name) {
+  if (!existsSync(lockfilePath)) return [];
+  const lock = JSON.parse(readFileSync(lockfilePath, "utf8"));
+  const found = [];
+  for (const [path, entry] of Object.entries(lock.packages ?? {})) {
+    // "node_modules/ai" and "node_modules/x/node_modules/ai" both count; a path
+    // ending in the name is the package itself rather than something beneath it.
+    if (path === `node_modules/${name}` || path.endsWith(`/node_modules/${name}`)) {
+      if (typeof entry.version === "string") found.push({ path, version: entry.version });
+    }
+  }
+  return found;
+}
+
+const watched = Object.keys(
+  JSON.parse(readFileSync(GUARD_MANIFEST, "utf8")).peerDependencies ?? {},
+);
+
+if (watched.length === 0) {
+  console.error(`No peer dependencies found in ${GUARD_MANIFEST}; nothing to check.`);
+  process.exit(1);
+}
+
+const lockfiles = ["package-lock.json"];
+for (const dir of readdirSync("examples")) {
+  const lock = join("examples", dir, "package-lock.json");
+  if (existsSync(lock)) lockfiles.push(lock);
+}
+
+let failed = false;
+
+for (const name of watched) {
+  /** @type {Map<string, string[]>} version -> where it was found */
+  const byVersion = new Map();
+  for (const lockfile of lockfiles) {
+    for (const { path, version } of versionsIn(lockfile, name)) {
+      const where = `${lockfile} (${path})`;
+      byVersion.set(version, [...(byVersion.get(version) ?? []), where]);
+    }
+  }
+
+  if (byVersion.size <= 1) {
+    const only = [...byVersion.keys()][0];
+    console.log(`ok  ${name}: ${only ?? "not installed anywhere"}`);
+    continue;
+  }
+
+  failed = true;
+  console.error(`\nFAIL ${name} resolves to ${byVersion.size} different versions:`);
+  for (const [version, locations] of [...byVersion].sort()) {
+    console.error(`  ${version}`);
+    for (const location of locations) console.error(`    ${location}`);
+  }
+}
+
+if (failed) {
+  console.error(
+    "\nA vendor SDK must resolve to one version everywhere. @arcjet/guard is linked\n" +
+      "into the examples by path, so a version that differs between an example and the\n" +
+      "workspace root gives TypeScript two declarations of the same type and every\n" +
+      "value crossing that boundary fails to assign.\n\n" +
+      "Align the versions — usually by pinning the example to whatever the root\n" +
+      "resolves — and re-run `npm install` in that example.",
+  );
+  process.exit(1);
+}
+
+console.log("\nAll vendor SDKs resolve to a single version.");

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -144,6 +144,7 @@ jobs:
           - nextjs-react-hook-form
           - nextjs-sensitive-info
           - nextjs-server-actions
+          - node-guard-policy
           - nodejs-rate-limit
           - react-router-middleware
           - react-router

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Pin npm
         uses: ./.github/actions/pin-npm
       - run: npm ci
+      # Reads lockfiles only, so it runs before the build and needs no example
+      # installs. Catches a vendor SDK that resolves to two versions across the
+      # repo, which typechecks as two distinct declarations of the same type.
+      - name: Check vendor SDK version alignment
+        run: node .github/scripts/check-sdk-version-alignment.mjs
       - name: Lint (oxlint)
         run: npm run lint
       - name: Format check (oxfmt)


### PR DESCRIPTION
## Summary

Closes two gaps that let the same class of breakage reach CI repeatedly: a vendor SDK resolving to two different versions across the repository, and an example that nothing ever built or typechecked.

## Version skew between the examples and the root

The examples install separately from the workspace root and pin their own lockfiles, while `@arcjet/guard` reaches them by path. TypeScript therefore resolves a vendor SDK for guard's declarations from the root, and for an example's own code from that example. Two copies are two nominally distinct declarations of the same type, so every value passed across the boundary stops assigning:

```
error TS2345: Argument of type '{ ... }' is not assignable to parameter of type 'Tool'.
```

Nothing fails at install time — resolution succeeds, and the failure surfaces later as an unrelated-looking type error in whichever example happens to build first. It has bitten several times while adding the Eve namespace, once in an example CI does not even run.

`.github/scripts/check-sdk-version-alignment.mjs` fails when a watched package resolves to more than one version anywhere in the repo, listing every location:

```
FAIL ai resolves to 2 different versions:
  7.0.36
    examples/nextjs-guard-policy/package-lock.json (node_modules/ai)
  7.0.38
    package-lock.json (node_modules/ai)
```

Two things worth noting about how it is scoped:

- **The watched set is `@arcjet/guard`'s peer dependencies**, read at runtime rather than hardcoded. Those are precisely the packages whose types cross the boundary, so a new vendor namespace is covered the day its peer is declared instead of whenever someone remembers this file exists.
- **It reads lockfiles, not `node_modules`.** No install is needed, so it runs early in the lint job rather than requiring every example to be installed first.

It catches nested duplication as well as top-level: a package split between a top-level copy and one nested under `ai` is the same hazard, and typechecks by luck until it doesn't.

## `node-guard-policy` was never verified

The example has no `build` script and was absent from the examples matrix, so nothing exercised it. Its `typecheck` would have caught a genuine break in it and simply never ran.

The job already runs `npm run build --if-present` followed by `npm run typecheck`, so adding the folder to the matrix is sufficient.

## Verification

The check was tested against both failure modes observed in practice, not only the passing case — an example pinned a patch behind the root, and a package split between a top-level and a nested copy. Each is caught with the offending paths named, and a consistent tree passes. `node-guard-policy` passes once the workspace is built, which is what the job does.
