### PR TITLE
feat: support explicit client IP sources

### DIFF
--- a/arcjet-astro/src/internal.ts
+++ b/arcjet-astro/src/internal.ts
@@ -196,7 +196,13 @@ export interface ArcjetAstro<Props extends PlainObject> {
    */
   protect(
     request: Request,
-    ...props: MaybeProperties<Props & { metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -252,9 +258,10 @@ export function createArcjetClient<
   function toArcjetRequest<Props extends PlainObject>(
     request: Request,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
-    const clientAddress = Reflect.get(request, ipSymbol);
-    if (!clientAddress) {
+    const clientAddress = ipSrc ? undefined : Reflect.get(request, ipSymbol);
+    if (!ipSrc && !clientAddress) {
       throw new Error("`protect()` cannot be used in prerendered pages");
     }
 
@@ -266,7 +273,9 @@ export function createArcjetClient<
     const url = new URL(request.url);
     const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
-      xArcjetIp || findIp({ ip: clientAddress, headers }, { platform: platform(env), proxies });
+      ipSrc ||
+      xArcjetIp ||
+      findIp({ ip: clientAddress, headers }, { platform: platform(env), proxies });
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
@@ -301,8 +310,9 @@ export function createArcjetClient<
         return withClient(client);
       },
       async protect(request, props?) {
+        const { ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, props || ({} as Properties));
+        const req = toArcjetRequest(request, properties as Properties, ipSrc);
 
         const getBody = async () => {
           const clonedRequest = request.clone();
@@ -327,7 +337,7 @@ export function createArcjetClient<
           return readBodyWeb(clonedRequest.body, { expectedLength });
         };
 
-        return aj.protect({ getBody }, req);
+        return aj.protect({ getBody }, { ...req, metadata });
       },
     };
 

--- a/arcjet-astro/test/ip-src.test.ts
+++ b/arcjet-astro/test/ip-src.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+test("explicit ipSrc permits protect without Astro middleware address", async function () {
+  register(
+    `data:text/javascript,export async function resolve(s,c,n){if(s==='astro:env/server')return {shortCircuit:true,url:'data:text/javascript,export const ARCJET_BASE_URL=undefined,ARCJET_ENV=undefined,ARCJET_KEY=undefined,ARCJET_LOG_LEVEL=undefined,FIREBASE_CONFIG=undefined,FLY_APP_NAME=undefined,RENDER=undefined,VERCEL=undefined'};return n(s,c)};export async function load(u,c,n){const r=await n(u,c);if(u.endsWith('/arcjet-astro/dist/internal.js'))return {...r,shortCircuit:true,source:r.source.toString().replace('import.meta.env.MODE','undefined')};return r}`,
+    import.meta.url,
+  );
+  const { createArcjetClient, ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } =
+    await import("../dist/internal.js");
+  let details: any;
+  const client = createArcjetClient({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+
+  await client.protect(new Request("https://example.com/"), { ipSrc: "203.0.113.10" });
+
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-bun/src/index.ts
+++ b/arcjet-bun/src/index.ts
@@ -177,7 +177,14 @@ export interface ArcjetBun<Props extends PlainObject> {
    */
   protect(
     request: Request,
-    ...properties: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...properties: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -255,6 +262,7 @@ export default function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     request: Request,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     const cookies = request.headers.get("cookie") ?? "";
 
@@ -264,6 +272,7 @@ export default function arcjet<
     const url = new URL(request.url);
     const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -312,9 +321,9 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, (properties || {}) as Properties);
+        const req = toArcjetRequest(request, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           if (request.bodyUsed) {

--- a/arcjet-bun/test/ip-src.test.ts
+++ b/arcjet-bun/test/ip-src.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+
+test("explicit ipSrc takes precedence over the cached Bun address and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+  const request = new Request("https://example.com/");
+  const server = {
+    requestIP(received: Request) {
+      assert.equal(received, request);
+      return { address: "192.0.2.1" };
+    },
+  };
+  const handler = client.handler(async (received) => {
+    await client.protect(received, { ipSrc: " application-owned:not-an-ip " });
+    return new Response();
+  });
+
+  await handler.call(server as any, request, server as any);
+
+  assert.equal(details.ip, " application-owned:not-an-ip ");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-deno/src/index.ts
+++ b/arcjet-deno/src/index.ts
@@ -175,7 +175,14 @@ export interface ArcjetDeno<Props extends PlainObject> {
    */
   protect(
     request: Request,
-    ...props: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -255,6 +262,7 @@ export default function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     request: Request,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     const cookies = request.headers.get("cookie") ?? "";
 
@@ -264,6 +272,7 @@ export default function arcjet<
     const url = new URL(request.url);
     const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -312,9 +321,9 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, (properties || {}) as Properties);
+        const req = toArcjetRequest(request, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           const clonedRequest = request.clone();

--- a/arcjet-deno/test/ip-src.test.ts
+++ b/arcjet-deno/test/ip-src.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+
+test("explicit ipSrc takes precedence over the cached Deno address and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+  const request = new Request("https://example.com/");
+  const handler = client.handler(async (received) => {
+    await client.protect(received, { ipSrc: " application-owned:not-an-ip " });
+    return new Response();
+  });
+
+  await handler(request, {
+    localAddr: { hostname: "127.0.0.1", port: 443, transport: "tcp" },
+    remoteAddr: { hostname: "192.0.2.1", port: 1234, transport: "tcp" },
+  });
+
+  assert.equal(details.ip, " application-owned:not-an-ip ");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-fastify/src/index.ts
+++ b/arcjet-fastify/src/index.ts
@@ -164,7 +164,14 @@ export interface ArcjetFastify<Props> {
    */
   protect(
     request: ArcjetFastifyRequest,
-    ...properties: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...properties: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -248,13 +255,14 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...ruleProps } = properties ?? {};
+        const { correlationId, ipSrc, metadata, ...ruleProps } = properties ?? {};
         const arcjetRequest = toArcjetRequest(
           fastifyRequest,
           log,
           proxies,
           // Cast of `{}` because here we switch from `undefined` to `Properties`.
           ruleProps as Properties,
+          ipSrc,
         );
 
         return arcjetCore.protect({ getBody }, { ...arcjetRequest, correlationId, metadata });
@@ -303,6 +311,7 @@ function toArcjetRequest<Properties extends PlainObject>(
   log: ArcjetLogger,
   proxies: ReadonlyArray<Cidr | string | ProxyService> | undefined,
   properties: Properties,
+  ipSrc?: string,
 ): ArcjetRequest<Properties> {
   const requestHeaders = request.headers || {};
   // Extract cookies from original headers.
@@ -315,6 +324,7 @@ function toArcjetRequest<Properties extends PlainObject>(
 
   const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
   let ip =
+    ipSrc ||
     xArcjetIp ||
     findIp({ headers, socket: request.socket }, { platform: platform(process.env), proxies });
 

--- a/arcjet-fastify/test/ip-src.test.ts
+++ b/arcjet-fastify/test/ip-src.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+
+test("explicit ipSrc bypasses the Fastify socket address and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+  await client.protect(
+    {
+      body: undefined,
+      headers: { host: "example.com" },
+      method: "GET",
+      protocol: "https",
+      server: {},
+      socket: {
+        get remoteAddress(): string {
+          throw new Error("must not read the automatic socket address");
+        },
+      },
+      url: "/",
+    },
+    { ipSrc: " application-owned:not-an-ip " },
+  );
+  assert.equal(details.ip, " application-owned:not-an-ip ");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-nest/src/index.ts
+++ b/arcjet-nest/src/index.ts
@@ -283,7 +283,14 @@ export interface ArcjetNest<Props extends PlainObject = PlainObject> {
    */
   protect(
     request: ArcjetNestRequest,
-    ...props: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -327,6 +334,7 @@ function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     request: ArcjetNestRequest,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     // We pull the cookies from the request before wrapping them in ArcjetHeaders
     const cookies = cookiesToString(request.headers?.cookie);
@@ -336,6 +344,7 @@ function arcjet<
 
     const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -430,9 +439,9 @@ function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, (properties || {}) as Properties);
+        const req = toArcjetRequest(request, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           // Read the stream if the body is not present.

--- a/arcjet-nest/test/ip-src.test.ts
+++ b/arcjet-nest/test/ip-src.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ARCJET,
+  ArcjetModule,
+  ArcjetAllowDecision,
+  ArcjetReason,
+  ArcjetRuleResult,
+} from "../dist/index.js";
+
+test("explicit ipSrc overrides the Nest request address and is stripped", async function () {
+  let details: any;
+  const options = {
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  };
+  const module = ArcjetModule.forRoot(options);
+  const provider: any = module.providers?.find((candidate: any) => candidate.provide === ARCJET);
+  const client = provider.useFactory(options);
+
+  await client.protect(
+    { headers: { host: "example.com" }, ip: "192.0.2.1", method: "GET", url: "/" },
+    { ipSrc: "203.0.113.10" },
+  );
+
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-next/src/index.ts
+++ b/arcjet-next/src/index.ts
@@ -420,7 +420,14 @@ export interface ArcjetNext<Props extends PlainObject> {
    */
   protect(
     request: ArcjetNextRequest,
-    ...props: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -536,12 +543,14 @@ export default function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     request: ArcjetNextRequest,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
     const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -643,9 +652,9 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, (properties || {}) as Properties);
+        const req = toArcjetRequest(request, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           if (typeof request.clone === "function") {

--- a/arcjet-next/test/ip-src.test.ts
+++ b/arcjet-next/test/ip-src.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+
+test("explicit ipSrc overrides Next request address sources and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+
+  await client.protect(
+    {
+      headers: new Headers({ host: "example.com", "x-forwarded-for": "192.0.2.1" }),
+      ip: "192.0.2.2",
+      method: "GET",
+      url: "/",
+    },
+    { ipSrc: "203.0.113.10" },
+  );
+
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-node/src/index.ts
+++ b/arcjet-node/src/index.ts
@@ -289,7 +289,14 @@ export interface ArcjetNode<Props extends PlainObject> {
    */
   protect(
     request: ArcjetNodeRequest,
-    ...props: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -351,6 +358,7 @@ export default function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     request: ArcjetNodeRequest,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     // We pull the cookies from the request before wrapping them in ArcjetHeaders
     const cookies = cookiesToString(request.headers?.cookie);
@@ -360,6 +368,7 @@ export default function arcjet<
 
     const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -433,9 +442,9 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, (properties || {}) as Properties);
+        const req = toArcjetRequest(request, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           // Read the stream if the body is not present.

--- a/arcjet-node/test/index.test.ts
+++ b/arcjet-node/test/index.test.ts
@@ -449,6 +449,59 @@ test("`arcjetNode`", async function (t) {
     ]);
   });
 
+  await t.test("should prefer and strip an explicit `ipSrc`", async function () {
+    const restore = capture();
+    let request: ArcjetRequestDetails | undefined;
+    const arcjet = arcjetNode({
+      client: createLocalClient(),
+      key: exampleKey,
+      rules: [
+        [
+          {
+            mode: "LIVE",
+            priority: 1,
+            async protect(_context, details) {
+              request = details;
+              return new ArcjetRuleResult({
+                conclusion: "ALLOW",
+                fingerprint: "",
+                reason: new ArcjetReason(),
+                ruleId: "",
+                state: "RUN",
+                ttl: 0,
+              });
+            },
+            validate() {},
+            version: 0,
+            type: "",
+          },
+        ],
+      ],
+    });
+    const { server, url } = await createSimpleServer({
+      decide(request) {
+        return arcjet.protect(request, {
+          correlationId: "wf_ip_src",
+          ipSrc: " application-owned:not-an-ip ",
+          metadata: { integration: "custom-ip" },
+        });
+      },
+    });
+
+    await fetch(url, { headers: { "x-forwarded-for": "185.199.108.1" } });
+    assert.equal(request?.ip, " application-owned:not-an-ip ");
+    assert.equal(request?.correlationId, "wf_ip_src");
+    assert.deepEqual(request?.extra, {});
+    assert.deepEqual(request?.metadata, { integration: "custom-ip" });
+
+    await arcjet.protect({ headers: { "x-forwarded-for": "185.199.108.1" } }, { ipSrc: "" });
+    await server.close();
+    restore();
+
+    assert.equal(request?.ip, "185.199.108.1");
+    assert.deepEqual(request?.extra, {});
+  });
+
   await t.test("should prefer `x-arcjet-ip` in development", async function () {
     const restore = capture();
 

--- a/arcjet-nuxt/src/internal.ts
+++ b/arcjet-nuxt/src/internal.ts
@@ -155,7 +155,13 @@ export interface ArcjetNuxt<Properties extends Record<PropertyKey, unknown>> {
    */
   protect(
     event: ArcjetH3Event,
-    ...props: MaybeProperties<Properties & { metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Properties & {
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -295,14 +301,16 @@ export default function arcjet<
         const context: ArcjetAdapterContext = {
           getBody: createGetBody(state, details),
         };
+        const { ipSrc, metadata, ...ruleProps } = properties ?? {};
         const request = toArcjetRequest(
           state,
           details,
           // Cast of `{}` because here we switch from `undefined` to `Properties`.
-          properties ?? ({} as Properties),
+          ruleProps as Properties,
+          ipSrc,
         );
 
-        return baseClient.protect(context, request);
+        return baseClient.protect(context, { ...request, metadata });
       },
       withRule(rule) {
         return withClient(baseClient.withRule(rule));
@@ -394,10 +402,12 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
   state: State,
   event: ArcjetH3Event,
   properties: Properties,
+  ipSrc?: string,
 ): ArcjetRequest<Properties> {
   const headers = new ArcjetHeaders(event.node.req.headers);
   const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
   let ip =
+    ipSrc ||
     xArcjetIp ||
     findIp(event.node.req, {
       platform: platform(process.env),

--- a/arcjet-nuxt/test/ip-src.test.ts
+++ b/arcjet-nuxt/test/ip-src.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/internal.js";
+
+test("explicit ipSrc overrides the H3 request address and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+  const event = {
+    node: {
+      req: {
+        headers: { host: "example.com", "x-forwarded-for": "192.0.2.1" },
+        method: "GET",
+        socket: { remoteAddress: "192.0.2.2" },
+        url: "/",
+      },
+    },
+  };
+
+  await client.protect(event as any, { ipSrc: "203.0.113.10" });
+
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-react-router/src/index.ts
+++ b/arcjet-react-router/src/index.ts
@@ -112,7 +112,14 @@ export interface ArcjetReactRouter<Properties extends Record<PropertyKey, unknow
    */
   protect(
     details: ArcjetReactRouterRequest,
-    ...rest: MaybeProperties<Properties & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...rest: MaybeProperties<
+      Properties & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -222,12 +229,13 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...ruleProps } = properties ?? {};
+        const { correlationId, ipSrc, metadata, ...ruleProps } = properties ?? {};
         const request = toArcjetRequest(
           state,
           details,
           // Cast of `{}` because here we switch from `undefined` to `Properties`.
           ruleProps as Properties,
+          ipSrc,
         );
 
         return baseClient.protect(context, { ...request, correlationId, metadata });
@@ -319,14 +327,16 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
   state: State,
   details: ArcjetReactRouterRequest,
   properties: Properties,
+  ipSrc?: string,
 ): ArcjetRequest<Properties> {
   const headers = new ArcjetHeaders(details.request.headers);
-  let ip: string | undefined;
+  let ip: string | undefined = ipSrc || undefined;
 
   // Get the IP from non-middleware context (no `future.v8_middleware` flag).
   // Users *themselves* must provide this `ip` field if they use a particular
   // adapter.
   if (
+    !ip &&
     details.context &&
     typeof details.context === "object" &&
     "ip" in details.context &&
@@ -337,7 +347,7 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
 
   const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
 
-  if (xArcjetIp) {
+  if (!ip && xArcjetIp) {
     ip = xArcjetIp;
   }
 

--- a/arcjet-react-router/test/ip-src.test.ts
+++ b/arcjet-react-router/test/ip-src.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+
+test("explicit ipSrc overrides React Router context.ip and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+  await client.protect(
+    { context: { ip: "192.0.2.1" }, request: new Request("https://example.com/") },
+    { ipSrc: "203.0.113.10" },
+  );
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-remix/src/index.ts
+++ b/arcjet-remix/src/index.ts
@@ -188,7 +188,14 @@ export interface ArcjetRemix<Props extends PlainObject> {
    */
   protect(
     request: ArcjetRemixRequest,
-    ...props: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -250,6 +257,7 @@ export default function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     { request, context }: ArcjetRemixRequest,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     const cookies = request.headers.get("cookie") ?? "";
 
@@ -259,6 +267,7 @@ export default function arcjet<
     const url = new URL(request.url);
     const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -305,9 +314,9 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(details, (properties || {}) as Properties);
+        const req = toArcjetRequest(details, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           const clonedRequest = details.request.clone();

--- a/arcjet-remix/test/ip-src.test.ts
+++ b/arcjet-remix/test/ip-src.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import arcjet, { ArcjetAllowDecision, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+
+test("explicit ipSrc overrides Remix context.ip and is stripped", async function () {
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+
+  await client.protect(
+    { context: { ip: "192.0.2.1" }, request: new Request("https://example.com/") },
+    { ipSrc: "203.0.113.10" },
+  );
+
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet-sveltekit/src/index.ts
+++ b/arcjet-sveltekit/src/index.ts
@@ -224,7 +224,14 @@ export interface ArcjetSvelteKit<Props extends PlainObject> {
    */
   protect(
     event: ArcjetSvelteKitRequestEvent,
-    ...props: MaybeProperties<Props & { correlationId?: string; metadata?: ArcjetMetadata }>
+    ...props: MaybeProperties<
+      Props & {
+        correlationId?: string;
+        /** Application-provided client IP address, used instead of automatic detection. */
+        ipSrc?: string;
+        metadata?: ArcjetMetadata;
+      }
+    >
   ): Promise<ArcjetDecision>;
 
   /**
@@ -286,6 +293,7 @@ export default function arcjet<
   function toArcjetRequest<Props extends PlainObject>(
     event: ArcjetSvelteKitRequestEvent,
     props: Props,
+    ipSrc?: string,
   ): ArcjetRequest<Props> {
     const cookies = cookiesToString(event.cookies.getAll());
 
@@ -294,6 +302,7 @@ export default function arcjet<
 
     const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
     let ip =
+      ipSrc ||
       xArcjetIp ||
       findIp(
         {
@@ -344,9 +353,9 @@ export default function arcjet<
         // `correlationId` and `metadata` are request-independent options, not rule
         // props, so pull them out before building the request from the rule
         // properties.
-        const { correlationId, metadata, ...properties } = props ?? {};
+        const { correlationId, ipSrc, metadata, ...properties } = props ?? {};
         // Cast of `{}` because here we switch from `undefined` to `Properties`.
-        const req = toArcjetRequest(request, (properties || {}) as Properties);
+        const req = toArcjetRequest(request, (properties || {}) as Properties, ipSrc);
 
         const getBody = async () => {
           const clonedRequest = request.request.clone();

--- a/arcjet-sveltekit/test/ip-src.test.ts
+++ b/arcjet-sveltekit/test/ip-src.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+test("explicit ipSrc bypasses getClientAddress and is stripped", async function () {
+  register(
+    `data:text/javascript,export async function resolve(s,c,n){if(s==='$env/dynamic/private')return {shortCircuit:true,url:'data:text/javascript,export const env={}'};return n(s,c)}`,
+    import.meta.url,
+  );
+  const {
+    default: arcjet,
+    ArcjetAllowDecision,
+    ArcjetReason,
+    ArcjetRuleResult,
+  } = await import("../dist/index.js");
+  let details: any;
+  const client = arcjet({
+    client: {
+      async decide() {
+        return new ArcjetAllowDecision({ reason: new ArcjetReason(), results: [], ttl: 0 });
+      },
+      report() {},
+    },
+    key: "",
+    rules: [
+      [
+        {
+          mode: "LIVE",
+          priority: 0,
+          async protect(_context: any, request: any) {
+            details = request;
+            return new ArcjetRuleResult({
+              conclusion: "ALLOW",
+              fingerprint: "",
+              reason: new ArcjetReason(),
+              ruleId: "",
+              state: "RUN",
+              ttl: 0,
+            });
+          },
+          validate() {},
+          version: 0,
+          type: "",
+        },
+      ],
+    ],
+  });
+  const request = new Request("https://example.com/");
+
+  await client.protect(
+    {
+      cookies: {
+        getAll() {
+          return [];
+        },
+      },
+      getClientAddress() {
+        throw new Error("must not be called");
+      },
+      request,
+      url: new URL(request.url),
+    },
+    { ipSrc: "203.0.113.10" },
+  );
+
+  assert.equal(details.ip, "203.0.113.10");
+  assert.deepEqual(details.extra, {});
+});

--- a/arcjet/README.md
+++ b/arcjet/README.md
@@ -383,6 +383,27 @@ Objects with a `toJSON()` method, including `Date`, are serialized by their
 `toJSON()` result. The Python SDK has no equivalent protocol and drops such values
 with a warning, so convert explicitly if both SDKs must agree on a value.
 
+## Overriding the client IP
+
+All framework adapters accept an application-owned `ipSrc` override:
+
+```ts
+const decision = await aj.protect(request, {
+  ipSrc: "185.191.171.15",
+});
+```
+
+> [!WARNING]
+> `ipSrc` is a dangerous override. Arcjet trusts and forwards the value without
+> validating it. You must verify that it is a valid client IP from a trusted
+> source. Passing a client-controlled header directly can let an attacker evade
+> IP-based security controls and rate limits.
+
+A non-empty `ipSrc` takes precedence over framework, platform, header, socket,
+and development fallback IP detection and is forwarded unchanged. Arcjet does
+not require it to be publicly routable. An empty string is not an override and
+preserves automatic detection.
+
 ## Inspecting decisions
 
 The `decision` object returned by `aj.protect()` provides information about


### PR DESCRIPTION
## Summary

- add an application-owned `ipSrc` override to every JavaScript framework adapter to make it consistent with the Python and Go SDKs.
- preserve automatic IP detection when the override is empty and keep it out of rule properties
- document that callers must validate and trust explicit IP values

ADR: https://github.com/arcjet/arcjet/pull/8770