### PR TITLE
feat(guard): graduate moderateContent from experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+
+### 🚀 New Features
+
+* **guard:** graduate moderateContent from experimental
+
+
 ## [1.10.0](https://github.com/arcjet/arcjet-js/compare/v1.9.1...v1.10.0) (2026-08-11)
 
 

--- a/arcjet-guard/CHANGELOG.md
+++ b/arcjet-guard/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+
+### 🚀 New Features
+
+* **guard:** graduate moderateContent from experimental
+
+
 ## [1.10.0](https://github.com/arcjet/arcjet-js/compare/v1.9.1...@arcjet/guard-v1.10.0) (2026-08-11)
 
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -65,6 +65,7 @@ non-HTTP contexts. Here's what's available where:
 | ------------------------------- | :----------: | :-------------: |
 | Rate Limiting                   |      ✅      |       ✅        |
 | Prompt Injection Detection      |      ✅      |       ✅        |
+| Content Moderation              |      —       |       ✅        |
 | Sensitive Information Detection |      ✅      |       ✅        |
 | Custom Rules                    |      —       |       ✅        |
 | Bot Protection                  |      ✅      |        —        |
@@ -77,6 +78,8 @@ non-HTTP contexts. Here's what's available where:
   window algorithms; model AI token budgets per user.
 - 🛡️ [Prompt Injection Detection](#prompt-injection-detection) — detect and
   block prompt injection attacks before they reach your LLM.
+- 🧹 [Content Moderation](#content-moderation) — detect and block harmful
+  content in user text, tool results, or model outputs.
 - 🕵️ [Sensitive Information Detection](#sensitive-information-detection) —
   block PII, credit cards, and custom patterns from entering your AI pipeline.
 - 🔧 [Custom Rules](#custom-rules) — define your own local evaluation logic
@@ -264,6 +267,34 @@ const result = piRule.result(decision);
 console.log(result?.billing?.unit, result?.billing?.count);
 
 // Forward to your AI model...
+```
+
+## Content moderation
+
+Detect and block harmful content in user-supplied text before it is stored,
+displayed, or forwarded to another service. Also useful for scanning tool
+call results or model outputs.
+
+```ts
+import { launchArcjet, moderateContent } from "@arcjet/guard";
+
+const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+
+const moderate = moderateContent();
+
+const decision = await arcjet.guard({
+  label: "tools.chat",
+  rules: [moderate(userMessage)],
+});
+
+if (decision.conclusion === "DENY" && decision.reason === "MODERATE_CONTENT") {
+  throw new Error("Harmful content detected — please rephrase your message");
+}
+
+const result = moderate.result(decision);
+// `detected` is true when harmful content was found. Billing is undefined
+// when the service does not report usage. Content moderation uses text_units.
+console.log(result?.detected, result?.billing?.unit, result?.billing?.count);
 ```
 
 ## Sensitive information detection

--- a/arcjet-guard/src/bun.test.ts
+++ b/arcjet-guard/src/bun.test.ts
@@ -9,7 +9,6 @@ import {
   slidingWindow,
   detectPromptInjection,
   moderateContent,
-  experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   launchArcjetWithTransport,
@@ -31,10 +30,6 @@ describe("bun entrypoint", () => {
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
     assert.equal(typeof moderateContent, "function");
-    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
-    assert.equal(typeof experimental_moderateContent, "function");
-    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
-    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
   });

--- a/arcjet-guard/src/bun.test.ts
+++ b/arcjet-guard/src/bun.test.ts
@@ -8,6 +8,8 @@ import {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
+  moderateContent,
+  experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   launchArcjetWithTransport,
@@ -28,6 +30,11 @@ describe("bun entrypoint", () => {
     assert.equal(typeof fixedWindow, "function");
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
+    assert.equal(typeof moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
+    assert.equal(typeof experimental_moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
+    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
   });

--- a/arcjet-guard/src/bun.ts
+++ b/arcjet-guard/src/bun.ts
@@ -76,6 +76,7 @@ export {
   type RuleResultFixedWindow,
   type RuleResultSlidingWindow,
   type RuleResultPromptInjection,
+  type RuleResultModerateContent,
   type RuleResultSensitiveInfo,
   type RuleResultCustom,
   type RuleResultNotRun,
@@ -107,6 +108,10 @@ export {
   type SlidingWindowConfig,
   type SlidingWindowInput,
   type DetectPromptInjectionConfig,
+  type ModerateContentConfig,
+  type ModerateContentInput,
+  type ExperimentalModerateContentConfig,
+  type ExperimentalModerateContentInput,
   type LocalDetectSensitiveInfoConfig,
   type SensitiveInfoEntityType,
   type SensitiveInfoBackend,
@@ -121,6 +126,7 @@ export {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
+  moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   policyInput,
@@ -138,6 +144,8 @@ export {
   // Internal
   _launchWithTransportFactory,
 } from "./index.ts";
+// oxlint-disable-next-line typescript/no-deprecated -- public deprecated alias
+export { experimental_moderateContent } from "./index.ts";
 
 import { _launchWithTransportFactory } from "./index.ts";
 import type { LaunchOptions, ArcjetGuard } from "./index.ts";

--- a/arcjet-guard/src/convert.test.ts
+++ b/arcjet-guard/src/convert.test.ts
@@ -37,7 +37,7 @@ import {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
-  experimental_moderateContent,
+  moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
 } from "./rules.ts";
@@ -112,6 +112,10 @@ describe("reasonFromProto", () => {
 
   test("PROMPT_INJECTION maps to 'PROMPT_INJECTION'", () => {
     assert.equal(reasonFromProto(GuardReason.PROMPT_INJECTION), "PROMPT_INJECTION");
+  });
+
+  test("MODERATE_CONTENT maps to 'MODERATE_CONTENT'", () => {
+    assert.equal(reasonFromProto(GuardReason.MODERATE_CONTENT), "MODERATE_CONTENT");
   });
 
   test("SENSITIVE_INFO maps to 'SENSITIVE_INFO'", () => {
@@ -268,6 +272,32 @@ describe("resultFromProto", () => {
     if (result.type === "MODERATE_CONTENT") {
       assert.equal(result.detected, true);
       assert.deepEqual(result.billing, { unit: "text_units", count: 456n });
+      assert.equal("scores" in result, false);
+    }
+  });
+
+  test("moderateContent ALLOW result freezes detected + billing", () => {
+    const pr = create(GuardRuleResultSchema, {
+      resultId: "gres_1",
+      type: GuardRuleType.MODERATE_CONTENT,
+      result: {
+        case: "moderateContent",
+        value: create(ResultModerateContentSchema, {
+          conclusion: GuardConclusion.ALLOW,
+          detected: false,
+          billing: create(BillingSchema, { unit: "text_units", count: 12n }),
+        }),
+      },
+    });
+
+    const result = resultFromProto(pr);
+    assert.equal(result.type, "MODERATE_CONTENT");
+    assert.equal(result.reason, "MODERATE_CONTENT");
+    assert.equal(result.conclusion, "ALLOW");
+    if (result.type === "MODERATE_CONTENT") {
+      assert.equal(result.detected, false);
+      assert.deepEqual(result.billing, { unit: "text_units", count: 12n });
+      assert.equal("scores" in result, false);
     }
   });
 
@@ -559,7 +589,7 @@ describe("ruleToProto", () => {
   });
 
   test("converts moderate content rule to proto", async () => {
-    const rule = experimental_moderateContent();
+    const rule = moderateContent();
     const input = rule("please moderate this");
     const proto = await ruleToProto(input);
 
@@ -570,7 +600,7 @@ describe("ruleToProto", () => {
   });
 
   test("merges moderate content config and call-time metadata into proto", async () => {
-    const rule = experimental_moderateContent({ metadata: { env: "test", expectedResponse: "x" } });
+    const rule = moderateContent({ metadata: { env: "test", expectedResponse: "x" } });
     const input = rule({
       inputText: "please moderate this",
       metadata: { expectedResponse: "pass" },

--- a/arcjet-guard/src/fetch.test.ts
+++ b/arcjet-guard/src/fetch.test.ts
@@ -8,6 +8,7 @@ import {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
+  moderateContent,
   experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
@@ -29,7 +30,11 @@ describe("fetch entrypoint", () => {
     assert.equal(typeof fixedWindow, "function");
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
+    assert.equal(typeof moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
     assert.equal(typeof experimental_moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
+    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
   });

--- a/arcjet-guard/src/fetch.test.ts
+++ b/arcjet-guard/src/fetch.test.ts
@@ -9,7 +9,6 @@ import {
   slidingWindow,
   detectPromptInjection,
   moderateContent,
-  experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   launchArcjetWithTransport,
@@ -31,10 +30,6 @@ describe("fetch entrypoint", () => {
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
     assert.equal(typeof moderateContent, "function");
-    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
-    assert.equal(typeof experimental_moderateContent, "function");
-    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
-    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
   });

--- a/arcjet-guard/src/fetch.ts
+++ b/arcjet-guard/src/fetch.ts
@@ -114,6 +114,8 @@ export {
   type SlidingWindowInput,
   type DetectPromptInjectionConfig,
   type DetectPromptInjectionInput,
+  type ModerateContentConfig,
+  type ModerateContentInput,
   type ExperimentalModerateContentConfig,
   type ExperimentalModerateContentInput,
   type LocalDetectSensitiveInfoConfig,
@@ -131,7 +133,7 @@ export {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
-  experimental_moderateContent,
+  moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   policyInput,
@@ -149,6 +151,8 @@ export {
   // Internal
   _launchWithTransportFactory,
 } from "./index.ts";
+// oxlint-disable-next-line typescript/no-deprecated -- public deprecated alias
+export { experimental_moderateContent } from "./index.ts";
 
 import { _launchWithTransportFactory } from "./index.ts";
 import type { LaunchOptions, ArcjetGuard } from "./index.ts";

--- a/arcjet-guard/src/index.test.ts
+++ b/arcjet-guard/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
+  moderateContent,
   experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
@@ -63,9 +64,37 @@ describe("re-exports", () => {
     assert.equal(typeof fixedWindow, "function");
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
+    assert.equal(typeof moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
     assert.equal(typeof experimental_moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
+    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
+  });
+
+  test("rule factories are exported from every entrypoint", () => {
+    // bun previously omitted experimental_moderateContent; GA must be on all
+    // runtime conditions of the "." export.
+    for (const [specifier, entrypoint] of entrypoints) {
+      for (const name of [
+        "tokenBucket",
+        "fixedWindow",
+        "slidingWindow",
+        "detectPromptInjection",
+        "moderateContent",
+        "experimental_moderateContent",
+        "localDetectSensitiveInfo",
+        "defineCustomRule",
+      ]) {
+        assert.equal(typeof entrypoint[name], "function", `${specifier} must export ${name}`);
+      }
+      assert.equal(
+        entrypoint["experimental_moderateContent"],
+        entrypoint.moderateContent,
+        `${specifier} experimental_moderateContent must alias moderateContent`,
+      );
+    }
   });
 
   test("launchArcjetWithTransport is exported", () => {

--- a/arcjet-guard/src/index.test.ts
+++ b/arcjet-guard/src/index.test.ts
@@ -74,8 +74,8 @@ describe("re-exports", () => {
   });
 
   test("rule factories are exported from every entrypoint", () => {
-    // bun previously omitted experimental_moderateContent; GA must be on all
-    // runtime conditions of the "." export.
+    // Single source of truth for runtime entrypoints (node/bun/fetch).
+    // The index barrel is covered by "rule factories are exported" above.
     for (const [specifier, entrypoint] of entrypoints) {
       for (const name of [
         "tokenBucket",

--- a/arcjet-guard/src/index.ts
+++ b/arcjet-guard/src/index.ts
@@ -82,12 +82,7 @@ import {
   type DiagnosticHandler,
   type DiagnosticLogger,
 } from "./diagnostics.ts";
-import type {
-  CaptureOptions,
-  Decision,
-  GuardOptions,
-  SensitiveInfoBackend,
-} from "./types.ts";
+import type { CaptureOptions, Decision, GuardOptions, SensitiveInfoBackend } from "./types.ts";
 // The type of `LaunchOptions.logger`, so a consumer can name what they have
 // to implement. `ArcjetDiagnostic` is deliberately not exported: it is the
 // internal handler payload and appears in no public signature — the logger
@@ -143,6 +138,8 @@ export type {
   SlidingWindowInput,
   DetectPromptInjectionConfig,
   DetectPromptInjectionInput,
+  ModerateContentConfig,
+  ModerateContentInput,
   ExperimentalModerateContentConfig,
   ExperimentalModerateContentInput,
   LocalDetectSensitiveInfoConfig,
@@ -167,10 +164,12 @@ export {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
-  experimental_moderateContent,
+  moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
 } from "./rules.ts";
+// oxlint-disable-next-line typescript/no-deprecated -- public deprecated alias
+export { experimental_moderateContent } from "./rules.ts";
 
 // Optional registration, and the free calls it enables. Nothing here takes
 // effect until an application calls `registerArcjet()` — `launchArcjet()`

--- a/arcjet-guard/src/node.test.ts
+++ b/arcjet-guard/src/node.test.ts
@@ -8,6 +8,7 @@ import {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
+  moderateContent,
   experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
@@ -29,7 +30,11 @@ describe("node entrypoint", () => {
     assert.equal(typeof fixedWindow, "function");
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
+    assert.equal(typeof moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
     assert.equal(typeof experimental_moderateContent, "function");
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
+    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
   });

--- a/arcjet-guard/src/node.test.ts
+++ b/arcjet-guard/src/node.test.ts
@@ -9,7 +9,6 @@ import {
   slidingWindow,
   detectPromptInjection,
   moderateContent,
-  experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   launchArcjetWithTransport,
@@ -31,10 +30,6 @@ describe("node entrypoint", () => {
     assert.equal(typeof slidingWindow, "function");
     assert.equal(typeof detectPromptInjection, "function");
     assert.equal(typeof moderateContent, "function");
-    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
-    assert.equal(typeof experimental_moderateContent, "function");
-    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
-    assert.equal(experimental_moderateContent, moderateContent);
     assert.equal(typeof localDetectSensitiveInfo, "function");
     assert.equal(typeof defineCustomRule, "function");
   });

--- a/arcjet-guard/src/node.ts
+++ b/arcjet-guard/src/node.ts
@@ -110,6 +110,8 @@ export {
   type SlidingWindowInput,
   type DetectPromptInjectionConfig,
   type DetectPromptInjectionInput,
+  type ModerateContentConfig,
+  type ModerateContentInput,
   type ExperimentalModerateContentConfig,
   type ExperimentalModerateContentInput,
   type LocalDetectSensitiveInfoConfig,
@@ -127,7 +129,7 @@ export {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
-  experimental_moderateContent,
+  moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
   policyInput,
@@ -145,6 +147,8 @@ export {
   // Internal
   _launchWithTransportFactory,
 } from "./index.ts";
+// oxlint-disable-next-line typescript/no-deprecated -- public deprecated alias
+export { experimental_moderateContent } from "./index.ts";
 
 import { _launchWithTransportFactory } from "./index.ts";
 import type { LaunchOptions, ArcjetGuard } from "./index.ts";

--- a/arcjet-guard/src/rules.test.ts
+++ b/arcjet-guard/src/rules.test.ts
@@ -6,6 +6,7 @@ import {
   fixedWindow,
   slidingWindow,
   detectPromptInjection,
+  moderateContent,
   experimental_moderateContent,
   localDetectSensitiveInfo,
   defineCustomRule,
@@ -236,22 +237,22 @@ describe("detectPromptInjection", () => {
   });
 });
 
-describe("experimental_moderateContent", () => {
+describe("moderateContent", () => {
   test("returns a callable with type discriminant", () => {
-    const rule = experimental_moderateContent();
+    const rule = moderateContent();
 
     assert.equal(rule.type, "MODERATE_CONTENT");
     assert.equal(typeof rule, "function");
   });
 
   test("default config is empty", () => {
-    const rule = experimental_moderateContent();
+    const rule = moderateContent();
 
     assert.deepEqual(rule.config, {});
   });
 
   test("normalizes a bare string to the input object", () => {
-    const rule = experimental_moderateContent();
+    const rule = moderateContent();
     const input = rule("some text");
 
     assert.equal(input.type, "MODERATE_CONTENT");
@@ -259,14 +260,14 @@ describe("experimental_moderateContent", () => {
   });
 
   test("preserves mode in config", () => {
-    const rule = experimental_moderateContent({ mode: "DRY_RUN" });
+    const rule = moderateContent({ mode: "DRY_RUN" });
     const input = rule("text");
 
     assert.equal(input.config.mode, "DRY_RUN");
   });
 
   test("attaches call-time metadata to the input", () => {
-    const rule = experimental_moderateContent();
+    const rule = moderateContent();
     const input = rule({
       inputText: "text",
       metadata: { expectedResponse: "pass" },
@@ -276,10 +277,15 @@ describe("experimental_moderateContent", () => {
   });
 
   test("a bare string input carries no metadata", () => {
-    const rule = experimental_moderateContent();
+    const rule = moderateContent();
     const input = rule("text");
 
     assert.equal("metadata" in input.input, false);
+  });
+
+  test("experimental_moderateContent is a deprecated alias of moderateContent", () => {
+    // oxlint-disable-next-line typescript/no-deprecated -- back-compat coverage of the deprecated alias
+    assert.equal(experimental_moderateContent, moderateContent);
   });
 });
 
@@ -772,7 +778,7 @@ describe("errorResult() and the error/non-error split", () => {
       fixedWindow({ maxRequests: 100, windowSeconds: 60 })({ key: "u" }),
       slidingWindow({ maxRequests: 100, intervalSeconds: 60 })({ key: "u" }),
       detectPromptInjection()("text"),
-      experimental_moderateContent()("text"),
+      moderateContent()("text"),
       localDetectSensitiveInfo()("text"),
       defineCustomRule({ evaluate: () => ({ conclusion: "ALLOW" as const }) })({
         data: {},

--- a/arcjet-guard/src/rules.ts
+++ b/arcjet-guard/src/rules.ts
@@ -451,8 +451,9 @@ export function detectPromptInjection(
  * found) and optional `billing`. Transport errors follow the `guard()`
  * fail-open convention.
  *
- * Per-request metadata can be attached at call time and is merged with any
- * config-level metadata (call-time wins on key conflict).
+ * Per-request metadata is attached on the input object
+ * (`{ inputText, metadata }`), not as a second argument, and is merged
+ * with any config-level metadata (call-time wins on key conflict).
  *
  * @example
  * ```ts

--- a/arcjet-guard/src/rules.ts
+++ b/arcjet-guard/src/rules.ts
@@ -32,8 +32,8 @@ import type {
   SlidingWindowInput,
   DetectPromptInjectionConfig,
   DetectPromptInjectionInput,
-  ExperimentalModerateContentConfig,
-  ExperimentalModerateContentInput,
+  ModerateContentConfig,
+  ModerateContentInput,
   LocalDetectSensitiveInfoConfig,
   LocalDetectSensitiveInfoInput,
   SensitiveInfoEntityType,
@@ -436,25 +436,27 @@ export function detectPromptInjection(
 }
 
 /**
- * Create a content moderation rule (experimental).
+ * Create a content moderation rule.
  *
- * Mirrors {@link detectPromptInjection}: returns a configured rule that can be
- * called with user-supplied text to produce a `RuleWithInput` ready for
- * `.guard()`. The text is sent to the Arcjet Cloud API for analysis.
+ * Use this when your application accepts user-supplied text and you want
+ * to block harmful content before it is stored, displayed, or forwarded
+ * to another service. Also useful for scanning tool call results or
+ * model outputs that should not contain disallowed content.
  *
- * **Experimental.** The rule name and result shape may change. This
- * functionality may not be available yet, so while this rule is experimental
- * a call may simply return an error result. Errors are fail open, so the
- * conclusion stays `"ALLOW"` and `decision.hasFailedOpen()` reports `true`
- * (inspect the errored result with `decision.errorResults()`). Check the
- * latest version of this SDK to see whether the rule is now stable.
+ * Returns a configured rule that can be called with user-supplied text
+ * to produce a `RuleWithInput` ready for `.guard()`. The text is sent
+ * to the Arcjet Cloud API for analysis.
+ *
+ * A successful result includes `detected` (whether harmful content was
+ * found) and optional `billing`. Transport errors follow the `guard()`
+ * fail-open convention.
  *
  * Per-request metadata can be attached at call time and is merged with any
  * config-level metadata (call-time wins on key conflict).
  *
  * @example
  * ```ts
- * const moderate = experimental_moderateContent();
+ * const moderate = moderateContent();
  * const decision = await arcjet.guard({
  *   label: "tools.chat",
  *   rules: [moderate(userMessage)],
@@ -464,20 +466,18 @@ export function detectPromptInjection(
  * @example
  * ```ts
  * // Attach per-request metadata for analytics/correlation.
- * const moderate = experimental_moderateContent({ metadata: { variant: "new" } });
+ * const moderate = moderateContent({ metadata: { variant: "new" } });
  * const decision = await arcjet.guard({
  *   label: "tools.chat",
- *   rules: [moderate(userMessage, { metadata: { expectedResponse: "pass" } })],
+ *   rules: [moderate({ inputText: userMessage, metadata: { expectedResponse: "pass" } })],
  * });
  * ```
  */
-export function experimental_moderateContent(
-  config: ExperimentalModerateContentConfig = {},
-): RuleWithConfigModerateContent {
+export function moderateContent(config: ModerateContentConfig = {}): RuleWithConfigModerateContent {
   const configId = randomId();
 
   const rule = Object.assign(
-    (input: string | ExperimentalModerateContentInput): RuleWithInputModerateContent => {
+    (input: string | ModerateContentInput): RuleWithInputModerateContent => {
       const inputId = randomId();
       return {
         type: "MODERATE_CONTENT" as const,
@@ -521,6 +521,13 @@ export function experimental_moderateContent(
 
   return rule;
 }
+
+/**
+ * Create a content moderation rule.
+ *
+ * @deprecated Use {@link moderateContent} instead.
+ */
+export const experimental_moderateContent: typeof moderateContent = moderateContent;
 
 /**
  * Throw if the config lists entity types the configured backend cannot detect.

--- a/arcjet-guard/src/types.ts
+++ b/arcjet-guard/src/types.ts
@@ -294,7 +294,8 @@ export type RuleResultPromptInjection = {
 /**
  * Result from a content moderation evaluation.
  *
- * Experimental — see {@link experimental_moderateContent}.
+ * See {@link moderateContent}. The public result shape is `detected` plus
+ * optional {@link Billing}; per-category scores are not part of this type.
  */
 export type RuleResultModerateContent = {
   /** Whether the request was allowed or denied by this rule. */
@@ -990,9 +991,9 @@ export interface DetectPromptInjectionConfig {
 /**
  * Content moderation config.
  *
- * Experimental — see {@link experimental_moderateContent}.
+ * See {@link moderateContent}.
  */
-export interface ExperimentalModerateContentConfig {
+export interface ModerateContentConfig {
   /**
    * Evaluation mode. `"LIVE"` enforces the rule; `"DRY_RUN"` evaluates
    * without blocking.
@@ -1023,6 +1024,11 @@ export interface ExperimentalModerateContentConfig {
 }
 
 /**
+ * Alias of {@link ModerateContentConfig}.
+ */
+export type ExperimentalModerateContentConfig = ModerateContentConfig;
+
+/**
  * Prompt injection detection input.
  *
  * Bind it by passing the object to the configured rule. A bare string is
@@ -1051,12 +1057,12 @@ export interface DetectPromptInjectionInput {
 }
 
 /**
- * Content moderation input (experimental).
+ * Content moderation input.
  *
  * Bind it by passing the object to the configured rule. A bare string is
  * accepted as shorthand for `{ inputText }`.
  */
-export interface ExperimentalModerateContentInput {
+export interface ModerateContentInput {
   /** The text to moderate. */
   inputText: string;
   /**
@@ -1077,6 +1083,11 @@ export interface ExperimentalModerateContentInput {
    */
   metadata?: ArcjetMetadata;
 }
+
+/**
+ * Alias of {@link ModerateContentInput}.
+ */
+export type ExperimentalModerateContentInput = ModerateContentInput;
 
 /**
  * Sensitive info detection input.
@@ -1489,13 +1500,13 @@ export type RuleWithConfigPromptInjection = {
 /**
  * A configured content moderation rule.
  *
- * Experimental — see {@link experimental_moderateContent}.
+ * See {@link moderateContent}.
  */
 export type RuleWithConfigModerateContent = {
   /** Discriminant — always `"MODERATE_CONTENT"`. */
   readonly type: "MODERATE_CONTENT";
   /** The content moderation configuration for this rule instance. */
-  readonly config: ExperimentalModerateContentConfig;
+  readonly config: ModerateContentConfig;
   /** @internal */
   readonly [symbolArcjetInternal]: { readonly configId: string };
   /**
@@ -1503,7 +1514,7 @@ export type RuleWithConfigModerateContent = {
    * `RuleWithInputModerateContent`. A bare string is shorthand for
    * `{ inputText }`; pass an object to also attach per-request metadata.
    */
-  (input: string | ExperimentalModerateContentInput): RuleWithInputModerateContent;
+  (input: string | ModerateContentInput): RuleWithInputModerateContent;
   /** Extract all content moderation results from a decision. */
   results(decision: Decision): RuleResultModerateContent[];
   /** Return the first content moderation result regardless of conclusion, or `null` if none. */
@@ -1682,15 +1693,15 @@ export type RuleWithInputPromptInjection = {
 /**
  * A content moderation rule with bound input.
  *
- * Experimental — see {@link experimental_moderateContent}.
+ * See {@link moderateContent}.
  */
 export type RuleWithInputModerateContent = {
   /** Discriminant — always `"MODERATE_CONTENT"`. */
   readonly type: "MODERATE_CONTENT";
   /** The content moderation configuration for this rule instance. */
-  readonly config: ExperimentalModerateContentConfig;
+  readonly config: ModerateContentConfig;
   /** The bound content moderation input. */
-  readonly input: ExperimentalModerateContentInput;
+  readonly input: ModerateContentInput;
   /** @internal */
   readonly [symbolArcjetInternal]: { readonly configId: string; readonly inputId: string };
   /** Find this submission's results as an array (empty or single-element). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Graduate `moderateContent` on Guard. `experimental_moderateContent` stays as a deprecated alias.

```ts
const moderate = moderateContent();

const decision = await arcjet.guard({
  label: "llm.output",
  rules: [moderate(text)],
});
```

Result is still `detected` + optional `billing`. Guard-only; callers of the experimental name keep working.

## Test plan

- [ ] Public export is `moderateContent`; alias still works
- [ ] Result shape stays `detected` + `billing`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36d68fce-603c-4b01-a703-592572d0fdad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36d68fce-603c-4b01-a703-592572d0fdad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

