### PR TITLE
feat(guard): add Claude Agent SDK support as @arcjet/guard/claude-agent-sdk/v0

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -108,6 +108,21 @@ jobs:
           node --test 'arcjet-guard/src/vercel-eve/**/*.test.ts'
         working-directory: ${{ github.workspace }}
 
+      # The claude-agent-sdk namespace imports the SDK for types only. A static
+      # scan proves the imports are written `import type`; this proves the
+      # consequence, catching a build step that re-emits one as a value import.
+      #
+      # Runs before the eve-absent step because that one deletes a different
+      # optional peer. Typecheck legitimately fails without the SDK.
+      - name: Unit tests with claude-agent-sdk absent
+        run: |
+          rm -rf node_modules/@anthropic-ai/claude-agent-sdk arcjet-guard/node_modules/@anthropic-ai/claude-agent-sdk
+          node -e "try { require.resolve('@anthropic-ai/claude-agent-sdk', { paths: ['arcjet-guard/src/claude-agent-sdk/v0'] }); console.error('claude-agent-sdk still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
+          count=$(find arcjet-guard/src/claude-agent-sdk -name '*.test.ts' | wc -l)
+          test "$count" -ge 5 || { echo "only $count claude-agent-sdk test files matched; the glob has gone stale" >&2; exit 1; }
+          node --test 'arcjet-guard/src/claude-agent-sdk/**/*.test.ts'
+        working-directory: ${{ github.workspace }}
+
       # The mastra namespace imports @mastra/core for types only. A static scan
       # proves the imports are written `import type`; this proves the
       # consequence, catching a build step that re-emits one as a value import.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,9 @@ change them:
   `mastra/v1` is the same idea on a different SDK: Mastra already runs
   channels through `processInput` and treats `requireApproval` as human HITL,
   so its helpers are `guardTool`, `guardProcessor`, and `guardHooks`.
+  `claude-agent-sdk/v0` is the same idea again: authored tools are `tool()`
+  handlers, inbound is `UserPromptSubmit`, and unwrapped built-ins are
+  `PreToolUse` — `canUseTool` is not a policy gate.
 - **Flat** — a single level under `@arcjet/guard`, no further nesting.
 - **Explicitly versioned, with no unversioned alias.** `@arcjet/guard/vercel-ai`
   does not resolve, and neither does a wildcard `./vercel-ai/*`. An alias would

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -931,6 +931,64 @@ helper. Currently available:
   export default defineHook(arcjetHooks(arcjet));
   ```
 
+- **`@arcjet/guard/claude-agent-sdk/v0`** — Claude Agent SDK v0 integration.
+  Exports `guardTool`, `guardHooks`, and `claudeAgentContext`. There is no
+  `guardInbound` (inbound is `UserPromptSubmit` on `guardHooks`) and no
+  `canUseTool` helper (`canUseTool` is skipped by `allowedTools`, allow
+  rules, and `bypassPermissions` / `acceptEdits`):
+
+  ```ts
+  import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+  import { guardTool, guardHooks } from "@arcjet/guard/claude-agent-sdk/v0";
+  import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+  import { z } from "zod";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const lookupOrder = guardTool(
+    arcjet,
+    tool(
+      "lookup_order",
+      "Look up an order",
+      { orderNumber: z.string() },
+      async ({ orderNumber }) => ({
+        content: [{ type: "text", text: `${orderNumber}: shipped` }],
+      }),
+    ),
+    {
+      action: "order.looked-up",
+      onGuardError: "deny",
+      rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
+    },
+  );
+
+  const sessionId = conversationId;
+
+  for await (const message of query({
+    prompt: userText,
+    options: {
+      sessionId,
+      mcpServers: {
+        app: createSdkMcpServer({ name: "app", tools: [lookupOrder] }),
+      },
+      hooks: guardHooks(arcjet, {
+        sessionId,
+        inbound: {
+          action: "message.received",
+          rules: ({ prompt }) => [detectPromptInjection()(prompt)],
+        },
+      }),
+    },
+  })) {
+    void message;
+  }
+  ```
+
 - **`@arcjet/guard/mastra/v1`** — Mastra v1 integration. Exports `guardTool`,
   `guardProcessor`, `guardHooks`, and `mastraAgentContext`. There is no
   `guardInbound` (channels already hit `processInput`) and no `guardApproval`
@@ -1016,6 +1074,9 @@ importing only core guards are not forced to install unneeded packages:
   Eve, ensure your deployment environment and CI both run Node 24 or later.
 - **`@arcjet/guard/mastra/v1`** requires `@mastra/core` (optional peer,
   installed only to use `@arcjet/guard/mastra/v1`). The peer range is `>=1 <2`.
+- **`@arcjet/guard/claude-agent-sdk/v0`** requires
+  `@anthropic-ai/claude-agent-sdk` (optional peer, installed only to use
+  `@arcjet/guard/claude-agent-sdk/v0`). The peer range is `>=0.1.0 <1`.
 
 **pnpm caveat**: pnpm does not reliably honour
 `peerDependenciesMeta.*.optional` (pnpm#5152, #8142), especially with
@@ -1041,6 +1102,11 @@ pnpm install @mastra/core
 ```
 
 ```sh
+# @arcjet/guard/claude-agent-sdk/v0
+pnpm install @anthropic-ai/claude-agent-sdk
+```
+
+```sh
 # or skip the peer install and relax the check:
 pnpm install --no-strict-peer-dependencies
 ```
@@ -1052,8 +1118,9 @@ are not tied to any AI SDK, and internally they are kept that way — nothing
 they import reaches `ai`. They are published on each vendor namespace, so there
 is one path to learn and no layering to reason about.
 
-`@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`, and
-`@arcjet/guard/mastra/v1` now export these helpers. The open next step is
+`@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`,
+`@arcjet/guard/mastra/v1`, and `@arcjet/guard/claude-agent-sdk/v0` now export
+these helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
 agnostic layer without installing a vendor peer. That change is a follow-up
 with its own ADR; there is still no public `@arcjet/guard/agents`.
@@ -1073,6 +1140,7 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 | `guardTool` / `guardAction`          | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Eve `guardInbound` / `guardApproval` | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Mastra `guardProcessor` / `guardHooks` | Deny (fail closed)                        | `onGuardError: "allow"`            |
+| Claude `guardTool` / `guardHooks`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -1423,9 +1491,11 @@ For an example with Vercel Eve, see [`eve-agent`](https://github.com/arcjet/exam
 
 For an example with Mastra, see [`mastra-agent`](https://github.com/arcjet/examples/tree/main/examples/mastra-agent), which shows inbound prompt-injection screening, guarded tools (deny, PII on args, rate limit, fail-closed), hooks for unwrapped tools, and thread/resource correlation. These Guard examples land with [arcjet/examples#193](https://github.com/arcjet/examples/pull/193).
 
+A Claude Agent SDK demo belongs in [`arcjet/examples`](https://github.com/arcjet/examples) as a follow-up; do not add one under `examples/` in this repository.
+
 ## Agent skill
 
-For integration help in Claude Code or other AI coding agents, three skill files are packaged with `@arcjet/guard`:
+For integration help in Claude Code or other AI coding agents, four skill files are packaged with `@arcjet/guard`:
 
 **For Vercel AI SDK:**
 
@@ -1458,6 +1528,16 @@ ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-mastra ~
 ```
 
 In Claude Code, use `/integrate-arcjet-guard-mastra` to start an integration session.
+
+**For the Claude Agent SDK:**
+
+```bash
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-claude-agent-sdk ~/.claude/skills/
+# or
+ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-claude-agent-sdk ~/.claude/skills/
+```
+
+In Claude Code, use `/integrate-arcjet-guard-claude-agent-sdk` to start an integration session.
 
 Each skill guides you through wrapping tools, screening inbound messages, and recording lifecycle events joined by correlation ID.
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1491,8 +1491,6 @@ For an example with Vercel Eve, see [`eve-agent`](https://github.com/arcjet/exam
 
 For an example with Mastra, see [`mastra-agent`](https://github.com/arcjet/examples/tree/main/examples/mastra-agent), which shows inbound prompt-injection screening, guarded tools (deny, PII on args, rate limit, fail-closed), hooks for unwrapped tools, and thread/resource correlation. These Guard examples land with [arcjet/examples#193](https://github.com/arcjet/examples/pull/193).
 
-A Claude Agent SDK demo belongs in [`arcjet/examples`](https://github.com/arcjet/examples) as a follow-up; do not add one under `examples/` in this repository.
-
 ## Agent skill
 
 For integration help in Claude Code or other AI coding agents, four skill files are packaged with `@arcjet/guard`:

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -79,6 +79,10 @@
     "./mastra/v1": {
       "types": "./dist/mastra/v1/index.d.ts",
       "import": "./dist/mastra/v1/index.js"
+    },
+    "./claude-agent-sdk/v0": {
+      "types": "./dist/claude-agent-sdk/v0/index.d.ts",
+      "import": "./dist/claude-agent-sdk/v0/index.js"
     }
   },
   "publishConfig": {
@@ -108,6 +112,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider-utils": "5.0.13",
+    "@anthropic-ai/claude-agent-sdk": "0.3.221",
     "@mastra/core": "1.58.0",
     "@types/node": "22.20.1",
     "ai": "7.0.38",
@@ -119,6 +124,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/provider-utils": ">=5 <6",
+    "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
     "@mastra/core": ">=1 <2",
     "ai": ">=7 <8",
     "eve": ">=0.25.1 <1"
@@ -134,6 +140,9 @@
       "optional": true
     },
     "@mastra/core": {
+      "optional": true
+    },
+    "@anthropic-ai/claude-agent-sdk": {
       "optional": true
     }
   },

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: integrate-arcjet-guard-claude-agent-sdk
+description: Integrate Arcjet security into a Claude Agent SDK agent using @arcjet/guard — wrap tool() handlers, screen inbound prompts with UserPromptSubmit, and deny unwrapped built-in/MCP tools with PreToolUse. Use when asked to add Arcjet to a Claude Agent SDK or Claude Code agent, rate limit its tools, screen inbound messages, or block prompt injection / PII.
+license: Apache-2.0
+compatibility: Requires the target app to use the Claude Agent SDK (@anthropic-ai/claude-agent-sdk >=0.1.0 <1) on Node.js >= 22.
+metadata:
+  author: arcjet
+---
+
+# Integrate Arcjet Guard into a Claude Agent SDK agent
+
+`@arcjet/guard`'s Claude Agent SDK v0 namespace wraps the agent's existing
+Arcjet client. It never talks to the Arcjet API itself. Three surfaces, one
+decision rule:
+
+- **An authored tool** (`tool()` + `createSdkMcpServer()`) → `guardTool()`.
+  DENY is a `CallToolResult` with `isError: true`. Do not throw.
+- **Inbound text** → `guardHooks()` `UserPromptSubmit`. DENY is
+  `{ decision: "block" }`. Timeout already fail-closes the prompt
+  (Claude Code v2.1.208+).
+- **Built-ins / unwrapped MCP** → `guardHooks()` `PreToolUse` with
+  `permissionDecision: "deny"`. Timeout already fail-closes (the tool does
+  not run). `PostToolUse` is capture only.
+- **Correlation** → `claudeAgentContext()` reads `session_id` from hook
+  input or `options.sessionId`. Subagents have `agent_id` (metadata only).
+  It never mints a new id.
+
+## Screen inbound with UserPromptSubmit
+
+This is the only place a turn can be declined before the model sees the
+prompt. There is no `guardInbound`. Put `detectPromptInjection` on
+`guardHooks({ inbound })`. A DENY returns `{ decision: "block", reason }`
+and Claude Code erases the prompt.
+
+## canUseTool is not a policy gate
+
+Claude's docs say `canUseTool` is skipped by `allowedTools`, allow rules,
+and `bypassPermissions` / `acceptEdits`. Same trap as Eve approval and
+Mastra `requireApproval`. There is no `guardCanUseTool`. Do not put Arcjet
+policy on `canUseTool`.
+
+## PreToolUse is the only deny for unwrapped tools
+
+Built-ins (Bash, Write, …) and MCP tools you did not pass through
+`guardTool` are gated here. Annotations (`readOnlyHint`, …) and sandbox
+settings are not enforcement. `PostToolUse` cannot undo a tool that already
+ran.
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those get `guardTool`. Built-ins and unwrapped
+   MCP get `guardHooks` PreToolUse.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. Session id is the
+   correlation id, not the user.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound
+   `UserPromptSubmit`: failing closed there means the agent stops answering
+   for the duration of the outage, so `"allow"` is a routine and legitimate
+   choice at that one call site.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection on
+   `guardHooks({ inbound })` via `UserPromptSubmit`.
+2. **`canUseTool` is not a policy gate.** It is skipped by `allowedTools`,
+   allow rules, and `bypassPermissions` / `acceptEdits`. Use `guardTool` or
+   `PreToolUse`.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/claude-agent-sdk/v0`. `@arcjet/guard/claude-agent-sdk`
+   does not resolve.
+4. **Correlation is read, never minted.** Do not call `createAgentContext`
+   inside a Claude callback — that generates a second id and splits the
+   Sequence. `claudeAgentContext` reads `session_id` / `options.sessionId`
+   and omits `correlationId` when neither is a valid id. Subagent
+   `agent_id` is metadata, not the correlation id.
+5. **Do not double-wrap with `@arcjet/guard/vercel-ai/v7` or
+   `@arcjet/guard/agents`.** Claude tools are `tool()`, not AI SDK
+   `tool()`. `guardTool` throws if the tool already carries the Arcjet
+   protection brand. Applying `guardTool` and `guardHooks` PreToolUse to
+   the same authored tool double-calls the guard.
+6. **A denial from `guardTool` is a `CallToolResult` with `isError: true`**,
+   not a throw. If `onDeny` throws, the handler still does not run and the
+   model still receives the default denial result.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `@anthropic-ai/claude-agent-sdk`
+(optional peer, needed for `@arcjet/guard/claude-agent-sdk/v0`). Always
+use the versioned path: `@arcjet/guard/claude-agent-sdk/v0` resolves;
+`@arcjet/guard/claude-agent-sdk` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+
+```sh
+npm install @arcjet/guard @anthropic-ai/claude-agent-sdk
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate authored tools
+
+```ts
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { guardTool } from "@arcjet/guard/claude-agent-sdk/v0";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  bucket: "lookups",
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+const detectPii = localDetectSensitiveInfo();
+
+export const lookupOrder = guardTool(
+  arcjet,
+  tool(
+    "lookup_order",
+    "Look up an order by ID",
+    {
+      orderId: z.string(),
+      note: z.string(),
+    },
+    async ({ orderId, note }) => ({
+      content: [{ type: "text", text: `${orderId}: shipped (${note})` }],
+    }),
+  ),
+  {
+    action: "order.looked-up",
+    rules: (input) => [lookupLimit({ key: input.orderId, requested: 1 }), detectPii(input.note)],
+  },
+);
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the tool's handler never runs. The model receives
+  `{ content, structuredContent: { arcjetDenied, reason, message, retryable }, isError: true }`.
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+- Pass the same `sessionId` you give `query({ options.sessionId })` on the
+  policy when the handler `extra` does not carry `session_id`.
+
+## Step 3: Screen inbound with UserPromptSubmit
+
+```ts
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { guardHooks } from "@arcjet/guard/claude-agent-sdk/v0";
+import { detectPromptInjection } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const sessionId = conversationId;
+
+for await (const message of query({
+  prompt: userText,
+  options: {
+    sessionId,
+    hooks: guardHooks(arcjet, {
+      sessionId,
+      inbound: {
+        action: "message.received",
+        rules: ({ prompt }) => [detectPromptInjection()(prompt)],
+      },
+    }),
+  },
+})) {
+  void message;
+}
+```
+
+- On DENY, `UserPromptSubmit` returns `{ decision: "block", reason }` and
+  the prompt is erased. The model never sees it.
+- Default `onGuardError: "deny"` — if the guard cannot be evaluated, the
+  prompt is blocked. Use `"allow"` on `inbound` when the human cost of
+  rejecting a legitimate message exceeds the security cost of an outage.
+
+## Step 4: Gate tools you did not wrap
+
+```ts
+import { guardHooks } from "@arcjet/guard/claude-agent-sdk/v0";
+import { detectPromptInjection, tokenBucket } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const mcpLimit = tokenBucket({
+  bucket: "mcp-access",
+  refillRate: 20,
+  intervalSeconds: 60,
+  maxTokens: 20,
+});
+
+export const hooks = guardHooks(arcjet, {
+  sessionId: conversationId,
+  action: ({ toolName }) => `${toolName}.invoked`,
+  rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+  inbound: {
+    action: "message.received",
+    rules: ({ prompt }) => [detectPromptInjection()(prompt)],
+  },
+});
+```
+
+Pass `hooks` to `query({ options.hooks })`. `PreToolUse` returns
+`permissionDecision: "deny"` so Bash / Write / unwrapped MCP never
+execute. `PostToolUse` is observe-only.
+
+Use this for tools you did **not** pass through `guardTool`. Applying both
+to the same authored tool double-calls the guard.
+
+## Step 5: Correlation
+
+Set `options.sessionId` on `query()` to a conversation identity you already
+have. `claudeAgentContext` reads hook `session_id` first, then
+`options.sessionId`. It never calls `createAgentContext`.
+
+```ts
+const sessionId = conversationId;
+
+for await (const message of query({
+  prompt: userText,
+  options: { sessionId, hooks: guardHooks(arcjet, { sessionId }) },
+})) {
+  void message;
+}
+```
+
+If neither is a valid 1–256 printable-ASCII string, the call is
+uncorrelated rather than joined to a generated id nobody has. Subagent
+`agent_id` is recorded as `claude.agent` metadata only.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI, a tool deny, PII on args, a rate limit, a built-in
+   deny (Bash / Write), and fail-closed (an unreachable guard).
+3. Confirm in the Arcjet dashboard that decisions share the session id as
+   their correlation id.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo belongs in
+[`arcjet/examples`](https://github.com/arcjet/examples)
+(follow-up; do not add an example under `examples/` in the JS SDK repo).
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
@@ -35,9 +35,8 @@ and Claude Code erases the prompt.
 ## canUseTool is not a policy gate
 
 Claude's docs say `canUseTool` is skipped by `allowedTools`, allow rules,
-and `bypassPermissions` / `acceptEdits`. Same trap as Eve approval and
-Mastra `requireApproval`. There is no `guardCanUseTool`. Do not put Arcjet
-policy on `canUseTool`.
+and `bypassPermissions` / `acceptEdits`. There is no `guardCanUseTool`.
+Do not put Arcjet policy on `canUseTool`.
 
 ## PreToolUse is the only deny for unwrapped tools
 

--- a/arcjet-guard/src/agents/index.test.ts
+++ b/arcjet-guard/src/agents/index.test.ts
@@ -99,7 +99,9 @@ function walkForForbiddenImports(
       spec === "eve" ||
       spec.startsWith("eve/") ||
       spec === "@mastra/core" ||
-      spec.startsWith("@mastra/core/")
+      spec.startsWith("@mastra/core/") ||
+      spec === "@anthropic-ai/claude-agent-sdk" ||
+      spec.startsWith("@anthropic-ai/claude-agent-sdk/")
     ) {
       errors.push(`File ${absolutePath} imports forbidden package: "${spec}"`);
     }

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -6,7 +6,8 @@
  *
  * @internal This barrel has no export map entry. Every symbol below reaches
  * users re-exported from a vendor namespace — `@arcjet/guard/vercel-ai/v7`,
- * `@arcjet/guard/vercel-eve/v0`, and `@arcjet/guard/mastra/v1`. The layer
+ * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`, and
+ * `@arcjet/guard/claude-agent-sdk/v0`. The layer
  * stays agnostic so multiple vendor namespaces can share the same code. A
  * public `@arcjet/guard/agents` path is still a follow-up with its own ADR.
  */

--- a/arcjet-guard/src/claude-agent-sdk/v0/assignability.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/assignability.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Compile-time assignability: Claude helpers fit the slots they document.
+ *
+ * Uses typed `const` declarations rather than casts — a cast would make the
+ * test pass regardless.
+ */
+import { test } from "node:test";
+
+import type { Options, SdkMcpToolDefinition } from "@anthropic-ai/claude-agent-sdk";
+
+import { decisionAllow, stubClient } from "../../../test/_shared/stub-client.ts";
+import { guardTool } from "./guard-tool.ts";
+import { guardHooks } from "./hooks.ts";
+
+test("helpers are assignable to Claude Agent SDK tool / hooks slots", () => {
+  const { client } = stubClient(decisionAllow());
+
+  const hooks: NonNullable<Options["hooks"]> = guardHooks(client, { action: "tool.invoked" });
+
+  const tool: SdkMcpToolDefinition = {
+    name: "assignability-tool",
+    description: "assignability",
+    inputSchema: {},
+    handler: (input: Record<string, unknown>) => {
+      const id = input["id"];
+      const text = typeof id === "string" ? id : "";
+      return Promise.resolve({
+        content: [{ type: "text", text }],
+      });
+    },
+  };
+  const wrapped: SdkMcpToolDefinition = guardTool(client, tool, {
+    action: "thing.read",
+  });
+
+  void [hooks, wrapped];
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/context.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/context.test.ts
@@ -1,0 +1,187 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { claudeAgentContext } from "./context.ts";
+
+test("prefers hook session_id over sessionId and options.sessionId", () => {
+  const result = claudeAgentContext(
+    { session_id: "hook-session", sessionId: "source-session", agent_id: "agent-1" },
+    { sessionId: "options-session" },
+  );
+
+  assert.equal(result.correlationId, "hook-session");
+  assert.equal(result.metadata?.["claude.session"], "hook-session");
+  assert.equal(result.metadata?.["claude.agent"], "agent-1");
+});
+
+test("falls back to source sessionId when session_id is absent", () => {
+  const result = claudeAgentContext({ sessionId: "options-shaped" });
+
+  assert.equal(result.correlationId, "options-shaped");
+  assert.equal(result.metadata?.["claude.session"], "options-shaped");
+});
+
+test("falls back to init.sessionId (options.sessionId) when the source has none", () => {
+  const result = claudeAgentContext({}, { sessionId: "query-session" });
+
+  assert.equal(result.correlationId, "query-session");
+  assert.equal(result.metadata?.["claude.session"], "query-session");
+});
+
+test("agent_id is metadata only and is never used as correlationId", () => {
+  const result = claudeAgentContext({ agent_id: "subagent-9", agent_type: "explore" });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+  assert.equal(result.metadata?.["claude.agent"], "subagent-9");
+  assert.equal(result.metadata?.["claude.agent-type"], "explore");
+});
+
+test("never mints an id when nothing valid is present", () => {
+  const result = claudeAgentContext({});
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+});
+
+test("never mints an id when the only candidate is invalid", () => {
+  const result = claudeAgentContext({ session_id: "" });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("claude.session" in (result.metadata ?? {}), false);
+});
+
+test("skips an invalid session_id and uses options.sessionId instead of minting", () => {
+  const result = claudeAgentContext({ session_id: "" }, { sessionId: "fallback-ok" });
+
+  assert.equal(result.correlationId, "fallback-ok");
+});
+
+test("rejects a session id over 256 characters and does not mint", () => {
+  const longId = "x".repeat(257);
+  const result = claudeAgentContext({ session_id: longId });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["claude.session"], longId);
+});
+
+test("caller metadata overrides derived keys", () => {
+  const result = claudeAgentContext(
+    { session_id: "session-1" },
+    {
+      metadata: { "claude.session": "override" },
+    },
+  );
+
+  assert.equal(result.metadata?.["claude.session"], "override");
+});
+
+test("derived metadata keys match /^[A-Za-z0-9._-]+$/", () => {
+  const result = claudeAgentContext({
+    session_id: "session-1",
+    agent_id: "agent-1",
+    agent_type: "explore",
+  });
+
+  assert.ok(result.metadata);
+  const validKeyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const key of Object.keys(result.metadata)) {
+    assert.ok(
+      validKeyPattern.test(key),
+      `derived key "${key}" must match the metadata character class`,
+    );
+  }
+});
+
+test("encoder round-trip produces no AJ1017 warnings", () => {
+  const result = claudeAgentContext({
+    session_id: "session-1",
+    agent_id: "agent-1",
+    agent_type: "explore",
+  });
+
+  assert.ok(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
+  assert.ok(metadataJson["claude.session"]);
+  assert.ok(metadataJson["claude.agent"]);
+  assert.ok(metadataJson["claude.agent-type"]);
+});
+
+test("undefined source does not throw and does not mint", () => {
+  const result = claudeAgentContext();
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("null and primitive sources do not mint", () => {
+  assert.equal("correlationId" in claudeAgentContext(null as never), false);
+  assert.equal("correlationId" in claudeAgentContext("session" as never), false);
+  assert.equal("correlationId" in claudeAgentContext(12 as never), false);
+});
+
+test("non-string candidates are skipped", () => {
+  const result = claudeAgentContext({ session_id: 99, sessionId: { id: "nope" } });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("non-printable session id is rejected and does not mint", () => {
+  const result = claudeAgentContext({ session_id: "bad\nid" });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["claude.session"], "bad\nid");
+});
+
+test("empty agent_id is not copied onto metadata", () => {
+  const result = claudeAgentContext({ session_id: "session-1", agent_id: "" });
+  assert.equal(result.correlationId, "session-1");
+  assert.equal("claude.agent" in (result.metadata ?? {}), false);
+});
+
+test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "info";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    claudeAgentContext({ session_id: "" });
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /rejected/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("does not warn when a later candidate is valid", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const result = claudeAgentContext({ session_id: "" }, { sessionId: "fallback-ok" });
+    assert.equal(result.correlationId, "fallback-ok");
+    assert.equal(warnings.length, 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/context.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/context.ts
@@ -1,0 +1,128 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `claudeAgentContext` can read. Accepts a Claude Agent SDK
+ * hook input (`session_id`, optional `agent_id`) or an options-shaped object
+ * (`sessionId`).
+ */
+export interface ClaudeContextSource {
+  session_id?: unknown;
+  sessionId?: unknown;
+  agent_id?: unknown;
+  agent_type?: unknown;
+}
+
+/**
+ * Context derived from a Claude Agent SDK session. `correlationId` is omitted
+ * when neither hook `session_id` nor `options.sessionId` is a valid id — this
+ * helper never mints one.
+ */
+export interface ClaudeAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asContextSource(source: unknown): ClaudeContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function firstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Derive correlation and metadata from a Claude Agent SDK hook input or
+ * `query({ options.sessionId })`. Never mints a new id.
+ *
+ * Preference order for `correlationId`:
+ * 1. Hook input `session_id`
+ * 2. Source `sessionId` (options-shaped objects)
+ * 3. `init.sessionId` (`options.sessionId` passed explicitly)
+ *
+ * Subagent `agent_id` is metadata only. An invalid candidate is skipped (and
+ * warned when `ARCJET_LOG_LEVEL` asks for warnings). If nothing valid remains,
+ * `correlationId` is omitted so the decision is uncorrelated rather than
+ * joined to a generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { claudeAgentContext } from "@arcjet/guard/claude-agent-sdk/v0";
+ *
+ * export function fromHook(input: { session_id: string; agent_id?: string }) {
+ *   return claudeAgentContext(input);
+ * }
+ * ```
+ */
+export function claudeAgentContext(
+  source?: ClaudeContextSource,
+  init?: { sessionId?: string; metadata?: ArcjetMetadata },
+): ClaudeAgentContext {
+  const ctx = asContextSource(source);
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: ctx?.session_id, label: "session_id" },
+    { value: ctx?.sessionId, label: "sessionId" },
+    { value: init?.sessionId, label: "options.sessionId" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: Claude ${rejected} rejected; no valid session id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const session = firstString([ctx?.session_id, ctx?.sessionId, init?.sessionId]);
+  if (session !== undefined) {
+    derivedMetadata["claude.session"] = session;
+  }
+
+  if (typeof ctx?.agent_id === "string" && ctx.agent_id.length > 0) {
+    derivedMetadata["claude.agent"] = ctx.agent_id;
+  }
+
+  if (typeof ctx?.agent_type === "string" && ctx.agent_type.length > 0) {
+    derivedMetadata["claude.agent-type"] = ctx.agent_type;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: ClaudeAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/claude-agent-sdk/v0/denial.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/denial.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  decisionDenyError,
+  decisionDenyPromptInjection,
+  decisionDenyPromptInjectionWithReset,
+  decisionDenyRateLimit,
+  decisionDenyRateLimitNoReset,
+} from "../../../test/_shared/stub-client.ts";
+import {
+  asCallToolResult,
+  denialCallToolResult,
+  denialResult,
+  deniedReason,
+  unavailableCallToolResult,
+  unavailableReason,
+  unavailableResult,
+  UNAVAILABLE_RETRY_AFTER_SECONDS,
+} from "./denial.ts";
+
+describe("claude-agent-sdk/v0/denial", () => {
+  test("rate-limit denial is retryable and may carry retry-after", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 30;
+    const decision = decisionDenyRateLimit(resetAt);
+    const result = denialResult(decision);
+
+    assert.equal(result.arcjetDenied, true);
+    assert.equal(result.reason, "RATE_LIMIT");
+    assert.equal(result.retryable, true);
+    assert.ok(typeof result.retryAfterSeconds === "number");
+    assert.match(deniedReason(decision), /RATE_LIMIT/);
+  });
+
+  test("prompt-injection denial is not retryable", () => {
+    const decision = decisionDenyPromptInjection();
+    const result = denialResult(decision);
+
+    assert.equal(result.retryable, false);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(result.message, /Do not retry/);
+  });
+
+  test("unavailable result is retryable with a fixed backoff", () => {
+    const result = unavailableResult();
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, true);
+    assert.equal(result.retryAfterSeconds, UNAVAILABLE_RETRY_AFTER_SECONDS);
+    assert.equal(result.message, unavailableReason());
+  });
+
+  test("RATE_LIMIT without reset is retryable without retryAfterSeconds", () => {
+    const decision = decisionDenyRateLimitNoReset();
+    const result = denialResult(decision);
+    assert.equal(result.retryable, true);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(deniedReason(decision), /retried later/);
+  });
+
+  test("non-rate-limit denial ignores a co-occurring reset time", () => {
+    const decision = decisionDenyPromptInjectionWithReset(Math.floor(Date.now() / 1000) + 30);
+    const result = denialResult(decision);
+    assert.equal(result.retryable, false);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(deniedReason(decision), /Do not retry/);
+  });
+
+  test("ERROR denial is not treated as unavailable", () => {
+    const decision = decisionDenyError();
+    const result = denialResult(decision);
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, false);
+    assert.match(deniedReason(decision), /Do not retry/);
+  });
+
+  test("denial CallToolResult is isError: true with structured content", () => {
+    const decision = decisionDenyPromptInjection();
+    const result = denialCallToolResult(decision);
+
+    assert.equal(result.isError, true);
+    assert.equal(result.content[0]?.type, "text");
+    assert.match(String(result.content[0]?.text), /PROMPT_INJECTION/);
+    assert.equal(result.structuredContent?.["arcjetDenied"], true);
+    assert.equal(result.structuredContent?.["reason"], "PROMPT_INJECTION");
+  });
+
+  test("unavailable CallToolResult is isError: true", () => {
+    const result = unavailableCallToolResult();
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent?.["reason"], "ERROR");
+  });
+
+  test("asCallToolResult keeps a CallToolResult-shaped value", () => {
+    const custom = { content: [{ type: "text" as const, text: "blocked" }], isError: true };
+    const result = asCallToolResult(custom, unavailableCallToolResult());
+    assert.strictEqual(result, custom);
+  });
+
+  test("asCallToolResult wraps a plain object as structuredContent", () => {
+    const fallback = unavailableCallToolResult();
+    const result = asCallToolResult({ blocked: true }, fallback);
+    assert.equal(result.isError, true);
+    assert.deepEqual(result.structuredContent, { blocked: true });
+    assert.deepEqual(result.content, fallback.content);
+  });
+
+  test("asCallToolResult uses the fallback for non-objects", () => {
+    const fallback = unavailableCallToolResult();
+    assert.strictEqual(asCallToolResult("nope", fallback), fallback);
+    assert.strictEqual(asCallToolResult(undefined, fallback), fallback);
+  });
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/denial.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/denial.ts
@@ -1,0 +1,171 @@
+import { retryAfterSeconds } from "../../agents/denial.ts";
+import type { DecisionDeny } from "../../types.ts";
+
+/**
+ * Structured denial payload returned to the model (as `structuredContent` on
+ * a `CallToolResult`, or as the PreToolUse / UserPromptSubmit reason).
+ *
+ * Intentionally structurally identical to `vercel-ai/v7`'s ArcjetDenialResult
+ * so the model trained on denial objects sees the same shape regardless of
+ * which integration is in use. Both declarations exist to avoid putting the
+ * `ai` SDK in this namespace's import graph.
+ */
+export interface ArcjetDenialResult {
+  arcjetDenied: true;
+  /** Denial reason, e.g. `"RATE_LIMIT"` or `"PROMPT_INJECTION"`. */
+  reason: string;
+  /** Human/model-readable explanation of the denial. */
+  message: string;
+  /** Whether retrying later can succeed (true for rate limits). */
+  retryable: boolean;
+  /** Seconds until a rate-limited call may be retried. */
+  retryAfterSeconds?: number;
+}
+
+/**
+ * MCP `CallToolResult` shape the Claude Agent SDK's `tool()` handler must
+ * return. Declared structurally so this module never value-imports the SDK
+ * (or `@modelcontextprotocol/sdk`, which does not re-export `CallToolResult`
+ * from `@anthropic-ai/claude-agent-sdk`).
+ */
+export interface ClaudeCallToolResult {
+  content: Array<{
+    type: "text" | "image" | "audio" | "resource" | "resource_link";
+    text?: string;
+    [key: string]: unknown;
+  }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+/** Model- and user-readable explanation of a denial. */
+export function deniedReason(decision: DecisionDeny): string {
+  const isRateLimit = decision.reason === "RATE_LIMIT";
+  let message: string;
+
+  if (isRateLimit) {
+    const retryAfter = retryAfterSeconds(decision);
+    message =
+      `Arcjet denied this call (${decision.reason}). It may be retried` +
+      (retryAfter === undefined ? " later." : ` after ${retryAfter} seconds.`);
+  } else {
+    message = `Arcjet denied this call (${decision.reason}). Do not retry; explain the denial to the user or try a different approach.`;
+  }
+
+  return message;
+}
+
+/** Explanation used when the policy could not be evaluated. */
+export function unavailableReason(): string {
+  return "Arcjet security check could not be completed; please retry later.";
+}
+
+/**
+ * Backoff hint returned to the model when the guard is unavailable.
+ *
+ * A rate-limit denial derives its hint from the denying rule's
+ * `resetAtUnixSeconds`. This path has nothing to derive from. Five seconds
+ * paces a model's retry loop.
+ */
+export const UNAVAILABLE_RETRY_AFTER_SECONDS: number = 5;
+
+export function denialResult(decision: DecisionDeny): ArcjetDenialResult {
+  const isRateLimit = decision.reason === "RATE_LIMIT";
+  let retryAfterSecs: number | undefined;
+
+  if (isRateLimit) {
+    retryAfterSecs = retryAfterSeconds(decision);
+  }
+
+  const result: ArcjetDenialResult = {
+    arcjetDenied: true,
+    reason: decision.reason,
+    message: deniedReason(decision),
+    retryable: isRateLimit,
+  };
+
+  if (isRateLimit && retryAfterSecs !== undefined) {
+    result.retryAfterSeconds = retryAfterSecs;
+  }
+
+  return result;
+}
+
+export function unavailableResult(): ArcjetDenialResult {
+  return {
+    arcjetDenied: true,
+    reason: "ERROR",
+    message: unavailableReason(),
+    retryable: true,
+    retryAfterSeconds: UNAVAILABLE_RETRY_AFTER_SECONDS,
+  };
+}
+
+function asStructuredContent(value: ArcjetDenialResult): Record<string, unknown> {
+  const content: Record<string, unknown> = {
+    arcjetDenied: value.arcjetDenied,
+    reason: value.reason,
+    message: value.message,
+    retryable: value.retryable,
+  };
+  if (value.retryAfterSeconds !== undefined) {
+    content["retryAfterSeconds"] = value.retryAfterSeconds;
+  }
+  return content;
+}
+
+/**
+ * DENY as a `CallToolResult` with `isError: true`. Prefer this over throwing:
+ * Claude reads the composed message instead of a raw exception.
+ */
+export function denialCallToolResult(decision: DecisionDeny): ClaudeCallToolResult {
+  const result = denialResult(decision);
+  return {
+    content: [{ type: "text", text: result.message }],
+    structuredContent: asStructuredContent(result),
+    isError: true,
+  };
+}
+
+export function unavailableCallToolResult(): ClaudeCallToolResult {
+  const result = unavailableResult();
+  return {
+    content: [{ type: "text", text: result.message }],
+    structuredContent: asStructuredContent(result),
+    isError: true,
+  };
+}
+
+function isCallToolResult(value: unknown): value is ClaudeCallToolResult {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- structural CallToolResult check
+  return Array.isArray((value as { content?: unknown }).content);
+}
+
+/**
+ * Coerce an `onDeny` return value into a `CallToolResult`. A value that
+ * already has a `content` array is used as-is; any other object becomes
+ * `structuredContent` on an `isError: true` result.
+ */
+export function asCallToolResult(
+  value: unknown,
+  fallback: ClaudeCallToolResult,
+): ClaudeCallToolResult {
+  if (isCallToolResult(value)) {
+    return value;
+  }
+  if (value !== null && typeof value === "object") {
+    const structuredContent: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      structuredContent[key] = entry;
+    }
+    return {
+      content: fallback.content,
+      structuredContent,
+      isError: true,
+    };
+  }
+  return fallback;
+}

--- a/arcjet-guard/src/claude-agent-sdk/v0/gate.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/gate.test.ts
@@ -1,0 +1,396 @@
+// oxlint-disable eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import type { ArcjetMetadata, DecisionAllow } from "../../types.ts";
+import { runGate } from "./gate.ts";
+
+test("guard threw, failing closed → onUnavailable, capture outcome unavailable", async () => {
+  const error = new Error("boom");
+  const { client, captureCalls } = stubClient(error);
+
+  let onUnavailableCalls = 0;
+  let receivedKind: string | undefined;
+  let receivedError: unknown;
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: (unavailable) => {
+      onUnavailableCalls += 1;
+      receivedKind = unavailable.kind;
+      if (unavailable.kind === "threw") {
+        receivedError = unavailable.error;
+      }
+      return "unavailable";
+    },
+    onGuardError: "deny",
+  });
+
+  assert.equal(result, "unavailable");
+  assert.equal(onUnavailableCalls, 1);
+  assert.equal(receivedKind, "threw");
+  assert.strictEqual(receivedError, error);
+  assert.equal(captureCalls.length, 1);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "unavailable");
+});
+
+test("fail-open ALLOW, failing closed → onUnavailable", async () => {
+  const decision = decisionFailOpenAllow();
+  const { client, captureCalls } = stubClient(decision);
+
+  let receivedKind: string | undefined;
+  let receivedDecision: DecisionAllow | undefined;
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: (unavailable) => {
+      receivedKind = unavailable.kind;
+      if (unavailable.kind === "failed-open") {
+        receivedDecision = unavailable.decision;
+      }
+      return "unavailable";
+    },
+  });
+
+  assert.equal(result, "unavailable");
+  assert.equal(receivedKind, "failed-open");
+  assert.strictEqual(receivedDecision, decision);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "unavailable");
+});
+
+test("ALLOW → onAllow and capture outcome allowed", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal(result, "allowed");
+  assert.equal(captureCalls.length, 1);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "allowed");
+});
+
+test("DENY → onDeny and capture outcome denied", async () => {
+  const { client, captureCalls } = stubClient(decisionDenyPromptInjection());
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: (decision) => `denied: ${decision.reason}`,
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal(result, "denied: PROMPT_INJECTION");
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "denied");
+});
+
+test("empty decision.id is omitted from the capture", async () => {
+  const { client, captureCalls } = stubClient(decisionFailOpenAllow());
+  await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal("decisionId" in recorded(captureCalls[0]), false);
+});
+
+test("non-empty decision.id is included on the capture", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal(recorded(captureCalls[0])["decisionId"], "gdec_allow1");
+});
+
+test("captures never use outcome success or error", async () => {
+  const { client: allowClient, captureCalls: allowCaptures } = stubClient(decisionAllow());
+  const { client: denyClient, captureCalls: denyCaptures } = stubClient(
+    decisionDenyPromptInjection(),
+  );
+  const { client: errorClient, captureCalls: errorCaptures } = stubClient(new Error("boom"));
+  const { client: failOpenClient, captureCalls: failOpenCaptures } =
+    stubClient(decisionFailOpenAllow());
+
+  const params = {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+    onGuardError: "deny" as const,
+  };
+
+  await runGate(allowClient, params);
+  await runGate(denyClient, params);
+  await runGate(errorClient, params);
+  await runGate(failOpenClient, params);
+
+  for (const captures of [allowCaptures, denyCaptures, errorCaptures, failOpenCaptures]) {
+    for (const capture of captures) {
+      const outcome = recorded(recorded(capture)["metadata"])["outcome"];
+      assert.notEqual(outcome, "success");
+      assert.notEqual(outcome, "error");
+    }
+  }
+});
+
+test("undefined correlationId is omitted from the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: undefined,
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("set correlationId is included on the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal(recorded(guardCalls[0])["correlationId"], "corr-123");
+});
+
+test("guard is always called, including when rules is undefined or empty", async () => {
+  const { client: a, guardCalls: callsA } = stubClient(decisionAllow());
+  const { client: b, guardCalls: callsB } = stubClient(decisionAllow());
+
+  await runGate(a, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+  await runGate(b, {
+    action: "test.action",
+    rules: [],
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.deepEqual(recorded(callsA[0])["rules"], []);
+  assert.deepEqual(recorded(callsB[0])["rules"], []);
+});
+
+test("metadata is not mutated", async () => {
+  const { client } = stubClient(decisionAllow());
+  const originalMetadata: ArcjetMetadata = { custom: "value" };
+  const metadataCopy = { ...originalMetadata };
+
+  await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: originalMetadata,
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.deepEqual(originalMetadata, metadataCopy);
+});
+
+test("onGuardError defaults to deny", async () => {
+  const { client } = stubClient(new Error("boom"));
+  let onUnavailableCalled = false;
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => {
+      onUnavailableCalled = true;
+      return "unavailable";
+    },
+  });
+
+  assert.equal(result, "unavailable");
+  assert.equal(onUnavailableCalled, true);
+});
+
+test("onGuardError allow + threw → onAllow", async () => {
+  const { client, captureCalls } = stubClient(new Error("boom"));
+  let onAllowCalled = false;
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => {
+      onAllowCalled = true;
+      return "allowed";
+    },
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+    onGuardError: "allow",
+  });
+
+  assert.equal(result, "allowed");
+  assert.equal(onAllowCalled, true);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "allowed");
+});
+
+test("onGuardError allow + failed-open → onAllow", async () => {
+  const { client, captureCalls } = stubClient(decisionFailOpenAllow());
+  let onAllowCalled = false;
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => {
+      onAllowCalled = true;
+      return "allowed";
+    },
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+    onGuardError: "allow",
+  });
+
+  assert.equal(result, "allowed");
+  assert.equal(onAllowCalled, true);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "allowed");
+});
+
+test("capture() throw does not reject runGate", async () => {
+  const { client } = stubClient(decisionAllow());
+  client.capture = () => {
+    throw new Error("capture failed");
+  };
+
+  const result = await runGate(client, {
+    action: "test.action",
+    rules: undefined,
+    correlationId: "corr-123",
+    metadata: {},
+    onAllow: () => "allowed",
+    onDeny: () => "denied",
+    onUnavailable: () => "unavailable",
+  });
+
+  assert.equal(result, "allowed");
+});
+
+test("warns on threw / failed-open when ARCJET_LOG_LEVEL asks for warnings", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client: threwDeny } = stubClient(new Error("boom"));
+    await runGate(threwDeny, {
+      action: "warn.threw-deny",
+      rules: undefined,
+      correlationId: undefined,
+      metadata: {},
+      onAllow: () => "allowed",
+      onDeny: () => "denied",
+      onUnavailable: () => "unavailable",
+    });
+
+    const { client: threwAllow } = stubClient(new Error("boom"));
+    await runGate(threwAllow, {
+      action: "warn.threw-allow",
+      rules: undefined,
+      correlationId: undefined,
+      metadata: {},
+      onAllow: () => "allowed",
+      onDeny: () => "denied",
+      onUnavailable: () => "unavailable",
+      onGuardError: "allow",
+    });
+
+    const { client: failClosed } = stubClient(decisionFailOpenAllow());
+    await runGate(failClosed, {
+      action: "warn.failed-open-deny",
+      rules: undefined,
+      correlationId: undefined,
+      metadata: {},
+      onAllow: () => "allowed",
+      onDeny: () => "denied",
+      onUnavailable: () => "unavailable",
+    });
+
+    const { client: failOpen } = stubClient(decisionFailOpenAllow());
+    await runGate(failOpen, {
+      action: "warn.failed-open-allow",
+      rules: undefined,
+      correlationId: undefined,
+      metadata: {},
+      onAllow: () => "allowed",
+      onDeny: () => "denied",
+      onUnavailable: () => "unavailable",
+      onGuardError: "allow",
+    });
+
+    assert.ok(warnings.length >= 4);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/gate.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/gate.ts
@@ -1,0 +1,126 @@
+import { captureEvent, shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type {
+  ArcjetMetadata,
+  Decision,
+  DecisionAllow,
+  DecisionDeny,
+  RuleWithInput,
+} from "../../types.ts";
+
+/**
+ * The guard → capture sequence for a call site that decides whether something
+ * may run but does not run it. Shared by `guardHooks` PreToolUse and
+ * UserPromptSubmit.
+ *
+ * The allow outcome is `"allowed"`, not `"success"` — a distinction that
+ * keeps "the tool ran" and "the tool was permitted to run" separate.
+ */
+export async function runGate<T>(
+  client: ArcjetAgentClient,
+  params: {
+    action: string;
+    rules: RuleWithInput[] | undefined;
+    correlationId: string | undefined;
+    metadata: ArcjetMetadata;
+    onAllow: () => T;
+    onDeny: (decision: DecisionDeny) => T;
+    onUnavailable: (
+      unavailable:
+        | { kind: "threw"; error: unknown }
+        | { kind: "failed-open"; decision: DecisionAllow },
+    ) => T;
+    onGuardError?: "allow" | "deny";
+  },
+): Promise<T> {
+  const {
+    action,
+    rules,
+    correlationId,
+    metadata,
+    onAllow,
+    onDeny,
+    onUnavailable,
+    onGuardError = "deny",
+  } = params;
+
+  const correlation = correlationId === undefined ? {} : { correlationId };
+  const failClosed = onGuardError === "deny";
+
+  let decisionId: string | undefined;
+  let decision: Decision | undefined;
+  try {
+    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+  } catch (error) {
+    if (failClosed) {
+      warnUnavailable(action, "threw", true, error);
+      captureEvent(client, {
+        action,
+        ...correlation,
+        metadata: { ...metadata, outcome: "unavailable" },
+      });
+      return onUnavailable({ kind: "threw", error });
+    }
+    warnUnavailable(action, "threw", false, error);
+  }
+
+  if (decision !== undefined) {
+    if (decision.id !== "") {
+      decisionId = decision.id;
+    }
+    if (decision.conclusion === "ALLOW" && decision.hasFailedOpen() && failClosed) {
+      warnUnavailable(action, "failed-open", true);
+      captureEvent(client, {
+        action,
+        ...correlation,
+        ...(decisionId !== undefined && { decisionId }),
+        metadata: { ...metadata, outcome: "unavailable" },
+      });
+      return onUnavailable({ kind: "failed-open", decision });
+    }
+    if (decision.conclusion === "ALLOW" && decision.hasFailedOpen()) {
+      warnUnavailable(action, "failed-open", false);
+    }
+    if (decision.conclusion === "DENY") {
+      captureEvent(client, {
+        action,
+        ...correlation,
+        ...(decisionId !== undefined && { decisionId }),
+        metadata: { ...metadata, outcome: "denied" },
+      });
+      return onDeny(decision);
+    }
+  }
+
+  captureEvent(client, {
+    action,
+    ...correlation,
+    ...(decisionId !== undefined && { decisionId }),
+    metadata: { ...metadata, outcome: "allowed" },
+  });
+  return onAllow();
+}
+
+function warnUnavailable(
+  action: string,
+  signal: "threw" | "failed-open",
+  failClosed: boolean,
+  error?: unknown,
+): void {
+  if (!shouldWarn()) {
+    return;
+  }
+  if (signal === "threw") {
+    if (failClosed) {
+      console.warn('@arcjet/guard: guard check for "%s" errored; failing closed:', action, error);
+    } else {
+      console.warn('@arcjet/guard: guard check for "%s" errored; failing open:', action, error);
+    }
+    return;
+  }
+  if (failClosed) {
+    console.warn('@arcjet/guard: guard check for "%s" was unavailable; failing closed.', action);
+  } else {
+    console.warn('@arcjet/guard: guard check for "%s" failed open (API error).', action);
+  }
+}

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
@@ -1,0 +1,413 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionDenyRateLimit,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { DecisionDeny } from "../../types.ts";
+import type { ArcjetDenialResult, ClaudeCallToolResult } from "./denial.ts";
+import type { ClaudeToolDefinition } from "./guard-tool.ts";
+import { guardTool } from "./guard-tool.ts";
+
+function createClaudeTool<
+  TInput extends Record<string, unknown> = Record<string, unknown>,
+>(overrides?: {
+  name?: string;
+  handler?: (input: TInput, extra: unknown) => Promise<ClaudeCallToolResult>;
+}): ClaudeToolDefinition<TInput> {
+  const tool = {
+    name: overrides?.name ?? "test-tool",
+    description: "test tool",
+    inputSchema: {},
+    handler:
+      overrides?.handler ?? (async () => ({ content: [{ type: "text" as const, text: "ok" }] })),
+  };
+  Object.defineProperty(tool, Symbol.for("claude.hidden"), {
+    value: "keep-me",
+    enumerable: false,
+    configurable: true,
+  });
+  return tool;
+}
+
+function sessionExtra(sessionId: string) {
+  return { session_id: sessionId };
+}
+
+function asToolResult(value: unknown): ClaudeCallToolResult {
+  return asDenial<ClaudeCallToolResult>(value);
+}
+
+function denialFromResult(result: unknown): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(asToolResult(result).structuredContent);
+}
+
+test("throws when the tool has no handler function", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = { name: "no-handler", description: "x", inputSchema: {} };
+  assert.throws(
+    () => guardTool(client, tool as ClaudeToolDefinition, { action: "test.executed" }),
+    /handler function/,
+  );
+});
+
+test("returned object is not the input tool and preserves non-enumerable markers", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createClaudeTool();
+  const wrapped = guardTool(client, tool, { action: "test.executed" });
+
+  assert.notStrictEqual(wrapped, tool);
+  assert.equal((wrapped as any)[Symbol.for("claude.hidden")], "keep-me");
+});
+
+test("input tool.handler is unchanged after wrapping", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createClaudeTool();
+  const originalHandler = tool.handler;
+  guardTool(client, tool, { action: "test.executed" });
+  assert.strictEqual(tool.handler, originalHandler);
+});
+
+test("ALLOW → handler called once with input and extra by reference", async () => {
+  const { client } = stubClient(decisionAllow());
+  const input = { orderNumber: "A-1" };
+  const extra = sessionExtra("session-1");
+  let calls = 0;
+  let capturedInput: unknown;
+  let capturedExtra: unknown;
+
+  const tool = createClaudeTool({
+    handler: async (inp, context) => {
+      calls += 1;
+      capturedInput = inp;
+      capturedExtra = context;
+      return { content: [{ type: "text", text: "shipped" }] };
+    },
+  });
+
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = await wrapped.handler(input, extra);
+
+  assert.equal(calls, 1);
+  assert.strictEqual(capturedInput, input);
+  assert.strictEqual(capturedExtra, extra);
+  assert.deepEqual(result, { content: [{ type: "text", text: "shipped" }] });
+});
+
+test("ALLOW → capture outcome is success and correlation comes from session_id", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.handler({}, sessionExtra("session-99"));
+
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "session-99");
+  assert.equal(captureCalls.length, 1);
+  assert.equal(
+    recorded(captureCalls[0])["metadata"] &&
+      (recorded(captureCalls[0])["metadata"] as Record<string, unknown>)["outcome"],
+    "success",
+  );
+});
+
+test("DENY → handler is not called and a CallToolResult with isError is returned (no throw)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.handler({}, sessionExtra("s")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.isError, true);
+  const denial = denialFromResult(result);
+  assert.equal(denial.arcjetDenied, true);
+  assert.equal(denial.reason, "PROMPT_INJECTION");
+  assert.equal(denial.retryable, false);
+});
+
+test("RATE_LIMIT DENY → structured result is retryable", async () => {
+  const resetAt = Math.floor(Date.now() / 1000) + 12;
+  const { client } = stubClient(decisionDenyRateLimit(resetAt));
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = denialFromResult(await wrapped.handler({}, sessionExtra("s")));
+
+  assert.equal(result.retryable, true);
+  assert.ok(typeof result.retryAfterSeconds === "number");
+});
+
+test("rules callback receives the tool input", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool<{ id: string }>({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    rules: (input) => {
+      assert.equal(input.id, "xyz");
+      return [fakeRule];
+    },
+  });
+  await wrapped.handler({ id: "xyz" }, sessionExtra("s"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("fail-closed unavailable → ERROR CallToolResult, handler not called", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.handler({}, sessionExtra("s")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.isError, true);
+  assert.equal(denialFromResult(result).reason, "ERROR");
+});
+
+test("onGuardError allow → handler still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+  });
+  const result = await wrapped.handler({}, sessionExtra("s"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { content: [{ type: "text", text: "ok" }] });
+});
+
+test("does not mint a correlation id when Claude provided none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.handler({}, {});
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("policy.sessionId is used when extra has no session_id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: "options-session",
+  });
+  await wrapped.handler({}, {});
+  assert.equal(recorded(guardCalls[0])["correlationId"], "options-session");
+});
+
+test("DENY + throwing onDeny still denies and does not throw", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      throw new Error("onDeny exploded");
+    },
+  });
+
+  const result = asToolResult(await wrapped.handler({}, sessionExtra("s")));
+  assert.equal(calls, 0);
+  assert.equal(result.isError, true);
+  assert.equal(denialFromResult(result).reason, "PROMPT_INJECTION");
+});
+
+test("onDeny reshape is returned and handler is not called", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let received: DecisionDeny | undefined;
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: (decision) => {
+      received = decision;
+      return { content: [{ type: "text", text: `blocked:${decision.reason}` }], isError: true };
+    },
+  });
+
+  const result = await wrapped.handler({}, sessionExtra("s"));
+  assert.equal(received?.reason, "PROMPT_INJECTION");
+  assert.deepEqual(result, {
+    content: [{ type: "text", text: "blocked:PROMPT_INJECTION" }],
+    isError: true,
+  });
+});
+
+test("onDeny is not called on unavailable", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let onDenyCalls = 0;
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      onDenyCalls += 1;
+      return { blocked: true };
+    },
+  });
+
+  const result = await wrapped.handler({}, sessionExtra("s"));
+  assert.equal(onDenyCalls, 0);
+  assert.equal(denialFromResult(result).reason, "ERROR");
+});
+
+test("guard throw with default fail-closed does not execute", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = await wrapped.handler({}, sessionExtra("s"));
+  assert.equal(calls, 0);
+  assert.equal(denialFromResult(result).reason, "ERROR");
+});
+
+test("omitted rules still submit an empty guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.handler({}, sessionExtra("s"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], []);
+});
+
+test("metadata callback is merged over derived context", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool<{ id: string }>({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: (input) => ({ "app.item": input.id }),
+  });
+  await wrapped.handler({ id: "item-9" }, sessionExtra("session-meta"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.item"], "item-9");
+  assert.equal(metadata["claude.tool"], "test-tool");
+});
+
+test("static metadata is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    name: "",
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: { "app.static": "yes" },
+  });
+  await wrapped.handler({}, sessionExtra("s"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.static"], "yes");
+  assert.equal("claude.tool" in metadata, false);
+});
+
+test("rejects a second wrap (claude or vercel-ai brand)", async () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createClaudeTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  assert.equal(arcjetProtectedTool in wrapped, true);
+  assert.throws(() => guardTool(client, wrapped, { action: "order.looked-up" }), /already guarded/);
+
+  const branded = createClaudeTool();
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  assert.throws(() => guardTool(client, branded, { action: "order.looked-up" }), /already guarded/);
+});
+
+test("handler throw is rethrown after capture", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    handler: async (): Promise<ClaudeCallToolResult> => {
+      throw new Error("tool failed");
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await assert.rejects(async () => wrapped.handler({}, sessionExtra("s")), /tool failed/);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "error");
+});
+
+test("non-object extra does not mint an id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool({
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.handler({}, "not-context");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client } = stubClient(decisionDenyPromptInjection());
+    const tool = createClaudeTool({
+      handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+    const wrapped = guardTool(client, tool, {
+      action: "order.looked-up",
+      onDeny: () => {
+        throw new Error("onDeny exploded");
+      },
+    });
+    await wrapped.handler({}, sessionExtra("s"));
+    assert.ok(warnings.length > 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
@@ -380,6 +380,113 @@ test("non-object extra does not mint an id", async () => {
   assert.equal("correlationId" in recorded(guardCalls[0]), false);
 });
 
+test("rules factory throw fail-closes and does not execute the handler", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.handler({}, sessionExtra("s")));
+  assert.equal(calls, 0);
+  assert.equal(result.isError, true);
+  assert.equal(denialFromResult(result).reason, "ERROR");
+});
+
+test("metadata factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    metadata: () => {
+      throw new Error("metadata exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.handler({}, sessionExtra("s")));
+  assert.equal(calls, 0);
+  assert.equal(denialFromResult(result).reason, "ERROR");
+});
+
+test("sessionId factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: () => {
+      throw new Error("sessionId exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.handler({}, sessionExtra("s")));
+  assert.equal(calls, 0);
+  assert.equal(denialFromResult(result).reason, "ERROR");
+});
+
+test("rules factory throw with onGuardError allow still executes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await wrapped.handler({}, sessionExtra("s"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { content: [{ type: "text", text: "ok" }] });
+});
+
+test("wraps a tool whose handler descriptor is non-writable", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool: ClaudeToolDefinition = {
+    name: "frozen-handler",
+    description: "x",
+    inputSchema: {},
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text" as const, text: "ok" }] };
+    },
+  };
+  Object.defineProperty(tool, "handler", {
+    value: tool.handler,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+  });
+
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = await wrapped.handler({}, sessionExtra("s"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { content: [{ type: "text", text: "ok" }] });
+});
+
 test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
   const previous = process.env["ARCJET_LOG_LEVEL"];
   process.env["ARCJET_LOG_LEVEL"] = "warn";

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
@@ -164,12 +164,35 @@ export function guardTool<TTool extends ClaudeToolDefinition<any>>(
     Object.getOwnPropertyDescriptors(tool),
   ) as TTool;
 
-  wrapped.handler = async (
+  const newHandler = async (
     input: ClaudeToolInput<TTool>,
     extra: unknown,
   ): Promise<ClaudeCallToolResult> => {
     const source = isContextSource(extra) ? extra : undefined;
-    const sessionId = resolveSessionId(policy, input);
+
+    let sessionId: string | undefined;
+    let rules: RuleWithInput[] | undefined;
+    let policyMetadata: ArcjetMetadata | undefined;
+    try {
+      sessionId = resolveSessionId(policy, input);
+      rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
+      policyMetadata =
+        typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
+    } catch (error) {
+      if (shouldWarn()) {
+        console.warn(
+          '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+          policy.action,
+          error,
+        );
+      }
+      if (policy.onGuardError === "allow") {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- original handler returns the SDK CallToolResult
+        return Promise.resolve(originalHandler(input, extra)) as Promise<ClaudeCallToolResult>;
+      }
+      return unavailableCallToolResult();
+    }
+
     const agentCtx = claudeAgentContext(
       source,
       sessionId === undefined ? undefined : { sessionId },
@@ -183,9 +206,6 @@ export function guardTool<TTool extends ClaudeToolDefinition<any>>(
         }),
     };
 
-    const rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
-    const policyMetadata =
-      typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
     const mergedMetadata = { ...metadata, ...policyMetadata };
 
     const result = await runGuarded<ClaudeCallToolResult>(client, {
@@ -221,6 +241,13 @@ export function guardTool<TTool extends ClaudeToolDefinition<any>>(
 
     return result;
   };
+
+  Object.defineProperty(wrapped, "handler", {
+    value: newHandler,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 
   Object.defineProperty(wrapped, arcjetProtectedTool, {
     value: true,

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
@@ -1,0 +1,232 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { claudeAgentContext } from "./context.ts";
+import type { ClaudeContextSource } from "./context.ts";
+import { asCallToolResult, denialCallToolResult, unavailableCallToolResult } from "./denial.ts";
+import type { ClaudeCallToolResult } from "./denial.ts";
+
+/**
+ * Structural `tool()` definition. Declared here so `guardTool` does not
+ * depend on the SDK's Zod schema parameter, which is not assignable across
+ * `SdkMcpToolDefinition` / `SdkMcpToolDefinition<any>` under
+ * `exactOptionalPropertyTypes`.
+ */
+export interface ClaudeToolDefinition<TInput = unknown> {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  handler: (args: TInput, extra: unknown) => Promise<unknown>;
+  annotations?: unknown;
+  _meta?: Record<string, unknown>;
+}
+
+/**
+ * Input type of a Claude Agent SDK `tool()` definition. Used so `guardTool`
+ * can keep the concrete tool type while still typing `policy.rules` against
+ * the handler args.
+ */
+export type ClaudeToolInput<TTool> = TTool extends {
+  handler: (args: infer TInput, extra: unknown) => Promise<unknown>;
+}
+  ? TInput
+  : never;
+
+/**
+ * Policy for `guardTool()` — how to guard an authored `tool()` handler.
+ *
+ * Specifies the guard action name, optional rules to evaluate, metadata
+ * context, and optional denial handler. Rules can be static or computed
+ * from the tool's input.
+ */
+export interface GuardToolPolicy<TInput> {
+  /** Guard label and capture action: `"resource.verb"`, past tense. */
+  action: string;
+  /**
+   * Rules to evaluate, static or computed from the tool's input. Omitting
+   * this, or returning `[]`, submits no rules — it does not skip the guard
+   * call, which still costs a round trip and returns a decision.
+   */
+  rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /** Metadata merged over the context's (object, or per-call function of the tool input). */
+  metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
+  /**
+   * Fallback session id when the handler `extra` does not carry `session_id`.
+   * Prefer `query({ options.sessionId })` plus hook input; this is the
+   * authored-tool equivalent of that option. Never mint a new id here.
+   */
+  sessionId?: string | ((input: TInput) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload the model sees for a real DENY decision.
+   * Return a `CallToolResult` (`isError: true` recommended) or a plain
+   * object, which is placed on `structuredContent`. Unavailable guards take
+   * the `onUnavailable` path instead; this callback does not fire for outages.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+function isContextSource(value: unknown): value is ClaudeContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function resolveSessionId<TInput>(
+  policy: GuardToolPolicy<TInput>,
+  input: TInput,
+): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(input);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+/**
+ * Wraps an authored Claude Agent SDK `tool()` definition with guard-gated
+ * execution.
+ *
+ * Always runs `guard()` before the handler, submitting `policy.rules` or none;
+ * on DENY the handler never executes and the model receives a `CallToolResult`
+ * with `isError: true` (or the result of `policy.onDeny`). This helper does
+ * not throw on DENY.
+ *
+ * Guard API errors depend on `policy.onGuardError` (defaults to `"deny"`):
+ * - `"deny"` (default): Handler does not execute; the model receives
+ *   `isError: true` with `reason: "ERROR"`.
+ * - `"allow"`: Handler still runs, with a warning gated on `ARCJET_LOG_LEVEL`.
+ *
+ * Correlation is read from the handler `extra` (`session_id`) or
+ * `policy.sessionId`. No id is minted.
+ *
+ * Do not also wrap the same tool with `@arcjet/guard/vercel-ai/v7` or
+ * `@arcjet/guard/agents`. Annotations and sandbox settings are not
+ * enforcement — they do not replace this wrapper or `guardHooks`.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardTool } from "@arcjet/guard/claude-agent-sdk/v0";
+ * import { tool } from "@anthropic-ai/claude-agent-sdk";
+ * import { z } from "zod";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * export const lookupOrder = guardTool(
+ *   arcjet,
+ *   tool(
+ *     "lookup_order",
+ *     "Look up an order by number",
+ *     { orderNumber: z.string() },
+ *     async ({ orderNumber }) => ({
+ *       content: [{ type: "text", text: `${orderNumber}: shipped` }],
+ *     }),
+ *   ),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ * ```
+ */
+export function guardTool<TTool extends ClaudeToolDefinition<any>>(
+  client: ArcjetAgentClient,
+  tool: TTool,
+  policy: GuardToolPolicy<ClaudeToolInput<TTool>>,
+): TTool {
+  if (typeof tool.handler !== "function") {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error("@arcjet/guard: guardTool() requires a tool with a handler function");
+  }
+  if (arcjetProtectedTool in tool) {
+    throw new Error(
+      "@arcjet/guard: guardTool() cannot wrap a tool that is already guarded; do not double-wrap with @arcjet/guard/claude-agent-sdk/v0, @arcjet/guard/vercel-ai/v7, or @arcjet/guard/agents",
+    );
+  }
+
+  const originalHandler = tool.handler.bind(tool);
+
+  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
+  const proto = Object.getPrototypeOf(tool) as object | null;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
+  const wrapped = Object.defineProperties(
+    Object.create(proto),
+    Object.getOwnPropertyDescriptors(tool),
+  ) as TTool;
+
+  wrapped.handler = async (
+    input: ClaudeToolInput<TTool>,
+    extra: unknown,
+  ): Promise<ClaudeCallToolResult> => {
+    const source = isContextSource(extra) ? extra : undefined;
+    const sessionId = resolveSessionId(policy, input);
+    const agentCtx = claudeAgentContext(
+      source,
+      sessionId === undefined ? undefined : { sessionId },
+    );
+
+    const metadata: ArcjetMetadata = {
+      ...agentCtx.metadata,
+      ...(typeof tool.name === "string" &&
+        tool.name.length > 0 && {
+          "claude.tool": tool.name,
+        }),
+    };
+
+    const rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
+    const policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
+    const mergedMetadata = { ...metadata, ...policyMetadata };
+
+    const result = await runGuarded<ClaudeCallToolResult>(client, {
+      action: policy.action,
+      rules,
+      correlationId: agentCtx.correlationId,
+      metadata: mergedMetadata,
+      onDeny: (decision: DecisionDeny) => {
+        const fallback = denialCallToolResult(decision);
+        if (policy.onDeny === undefined) {
+          return fallback;
+        }
+        try {
+          return asCallToolResult(policy.onDeny(decision), fallback);
+        } catch (error) {
+          if (shouldWarn()) {
+            console.warn(
+              '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+              policy.action,
+              error,
+            );
+          }
+          return fallback;
+        }
+      },
+      onUnavailable: () => unavailableCallToolResult(),
+      execute: () => {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- original handler returns the SDK CallToolResult; ALLOW path is that result
+        return Promise.resolve(originalHandler(input, extra)) as Promise<ClaudeCallToolResult>;
+      },
+      onGuardError: policy.onGuardError ?? "deny",
+    });
+
+    return result;
+  };
+
+  Object.defineProperty(wrapped, arcjetProtectedTool, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return wrapped;
+}

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.test.ts
@@ -1,0 +1,329 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { HookCallback, HookInput } from "@anthropic-ai/claude-agent-sdk";
+
+import { recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { guardHooks } from "./hooks.ts";
+
+function preToolInput(input?: unknown): HookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "session-hooks",
+    transcript_path: "/tmp/t.jsonl",
+    cwd: "/tmp",
+    tool_name: "Bash",
+    tool_input: input === undefined ? { command: "ls" } : input,
+    tool_use_id: "tu-1",
+  };
+}
+
+function userPromptInput(prompt = "hello"): HookInput {
+  return {
+    hook_event_name: "UserPromptSubmit",
+    session_id: "session-hooks",
+    transcript_path: "/tmp/t.jsonl",
+    cwd: "/tmp",
+    prompt,
+  };
+}
+
+function postToolInput(): HookInput {
+  return {
+    hook_event_name: "PostToolUse",
+    session_id: "session-hooks",
+    transcript_path: "/tmp/t.jsonl",
+    cwd: "/tmp",
+    tool_name: "Bash",
+    tool_input: { command: "ls" },
+    tool_response: { ok: true },
+    tool_use_id: "tu-1",
+  };
+}
+
+function runHook(
+  matchers: { hooks: HookCallback[] }[] | undefined,
+  input: HookInput,
+): Promise<unknown> {
+  assert.ok(matchers !== undefined);
+  assert.equal(matchers.length, 1);
+  const hook = matchers[0]?.hooks[0];
+  assert.equal(typeof hook, "function");
+  return hook(input, "tu-1", { signal: new AbortController().signal });
+}
+
+test("PreToolUse ALLOW returns an empty object so the tool proceeds", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, { action: "mcp.invoked" });
+  const result = await runHook(hooks.PreToolUse, preToolInput());
+
+  assert.deepEqual(result, {});
+  assert.equal(recorded(guardCalls[0])["correlationId"], "session-hooks");
+  assert.equal(
+    (recorded(captureCalls[0])["metadata"] as Record<string, unknown>)["outcome"],
+    "allowed",
+  );
+});
+
+test("PreToolUse DENY returns permissionDecision deny", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const hooks = guardHooks(client, { action: "mcp.invoked" });
+  const result = (await runHook(hooks.PreToolUse, preToolInput())) as {
+    hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string };
+  };
+
+  assert.equal(result.hookSpecificOutput?.permissionDecision, "deny");
+  assert.match(String(result.hookSpecificOutput?.permissionDecisionReason), /PROMPT_INJECTION/);
+});
+
+test("PreToolUse fail-closed unavailable returns permissionDecision deny", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const hooks = guardHooks(client);
+  const result = (await runHook(hooks.PreToolUse, preToolInput())) as {
+    hookSpecificOutput?: { permissionDecision?: string };
+  };
+
+  assert.equal(result.hookSpecificOutput?.permissionDecision, "deny");
+});
+
+test("UserPromptSubmit ALLOW returns an empty object", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    inbound: { action: "message.received" },
+  });
+  const result = await runHook(hooks.UserPromptSubmit, userPromptInput("hi"));
+
+  assert.deepEqual(result, {});
+  assert.equal(recorded(guardCalls[0])["label"], "message.received");
+  assert.equal(recorded(guardCalls[0])["correlationId"], "session-hooks");
+});
+
+test("UserPromptSubmit DENY returns decision block", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const hooks = guardHooks(client, {
+    inbound: { rules: ({ prompt }) => (prompt.length > 0 ? [fakeRule] : []) },
+  });
+  const result = (await runHook(hooks.UserPromptSubmit, userPromptInput("inject"))) as {
+    decision?: string;
+    reason?: string;
+  };
+
+  assert.equal(result.decision, "block");
+  assert.match(String(result.reason), /PROMPT_INJECTION/);
+});
+
+test("UserPromptSubmit fail-closed unavailable returns decision block", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const hooks = guardHooks(client);
+  const result = (await runHook(hooks.UserPromptSubmit, userPromptInput())) as {
+    decision?: string;
+  };
+
+  assert.equal(result.decision, "block");
+});
+
+test("inbound rules callback receives the prompt", async () => {
+  const { client } = stubClient(decisionAllow());
+  let seen = "";
+  const hooks = guardHooks(client, {
+    inbound: {
+      rules: ({ prompt }) => {
+        seen = prompt;
+        return [fakeRule];
+      },
+    },
+  });
+  await runHook(hooks.UserPromptSubmit, userPromptInput("screen me"));
+  assert.equal(seen, "screen me");
+});
+
+test("rules callback receives the tool name and input", async () => {
+  const { client } = stubClient(decisionAllow());
+  let seenName = "";
+  const hooks = guardHooks(client, {
+    rules: ({ toolName, input }) => {
+      seenName = toolName;
+      assert.deepEqual(input, { command: "rm" });
+      return [fakeRule];
+    },
+  });
+  await runHook(hooks.PreToolUse, preToolInput({ command: "rm" }));
+  assert.equal(seenName, "Bash");
+});
+
+test("PostToolUse captures success and never throws", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, { action: "mcp.invoked" });
+  const result = await runHook(hooks.PostToolUse, postToolInput());
+
+  assert.deepEqual(result, {});
+  assert.equal(captureCalls.length, 1);
+  const metadata = recorded(captureCalls[0])["metadata"] as Record<string, unknown>;
+  assert.equal(metadata["outcome"], "success");
+  assert.equal(metadata["claude.phase"], "after");
+  assert.equal(metadata["claude.tool"], "Bash");
+});
+
+test("default tool action is tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client);
+  await runHook(hooks.PreToolUse, preToolInput());
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("action callback is used when provided", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+  await runHook(hooks.PreToolUse, preToolInput());
+  assert.equal(recorded(guardCalls[0])["label"], "Bash.invoked");
+});
+
+test("empty action string falls back to tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, { action: "" });
+  await runHook(hooks.PreToolUse, preToolInput());
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("onGuardError allow lets PreToolUse proceed on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const hooks = guardHooks(client, { onGuardError: "allow" });
+  const result = await runHook(hooks.PreToolUse, preToolInput());
+  assert.deepEqual(result, {});
+});
+
+test("inbound onGuardError allow lets UserPromptSubmit proceed on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const hooks = guardHooks(client, { inbound: { onGuardError: "allow" } });
+  const result = await runHook(hooks.UserPromptSubmit, userPromptInput());
+  assert.deepEqual(result, {});
+});
+
+test("rules throw still denies PreToolUse (fail closed)", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client } = stubClient(decisionAllow());
+    const hooks = guardHooks(client, {
+      rules: () => {
+        throw new Error("rules exploded");
+      },
+    });
+    const result = (await runHook(hooks.PreToolUse, preToolInput())) as {
+      hookSpecificOutput?: { permissionDecision?: string };
+    };
+    assert.equal(result.hookSpecificOutput?.permissionDecision, "deny");
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /PreToolUse threw/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("rules throw with onGuardError allow proceeds", async () => {
+  const { client } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await runHook(hooks.PreToolUse, preToolInput());
+  assert.deepEqual(result, {});
+});
+
+test("empty toolName is omitted from metadata", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client);
+  await runHook(hooks.PreToolUse, { ...preToolInput(), tool_name: "" } as HookInput);
+  assert.equal("claude.tool" in recorded(recorded(guardCalls[0])["metadata"]), false);
+});
+
+test("policy.sessionId is used when hook input has no session_id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, { sessionId: "options-session" });
+  await runHook(hooks.PreToolUse, { ...preToolInput(), session_id: "" });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "options-session");
+});
+
+test("does not mint a correlation id when neither hook nor options provide one", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client);
+  await runHook(hooks.PreToolUse, { ...preToolInput(), session_id: "" });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("subagent agent_id is metadata only", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client);
+  await runHook(hooks.PreToolUse, { ...preToolInput(), agent_id: "sub-1" });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "session-hooks");
+  assert.equal(recorded(recorded(guardCalls[0])["metadata"])["claude.agent"], "sub-1");
+});
+
+test("metadata callback is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    metadata: ({ toolName }) => ({ "app.tool": toolName }),
+  });
+  await runHook(hooks.PreToolUse, preToolInput());
+  assert.equal(recorded(recorded(guardCalls[0])["metadata"])["app.tool"], "Bash");
+});
+
+test("static metadata is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, { metadata: { "app.static": "yes" } });
+  await runHook(hooks.PreToolUse, preToolInput());
+  assert.equal(recorded(recorded(guardCalls[0])["metadata"])["app.static"], "yes");
+});
+
+test("PostToolUse never throws when capture or metadata throws", async () => {
+  const { client } = stubClient(decisionAllow());
+  client.capture = () => {
+    throw new Error("capture failed");
+  };
+  const hooks = guardHooks(client, {
+    metadata: () => {
+      throw new Error("metadata exploded");
+    },
+  });
+  const result = await runHook(hooks.PostToolUse, postToolInput());
+  assert.deepEqual(result, {});
+});
+
+test("registers PreToolUse, UserPromptSubmit, and PostToolUse only", () => {
+  const { client } = stubClient(decisionAllow());
+  const hooks = guardHooks(client);
+  const names = Object.keys(hooks);
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  names.sort();
+  assert.deepEqual(names, ["PostToolUse", "PreToolUse", "UserPromptSubmit"]);
+});
+
+test("default inbound action is message.received", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client);
+  await runHook(hooks.UserPromptSubmit, userPromptInput());
+  assert.equal(recorded(guardCalls[0])["label"], "message.received");
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
@@ -1,0 +1,343 @@
+import type {
+  HookCallback,
+  HookCallbackMatcher,
+  HookEvent,
+  HookJSONOutput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  UserPromptSubmitHookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+
+import { captureEvent, shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import type { ArcjetMetadata, RuleWithInput } from "../../types.ts";
+import { claudeAgentContext } from "./context.ts";
+import type { ClaudeContextSource } from "./context.ts";
+import { deniedReason, unavailableReason } from "./denial.ts";
+import { runGate } from "./gate.ts";
+
+/**
+ * Input passed to `rules` / `metadata` / `action` callbacks on `guardHooks`
+ * for PreToolUse / PostToolUse.
+ */
+export interface GuardHooksCall {
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Input passed to inbound (`UserPromptSubmit`) policy callbacks.
+ */
+export interface GuardHooksInbound {
+  prompt: string;
+}
+
+/**
+ * Inbound screen for `UserPromptSubmit`. This is the only place a turn can
+ * be declined before the model sees the prompt.
+ */
+export interface GuardHooksInboundPolicy {
+  /**
+   * Guard label and capture action. Defaults to `"message.received"`.
+   */
+  action?: string | ((input: GuardHooksInbound) => string);
+  /**
+   * Rules to evaluate before the prompt is processed. Omitting this still
+   * performs the guard call.
+   */
+  rules?: RuleWithInput[] | ((input: GuardHooksInbound) => RuleWithInput[]);
+  /** Metadata merged over the derived Claude context. */
+  metadata?: ArcjetMetadata | ((input: GuardHooksInbound) => ArcjetMetadata);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+}
+
+/**
+ * Policy for `guardHooks()` — PreToolUse (deny unwrapped / built-in tools),
+ * UserPromptSubmit (inbound), and PostToolUse (capture only).
+ *
+ * ## Screen inbound with UserPromptSubmit
+ *
+ * Put prompt-injection and other inbound rules on `inbound`. A DENY returns
+ * `{ decision: "block" }` so the prompt is erased. A timeout already
+ * fail-closes the prompt (Claude Code v2.1.208+).
+ *
+ * ## canUseTool is not a policy gate
+ *
+ * Claude's docs say `canUseTool` is skipped by `allowedTools`, allow rules,
+ * and `bypassPermissions` / `acceptEdits`. Do not put Arcjet policy there.
+ * There is no `guardCanUseTool`.
+ *
+ * ## PreToolUse is the only deny for unwrapped tools
+ *
+ * Built-ins (Bash, Write, …) and MCP tools you did not pass through
+ * `guardTool` are gated here with `permissionDecision: "deny"`. A timeout
+ * already fail-closes (the tool does not run). PostToolUse is capture only.
+ * Annotations and sandbox settings are not enforcement.
+ */
+export interface GuardHooksPolicy {
+  /**
+   * Fallback session id when hook input has no valid `session_id`. Pass the
+   * same value you give `query({ options.sessionId })`. Never mint a new id.
+   */
+  sessionId?: string;
+  /**
+   * Guard label and capture action for tool hooks. Defaults to
+   * `"tool.invoked"`. May be a function of the tool name and input.
+   */
+  action?: string | ((call: GuardHooksCall) => string);
+  /**
+   * Rules to evaluate before an unwrapped / built-in tool runs. Omitting
+   * this still performs the guard call.
+   */
+  rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
+  /** Metadata merged over the derived Claude context for tool hooks. */
+  metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
+  /** How to respond when a tool-gate evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /** Inbound screen on `UserPromptSubmit`. Defaults to action `"message.received"`. */
+  inbound?: GuardHooksInboundPolicy;
+}
+
+function isContextSource(value: unknown): value is ClaudeContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function resolveToolAction(policy: GuardHooksPolicy, call: GuardHooksCall): string {
+  if (typeof policy.action === "function") {
+    return policy.action(call);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "tool.invoked";
+}
+
+function resolveInboundAction(policy: GuardHooksInboundPolicy, input: GuardHooksInbound): string {
+  if (typeof policy.action === "function") {
+    return policy.action(input);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "message.received";
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function preToolUseDeny(reason: string): HookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+function userPromptBlock(reason: string): HookJSONOutput {
+  return {
+    decision: "block",
+    reason,
+  };
+}
+
+/**
+ * Claude Agent SDK hooks that screen inbound prompts and gate unwrapped tools.
+ *
+ * Registers three events:
+ * - `UserPromptSubmit` — inbound screen. DENY is `{ decision: "block" }`.
+ * - `PreToolUse` — the only deny for built-ins and unwrapped MCP. DENY is
+ *   `permissionDecision: "deny"`.
+ * - `PostToolUse` — capture only; never blocks.
+ *
+ * Use this for tools you did not pass through `guardTool`. Do not also wrap
+ * the same authored tool with `@arcjet/guard/vercel-ai/v7`. Do not put
+ * policy on `canUseTool`.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardHooks } from "@arcjet/guard/claude-agent-sdk/v0";
+ * import { query } from "@anthropic-ai/claude-agent-sdk";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const mcpLimit = tokenBucket({
+ *   refillRate: 20,
+ *   intervalSeconds: 60,
+ *   maxTokens: 20,
+ * });
+ *
+ * const sessionId = conversationId;
+ *
+ * for await (const message of query({
+ *   prompt: userText,
+ *   options: {
+ *     sessionId,
+ *     hooks: guardHooks(arcjet, {
+ *       sessionId,
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+ *       inbound: {
+ *         action: "message.received",
+ *         rules: ({ prompt }) => [detectPromptInjection()(prompt)],
+ *       },
+ *     }),
+ *   },
+ * })) {
+ *   void message;
+ * }
+ * ```
+ */
+export function guardHooks(
+  client: ArcjetAgentClient,
+  policy: GuardHooksPolicy = {},
+): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+  const inboundPolicy: GuardHooksInboundPolicy = policy.inbound ?? {};
+
+  const preToolUse: HookCallback = async (input): Promise<HookJSONOutput> => {
+    try {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- this matcher is registered only on PreToolUse
+      const hookInput = input as PreToolUseHookInput;
+      const call: GuardHooksCall = {
+        toolName: stringField(hookInput.tool_name),
+        input: hookInput.tool_input,
+      };
+      const action = resolveToolAction(policy, call);
+      const source = isContextSource(hookInput) ? hookInput : undefined;
+      const agentCtx = claudeAgentContext(
+        source,
+        policy.sessionId === undefined ? undefined : { sessionId: policy.sessionId },
+      );
+
+      const rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
+      const policyMetadata =
+        typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+      const metadata: ArcjetMetadata = {
+        ...agentCtx.metadata,
+        "claude.phase": "before",
+        ...(call.toolName.length > 0 && { "claude.tool": call.toolName }),
+        ...policyMetadata,
+      };
+
+      return await runGate<HookJSONOutput>(client, {
+        action,
+        rules,
+        correlationId: agentCtx.correlationId,
+        metadata,
+        onAllow: () => ({}),
+        onDeny: (decision) => preToolUseDeny(deniedReason(decision)),
+        onUnavailable: () => preToolUseDeny(unavailableReason()),
+        onGuardError: policy.onGuardError ?? "deny",
+      });
+    } catch (error) {
+      if (shouldWarn()) {
+        console.warn("@arcjet/guard: guardHooks PreToolUse threw; denying the tool:", error);
+      }
+      if (policy.onGuardError === "allow") {
+        return {};
+      }
+      return preToolUseDeny(unavailableReason());
+    }
+  };
+
+  const userPromptSubmit: HookCallback = async (input): Promise<HookJSONOutput> => {
+    try {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- this matcher is registered only on UserPromptSubmit
+      const hookInput = input as UserPromptSubmitHookInput;
+      const inbound: GuardHooksInbound = {
+        prompt: stringField(hookInput.prompt),
+      };
+      const action = resolveInboundAction(inboundPolicy, inbound);
+      const source = isContextSource(hookInput) ? hookInput : undefined;
+      const agentCtx = claudeAgentContext(
+        source,
+        policy.sessionId === undefined ? undefined : { sessionId: policy.sessionId },
+      );
+
+      const rules =
+        typeof inboundPolicy.rules === "function"
+          ? inboundPolicy.rules(inbound)
+          : inboundPolicy.rules;
+      const policyMetadata =
+        typeof inboundPolicy.metadata === "function"
+          ? inboundPolicy.metadata(inbound)
+          : inboundPolicy.metadata;
+      const metadata: ArcjetMetadata = {
+        ...agentCtx.metadata,
+        "claude.phase": "inbound",
+        ...policyMetadata,
+      };
+
+      return await runGate<HookJSONOutput>(client, {
+        action,
+        rules,
+        correlationId: agentCtx.correlationId,
+        metadata,
+        onAllow: () => ({}),
+        onDeny: (decision) => userPromptBlock(deniedReason(decision)),
+        onUnavailable: () => userPromptBlock(unavailableReason()),
+        onGuardError: inboundPolicy.onGuardError ?? policy.onGuardError ?? "deny",
+      });
+    } catch (error) {
+      if (shouldWarn()) {
+        console.warn(
+          "@arcjet/guard: guardHooks UserPromptSubmit threw; blocking the prompt:",
+          error,
+        );
+      }
+      if ((inboundPolicy.onGuardError ?? policy.onGuardError) === "allow") {
+        return {};
+      }
+      return userPromptBlock(unavailableReason());
+    }
+  };
+
+  const postToolUse: HookCallback = (input): Promise<HookJSONOutput> => {
+    try {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- this matcher is registered only on PostToolUse
+      const hookInput = input as PostToolUseHookInput;
+      const call: GuardHooksCall = {
+        toolName: stringField(hookInput.tool_name),
+        input: hookInput.tool_input,
+      };
+      const action = resolveToolAction(policy, call);
+      const source = isContextSource(hookInput) ? hookInput : undefined;
+      const agentCtx = claudeAgentContext(
+        source,
+        policy.sessionId === undefined ? undefined : { sessionId: policy.sessionId },
+      );
+
+      const policyMetadata =
+        typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+      const metadata: ArcjetMetadata = {
+        ...agentCtx.metadata,
+        "claude.phase": "after",
+        outcome: "success",
+        ...(call.toolName.length > 0 && { "claude.tool": call.toolName }),
+        ...policyMetadata,
+      };
+
+      const correlation =
+        agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
+
+      captureEvent(client, {
+        action,
+        ...correlation,
+        metadata,
+      });
+    } catch {
+      // Never throw from a hook
+    }
+    return Promise.resolve({});
+  };
+
+  return {
+    PreToolUse: [{ hooks: [preToolUse] }],
+    UserPromptSubmit: [{ hooks: [userPromptSubmit] }],
+    PostToolUse: [{ hooks: [postToolUse] }],
+  };
+}

--- a/arcjet-guard/src/claude-agent-sdk/v0/index.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/index.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import {
+  EXPECTED_CONDITIONS,
+  EXPECTED_ROOT_KEYS,
+  sortedKeys,
+} from "../../../test/_shared/source-scan.ts";
+import * as agentsBarrel from "../../agents/index.ts";
+import * as v7Namespace from "../../vercel-ai/v7/index.ts";
+import * as claudeNamespace from "./index.ts";
+import type {
+  ArcjetDenialResult,
+  ClaudeAgentContext,
+  GuardHooksPolicy,
+  GuardToolPolicy,
+} from "./index.ts";
+
+function verifyTypeExports(): void {
+  const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
+  const hooksPolicy: GuardHooksPolicy | undefined = undefined;
+  const denialResult: ArcjetDenialResult | undefined = undefined;
+  const agentContext: ClaudeAgentContext | undefined = undefined;
+  void [toolPolicy, hooksPolicy, denialResult, agentContext];
+}
+
+verifyTypeExports();
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("exports the three own helpers as functions", () => {
+  const ownExports = ["claudeAgentContext", "guardTool", "guardHooks"] as const;
+
+  for (const funcName of ownExports) {
+    const func = (claudeNamespace as Record<string, unknown>)[funcName];
+    assert.equal(
+      typeof func,
+      "function",
+      `@arcjet/guard/claude-agent-sdk/v0 must export ${funcName} as a function`,
+    );
+  }
+});
+
+test("claude namespace exports the agnostic helpers", () => {
+  const requiredSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+  ] as const;
+
+  for (const symbol of requiredSymbols) {
+    const value = (claudeNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/claude-agent-sdk/v0 must export ${symbol}`);
+  }
+});
+
+test("agnostic exports have same identity across Claude and v7 namespaces", () => {
+  const agnosticSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+    "ArcjetGuardUnavailableError",
+  ] as const;
+
+  for (const symbol of agnosticSymbols) {
+    const claudeValue = (claudeNamespace as Record<string, unknown>)[symbol];
+    const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
+
+    assert.strictEqual(
+      claudeValue,
+      v7Value,
+      `${symbol} must be the same object identity from both @arcjet/guard/claude-agent-sdk/v0 and @arcjet/guard/vercel-ai/v7`,
+    );
+  }
+});
+
+test("Claude namespace is a strict superset of the agents barrel with same identity", () => {
+  const claudeKeys = Object.keys(claudeNamespace);
+  const agentKeys = Object.keys(agentsBarrel);
+
+  for (const key of agentKeys) {
+    assert.ok(
+      claudeKeys.includes(key),
+      `agents barrel key "${key}" must be present in claude namespace`,
+    );
+    assert.strictEqual(
+      (claudeNamespace as Record<string, unknown>)[key],
+      (agentsBarrel as Record<string, unknown>)[key],
+      `${key} must be the same object identity from both imports`,
+    );
+  }
+
+  const expectedAdditions = 3;
+  assert.equal(
+    claudeKeys.length,
+    agentKeys.length + expectedAdditions,
+    `claude namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+  );
+
+  const claudeOnlyKeys = claudeKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["claudeAgentContext", "guardHooks", "guardTool"];
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const expectedOwnExports: readonly string[] = ownExportsArray.sort();
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const sorted: readonly string[] = claudeOnlyKeys.sort();
+  assert.deepEqual(sorted, expectedOwnExports);
+});
+
+test("export map has no unversioned ./claude-agent-sdk and no wildcard subpaths", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap, "package.json must have an exports field");
+
+  const exportKeys = Object.keys(exportsMap);
+
+  assert.ok(
+    !exportKeys.includes("./claude-agent-sdk"),
+    'export map must not have "./claude-agent-sdk"',
+  );
+  assert.ok(
+    exportKeys.includes("./claude-agent-sdk/v0"),
+    'export map must have "./claude-agent-sdk/v0"',
+  );
+
+  for (const key of exportKeys) {
+    if (key.startsWith("./claude-agent-sdk/")) {
+      assert.equal(
+        key,
+        "./claude-agent-sdk/v0",
+        `export map must not have wildcard claude-agent-sdk subpaths; found "${key}"`,
+      );
+    }
+  }
+});
+
+test("does not export Eve-only or Mastra-only APIs onto the Claude namespace", () => {
+  const forbidden = [
+    "eveAgentContext",
+    "guardInbound",
+    "guardApproval",
+    "arcjetHooks",
+    "guardConnection",
+    "mastraAgentContext",
+    "guardProcessor",
+    "canUseTool",
+    "guardCanUseTool",
+  ];
+  for (const key of forbidden) {
+    assert.equal(
+      (claudeNamespace as Record<string, unknown>)[key],
+      undefined,
+      `claude namespace must not export "${key}"`,
+    );
+  }
+});
+
+test("export map must not have ./agents", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap);
+  assert.ok(!Object.keys(exportsMap).includes("./agents"));
+});
+
+test("root export map keys and runtime conditions are correct", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap);
+
+  assert.deepEqual(sortedKeys(exportsMap), EXPECTED_ROOT_KEYS);
+
+  const rootEntry = objectField(exportsMap, ".");
+  assert.ok(rootEntry);
+  assert.deepEqual(sortedKeys(rootEntry), EXPECTED_CONDITIONS);
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/index.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/index.ts
@@ -1,0 +1,117 @@
+/**
+ * @packageDocumentation
+ *
+ * Claude Agent SDK namespace for Arcjet Guards.
+ *
+ * This module provides Claude Agent SDK-specific guard helpers plus the
+ * framework-agnostic layer they build on, so a Claude agent needs one import
+ * path and no notion of layering.
+ *
+ * **Requires the optional peer dependency `@anthropic-ai/claude-agent-sdk`
+ * (`>=0.1.0 <1`)**. Nothing in this module imports the SDK at runtime: every
+ * Claude type arrives through `import type`, so installing `@arcjet/guard`
+ * never pulls the Claude Agent SDK in.
+ *
+ * **Note:** the version segment is `v0` because the Claude Agent SDK is
+ * pre-1.0. There is deliberately no unversioned
+ * `@arcjet/guard/claude-agent-sdk` alias. A `v1` namespace is added when the
+ * SDK reaches 1.0; the segment names the SDK's major, not this integration's
+ * iteration.
+ *
+ * Three surfaces, and three things this namespace does not build:
+ *
+ * - **An authored tool** (`tool()` + `createSdkMcpServer()`) → `guardTool()`.
+ *   DENY returns a `CallToolResult` with `isError: true`; it does not throw.
+ * - **Inbound text** → `guardHooks()` `UserPromptSubmit`. DENY is
+ *   `{ decision: "block" }`. Timeout already fail-closes the prompt
+ *   (Claude Code v2.1.208+).
+ * - **Built-ins / unwrapped MCP** → `guardHooks()` `PreToolUse` with
+ *   `permissionDecision: "deny"`. Timeout already fail-closes (the tool does
+ *   not run). `PostToolUse` is capture only.
+ * - **Correlation** → `claudeAgentContext()` reads `session_id` from hook
+ *   input or `options.sessionId`. Subagents have `agent_id` (metadata only).
+ *   It never mints a new id.
+ *
+ * ## Screen inbound with UserPromptSubmit
+ *
+ * This is the only place a turn can be declined before the model sees the
+ * prompt. There is no `guardInbound`.
+ *
+ * ## canUseTool is not a policy gate
+ *
+ * Claude's docs say `canUseTool` is skipped by `allowedTools`, allow rules,
+ * and `bypassPermissions` / `acceptEdits`. Same trap as Eve approval and
+ * Mastra `requireApproval`. There is no `guardCanUseTool`.
+ *
+ * ## PreToolUse is the only deny for unwrapped tools
+ *
+ * Built-ins (Bash, Write, …) and MCP you did not wrap are gated here.
+ * Annotations and sandbox are not enforcement. Do not also wrap these tools
+ * with `@arcjet/guard/vercel-ai/v7` or `@arcjet/guard/agents`.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardTool, guardHooks } from "@arcjet/guard/claude-agent-sdk/v0";
+ * import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+ * import { z } from "zod";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const lookupOrder = guardTool(
+ *   client,
+ *   tool(
+ *     "lookup_order",
+ *     "Look up an order",
+ *     { orderNumber: z.string() },
+ *     async ({ orderNumber }) => ({
+ *       content: [{ type: "text", text: `${orderNumber}: shipped` }],
+ *     }),
+ *   ),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ *
+ * const sessionId = conversationId;
+ *
+ * for await (const message of query({
+ *   prompt: userText,
+ *   options: {
+ *     sessionId,
+ *     mcpServers: {
+ *       app: createSdkMcpServer({ name: "app", tools: [lookupOrder] }),
+ *     },
+ *     hooks: guardHooks(client, {
+ *       sessionId,
+ *       inbound: {
+ *         action: "message.received",
+ *         rules: ({ prompt }) => [detectPromptInjection()(prompt)],
+ *       },
+ *     }),
+ *   },
+ * })) {
+ *   void message;
+ * }
+ * ```
+ */
+
+export { claudeAgentContext } from "./context.ts";
+export type { ClaudeAgentContext, ClaudeContextSource } from "./context.ts";
+export { guardTool } from "./guard-tool.ts";
+export type { GuardToolPolicy, ClaudeToolInput, ClaudeToolDefinition } from "./guard-tool.ts";
+export { guardHooks } from "./hooks.ts";
+export type {
+  GuardHooksPolicy,
+  GuardHooksCall,
+  GuardHooksInbound,
+  GuardHooksInboundPolicy,
+} from "./hooks.ts";
+export type { ArcjetDenialResult, ClaudeCallToolResult } from "./denial.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/claude-agent-sdk/v0/peer.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/peer.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("@anthropic-ai/claude-agent-sdk is an optional peer and not a dependency", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+
+  const peerDependencies = objectField(packageJson, "peerDependencies");
+  assert.ok(peerDependencies);
+  assert.equal(peerDependencies["@anthropic-ai/claude-agent-sdk"], ">=0.1.0 <1");
+
+  const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
+  assert.ok(peerDependenciesMeta);
+  const claudeMeta = objectField(peerDependenciesMeta, "@anthropic-ai/claude-agent-sdk");
+  assert.ok(claudeMeta);
+  assert.equal(claudeMeta["optional"], true);
+
+  const dependencies = objectField(packageJson, "dependencies");
+  assert.ok(!(dependencies && "@anthropic-ai/claude-agent-sdk" in dependencies));
+});

--- a/arcjet-guard/src/claude-agent-sdk/v0/type-only.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/type-only.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+const PEER = "@anthropic-ai/claude-agent-sdk";
+
+function isClaudeImport(specifier: string): boolean {
+  return specifier === PEER || specifier.startsWith(`${PEER}/`);
+}
+
+test("type-only import scanner works on @anthropic-ai/claude-agent-sdk fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveClaudeImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of the Claude Agent SDK",
+      content: `import { tool } from "${PEER}";\nvoid tool;`,
+      shouldHaveClaudeImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of the Claude Agent SDK",
+      content: `import type { SdkMcpToolDefinition } from "${PEER}";\nvoid 0;`,
+      shouldHaveClaudeImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content: `import { type Options, tool } from "${PEER}";\nvoid tool;`,
+      shouldHaveClaudeImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of the Claude Agent SDK",
+      content: `export type { HookCallback } from "${PEER}";`,
+      shouldHaveClaudeImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { handler } from "@anthropic-ai/sdk";\nvoid handler;',
+      shouldHaveClaudeImport: false,
+    },
+    {
+      name: "detects dynamic import of the Claude Agent SDK",
+      content: `const sdk = await import("${PEER}");\nvoid sdk;`,
+      shouldHaveClaudeImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const claudeImports = imports.filter((imp) => isClaudeImport(imp.specifier));
+
+    if (fixture.shouldHaveClaudeImport === false) {
+      assert.equal(claudeImports.length, 0, `${fixture.name}: should not have claude imports`);
+    } else {
+      assert.equal(
+        claudeImports.length,
+        1,
+        `${fixture.name}: should have exactly one claude import`,
+      );
+      assert.equal(
+        claudeImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all @anthropic-ai/claude-agent-sdk imports in the namespace are type-only", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (isClaudeImport(imp.specifier) && !imp.typeOnly) {
+        errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+      }
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in claude-agent-sdk namespace:\n${errors.join("\n")}`,
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-claude-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, `import { tool } from "${PEER}";\nvoid tool;`);
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const claudeImports = imports.filter((imp) => isClaudeImport(imp.specifier));
+    assert.equal(claudeImports.length, 1);
+    assert.equal(claudeImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -290,6 +290,7 @@ export function asDenial<TResult>(value: unknown): TResult {
 export const EXPECTED_ROOT_KEYS = [
   ".",
   "./bun",
+  "./claude-agent-sdk/v0",
   "./fetch",
   "./mastra/v1",
   "./node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,6 +185,7 @@
       },
       "devDependencies": {
         "@ai-sdk/provider-utils": "5.0.13",
+        "@anthropic-ai/claude-agent-sdk": "0.3.221",
         "@mastra/core": "1.58.0",
         "@types/node": "22.20.1",
         "ai": "7.0.38",
@@ -199,12 +200,16 @@
       },
       "peerDependencies": {
         "@ai-sdk/provider-utils": ">=5 <6",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
         "@mastra/core": ">=1 <2",
         "ai": ">=7 <8",
         "eve": ">=0.25.1 <1"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/provider-utils": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
           "optional": true
         },
         "@mastra/core": {
@@ -775,6 +780,166 @@
         "node": ">=22"
       }
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.221.tgz",
+      "integrity": "sha512-qOXebuNlK5hKkYmXSdSNJHDw4ulAJYQ7hdGuOmv5pXtaRCvfkIRlNGKoiFjGDq55n8aneAp3/BIzAVcxSQln+g==",
+      "dev": true,
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.221",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.221"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.221.tgz",
+      "integrity": "sha512-/J4MnpoOqJqrIjH6c6GQAB6Tlcp+kvTEWSM9+5yCkGF2cUmXgaQk7eJlu05ldp+GuSS5AVKq5goIjhYFgY3+Sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.221.tgz",
+      "integrity": "sha512-je33rwPBGEHDoW/kMzoMw/Pg4mcRfvzirkhEx/rykAK4/w0t3Czwt5DeF0HXVQzW+M8bXPN1486wMxONNFLQMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.221.tgz",
+      "integrity": "sha512-6HhD/5poDNEpITda9NyTmqwrxaFi4dn5nROLCVC1BG4IhEHfeBIVocr1TAgTy7RjoScr3RHl9SA9OFpUMzuifQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.221.tgz",
+      "integrity": "sha512-Gi84q2ULzWhduMoP69NGwMpo9AibXcO+PtbF0eHCUJAQ/qUu0PxcrTg6S73WotQ2qAP8LhtN6a8x+8EszU64MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.221.tgz",
+      "integrity": "sha512-pPrpl84Pe563tLci6ndBuBK6IY85RKhcAAJMU73/VPB240yiSnnPaxqKTEgXnw7qbAFYTQ1TOasum/awUs4BdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.221.tgz",
+      "integrity": "sha512-/tm6HdYV1EnnZJpN9l1yxZGRaE5K+zj0OLycBBHc0CBXtAQ1we/7aMpqX39iJ01c7J5TG9coEJOI/G9K2FhQoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.221.tgz",
+      "integrity": "sha512-IK2aOH58U7iMM4nAc45B8pcHZhFCUAPml6N8WFBHNr41+hRelI++xEVJpQQk55SyrRQ8HVeCoMeTlp858i9KgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.221",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.221.tgz",
+      "integrity": "sha512-vqa6DOMfqSr+JoXqc7p6mjqwuTOYQLdXVBVCOwg7HEc/O0JgrFLeC4lCQs8hIkLrO0r/pBwv8KbfmYz1DwIeew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.117.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
+      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@arcjet/analyze": {
       "resolved": "analyze",
       "link": true
@@ -1180,6 +1345,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -2348,6 +2524,20 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
@@ -3088,6 +3278,48 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@modelcontextprotocol/server": {
@@ -4749,6 +4981,14 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5715,6 +5955,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -6047,6 +6302,47 @@
         "wasm2js": "bin/wasm2js"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -6076,6 +6372,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/c12": {
@@ -6115,6 +6422,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -6388,6 +6728,32 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -6408,6 +6774,36 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/croner": {
       "version": "10.0.1",
@@ -6652,6 +7048,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6830,6 +7237,30 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -6845,6 +7276,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/entities": {
@@ -6953,6 +7395,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -7000,6 +7456,14 @@
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7057,6 +7521,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eve": {
       "version": "0.31.0",
       "resolved": "https://registry.npmjs.org/eve/-/eve-0.31.0.tgz",
@@ -7112,6 +7587,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
@@ -7147,6 +7636,83 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/exsolve": {
@@ -7224,6 +7790,14 @@
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -7366,6 +7940,29 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
@@ -7420,6 +8017,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7435,6 +8054,17 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -7446,6 +8076,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -7626,6 +8297,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
@@ -7736,6 +8435,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookable": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
@@ -7768,6 +8478,28 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/httpxy": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
@@ -7783,6 +8515,24 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -7827,6 +8577,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -7913,6 +8682,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
@@ -8043,6 +8820,21 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-to-zod": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
@@ -8059,6 +8851,14 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -8537,6 +9337,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -8778,6 +9589,35 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -9370,6 +10210,35 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -9486,6 +10355,17 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/neotraverse": {
@@ -9859,6 +10739,31 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9919,6 +10824,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -10232,6 +11162,17 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -10240,6 +11181,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -10322,6 +11275,17 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/pkg-types": {
       "version": "2.3.1",
@@ -10478,6 +11442,50 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quansync": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
@@ -10508,6 +11516,38 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc9": {
       "version": "3.0.1",
@@ -10886,6 +11926,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -10928,6 +11986,14 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/satteri": {
       "version": "0.9.5",
@@ -11026,6 +12092,34 @@
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -11041,12 +12135,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/sharp": {
       "version": "0.35.3",
@@ -11138,6 +12261,86 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -11267,6 +12470,29 @@
       },
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -11599,6 +12825,17 @@
         "node": ">=20"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
@@ -11666,6 +12903,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tsdown": {
       "version": "0.22.7",
@@ -11775,6 +13020,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -12041,6 +13321,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unplugin": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
@@ -12183,6 +13474,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -12383,6 +13685,14 @@
         "@cloudflare/workerd-windows-64": "1.20260708.1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -12556,6 +13866,17 @@
         "zod": "^4.0.17"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -12623,9 +13944,9 @@
       }
     },
     "nosecone-sveltekit/node_modules/@sveltejs/kit": {
-      "version": "2.70.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
-      "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
+      "version": "2.69.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.3.tgz",
+      "integrity": "sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12675,9 +13996,9 @@
       }
     },
     "nosecone-sveltekit/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,6 +841,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -855,6 +858,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -869,6 +875,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -883,6 +892,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1952,7 +1964,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1970,7 +1981,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1988,7 +1998,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2006,7 +2015,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2024,7 +2032,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2042,7 +2049,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2060,7 +2066,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2078,7 +2083,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2096,7 +2100,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2114,7 +2117,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2132,7 +2134,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2150,7 +2151,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2168,7 +2168,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2186,7 +2185,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2204,7 +2202,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,7 +2219,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2240,7 +2236,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2258,7 +2253,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2276,7 +2270,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2294,7 +2287,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2312,7 +2304,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2330,7 +2321,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2348,7 +2338,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2366,7 +2355,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2384,7 +2372,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2402,7 +2389,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13944,9 +13930,9 @@
       }
     },
     "nosecone-sveltekit/node_modules/@sveltejs/kit": {
-      "version": "2.69.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.3.tgz",
-      "integrity": "sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+      "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13996,9 +13982,9 @@
       }
     },
     "nosecone-sveltekit/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,13 @@
       "matchPackageNames": ["@mastra/core"],
       "automerge": false,
       "allowedVersions": "<2"
+    },
+    {
+      "description": "Never automerge @anthropic-ai/claude-agent-sdk. It is pre-1.0 and tracks Claude Code patch-for-patch, so a minor release may break. `@arcjet/guard/claude-agent-sdk/v0` types against SdkMcpToolDefinition, Options.hooks, HookCallback, and HookJSONOutput. Keep the range below 1.0; claude-agent-sdk/v1 is added deliberately, not by a bump.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@anthropic-ai/claude-agent-sdk"],
+      "automerge": false,
+      "allowedVersions": "<1"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `@arcjet/guard/claude-agent-sdk/v0` for the Claude Agent SDK: wrap authored `tool()` handlers, screen inbound prompts, and deny unwrapped / built-in tools. Correlation is read from `session_id` / `options.sessionId` — never minted. `canUseTool` is not a policy gate.

Full working demo: [arcjet/examples#193](https://github.com/arcjet/examples/pull/193).

```ts
import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
import { guardTool, guardHooks } from "@arcjet/guard/claude-agent-sdk/v0";
import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
import { z } from "zod";

const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
const limit = tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 10 });

const lookupOrder = guardTool(
  arcjet,
  tool("lookup_order", "Look up an order", { orderNumber: z.string() }, async ({ orderNumber }) => ({
    content: [{ type: "text", text: `${orderNumber}: shipped` }],
  })),
  {
    action: "order.looked-up",
    rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
  },
);

const sessionId = conversationId;

for await (const message of query({
  prompt: userText,
  options: {
    sessionId,
    mcpServers: { app: createSdkMcpServer({ name: "app", tools: [lookupOrder] }) },
    hooks: guardHooks(arcjet, {
      sessionId,
      inbound: {
        action: "message.received",
        rules: ({ prompt }) => [detectPromptInjection()(prompt)],
      },
    }),
  },
})) {
  void message;
}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3361126e-bdb9-4fcb-84ed-2da8232a16a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3361126e-bdb9-4fcb-84ed-2da8232a16a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

