### PR TITLE
feat(guard): add LangGraph support as @arcjet/guard/langgraph/v1

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -113,6 +113,10 @@ jobs:
       # written `import type`; this proves the consequence, catching a build
       # step that re-emits one as a value import.
       #
+      # Only `src/langgraph` is globbed. The suite that exercises the real
+      # ToolNode value-imports both peers, so it lives in `test/langgraph`
+      # and runs in the unit-test step above, where the peers are installed.
+      #
       # Runs before the eve-absent step because that one deletes a different
       # optional peer. Typecheck legitimately fails without the peers.
       - name: Unit tests with langgraph absent

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -108,6 +108,23 @@ jobs:
           node --test 'arcjet-guard/src/vercel-eve/**/*.test.ts'
         working-directory: ${{ github.workspace }}
 
+      # The langgraph namespace imports @langchain/langgraph and
+      # @langchain/core for types only. A static scan proves the imports are
+      # written `import type`; this proves the consequence, catching a build
+      # step that re-emits one as a value import.
+      #
+      # Runs before the eve-absent step because that one deletes a different
+      # optional peer. Typecheck legitimately fails without the peers.
+      - name: Unit tests with langgraph absent
+        run: |
+          rm -rf node_modules/@langchain/langgraph node_modules/@langchain/core arcjet-guard/node_modules/@langchain/langgraph arcjet-guard/node_modules/@langchain/core
+          node -e "try { require.resolve('@langchain/langgraph', { paths: ['arcjet-guard/src/langgraph/v1'] }); console.error('langgraph still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
+          node -e "try { require.resolve('@langchain/core', { paths: ['arcjet-guard/src/langgraph/v1'] }); console.error('langchain core still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
+          count=$(find arcjet-guard/src/langgraph -name '*.test.ts' | wc -l)
+          test "$count" -ge 5 || { echo "only $count langgraph test files matched; the glob has gone stale" >&2; exit 1; }
+          node --test 'arcjet-guard/src/langgraph/**/*.test.ts'
+        working-directory: ${{ github.workspace }}
+
       # The mastra namespace imports @mastra/core for types only. A static scan
       # proves the imports are written `import type`; this proves the
       # consequence, catching a build step that re-emits one as a value import.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,10 @@ change them:
   `mastra/v1` is the same idea on a different SDK: Mastra already runs
   channels through `processInput` and treats `requireApproval` as human HITL,
   so its helpers are `guardTool`, `guardProcessor`, and `guardHooks`.
+  `langgraph/v1` is Graph API (`StateGraph` + `ToolNode`): authored tools
+  are `guardTool`, unwrapped / MCP tools go through `guardToolNode`, and
+  `interrupt()` is HITL not policy. `createReactAgent` is deprecated; do not
+  build on it or on LangChain `createAgent`.
 - **Flat** — a single level under `@arcjet/guard`, no further nesting.
 - **Explicitly versioned, with no unversioned alias.** `@arcjet/guard/vercel-ai`
   does not resolve, and neither does a wildcard `./vercel-ai/*`. An alias would

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -590,7 +590,7 @@ before the event exists.
 <details>
 <summary>Without <code>using</code> — Node.js 22, or no TypeScript compile step</summary>
 
-The `using` *syntax* needs Node.js 24 to run natively, or compilation through
+The `using` _syntax_ needs Node.js 24 to run natively, or compilation through
 TypeScript. Node.js 22 defines `Symbol.dispose` but cannot parse `using`. Call
 `unregister()` from a `finally` instead:
 
@@ -765,7 +765,12 @@ Methods available on both `RuleWithConfig` and `RuleWithInput`:
   }
   const decision = await getArcjet().guard({
     label: "tools.chat",
-    rules: [tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 100 })({ key: userId, requested: 1 })],
+    rules: [
+      tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 100 })({
+        key: userId,
+        requested: 1,
+      }),
+    ],
   });
   ```
 
@@ -775,7 +780,12 @@ Methods available on both `RuleWithConfig` and `RuleWithInput`:
   const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
   const decision = await arcjet.guard({
     label: "tools.chat",
-    rules: [tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 100 })({ key: userId, requested: 1 })],
+    rules: [
+      tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 100 })({
+        key: userId,
+        requested: 1,
+      }),
+    ],
   });
   ```
 
@@ -833,7 +843,10 @@ const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 const decision = await arcjet.guard({
   label: "tools.chat",
   rules: [
-    tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 100 })({ key: userId, requested: 1 }),
+    tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 100 })({
+      key: userId,
+      requested: 1,
+    }),
     detectPromptInjection()(userMessage),
   ],
 });
@@ -901,10 +914,7 @@ helper. Currently available:
 
   ```ts
   import { launchArcjet, tokenBucket } from "@arcjet/guard";
-  import {
-    guardApproval,
-    arcjetHooks,
-  } from "@arcjet/guard/vercel-eve/v0";
+  import { guardApproval, arcjetHooks } from "@arcjet/guard/vercel-eve/v0";
   import { defineOpenAPIConnection } from "eve/connections";
   import { defineHook } from "eve/hooks";
 
@@ -918,7 +928,7 @@ helper. Currently available:
   // Gate a connection's operations
   export const ordersConnection = defineOpenAPIConnection({
     description: "Orders API",
-    spec: { /* ... */ },
+    spec: {/* ... */},
     approval: guardApproval(arcjet, {
       action: "orders-api.read",
       onGuardError: "deny", // default — blocks the call if Arcjet is unreachable
@@ -987,7 +997,16 @@ helper. Currently available:
   `wrapToolCall`, and `createReactAgent` is deprecated in LangGraph JS v1
   — do not build on it. There is no `guardInbound` (screen before
   `invoke` or at the first graph node) and no `guardInterrupt` /
-  `guardApproval` (`interrupt()` is human HITL, not policy):
+  `guardApproval` (`interrupt()` is human HITL, not policy).
+
+  On DENY a guarded tool does not run and does not throw: it returns a
+  structured `ArcjetDenialResult`, which `ToolNode` turns into a real
+  `ToolMessage` the model reads. Because the tool did not throw, that
+  message's `status` is `success` — the denial is in the payload
+  (`arcjetDenied: true`), not the envelope. `guardToolNode` guards a
+  `ToolNode`'s tools **in place** and returns the same node, because
+  `ToolNode` resolves its tools through a closure captured when it was
+  constructed:
 
   ```ts
   import { launchArcjet, tokenBucket } from "@arcjet/guard";
@@ -1005,14 +1024,11 @@ helper. Currently available:
 
   const lookupOrder = guardTool(
     arcjet,
-    tool(
-      async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
-      {
-        name: "lookup_order",
-        description: "Look up an order",
-        schema: z.object({ orderNumber: z.string() }),
-      },
-    ),
+    tool(async ({ orderNumber }) => ({ orderNumber, status: "shipped" }), {
+      name: "lookup_order",
+      description: "Look up an order",
+      schema: z.object({ orderNumber: z.string() }),
+    }),
     {
       action: "order.looked-up",
       onGuardError: "deny",
@@ -1040,6 +1056,21 @@ There is no `guardInterrupt`.
 Unwrapped and MCP tools run inside `ToolNode`. Graph hooks and HITL
 pauses cannot stop `tool.invoke`. Use `guardToolNode` (or `guardTool` for
 authored tools you invoke yourself).
+
+`guardToolNode` guards the node's tools in place and hands the same node
+back. That is not an optimisation: `ToolNode`'s constructor captures
+`func: (input, config) => this.run(input, config)`, and `run` reads
+`this.tools`, so a copy holding a fresh tools array would leave the original
+node executing unguarded tools. Guarding in place also means a caller that
+still holds the pre-wrap node cannot bypass Guard. Passing an array of tools
+instead returns guarded copies and leaves your array untouched. Tools
+appended after wrapping — MCP discovered mid-run — are guarded on the next
+`invoke`.
+
+If you invoke a guarded tool yourself rather than through `ToolNode`, read
+the denial and build your own `ToolMessage`; do not push the denial object
+straight into `messages`, because the graph's message reducer only accepts
+real messages.
 
 ### Naming and versions
 
@@ -1136,13 +1167,13 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 > actions that are assumed to be sensitive. The core client reports degraded
 > evaluation via `hasFailedOpen()`; the helpers decide to block on it.
 
-| API                                  | Default on Arcjet outage                    | How to flip                        |
-| ------------------------------------ | ------------------------------------------- | ---------------------------------- |
-| `guard()` (core)                     | Allow (fail open), `hasFailedOpen()===true` | gate manually on `hasFailedOpen()` |
-| `guardTool` / `guardAction`          | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| Eve `guardInbound` / `guardApproval` | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| Mastra `guardProcessor` / `guardHooks` | Deny (fail closed)                        | `onGuardError: "allow"`            |
-| LangGraph `guardTool` / `guardToolNode` | Deny (fail closed)                       | `onGuardError: "allow"`            |
+| API                                     | Default on Arcjet outage                    | How to flip                        |
+| --------------------------------------- | ------------------------------------------- | ---------------------------------- |
+| `guard()` (core)                        | Allow (fail open), `hasFailedOpen()===true` | gate manually on `hasFailedOpen()` |
+| `guardTool` / `guardAction`             | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Eve `guardInbound` / `guardApproval`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Mastra `guardProcessor` / `guardHooks`  | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| LangGraph `guardTool` / `guardToolNode` | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -1185,8 +1216,8 @@ what happens:
     human cost of rejecting a legitimate message exceeds the security cost.
 
 The layering resolves a potential confusion: the core `@arcjet/guard` client
-still fails open by construction and *reports* it via `hasFailedOpen()`; the
-agent-level helpers *decide* to block on it.
+still fails open by construction and _reports_ it via `hasFailedOpen()`; the
+agent-level helpers _decide_ to block on it.
 
 ### The explicit-call alternative
 
@@ -1318,8 +1349,7 @@ const sendEmail = guardTool(
 const tools = { sendEmail };
 const result = await generateText({
   model: languageModel, // Use a real language model, e.g., from @ai-sdk/openai
-  instructions:
-    "If a tool is denied by Arcjet, explain to the user instead of retrying.",
+  instructions: "If a tool is denied by Arcjet, explain to the user instead of retrying.",
   tools,
   toolsContext: aiToolsContext(ctx, tools),
   prompt: userMessage, // User input or conversation context
@@ -1360,11 +1390,11 @@ The `action` is the guard label: use `resource.verb` past tense (e.g. `order.loo
 
 ### Which helper?
 
-| Scenario | Helper | Guard | Model Sees |
-|----------|--------|-------|-----------|
-| LLM decided to call a tool | `guardTool()` | Always | `ArcjetDenialResult` on DENY |
-| Your app invokes an action | `guardAction()` | Always | Throws `ArcjetDeniedError` on DENY |
-| Record that something happened | `captureAction()` | No | — (fire-and-forget) |
+| Scenario                       | Helper            | Guard  | Model Sees                         |
+| ------------------------------ | ----------------- | ------ | ---------------------------------- |
+| LLM decided to call a tool     | `guardTool()`     | Always | `ArcjetDenialResult` on DENY       |
+| Your app invokes an action     | `guardAction()`   | Always | Throws `ArcjetDeniedError` on DENY |
+| Record that something happened | `captureAction()` | No     | — (fire-and-forget)                |
 
 `guardTool` and `guardAction` call `guard()` on every invocation, including when
 `rules` is omitted or resolves to `[]`. Submitting no rules is not the same as
@@ -1475,15 +1505,15 @@ When a guard check denies an action, `guardAction` throws `ArcjetDeniedError` ca
 
 Use `securityMetadata()` keys consistently across your app:
 
-| Key | Meaning | Example |
-|-----|---------|---------|
-| `user` | Whose authority (opaque ID, not PII) | `"user_alice"`, `"org_123"` |
-| `agent` | Type or identity of the AI actor | `"support-agent"`, `"code-reviewer"` |
-| `workflow` | Process name this request belongs to | `"support-request"`, `"pr-review"` |
-| `dataClass` | Data sensitivity level | `"public"`, `"confidential"`, `"regulated"` |
-| `destination` | Where effects are sent | `"github"`, `"slack"`, `"email"` |
-| `reversibility` | Whether the action can be undone | `"reversible"`, `"compensable"`, `"irreversible"` |
-| `resource` | What's being acted on | `"order:12345"`, `"repo:owner/name"` |
+| Key             | Meaning                              | Example                                           |
+| --------------- | ------------------------------------ | ------------------------------------------------- |
+| `user`          | Whose authority (opaque ID, not PII) | `"user_alice"`, `"org_123"`                       |
+| `agent`         | Type or identity of the AI actor     | `"support-agent"`, `"code-reviewer"`              |
+| `workflow`      | Process name this request belongs to | `"support-request"`, `"pr-review"`                |
+| `dataClass`     | Data sensitivity level               | `"public"`, `"confidential"`, `"regulated"`       |
+| `destination`   | Where effects are sent               | `"github"`, `"slack"`, `"email"`                  |
+| `reversibility` | Whether the action can be undone     | `"reversible"`, `"compensable"`, `"irreversible"` |
+| `resource`      | What's being acted on                | `"order:12345"`, `"repo:owner/name"`              |
 
 ## Example
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -981,6 +981,66 @@ helper. Currently available:
   });
   ```
 
+- **`@arcjet/guard/langgraph/v1`** — LangGraph Graph API (`StateGraph` +
+  `ToolNode`) integration. Exports `guardTool`, `guardToolNode`, and
+  `langgraphAgentContext`. This is **not** LangChain `createAgent` /
+  `wrapToolCall`, and `createReactAgent` is deprecated in LangGraph JS v1
+  — do not build on it. There is no `guardInbound` (screen before
+  `invoke` or at the first graph node) and no `guardInterrupt` /
+  `guardApproval` (`interrupt()` is human HITL, not policy):
+
+  ```ts
+  import { launchArcjet, tokenBucket } from "@arcjet/guard";
+  import { guardTool, guardToolNode } from "@arcjet/guard/langgraph/v1";
+  import { ToolNode } from "@langchain/langgraph/prebuilt";
+  import { tool } from "@langchain/core/tools";
+  import { z } from "zod";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const lookupOrder = guardTool(
+    arcjet,
+    tool(
+      async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+      {
+        name: "lookup_order",
+        description: "Look up an order",
+        schema: z.object({ orderNumber: z.string() }),
+      },
+    ),
+    {
+      action: "order.looked-up",
+      onGuardError: "deny",
+      rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
+    },
+  );
+
+  export const tools = guardToolNode(arcjet, new ToolNode([lookupOrder]));
+  ```
+
+#### Screen inbound before `invoke` (or at the first graph node)
+
+LangGraph has no first-class inbound channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `graph.invoke`, or in the graph's first node.
+
+#### `interrupt()` is not a policy gate
+
+`interrupt()` / `interrupt_before=["tools"]` is human-in-the-loop, not
+policy. Same trap as Mastra `requireApproval` and Claude `canUseTool`.
+There is no `guardInterrupt`.
+
+#### `ToolNode` is the deny point for tools; hooks / HITL cannot enforce
+
+Unwrapped and MCP tools run inside `ToolNode`. Graph hooks and HITL
+pauses cannot stop `tool.invoke`. Use `guardToolNode` (or `guardTool` for
+authored tools you invoke yourself).
+
 ### Naming and versions
 
 Integration paths are `@arcjet/guard/<vendor-sdk>/v<major>` — the SDK being
@@ -1016,6 +1076,9 @@ importing only core guards are not forced to install unneeded packages:
   Eve, ensure your deployment environment and CI both run Node 24 or later.
 - **`@arcjet/guard/mastra/v1`** requires `@mastra/core` (optional peer,
   installed only to use `@arcjet/guard/mastra/v1`). The peer range is `>=1 <2`.
+- **`@arcjet/guard/langgraph/v1`** requires `@langchain/langgraph` and
+  `@langchain/core` (optional peers, installed only to use
+  `@arcjet/guard/langgraph/v1`). The peer range is `>=1 <2` for both.
 
 **pnpm caveat**: pnpm does not reliably honour
 `peerDependenciesMeta.*.optional` (pnpm#5152, #8142), especially with
@@ -1041,6 +1104,11 @@ pnpm install @mastra/core
 ```
 
 ```sh
+# @arcjet/guard/langgraph/v1
+pnpm install @langchain/langgraph @langchain/core
+```
+
+```sh
 # or skip the peer install and relax the check:
 pnpm install --no-strict-peer-dependencies
 ```
@@ -1052,8 +1120,9 @@ are not tied to any AI SDK, and internally they are kept that way — nothing
 they import reaches `ai`. They are published on each vendor namespace, so there
 is one path to learn and no layering to reason about.
 
-`@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`, and
-`@arcjet/guard/mastra/v1` now export these helpers. The open next step is
+`@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`,
+`@arcjet/guard/mastra/v1`, and `@arcjet/guard/langgraph/v1` now export these
+helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
 agnostic layer without installing a vendor peer. That change is a follow-up
 with its own ADR; there is still no public `@arcjet/guard/agents`.
@@ -1073,6 +1142,7 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 | `guardTool` / `guardAction`          | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Eve `guardInbound` / `guardApproval` | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Mastra `guardProcessor` / `guardHooks` | Deny (fail closed)                        | `onGuardError: "allow"`            |
+| LangGraph `guardTool` / `guardToolNode` | Deny (fail closed)                       | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -1423,9 +1493,11 @@ For an example with Vercel Eve, see [`eve-agent`](https://github.com/arcjet/exam
 
 For an example with Mastra, see [`mastra-agent`](https://github.com/arcjet/examples/tree/main/examples/mastra-agent), which shows inbound prompt-injection screening, guarded tools (deny, PII on args, rate limit, fail-closed), hooks for unwrapped tools, and thread/resource correlation. These Guard examples land with [arcjet/examples#193](https://github.com/arcjet/examples/pull/193).
 
+For an example with LangGraph, see [`langgraph-agent`](https://github.com/arcjet/examples/tree/main/examples/langgraph-agent) (follow-up on that same PR): inbound screening before `invoke`, `guardTool` / `guardToolNode` (deny, PII on args, rate limit, fail-closed), and `thread_id` correlation. `interrupt()` is HITL, not a policy gate; `ToolNode` is the deny point for tools.
+
 ## Agent skill
 
-For integration help in Claude Code or other AI coding agents, three skill files are packaged with `@arcjet/guard`:
+For integration help in Claude Code or other AI coding agents, skill files are packaged with `@arcjet/guard`:
 
 **For Vercel AI SDK:**
 
@@ -1458,6 +1530,16 @@ ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-mastra ~
 ```
 
 In Claude Code, use `/integrate-arcjet-guard-mastra` to start an integration session.
+
+**For LangGraph:**
+
+```bash
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-langgraph ~/.claude/skills/
+# or
+ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-langgraph ~/.claude/skills/
+```
+
+In Claude Code, use `/integrate-arcjet-guard-langgraph` to start an integration session.
 
 Each skill guides you through wrapping tools, screening inbound messages, and recording lifecycle events joined by correlation ID.
 

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -95,7 +95,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts'",
+    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/langgraph/**/*.test.ts'",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
     "test-runtime-deno": "npm run build && deno test --no-check --allow-all test/runtime/deno.test.ts",

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -79,6 +79,10 @@
     "./mastra/v1": {
       "types": "./dist/mastra/v1/index.d.ts",
       "import": "./dist/mastra/v1/index.js"
+    },
+    "./langgraph/v1": {
+      "types": "./dist/langgraph/v1/index.d.ts",
+      "import": "./dist/langgraph/v1/index.js"
     }
   },
   "publishConfig": {
@@ -108,6 +112,8 @@
   },
   "devDependencies": {
     "@ai-sdk/provider-utils": "5.0.13",
+    "@langchain/core": "1.2.8",
+    "@langchain/langgraph": "1.4.10",
     "@mastra/core": "1.58.0",
     "@types/node": "22.20.1",
     "ai": "7.0.38",
@@ -119,6 +125,8 @@
   },
   "peerDependencies": {
     "@ai-sdk/provider-utils": ">=5 <6",
+    "@langchain/core": ">=1 <2",
+    "@langchain/langgraph": ">=1 <2",
     "@mastra/core": ">=1 <2",
     "ai": ">=7 <8",
     "eve": ">=0.25.1 <1"
@@ -134,6 +142,12 @@
       "optional": true
     },
     "@mastra/core": {
+      "optional": true
+    },
+    "@langchain/core": {
+      "optional": true
+    },
+    "@langchain/langgraph": {
       "optional": true
     }
   },

--- a/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
@@ -14,12 +14,13 @@ client. It never talks to the Arcjet API itself. Two surfaces, one
 decision rule:
 
 - **An authored tool** (`tool()` / `StructuredTool`) → `guardTool()`. DENY
-  is a tool result with `status: "error"`. Do not throw.
+  returns a structured `ArcjetDenialResult`. Do not throw.
 - **MCP / runtime-discovered / unwrapped tools** → `guardToolNode()`.
-  Wraps `ToolNode` from `@langchain/langgraph/prebuilt` so execute still
-  hits Guard. Already-branded tools are skipped (no double-call).
+  Guards the tools a `ToolNode` from `@langchain/langgraph/prebuilt`
+  executes, in place, so execute still hits Guard. Already-branded tools
+  are skipped (no double-call).
 - **Correlation** → `langgraphAgentContext()` reads
-  `configurable.thread_id`, then `checkpoint_ns`, then run id. It never
+  `configurable.thread_id`, then the run id, then `checkpoint_ns`. It never
   mints a new id.
 
 This namespace is LangGraph **Graph API** (`StateGraph` + `ToolNode`).
@@ -45,6 +46,13 @@ Guard.
 Unwrapped and MCP tools run inside `ToolNode`. Graph hooks and HITL
 pauses cannot stop `tool.invoke`. Use `guardToolNode` (or `guardTool` for
 authored tools you invoke yourself).
+
+`guardToolNode` guards the node's tools **in place** and returns the same
+node. `ToolNode`'s constructor captures
+`func: (input, config) => this.run(input, config)` and `run` reads
+`this.tools`, so guarding a copy would leave the original node running
+unguarded tools. This also means a caller still holding the pre-wrap node
+cannot bypass Guard.
 
 ## Questions to ask the human first
 
@@ -79,9 +87,14 @@ Ask only what you cannot infer from the code; suggest defaults.
    tools are LangChain `tool()`, but this namespace brands them. `guardTool`
    throws if the tool already carries the Arcjet protection brand.
    `guardToolNode` skips already-branded tools so Guard is not double-called.
-6. **A denial from `guardTool` is a tool result with `status: "error"`**,
-   not a throw. If `onDeny` throws, the tool still does not run and the
-   model still receives the default denial result.
+6. **A denial from `guardTool` is a structured object, not a throw.**
+   `ToolNode` turns it into a real `ToolMessage`. Because the tool did not
+   throw, that message's `status` is `success` — the denial is in the
+   payload (`arcjetDenied: true`). Do not fabricate a `ToolMessage`
+   yourself to force `status: "error"`: an object that only looks like a
+   message reaches the graph's message reducer and crashes it. If `onDeny`
+   throws, the tool still does not run and the model still receives the
+   default denial.
 
 ## Step 1: Install and find the guard client
 
@@ -143,7 +156,10 @@ export const lookupOrder = guardTool(
 
 - Omit `rules` to submit none. The guard call still happens.
 - On DENY the tool's `func` / `invoke` never runs. The model receives
-  `{ status: "error", arcjetDenied: true, reason, message, retryable }`.
+  `{ arcjetDenied: true, reason, message, retryable }` as the tool result
+  content. If you invoke a guarded tool outside `ToolNode`, read that
+  object and build your own `ToolMessage` rather than pushing it into
+  `messages`.
 - Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
 
 ## Step 3: Screen inbound before invoke
@@ -194,10 +210,12 @@ export const tools = guardToolNode(arcjet, new ToolNode(mcpTools), {
 });
 ```
 
-Pass the wrapped node to `StateGraph.addNode("tools", tools)`. Use this
+Pass the wrapped node to `StateGraph.addNode("tools", tools)`. It is the
+same node object you passed in, with its tools guarded in place. Use this
 for tools you did **not** pass through `guardTool`. `guardToolNode` skips
-already-branded tools so applying both to the same authored tool does not
-double-call the guard.
+already-branded tools, so applying both to the same authored tool does not
+double-call the guard. Tools discovered after wrapping are guarded on the
+next `invoke`.
 
 ## Step 5: Correlation
 
@@ -210,8 +228,10 @@ const config = { configurable: { thread_id: conversationId } };
 await graph.invoke({ messages }, config);
 ```
 
-Preference order: `configurable.thread_id`, then
-`configurable.checkpoint_ns`, then run id. If none is a valid 1–256
+Preference order: `configurable.thread_id`, then the run id, then
+`configurable.checkpoint_ns`. The namespace is last because it names one
+subgraph (`""` for the parent), so preferring it would split sibling
+subgraphs of a single run across correlation ids. If none is a valid 1–256
 printable-ASCII string, the call is uncorrelated rather than joined to a
 generated id nobody has.
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: integrate-arcjet-guard-langgraph
+description: Integrate Arcjet security into a LangGraph Graph API agent using @arcjet/guard — wrap tool() / StructuredTool, wrap ToolNode for unwrapped MCP tools, and read thread_id for correlation. Use when asked to add Arcjet to a LangGraph StateGraph / ToolNode agent, rate limit its tools, screen inbound messages, or block prompt injection / PII.
+license: Apache-2.0
+compatibility: Requires the target app to use LangGraph (@langchain/langgraph >=1 <2) on Node.js >= 22. This is Graph API (StateGraph + ToolNode), not LangChain createAgent.
+metadata:
+  author: arcjet
+---
+
+# Integrate Arcjet Guard into a LangGraph agent
+
+`@arcjet/guard`'s LangGraph v1 namespace wraps the agent's existing Arcjet
+client. It never talks to the Arcjet API itself. Two surfaces, one
+decision rule:
+
+- **An authored tool** (`tool()` / `StructuredTool`) → `guardTool()`. DENY
+  is a tool result with `status: "error"`. Do not throw.
+- **MCP / runtime-discovered / unwrapped tools** → `guardToolNode()`.
+  Wraps `ToolNode` from `@langchain/langgraph/prebuilt` so execute still
+  hits Guard. Already-branded tools are skipped (no double-call).
+- **Correlation** → `langgraphAgentContext()` reads
+  `configurable.thread_id`, then `checkpoint_ns`, then run id. It never
+  mints a new id.
+
+This namespace is LangGraph **Graph API** (`StateGraph` + `ToolNode`).
+`createReactAgent` is deprecated in LangGraph JS v1 in favor of LangChain
+`createAgent` / `wrapToolCall`. Do not build on `createReactAgent`. Do not
+use this path for a LangChain `createAgent` app — that is a later adapter.
+
+## Screen inbound before `invoke` (or at the first graph node)
+
+There is no first-class LangGraph channel for inbound screening, so there
+is no `guardInbound`. Put prompt-injection (and other inbound rules) in
+the application before `graph.invoke`, or in the graph's first node.
+
+## `interrupt()` is not a policy gate
+
+`interrupt()` / `interrupt_before=["tools"]` is human-in-the-loop, not
+policy. Same trap as Mastra `requireApproval` and Claude `canUseTool`.
+There is no `guardInterrupt` and no `guardApproval`. Do not wrap them as
+Guard.
+
+## `ToolNode` is the deny point for tools; hooks / HITL cannot enforce
+
+Unwrapped and MCP tools run inside `ToolNode`. Graph hooks and HITL
+pauses cannot stop `tool.invoke`. Use `guardToolNode` (or `guardTool` for
+authored tools you invoke yourself).
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those get `guardTool`. MCP / tools you did not
+   author get `guardToolNode`.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. `thread_id` is the
+   correlation id, not the user.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound screening before
+   `invoke`: failing closed there means the graph does not run for the
+   duration of the outage, so `"allow"` is a routine and legitimate
+   choice at that one call site.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection before
+   `graph.invoke` or in the first graph node.
+2. **`interrupt()` is not a policy gate.** It is HITL. Use `guardTool` or
+   `guardToolNode`.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/langgraph/v1`. `@arcjet/guard/langgraph` does not resolve.
+4. **Correlation is read, never minted.** Do not call `createAgentContext`
+   inside a LangGraph callback — that generates a second id and splits the
+   Sequence. `langgraphAgentContext` reads `thread_id` / `checkpoint_ns` /
+   run id and omits `correlationId` when none of those is a valid id.
+5. **Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.** LangGraph
+   tools are LangChain `tool()`, but this namespace brands them. `guardTool`
+   throws if the tool already carries the Arcjet protection brand.
+   `guardToolNode` skips already-branded tools so Guard is not double-called.
+6. **A denial from `guardTool` is a tool result with `status: "error"`**,
+   not a throw. If `onDeny` throws, the tool still does not run and the
+   model still receives the default denial result.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `@langchain/langgraph` and
+`@langchain/core` (optional peers, needed for
+`@arcjet/guard/langgraph/v1`). Always use the versioned path:
+`@arcjet/guard/langgraph/v1` resolves; `@arcjet/guard/langgraph` throws
+`ERR_PACKAGE_PATH_NOT_EXPORTED`.
+
+```sh
+npm install @arcjet/guard @langchain/langgraph @langchain/core
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate authored tools
+
+```ts
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+import { guardTool } from "@arcjet/guard/langgraph/v1";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  bucket: "lookups",
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+// Factory then text — same shape as `detectPromptInjection()(text)`.
+// Scan free-text args (a note, reason, body). An opaque `orderId` will
+// not trip EMAIL / phone / card / IP, so do not pass it here.
+const detectPii = localDetectSensitiveInfo();
+
+export const lookupOrder = guardTool(
+  arcjet,
+  tool(async ({ orderId, note }) => ({ orderId, note, status: "shipped" }), {
+    name: "lookup_order",
+    description: "Look up an order by ID",
+    schema: z.object({
+      orderId: z.string(),
+      note: z.string(),
+    }),
+  }),
+  {
+    action: "order.looked-up",
+    rules: (input) => [lookupLimit({ key: input.orderId, requested: 1 }), detectPii(input.note)],
+  },
+);
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the tool's `func` / `invoke` never runs. The model receives
+  `{ status: "error", arcjetDenied: true, reason, message, retryable }`.
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+
+## Step 3: Screen inbound before invoke
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { langgraphAgentContext } from "@arcjet/guard/langgraph/v1";
+
+import { arcjet } from "./arcjet.js";
+
+const config = { configurable: { thread_id: conversationId } };
+const inbound = detectPromptInjection();
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...langgraphAgentContext(config),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+
+await graph.invoke({ messages: [{ role: "user", content: userText }] }, config);
+```
+
+Or put the same screen in the graph's first node. There is no
+`guardInbound`.
+
+## Step 4: Gate tools you did not wrap
+
+```ts
+import { ToolNode } from "@langchain/langgraph/prebuilt";
+import { guardToolNode } from "@arcjet/guard/langgraph/v1";
+import { tokenBucket } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const mcpLimit = tokenBucket({
+  bucket: "mcp-access",
+  refillRate: 20,
+  intervalSeconds: 60,
+  maxTokens: 20,
+});
+
+export const tools = guardToolNode(arcjet, new ToolNode(mcpTools), {
+  action: ({ toolName }) => `${toolName}.invoked`,
+  rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+});
+```
+
+Pass the wrapped node to `StateGraph.addNode("tools", tools)`. Use this
+for tools you did **not** pass through `guardTool`. `guardToolNode` skips
+already-branded tools so applying both to the same authored tool does not
+double-call the guard.
+
+## Step 5: Correlation
+
+Pass the checkpointer `thread_id` you already have on
+`graph.invoke(input, { configurable: { thread_id } })`.
+`langgraphAgentContext` reads it; it never calls `createAgentContext`.
+
+```ts
+const config = { configurable: { thread_id: conversationId } };
+await graph.invoke({ messages }, config);
+```
+
+Preference order: `configurable.thread_id`, then
+`configurable.checkpoint_ns`, then run id. If none is a valid 1–256
+printable-ASCII string, the call is uncorrelated rather than joined to a
+generated id nobody has.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI (before invoke), a tool deny, PII on args, a rate
+   limit, an unwrapped ToolNode deny, and fail-closed (an unreachable
+   guard).
+3. Confirm in the Arcjet dashboard that decisions share the thread id as
+   their correlation id.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo will land in
+[`arcjet/examples` `langgraph-agent`](https://github.com/arcjet/examples/tree/main/examples/langgraph-agent)
+with [arcjet/examples#193](https://github.com/arcjet/examples/pull/193).
+Do not add an example under `examples/` in the JS SDK repo.
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/src/agents/index.test.ts
+++ b/arcjet-guard/src/agents/index.test.ts
@@ -99,7 +99,11 @@ function walkForForbiddenImports(
       spec === "eve" ||
       spec.startsWith("eve/") ||
       spec === "@mastra/core" ||
-      spec.startsWith("@mastra/core/")
+      spec.startsWith("@mastra/core/") ||
+      spec === "@langchain/langgraph" ||
+      spec.startsWith("@langchain/langgraph/") ||
+      spec === "@langchain/core" ||
+      spec.startsWith("@langchain/core/")
     ) {
       errors.push(`File ${absolutePath} imports forbidden package: "${spec}"`);
     }

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -6,7 +6,8 @@
  *
  * @internal This barrel has no export map entry. Every symbol below reaches
  * users re-exported from a vendor namespace — `@arcjet/guard/vercel-ai/v7`,
- * `@arcjet/guard/vercel-eve/v0`, and `@arcjet/guard/mastra/v1`. The layer
+ * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`, and
+ * `@arcjet/guard/langgraph/v1`. The layer
  * stays agnostic so multiple vendor namespaces can share the same code. A
  * public `@arcjet/guard/agents` path is still a follow-up with its own ADR.
  */

--- a/arcjet-guard/src/langgraph/v1/assignability.test.ts
+++ b/arcjet-guard/src/langgraph/v1/assignability.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Compile-time assignability: LangGraph helpers fit the slots they document.
+ *
+ * Uses typed `const` declarations rather than casts on the helper output —
+ * a cast of the result would make the test pass regardless. Vendor types
+ * are imported so a rename on `ToolNode.tools` or `StructuredToolInterface.name`
+ * fails this file's typecheck.
+ */
+import { test } from "node:test";
+
+import type { StructuredToolInterface } from "@langchain/core/tools";
+import type { ToolNode } from "@langchain/langgraph/prebuilt";
+
+import { decisionAllow, stubClient } from "../../../test/_shared/stub-client.ts";
+import { guardToolNode } from "./guard-tool-node.ts";
+import type { LangGraphToolNodeLike } from "./guard-tool-node.ts";
+import { guardTool } from "./guard-tool.ts";
+import type { LangGraphTool } from "./guard-tool.ts";
+
+test("helpers are assignable to LangGraph tool / ToolNode slots", () => {
+  const { client } = stubClient(decisionAllow());
+
+  const tool: LangGraphTool<{ id: string }> = {
+    name: "assignability-tool",
+    description: "assignability",
+    func: (input: { id: string }) => Promise.resolve({ ok: input.id.length > 0 }),
+    invoke: (input: unknown) => Promise.resolve(input),
+  };
+  const wrapped: LangGraphTool<{ id: string }> = guardTool(client, tool, {
+    action: "thing.read",
+  });
+
+  const toolName: StructuredToolInterface["name"] = wrapped.name;
+
+  const nodeTool: LangGraphTool = {
+    name: "node-tool",
+    invoke: (input: unknown) => Promise.resolve(input),
+  };
+  const node: LangGraphToolNodeLike = {
+    tools: [nodeTool],
+    invoke: (input: unknown, config?: unknown) => Promise.resolve(wrapped.invoke?.(input, config)),
+  };
+  const wrappedNode: LangGraphToolNodeLike = guardToolNode(client, node, {
+    action: "tool.invoked",
+  });
+  const toolNodeTools: ToolNode["tools"] | LangGraphTool[] = wrappedNode.tools;
+
+  void [toolName, toolNodeTools];
+});

--- a/arcjet-guard/src/langgraph/v1/assignability.test.ts
+++ b/arcjet-guard/src/langgraph/v1/assignability.test.ts
@@ -1,49 +1,55 @@
 /**
- * Compile-time assignability: LangGraph helpers fit the slots they document.
+ * Compile-time assignability: the helpers accept the values a LangGraph app
+ * actually has, with no casts at the call site.
  *
- * Uses typed `const` declarations rather than casts on the helper output —
- * a cast of the result would make the test pass regardless. Vendor types
- * are imported so a rename on `ToolNode.tools` or `StructuredToolInterface.name`
- * fails this file's typecheck.
+ * This file exists because the first version of this namespace typed `invoke`
+ * as a property rather than a method, which made its parameters contravariant
+ * and rejected every real `DynamicStructuredTool` and `ToolNode` — a user
+ * could only call the helpers by writing `as never`. Nothing below may cast
+ * an argument or a helper's result: a cast is exactly what a user would have
+ * been forced to write, so it would hide the regression this file catches.
+ *
+ * The declarations are types only (`declare const`, never executed) so this
+ * suite still runs in the langgraph-absent CI job, where the peers are gone
+ * and the type-only import scan applies. Runtime behaviour against the real
+ * classes lives in `test/langgraph/real-tool-node.test.ts`.
  */
+import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { StructuredToolInterface } from "@langchain/core/tools";
+import type { DynamicStructuredTool, StructuredToolInterface } from "@langchain/core/tools";
 import type { ToolNode } from "@langchain/langgraph/prebuilt";
 
-import { decisionAllow, stubClient } from "../../../test/_shared/stub-client.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { guardToolNode } from "./guard-tool-node.ts";
-import type { LangGraphToolNodeLike } from "./guard-tool-node.ts";
 import { guardTool } from "./guard-tool.ts";
-import type { LangGraphTool } from "./guard-tool.ts";
 
-test("helpers are assignable to LangGraph tool / ToolNode slots", () => {
-  const { client } = stubClient(decisionAllow());
+declare const client: ArcjetAgentClient;
+declare const authoredTool: DynamicStructuredTool;
+declare const toolNode: ToolNode;
 
-  const tool: LangGraphTool<{ id: string }> = {
-    name: "assignability-tool",
-    description: "assignability",
-    func: (input: { id: string }) => Promise.resolve({ ok: input.id.length > 0 }),
-    invoke: (input: unknown) => Promise.resolve(input),
-  };
-  const wrapped: LangGraphTool<{ id: string }> = guardTool(client, tool, {
-    action: "thing.read",
+// Never called: the declarations above have no runtime value. Typecheck is
+// the assertion.
+function typeProbe(): void {
+  const guarded: DynamicStructuredTool = guardTool(client, authoredTool, {
+    action: "order.looked-up",
   });
 
-  const toolName: StructuredToolInterface["name"] = wrapped.name;
+  // A guarded tool must still be usable everywhere the unguarded one was.
+  const asStructured: StructuredToolInterface = guarded;
+  const asNodeTools: ToolNode["tools"] = [guarded];
 
-  const nodeTool: LangGraphTool = {
-    name: "node-tool",
-    invoke: (input: unknown) => Promise.resolve(input),
-  };
-  const node: LangGraphToolNodeLike = {
-    tools: [nodeTool],
-    invoke: (input: unknown, config?: unknown) => Promise.resolve(wrapped.invoke?.(input, config)),
-  };
-  const wrappedNode: LangGraphToolNodeLike = guardToolNode(client, node, {
+  // Both call shapes: an existing node, and a tools array.
+  const guardedNode: ToolNode = guardToolNode(client, toolNode, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+  const guardedTools: DynamicStructuredTool[] = guardToolNode(client, [authoredTool], {
     action: "tool.invoked",
   });
-  const toolNodeTools: ToolNode["tools"] | LangGraphTool[] = wrappedNode.tools;
 
-  void [toolName, toolNodeTools];
+  void [guarded, asStructured, asNodeTools, guardedNode, guardedTools];
+}
+
+test("helpers accept real LangGraph values without casts", () => {
+  assert.equal(typeof typeProbe, "function");
 });

--- a/arcjet-guard/src/langgraph/v1/context.test.ts
+++ b/arcjet-guard/src/langgraph/v1/context.test.ts
@@ -1,0 +1,208 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { langgraphAgentContext } from "./context.ts";
+
+test("prefers configurable.thread_id", () => {
+  const result = langgraphAgentContext({
+    configurable: {
+      thread_id: "thread-abc",
+      checkpoint_ns: "node:uuid",
+      run_id: "run-1",
+    },
+  });
+
+  assert.equal(result.correlationId, "thread-abc");
+  assert.equal(result.metadata?.["langgraph.thread"], "thread-abc");
+  assert.equal(result.metadata?.["langgraph.checkpoint_ns"], "node:uuid");
+  assert.equal(result.metadata?.["langgraph.run"], "run-1");
+});
+
+test("falls back to checkpoint_ns when thread_id is absent", () => {
+  const result = langgraphAgentContext({
+    configurable: { checkpoint_ns: "subgraph:1" },
+  });
+
+  assert.equal(result.correlationId, "subgraph:1");
+  assert.equal(result.metadata?.["langgraph.checkpoint_ns"], "subgraph:1");
+  assert.ok(!("langgraph.thread" in (result.metadata ?? {})));
+});
+
+test("skips empty checkpoint_ns (parent graph) and uses run id", () => {
+  const result = langgraphAgentContext({
+    configurable: { checkpoint_ns: "", run_id: "run-555" },
+  });
+
+  assert.equal(result.correlationId, "run-555");
+  assert.equal(result.metadata?.["langgraph.run"], "run-555");
+  assert.equal("langgraph.checkpoint_ns" in (result.metadata ?? {}), false);
+});
+
+test("reads runId from the config object when configurable has none", () => {
+  const result = langgraphAgentContext({ runId: "run-from-config" });
+  assert.equal(result.correlationId, "run-from-config");
+  assert.equal(result.metadata?.["langgraph.run"], "run-from-config");
+});
+
+test("reads nested ToolRuntime.config.configurable.thread_id", () => {
+  const result = langgraphAgentContext({
+    config: { configurable: { thread_id: "nested-thread" } },
+  });
+  assert.equal(result.correlationId, "nested-thread");
+});
+
+test("accepts a configurable-shaped object passed directly", () => {
+  const result = langgraphAgentContext({ thread_id: "direct-thread" });
+  assert.equal(result.correlationId, "direct-thread");
+});
+
+test("never mints an id when nothing valid is present", () => {
+  const result = langgraphAgentContext({});
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+});
+
+test("never mints an id when the only candidate is invalid", () => {
+  const result = langgraphAgentContext({ configurable: { thread_id: "" } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("langgraph.thread" in (result.metadata ?? {}), false);
+});
+
+test("skips an invalid thread id and uses checkpoint_ns instead of minting", () => {
+  const result = langgraphAgentContext({
+    configurable: { thread_id: "", checkpoint_ns: "ns-ok" },
+  });
+
+  assert.equal(result.correlationId, "ns-ok");
+});
+
+test("rejects a thread id over 256 characters and does not mint", () => {
+  const longId = "x".repeat(257);
+  const result = langgraphAgentContext({ configurable: { thread_id: longId } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["langgraph.thread"], longId);
+});
+
+test("caller metadata overrides derived keys", () => {
+  const result = langgraphAgentContext(
+    { configurable: { thread_id: "thread-1" } },
+    { metadata: { "langgraph.thread": "override" } },
+  );
+
+  assert.equal(result.metadata?.["langgraph.thread"], "override");
+});
+
+test("derived metadata keys match /^[A-Za-z0-9._-]+$/", () => {
+  const result = langgraphAgentContext({
+    configurable: {
+      thread_id: "thread-1",
+      checkpoint_ns: "ns-1",
+      run_id: "run-1",
+    },
+  });
+
+  assert.ok(result.metadata);
+  const validKeyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const key of Object.keys(result.metadata)) {
+    assert.ok(
+      validKeyPattern.test(key),
+      `derived key "${key}" must match the metadata character class`,
+    );
+  }
+});
+
+test("encoder round-trip produces no AJ1017 warnings", () => {
+  const result = langgraphAgentContext({
+    configurable: {
+      thread_id: "thread-1",
+      checkpoint_ns: "ns-1",
+      run_id: "run-1",
+    },
+  });
+
+  assert.ok(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
+  assert.ok(metadataJson["langgraph.thread"]);
+  assert.ok(metadataJson["langgraph.checkpoint_ns"]);
+  assert.ok(metadataJson["langgraph.run"]);
+});
+
+test("undefined source does not throw and does not mint", () => {
+  const result = langgraphAgentContext();
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("null and primitive sources do not mint", () => {
+  assert.equal("correlationId" in langgraphAgentContext(null as never), false);
+  assert.equal("correlationId" in langgraphAgentContext("thread" as never), false);
+  assert.equal("correlationId" in langgraphAgentContext(12 as never), false);
+});
+
+test("non-string candidates are skipped", () => {
+  const result = langgraphAgentContext({
+    configurable: { thread_id: 99, checkpoint_ns: { id: "nope" } },
+  });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("non-printable thread id is rejected and does not mint", () => {
+  const result = langgraphAgentContext({ configurable: { thread_id: "bad\nid" } });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["langgraph.thread"], "bad\nid");
+});
+
+test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "info";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    langgraphAgentContext({ configurable: { thread_id: "" } });
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /rejected/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("does not warn when a later candidate is valid", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const result = langgraphAgentContext({
+      configurable: { thread_id: "", checkpoint_ns: "ns-ok" },
+    });
+    assert.equal(result.correlationId, "ns-ok");
+    assert.equal(warnings.length, 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/langgraph/v1/context.test.ts
+++ b/arcjet-guard/src/langgraph/v1/context.test.ts
@@ -20,7 +20,20 @@ test("prefers configurable.thread_id", () => {
   assert.equal(result.metadata?.["langgraph.run"], "run-1");
 });
 
-test("falls back to checkpoint_ns when thread_id is absent", () => {
+// A run id covers the whole run; `checkpoint_ns` names one subgraph, so
+// preferring it would split sibling subgraphs of a single run across
+// correlation ids.
+test("prefers the run id over checkpoint_ns when thread_id is absent", () => {
+  const result = langgraphAgentContext({
+    configurable: { checkpoint_ns: "subgraph:1", run_id: "run-555" },
+  });
+
+  assert.equal(result.correlationId, "run-555");
+  assert.equal(result.metadata?.["langgraph.run"], "run-555");
+  assert.equal(result.metadata?.["langgraph.checkpoint_ns"], "subgraph:1");
+});
+
+test("falls back to checkpoint_ns when thread and run ids are absent", () => {
   const result = langgraphAgentContext({
     configurable: { checkpoint_ns: "subgraph:1" },
   });
@@ -38,6 +51,12 @@ test("skips empty checkpoint_ns (parent graph) and uses run id", () => {
   assert.equal(result.correlationId, "run-555");
   assert.equal(result.metadata?.["langgraph.run"], "run-555");
   assert.equal("langgraph.checkpoint_ns" in (result.metadata ?? {}), false);
+});
+
+test("a null configurable does not throw and does not mint", () => {
+  const result = langgraphAgentContext({ configurable: null as never });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
 });
 
 test("reads runId from the config object when configurable has none", () => {
@@ -72,7 +91,7 @@ test("never mints an id when the only candidate is invalid", () => {
   assert.equal("langgraph.thread" in (result.metadata ?? {}), false);
 });
 
-test("skips an invalid thread id and uses checkpoint_ns instead of minting", () => {
+test("skips an invalid thread id and uses the next candidate instead of minting", () => {
   const result = langgraphAgentContext({
     configurable: { thread_id: "", checkpoint_ns: "ns-ok" },
   });

--- a/arcjet-guard/src/langgraph/v1/context.ts
+++ b/arcjet-guard/src/langgraph/v1/context.ts
@@ -1,0 +1,172 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `langgraphAgentContext` can read. Accepts a LangGraph
+ * `RunnableConfig` (`configurable.thread_id`), a `ToolRuntime` (which spreads
+ * that config and also nests it on `config`), or the `configurable` object
+ * itself.
+ *
+ * Declared here so this module never value-imports `@langchain/langgraph` or
+ * `@langchain/core` — CI must pass with those packages absent from
+ * `node_modules`.
+ */
+export interface LangGraphContextSource {
+  configurable?: Record<string, unknown>;
+  config?: {
+    configurable?: Record<string, unknown>;
+    runId?: unknown;
+    metadata?: Record<string, unknown>;
+  };
+  runId?: unknown;
+  metadata?: Record<string, unknown>;
+  thread_id?: unknown;
+  checkpoint_ns?: unknown;
+}
+
+/**
+ * Context derived from a LangGraph run. `correlationId` is omitted when the
+ * graph did not provide a valid thread / checkpoint namespace / run id —
+ * this helper never mints one.
+ */
+export interface LangGraphAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asContextSource(source: unknown): LangGraphContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function firstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readConfigurable(
+  source: LangGraphContextSource | undefined,
+): Record<string, unknown> | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  if (source.configurable !== undefined && typeof source.configurable === "object") {
+    return source.configurable;
+  }
+  if (source.config?.configurable !== undefined && typeof source.config.configurable === "object") {
+    return source.config.configurable;
+  }
+  if (source.thread_id !== undefined || source.checkpoint_ns !== undefined) {
+    const configurable: Record<string, unknown> = {};
+    if (source.thread_id !== undefined) {
+      configurable["thread_id"] = source.thread_id;
+    }
+    if (source.checkpoint_ns !== undefined) {
+      configurable["checkpoint_ns"] = source.checkpoint_ns;
+    }
+    return configurable;
+  }
+  return undefined;
+}
+
+/**
+ * Derive correlation and metadata from a LangGraph `RunnableConfig` /
+ * `ToolRuntime`. Never mints a new id. Never calls `createAgentContext`.
+ *
+ * Preference order for `correlationId`:
+ * 1. `configurable.thread_id` — the checkpointer thread, what the graph
+ *    already has
+ * 2. `configurable.checkpoint_ns` — subgraph namespace (`""` for the parent
+ *    is skipped as empty)
+ * 3. `runId` / `configurable.run_id` — only if the graph already set one
+ *
+ * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL` asks
+ * for warnings). If nothing valid remains, `correlationId` is omitted so the
+ * decision is uncorrelated rather than joined to a generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { langgraphAgentContext } from "@arcjet/guard/langgraph/v1";
+ *
+ * export function fromConfig(config: { configurable?: { thread_id?: string } }) {
+ *   return langgraphAgentContext(config);
+ * }
+ * ```
+ */
+export function langgraphAgentContext(
+  source?: LangGraphContextSource,
+  init?: { metadata?: ArcjetMetadata },
+): LangGraphAgentContext {
+  const ctx = asContextSource(source);
+  const configurable = readConfigurable(ctx);
+
+  const threadId = configurable?.["thread_id"];
+  const checkpointNs = configurable?.["checkpoint_ns"];
+  const runId = ctx?.runId ?? ctx?.config?.runId ?? configurable?.["run_id"];
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: threadId, label: "thread_id" },
+    { value: checkpointNs, label: "checkpoint_ns" },
+    { value: runId, label: "run id" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: LangGraph ${rejected} rejected; no valid thread/checkpoint/run id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const thread = firstString([threadId]);
+  if (thread !== undefined) {
+    derivedMetadata["langgraph.thread"] = thread;
+  }
+
+  const namespace = firstString([checkpointNs]);
+  if (namespace !== undefined) {
+    derivedMetadata["langgraph.checkpoint_ns"] = namespace;
+  }
+
+  const run = firstString([runId]);
+  if (run !== undefined) {
+    derivedMetadata["langgraph.run"] = run;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: LangGraphAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/langgraph/v1/context.ts
+++ b/arcjet-guard/src/langgraph/v1/context.ts
@@ -75,10 +75,10 @@ function readConfigurable(
   if (source === undefined) {
     return undefined;
   }
-  if (source.configurable !== undefined && typeof source.configurable === "object") {
+  if (source.configurable !== null && typeof source.configurable === "object") {
     return source.configurable;
   }
-  if (source.config?.configurable !== undefined && typeof source.config.configurable === "object") {
+  if (source.config?.configurable !== null && typeof source.config?.configurable === "object") {
     return source.config.configurable;
   }
   if (source.thread_id !== undefined || source.checkpoint_ns !== undefined) {
@@ -101,9 +101,9 @@ function readConfigurable(
  * Preference order for `correlationId`:
  * 1. `configurable.thread_id` — the checkpointer thread, what the graph
  *    already has
- * 2. `configurable.checkpoint_ns` — subgraph namespace (`""` for the parent
- *    is skipped as empty)
- * 3. `runId` / `configurable.run_id` — only if the graph already set one
+ * 2. `runId` / `configurable.run_id` — only if the graph already set one
+ * 3. `configurable.checkpoint_ns` — subgraph namespace, a last resort
+ *    (`""` for the parent graph is skipped as empty)
  *
  * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL` asks
  * for warnings). If nothing valid remains, `correlationId` is omitted so the
@@ -129,10 +129,15 @@ export function langgraphAgentContext(
   const checkpointNs = configurable?.["checkpoint_ns"];
   const runId = ctx?.runId ?? ctx?.config?.runId ?? configurable?.["run_id"];
 
+  // Run id before checkpoint namespace: `checkpoint_ns` names a subgraph
+  // (`"node_name:uuid"`, `""` for the parent), so sibling subgraphs of one
+  // run would land under different correlation ids. A run id covers the whole
+  // run, which is what a Sequence should join. The namespace stays as a last
+  // resort and as metadata.
   const { id: correlationId, rejected } = firstValidId([
     { value: threadId, label: "thread_id" },
-    { value: checkpointNs, label: "checkpoint_ns" },
     { value: runId, label: "run id" },
+    { value: checkpointNs, label: "checkpoint_ns" },
   ]);
 
   if (rejected !== undefined && correlationId === undefined && shouldWarn()) {

--- a/arcjet-guard/src/langgraph/v1/denial.test.ts
+++ b/arcjet-guard/src/langgraph/v1/denial.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  decisionDenyError,
+  decisionDenyPromptInjection,
+  decisionDenyPromptInjectionWithReset,
+  decisionDenyRateLimit,
+  decisionDenyRateLimitNoReset,
+} from "../../../test/_shared/stub-client.ts";
+import {
+  asToolResult,
+  denialResult,
+  denialToolResult,
+  deniedReason,
+  unavailableReason,
+  unavailableResult,
+  unavailableToolResult,
+  UNAVAILABLE_RETRY_AFTER_SECONDS,
+} from "./denial.ts";
+
+describe("langgraph/v1/denial", () => {
+  test("rate-limit denial is retryable and may carry retry-after", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 30;
+    const decision = decisionDenyRateLimit(resetAt);
+    const result = denialResult(decision);
+
+    assert.equal(result.arcjetDenied, true);
+    assert.equal(result.reason, "RATE_LIMIT");
+    assert.equal(result.retryable, true);
+    assert.ok(typeof result.retryAfterSeconds === "number");
+    assert.match(deniedReason(decision), /RATE_LIMIT/);
+  });
+
+  test("prompt-injection denial is not retryable", () => {
+    const decision = decisionDenyPromptInjection();
+    const result = denialResult(decision);
+
+    assert.equal(result.retryable, false);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(result.message, /Do not retry/);
+  });
+
+  test("unavailable result is retryable with a fixed backoff", () => {
+    const result = unavailableResult();
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, true);
+    assert.equal(result.retryAfterSeconds, UNAVAILABLE_RETRY_AFTER_SECONDS);
+    assert.equal(result.message, unavailableReason());
+  });
+
+  test("RATE_LIMIT without reset is retryable without retryAfterSeconds", () => {
+    const decision = decisionDenyRateLimitNoReset();
+    const result = denialResult(decision);
+    assert.equal(result.retryable, true);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(deniedReason(decision), /retried later/);
+  });
+
+  test("non-rate-limit denial ignores a co-occurring reset time", () => {
+    const decision = decisionDenyPromptInjectionWithReset(Math.floor(Date.now() / 1000) + 30);
+    const result = denialResult(decision);
+    assert.equal(result.retryable, false);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(deniedReason(decision), /Do not retry/);
+  });
+
+  test("ERROR denial is not treated as unavailable", () => {
+    const decision = decisionDenyError();
+    const result = denialResult(decision);
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, false);
+    assert.match(deniedReason(decision), /Do not retry/);
+  });
+
+  test("denialToolResult is a status:error tool result the model can read", () => {
+    const result = denialToolResult(decisionDenyPromptInjection(), {
+      name: "lookup_order",
+      toolCallId: "call-1",
+    });
+    assert.equal(result.status, "error");
+    assert.equal(result.type, "tool");
+    assert.equal(result.getType(), "tool");
+    assert.equal(result.name, "lookup_order");
+    assert.equal(result.tool_call_id, "call-1");
+    assert.equal(result.arcjetDenied, true);
+    assert.equal(result.content, result.message);
+  });
+
+  test("unavailableToolResult is a status:error tool result", () => {
+    const result = unavailableToolResult({ name: "lookup_order" });
+    assert.equal(result.status, "error");
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, true);
+  });
+
+  test("asToolResult passes through an existing tool result", () => {
+    const first = unavailableToolResult({ name: "a", toolCallId: "id-1" });
+    assert.equal(asToolResult(first), first);
+  });
+
+  test("asToolResult lifts a denial object", () => {
+    const denial = denialResult(decisionDenyPromptInjection());
+    const result = asToolResult(denial, { name: "t", toolCallId: "c" });
+    assert.equal(result.status, "error");
+    assert.equal(result.reason, "PROMPT_INJECTION");
+    assert.equal(result.name, "t");
+  });
+});

--- a/arcjet-guard/src/langgraph/v1/denial.test.ts
+++ b/arcjet-guard/src/langgraph/v1/denial.test.ts
@@ -9,13 +9,10 @@ import {
   decisionDenyRateLimitNoReset,
 } from "../../../test/_shared/stub-client.ts";
 import {
-  asToolResult,
   denialResult,
-  denialToolResult,
   deniedReason,
   unavailableReason,
   unavailableResult,
-  unavailableToolResult,
   UNAVAILABLE_RETRY_AFTER_SECONDS,
 } from "./denial.ts";
 
@@ -73,37 +70,36 @@ describe("langgraph/v1/denial", () => {
     assert.match(deniedReason(decision), /Do not retry/);
   });
 
-  test("denialToolResult is a status:error tool result the model can read", () => {
-    const result = denialToolResult(decisionDenyPromptInjection(), {
-      name: "lookup_order",
-      toolCallId: "call-1",
+  // A denial must stay a plain object. Faking `_getType` would satisfy
+  // `isBaseMessage`, which makes `ToolNode` hand it straight to
+  // `messagesStateReducer` — and that assigns `m.lc_kwargs.id`, throwing on a
+  // duck-typed message and taking the graph down.
+  test("a denial does not pretend to be a BaseMessage", () => {
+    const results: Array<Record<string, unknown>> = [
+      { ...denialResult(decisionDenyPromptInjection()) },
+      { ...unavailableResult() },
+    ];
+
+    for (const result of results) {
+      for (const messageField of ["_getType", "getType", "lc_kwargs", "lc_serializable"]) {
+        assert.equal(
+          messageField in result,
+          false,
+          `a denial must not carry the message field "${messageField}"`,
+        );
+      }
+    }
+  });
+
+  test("a denial is JSON-serializable, which is how ToolNode passes it on", () => {
+    const decoded: unknown = JSON.parse(
+      JSON.stringify(denialResult(decisionDenyPromptInjection())),
+    );
+    assert.deepEqual(decoded, {
+      arcjetDenied: true,
+      reason: "PROMPT_INJECTION",
+      message: deniedReason(decisionDenyPromptInjection()),
+      retryable: false,
     });
-    assert.equal(result.status, "error");
-    assert.equal(result.type, "tool");
-    assert.equal(result.getType(), "tool");
-    assert.equal(result.name, "lookup_order");
-    assert.equal(result.tool_call_id, "call-1");
-    assert.equal(result.arcjetDenied, true);
-    assert.equal(result.content, result.message);
-  });
-
-  test("unavailableToolResult is a status:error tool result", () => {
-    const result = unavailableToolResult({ name: "lookup_order" });
-    assert.equal(result.status, "error");
-    assert.equal(result.reason, "ERROR");
-    assert.equal(result.retryable, true);
-  });
-
-  test("asToolResult passes through an existing tool result", () => {
-    const first = unavailableToolResult({ name: "a", toolCallId: "id-1" });
-    assert.equal(asToolResult(first), first);
-  });
-
-  test("asToolResult lifts a denial object", () => {
-    const denial = denialResult(decisionDenyPromptInjection());
-    const result = asToolResult(denial, { name: "t", toolCallId: "c" });
-    assert.equal(result.status, "error");
-    assert.equal(result.reason, "PROMPT_INJECTION");
-    assert.equal(result.name, "t");
   });
 });

--- a/arcjet-guard/src/langgraph/v1/denial.ts
+++ b/arcjet-guard/src/langgraph/v1/denial.ts
@@ -1,0 +1,176 @@
+import { retryAfterSeconds } from "../../agents/denial.ts";
+import type { DecisionDeny } from "../../types.ts";
+
+/**
+ * Structured tool result returned to the model when a call is denied.
+ *
+ * Intentionally structurally identical to `vercel-ai/v7`'s ArcjetDenialResult
+ * so the model trained on denial objects sees the same shape regardless of
+ * which integration is in use. Both declarations exist to avoid putting the
+ * `ai` SDK in this namespace's import graph.
+ */
+export interface ArcjetDenialResult {
+  arcjetDenied: true;
+  /** Denial reason, e.g. `"RATE_LIMIT"` or `"PROMPT_INJECTION"`. */
+  reason: string;
+  /** Human/model-readable explanation of the denial. */
+  message: string;
+  /** Whether retrying later can succeed (true for rate limits). */
+  retryable: boolean;
+  /** Seconds until a rate-limited call may be retried. */
+  retryAfterSeconds?: number;
+}
+
+/**
+ * Tool-result shape `ToolNode` / the model can read on DENY.
+ *
+ * LangGraph's `ToolNode` treats a returned object with `getType() === "tool"`
+ * as a `ToolMessage` and otherwise wraps the value in one with
+ * `status: "success"`. This object carries `status: "error"` plus the
+ * structured denial so either path is readable. We do not construct a
+ * `@langchain/core` `ToolMessage` — that would be a value import, and CI
+ * must pass with the peer absent.
+ */
+export interface LangGraphToolResult extends ArcjetDenialResult {
+  status: "error";
+  content: string;
+  type: "tool";
+  name: string;
+  tool_call_id: string;
+  getType: () => "tool";
+}
+
+/** Model- and user-readable explanation of a denial. */
+export function deniedReason(decision: DecisionDeny): string {
+  const isRateLimit = decision.reason === "RATE_LIMIT";
+  let message: string;
+
+  if (isRateLimit) {
+    const retryAfter = retryAfterSeconds(decision);
+    message =
+      `Arcjet denied this call (${decision.reason}). It may be retried` +
+      (retryAfter === undefined ? " later." : ` after ${retryAfter} seconds.`);
+  } else {
+    message = `Arcjet denied this call (${decision.reason}). Do not retry; explain the denial to the user or try a different approach.`;
+  }
+
+  return message;
+}
+
+/** Explanation used when the policy could not be evaluated. */
+export function unavailableReason(): string {
+  return "Arcjet security check could not be completed; please retry later.";
+}
+
+/**
+ * Backoff hint returned to the model when the guard is unavailable.
+ *
+ * A rate-limit denial derives its hint from the denying rule's
+ * `resetAtUnixSeconds`. This path has nothing to derive from. Five seconds
+ * paces a model's retry loop.
+ */
+export const UNAVAILABLE_RETRY_AFTER_SECONDS: number = 5;
+
+export function denialResult(decision: DecisionDeny): ArcjetDenialResult {
+  const isRateLimit = decision.reason === "RATE_LIMIT";
+  let retryAfterSecs: number | undefined;
+
+  if (isRateLimit) {
+    retryAfterSecs = retryAfterSeconds(decision);
+  }
+
+  const result: ArcjetDenialResult = {
+    arcjetDenied: true,
+    reason: decision.reason,
+    message: deniedReason(decision),
+    retryable: isRateLimit,
+  };
+
+  if (isRateLimit && retryAfterSecs !== undefined) {
+    result.retryAfterSeconds = retryAfterSecs;
+  }
+
+  return result;
+}
+
+export function unavailableResult(): ArcjetDenialResult {
+  return {
+    arcjetDenied: true,
+    reason: "ERROR",
+    message: unavailableReason(),
+    retryable: true,
+    retryAfterSeconds: UNAVAILABLE_RETRY_AFTER_SECONDS,
+  };
+}
+
+export function denialToolResult(
+  decision: DecisionDeny,
+  extras?: { name?: string; toolCallId?: string },
+): LangGraphToolResult {
+  return asToolResult(denialResult(decision), extras);
+}
+
+export function unavailableToolResult(extras?: {
+  name?: string;
+  toolCallId?: string;
+}): LangGraphToolResult {
+  return asToolResult(unavailableResult(), extras);
+}
+
+/**
+ * Lift a denial payload (or a caller `onDeny` object) into the tool-result
+ * shape. A value that already looks like a tool result is returned as-is.
+ */
+export function asToolResult(
+  value: unknown,
+  extras?: { name?: string; toolCallId?: string },
+): LangGraphToolResult {
+  if (isToolResult(value)) {
+    return value;
+  }
+
+  const denial = isDenialResult(value)
+    ? value
+    : {
+        arcjetDenied: true as const,
+        reason: "ERROR",
+        message: typeof value === "string" ? value : unavailableReason(),
+        retryable: false,
+      };
+
+  const name = extras?.name ?? "";
+  const toolCallId = extras?.toolCallId ?? "";
+
+  return {
+    ...denial,
+    status: "error",
+    content: denial.message,
+    type: "tool",
+    name,
+    tool_call_id: toolCallId,
+    getType: () => "tool",
+  };
+}
+
+function isDenialResult(value: unknown): value is ArcjetDenialResult {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "arcjetDenied" in value &&
+    (value as { arcjetDenied?: unknown }).arcjetDenied === true &&
+    "reason" in value &&
+    typeof (value as { reason?: unknown }).reason === "string" &&
+    "message" in value &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
+}
+
+function isToolResult(value: unknown): value is LangGraphToolResult {
+  return (
+    isDenialResult(value) &&
+    "status" in value &&
+    (value as { status?: unknown }).status === "error" &&
+    "getType" in value &&
+    typeof (value as { getType?: unknown }).getType === "function"
+  );
+}

--- a/arcjet-guard/src/langgraph/v1/denial.ts
+++ b/arcjet-guard/src/langgraph/v1/denial.ts
@@ -4,10 +4,26 @@ import type { DecisionDeny } from "../../types.ts";
 /**
  * Structured tool result returned to the model when a call is denied.
  *
- * Intentionally structurally identical to `vercel-ai/v7`'s ArcjetDenialResult
- * so the model trained on denial objects sees the same shape regardless of
- * which integration is in use. Both declarations exist to avoid putting the
- * `ai` SDK in this namespace's import graph.
+ * Intentionally structurally identical to `vercel-ai/v7`'s and `mastra/v1`'s
+ * ArcjetDenialResult so the model trained on denial objects sees the same
+ * shape regardless of which integration is in use. Each declaration exists
+ * separately to avoid putting another vendor's SDK in this namespace's import
+ * graph.
+ *
+ * **Why this is not a `ToolMessage`.** `ToolNode` returns a tool's output
+ * unchanged when `isBaseMessage(output)` holds, and otherwise wraps it in a
+ * real `ToolMessage` carrying the tool call id. Passing that check needs a
+ * `_getType` method, and an object that fakes it is then handed to
+ * `messagesStateReducer`, which forwards anything `isBaseMessage` accepts and
+ * assigns `m.lc_kwargs.id` — throwing on a duck-typed message and taking the
+ * graph down. Constructing a genuine `ToolMessage` would need a value import
+ * of `@langchain/core`, which this namespace must not have. So a denial is a
+ * plain object: `ToolNode` wraps it, the model reads these fields as the tool
+ * result content, and no graph internals are faked.
+ *
+ * A consequence worth knowing: because the tool does not throw, the
+ * `ToolMessage` `ToolNode` builds carries `status: "success"`. The denial is
+ * in the payload (`arcjetDenied: true`), not the envelope.
  */
 export interface ArcjetDenialResult {
   arcjetDenied: true;
@@ -19,25 +35,6 @@ export interface ArcjetDenialResult {
   retryable: boolean;
   /** Seconds until a rate-limited call may be retried. */
   retryAfterSeconds?: number;
-}
-
-/**
- * Tool-result shape `ToolNode` / the model can read on DENY.
- *
- * LangGraph's `ToolNode` treats a returned object with `getType() === "tool"`
- * as a `ToolMessage` and otherwise wraps the value in one with
- * `status: "success"`. This object carries `status: "error"` plus the
- * structured denial so either path is readable. We do not construct a
- * `@langchain/core` `ToolMessage` — that would be a value import, and CI
- * must pass with the peer absent.
- */
-export interface LangGraphToolResult extends ArcjetDenialResult {
-  status: "error";
-  content: string;
-  type: "tool";
-  name: string;
-  tool_call_id: string;
-  getType: () => "tool";
 }
 
 /** Model- and user-readable explanation of a denial. */
@@ -101,76 +98,4 @@ export function unavailableResult(): ArcjetDenialResult {
     retryable: true,
     retryAfterSeconds: UNAVAILABLE_RETRY_AFTER_SECONDS,
   };
-}
-
-export function denialToolResult(
-  decision: DecisionDeny,
-  extras?: { name?: string; toolCallId?: string },
-): LangGraphToolResult {
-  return asToolResult(denialResult(decision), extras);
-}
-
-export function unavailableToolResult(extras?: {
-  name?: string;
-  toolCallId?: string;
-}): LangGraphToolResult {
-  return asToolResult(unavailableResult(), extras);
-}
-
-/**
- * Lift a denial payload (or a caller `onDeny` object) into the tool-result
- * shape. A value that already looks like a tool result is returned as-is.
- */
-export function asToolResult(
-  value: unknown,
-  extras?: { name?: string; toolCallId?: string },
-): LangGraphToolResult {
-  if (isToolResult(value)) {
-    return value;
-  }
-
-  const denial = isDenialResult(value)
-    ? value
-    : {
-        arcjetDenied: true as const,
-        reason: "ERROR",
-        message: typeof value === "string" ? value : unavailableReason(),
-        retryable: false,
-      };
-
-  const name = extras?.name ?? "";
-  const toolCallId = extras?.toolCallId ?? "";
-
-  return {
-    ...denial,
-    status: "error",
-    content: denial.message,
-    type: "tool",
-    name,
-    tool_call_id: toolCallId,
-    getType: () => "tool",
-  };
-}
-
-function isDenialResult(value: unknown): value is ArcjetDenialResult {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "arcjetDenied" in value &&
-    (value as { arcjetDenied?: unknown }).arcjetDenied === true &&
-    "reason" in value &&
-    typeof (value as { reason?: unknown }).reason === "string" &&
-    "message" in value &&
-    typeof (value as { message?: unknown }).message === "string"
-  );
-}
-
-function isToolResult(value: unknown): value is LangGraphToolResult {
-  return (
-    isDenialResult(value) &&
-    "status" in value &&
-    (value as { status?: unknown }).status === "error" &&
-    "getType" in value &&
-    typeof (value as { getType?: unknown }).getType === "function"
-  );
 }

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
@@ -1,0 +1,184 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, typescript/no-unnecessary-type-assertion -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { LangGraphToolResult } from "./denial.ts";
+import type { LangGraphToolNodeLike } from "./guard-tool-node.ts";
+import { guardToolNode } from "./guard-tool-node.ts";
+import type { LangGraphTool } from "./guard-tool.ts";
+import { guardTool } from "./guard-tool.ts";
+
+function createTool(
+  name: string,
+  impl?: (input: unknown, runtime?: unknown) => Promise<unknown>,
+): LangGraphTool {
+  const func = impl ?? (async () => ({ ok: name }));
+  return {
+    name,
+    description: name,
+    func,
+    invoke: async (input: unknown, config?: unknown) => func(input, config),
+  };
+}
+
+function createNode(tools: LangGraphTool[]): LangGraphToolNodeLike {
+  const node: LangGraphToolNodeLike = {
+    tools,
+    invoke: async function (this: LangGraphToolNodeLike, input: unknown, config?: unknown) {
+      const results = [];
+      for (const tool of this.tools) {
+        results.push(await tool.invoke?.(input, config));
+      }
+      return { messages: results };
+    },
+  };
+  return node;
+}
+
+test("wraps a tools array and brands each unwrapped tool", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const raw = createTool("lookup");
+  const wrapped = guardToolNode(client, [raw], { action: "tool.invoked" });
+
+  assert.equal(wrapped.length, 1);
+  assert.notStrictEqual(wrapped[0], raw);
+  assert.equal(arcjetProtectedTool in wrapped[0]!, true);
+  await wrapped[0]!.func!({}, { configurable: { thread_id: "t" } });
+  assert.equal(guardCalls.length, 1);
+});
+
+test("wraps a ToolNode, leaving already-guarded tools unwrapped a second time", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const authored = guardTool(client, createTool("authored"), { action: "order.looked-up" });
+  const mcp = createTool("mcp_search");
+  const node = createNode([authored, mcp]);
+
+  const wrapped = guardToolNode(client, node, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+
+  assert.notStrictEqual(wrapped, node);
+  assert.equal(arcjetProtectedTool in wrapped, true);
+  assert.equal(wrapped.tools[0], authored);
+  assert.notStrictEqual(wrapped.tools[1], mcp);
+  assert.equal(arcjetProtectedTool in wrapped.tools[1]!, true);
+
+  await wrapped.tools[0]!.func!({}, { configurable: { thread_id: "t" } });
+  await wrapped.tools[1]!.func!({}, { configurable: { thread_id: "t" } });
+  assert.equal(guardCalls.length, 2);
+  assert.equal(recorded(guardCalls[0])["label"], "order.looked-up");
+  assert.equal(recorded(guardCalls[1])["label"], "mcp_search.invoked");
+});
+
+test("authored guardTool + ToolNode wrap is one guard call, not two", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const authored = guardTool(client, createTool("authored"), { action: "order.looked-up" });
+  const wrapped = guardToolNode(client, createNode([authored]), {
+    action: "node.invoked",
+  });
+
+  await wrapped.invoke({ orderNumber: "A-1" }, { configurable: { thread_id: "t" } });
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["label"], "order.looked-up");
+});
+
+test("unwrapped tool through ToolNode is denied and does not execute", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const mcp = createTool("mcp_search", async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  const wrapped = guardToolNode(client, createNode([mcp]), { action: "mcp.invoked" });
+  const result = asDenial<LangGraphToolResult>(
+    ((await wrapped.invoke({}, { configurable: { thread_id: "t" } })) as { messages: unknown[] })
+      .messages[0],
+  );
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("throws when wrapping a ToolNode that is already guarded", () => {
+  const { client } = stubClient(decisionAllow());
+  const wrapped = guardToolNode(client, createNode([createTool("a")]));
+  assert.throws(() => guardToolNode(client, wrapped), /already guarded/);
+});
+
+test("skips branded tools in a tools array (no second wrap)", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const authored = guardTool(client, createTool("authored"), { action: "order.looked-up" });
+  const [again] = guardToolNode(client, [authored], { action: "node.invoked" });
+  assert.equal(again, authored);
+  await again!.func!({}, { configurable: { thread_id: "t" } });
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["label"], "order.looked-up");
+});
+
+test("invoke re-wraps tools added after the initial wrap", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const node = createNode([]);
+  const wrapped = guardToolNode(client, node, { action: "late.invoked" });
+  wrapped.tools.push(
+    createTool("late", async () => {
+      calls += 1;
+      return { ok: true };
+    }),
+  );
+  const result = asDenial<LangGraphToolResult>(
+    ((await wrapped.invoke({}, { configurable: { thread_id: "t" } })) as { messages: unknown[] })
+      .messages[0],
+  );
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+  assert.equal(arcjetProtectedTool in wrapped.tools[0]!, true);
+});
+
+test("node policy rules receive the tool name and free-text args", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mcp = createTool("mcp_search", async () => ({ ok: true }));
+  const wrapped = guardToolNode(client, [mcp], {
+    action: ({ toolName }) => `${toolName}.invoked`,
+    rules: (call) => {
+      assert.equal(call.toolName, "mcp_search");
+      assert.equal((call.input as { q: string }).q, "free text");
+      return [fakeRule];
+    },
+  });
+  await wrapped[0]!.func!({ q: "free text" }, { configurable: { thread_id: "t" } });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+  assert.equal(recorded(guardCalls[0])["label"], "mcp_search.invoked");
+});
+
+test("node-level fail-closed does not execute an unwrapped tool", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const mcp = createTool("mcp_search", async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  const wrapped = guardToolNode(client, [mcp], { action: "mcp.invoked" });
+  const result = asDenial<LangGraphToolResult>(
+    await wrapped[0]!.func!({}, { configurable: { thread_id: "t" } }),
+  );
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("throws when the argument is neither a ToolNode nor a tools array", () => {
+  const { client } = stubClient(decisionAllow());
+  assert.throws(
+    () => guardToolNode(client, { name: "not-a-node" } as never),
+    /ToolNode or an array/,
+  );
+});

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
@@ -11,7 +11,7 @@ import {
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { LangGraphToolResult } from "./denial.ts";
+import type { ArcjetDenialResult } from "./denial.ts";
 import type { LangGraphToolNodeLike } from "./guard-tool-node.ts";
 import { guardToolNode } from "./guard-tool-node.ts";
 import type { LangGraphTool } from "./guard-tool.ts";
@@ -30,12 +30,20 @@ function createTool(
   };
 }
 
+/**
+ * Stand-in for `ToolNode`. `invoke` reads `this.tools` through a closure
+ * captured up front, exactly as the real class does
+ * (`func: (input, config) => this.run(input, config)` in its constructor), so
+ * this fake cannot report success where the real class would run unguarded
+ * tools. `test/langgraph/real-tool-node.test.ts` asserts the same behaviour
+ * against the real class.
+ */
 function createNode(tools: LangGraphTool[]): LangGraphToolNodeLike {
   const node: LangGraphToolNodeLike = {
     tools,
-    invoke: async function (this: LangGraphToolNodeLike, input: unknown, config?: unknown) {
+    invoke: async (input: unknown, config?: unknown) => {
       const results = [];
-      for (const tool of this.tools) {
+      for (const tool of node.tools) {
         results.push(await tool.invoke?.(input, config));
       }
       return { messages: results };
@@ -44,54 +52,68 @@ function createNode(tools: LangGraphTool[]): LangGraphToolNodeLike {
   return node;
 }
 
+function threadConfig(threadId: string) {
+  return { configurable: { thread_id: threadId } };
+}
+
+async function invokeNode(node: LangGraphToolNodeLike, input: unknown = {}): Promise<unknown[]> {
+  const output = await node.invoke?.(input, threadConfig("t"));
+  return (output as { messages: unknown[] }).messages;
+}
+
 test("wraps a tools array and brands each unwrapped tool", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const raw = createTool("lookup");
   const wrapped = guardToolNode(client, [raw], { action: "tool.invoked" });
 
   assert.equal(wrapped.length, 1);
-  assert.notStrictEqual(wrapped[0], raw);
+  assert.notStrictEqual(wrapped[0], raw, "the array form returns guarded copies");
   assert.equal(arcjetProtectedTool in wrapped[0]!, true);
-  await wrapped[0]!.func!({}, { configurable: { thread_id: "t" } });
+  assert.equal(arcjetProtectedTool in raw, false, "the input array is left alone");
+  await wrapped[0]!.func!({}, threadConfig("t"));
   assert.equal(guardCalls.length, 1);
 });
 
-test("wraps a ToolNode, leaving already-guarded tools unwrapped a second time", async () => {
+test("guards a node's tools in place and returns the same node", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const authored = guardTool(client, createTool("authored"), { action: "order.looked-up" });
   const mcp = createTool("mcp_search");
-  const node = createNode([authored, mcp]);
+  const tools = [authored, mcp];
+  const node = createNode(tools);
 
   const wrapped = guardToolNode(client, node, {
     action: ({ toolName }) => `${toolName}.invoked`,
   });
 
-  assert.notStrictEqual(wrapped, node);
+  // The real ToolNode resolves tools through a closure captured at
+  // construction, so the node and its array must be the ones we guarded.
+  assert.strictEqual(wrapped, node);
+  assert.strictEqual(wrapped.tools, tools);
   assert.equal(arcjetProtectedTool in wrapped, true);
-  assert.equal(wrapped.tools[0], authored);
+  assert.strictEqual(wrapped.tools[0], authored, "an already-guarded tool is left as-is");
   assert.notStrictEqual(wrapped.tools[1], mcp);
   assert.equal(arcjetProtectedTool in wrapped.tools[1]!, true);
 
-  await wrapped.tools[0]!.func!({}, { configurable: { thread_id: "t" } });
-  await wrapped.tools[1]!.func!({}, { configurable: { thread_id: "t" } });
+  await wrapped.tools[0]!.func!({}, threadConfig("t"));
+  await wrapped.tools[1]!.func!({}, threadConfig("t"));
   assert.equal(guardCalls.length, 2);
   assert.equal(recorded(guardCalls[0])["label"], "order.looked-up");
   assert.equal(recorded(guardCalls[1])["label"], "mcp_search.invoked");
 });
 
-test("authored guardTool + ToolNode wrap is one guard call, not two", async () => {
+test("authored guardTool + node wrap is one guard call, not two", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const authored = guardTool(client, createTool("authored"), { action: "order.looked-up" });
   const wrapped = guardToolNode(client, createNode([authored]), {
     action: "node.invoked",
   });
 
-  await wrapped.invoke({ orderNumber: "A-1" }, { configurable: { thread_id: "t" } });
+  await invokeNode(wrapped, { orderNumber: "A-1" });
   assert.equal(guardCalls.length, 1);
   assert.equal(recorded(guardCalls[0])["label"], "order.looked-up");
 });
 
-test("unwrapped tool through ToolNode is denied and does not execute", async () => {
+test("unwrapped tool through the node is denied and does not execute", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   let calls = 0;
   const mcp = createTool("mcp_search", async () => {
@@ -99,19 +121,40 @@ test("unwrapped tool through ToolNode is denied and does not execute", async () 
     return { ok: true };
   });
   const wrapped = guardToolNode(client, createNode([mcp]), { action: "mcp.invoked" });
-  const result = asDenial<LangGraphToolResult>(
-    ((await wrapped.invoke({}, { configurable: { thread_id: "t" } })) as { messages: unknown[] })
-      .messages[0],
-  );
+  const result = asDenial<ArcjetDenialResult>((await invokeNode(wrapped))[0]);
+
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
 });
 
-test("throws when wrapping a ToolNode that is already guarded", () => {
+test("a pre-wrap reference to the node cannot bypass the guard", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const mcp = createTool("mcp_search", async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  const node = createNode([mcp]);
+  guardToolNode(client, node, { action: "mcp.invoked" });
+
+  await invokeNode(node);
+
+  assert.equal(calls, 0);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("throws when wrapping a node that is already guarded", () => {
   const { client } = stubClient(decisionAllow());
   const wrapped = guardToolNode(client, createNode([createTool("a")]));
   assert.throws(() => guardToolNode(client, wrapped), /already guarded/);
+});
+
+test("throws rather than silently ungating a frozen tools array", () => {
+  const { client } = stubClient(decisionAllow());
+  const node = createNode([createTool("a")]);
+  Object.freeze(node.tools);
+  assert.throws(() => guardToolNode(client, node), /frozen tools array/);
 });
 
 test("skips branded tools in a tools array (no second wrap)", async () => {
@@ -119,12 +162,12 @@ test("skips branded tools in a tools array (no second wrap)", async () => {
   const authored = guardTool(client, createTool("authored"), { action: "order.looked-up" });
   const [again] = guardToolNode(client, [authored], { action: "node.invoked" });
   assert.equal(again, authored);
-  await again!.func!({}, { configurable: { thread_id: "t" } });
+  await again!.func!({}, threadConfig("t"));
   assert.equal(guardCalls.length, 1);
   assert.equal(recorded(guardCalls[0])["label"], "order.looked-up");
 });
 
-test("invoke re-wraps tools added after the initial wrap", async () => {
+test("invoke guards tools added after the initial wrap", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   let calls = 0;
   const node = createNode([]);
@@ -135,12 +178,10 @@ test("invoke re-wraps tools added after the initial wrap", async () => {
       return { ok: true };
     }),
   );
-  const result = asDenial<LangGraphToolResult>(
-    ((await wrapped.invoke({}, { configurable: { thread_id: "t" } })) as { messages: unknown[] })
-      .messages[0],
-  );
+  const result = asDenial<ArcjetDenialResult>((await invokeNode(wrapped))[0]);
+
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
   assert.equal(arcjetProtectedTool in wrapped.tools[0]!, true);
 });
 
@@ -155,9 +196,22 @@ test("node policy rules receive the tool name and free-text args", async () => {
       return [fakeRule];
     },
   });
-  await wrapped[0]!.func!({ q: "free text" }, { configurable: { thread_id: "t" } });
+  await wrapped[0]!.func!({ q: "free text" }, threadConfig("t"));
   assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
   assert.equal(recorded(guardCalls[0])["label"], "mcp_search.invoked");
+});
+
+test("node metadata policy is merged over the derived context", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mcp = createTool("mcp_search", async () => ({ ok: true }));
+  const wrapped = guardToolNode(client, [mcp], {
+    action: "mcp.invoked",
+    metadata: ({ toolName }) => ({ "app.tool": toolName }),
+  });
+  await wrapped[0]!.func!({}, threadConfig("thread-node"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.tool"], "mcp_search");
+  assert.equal(metadata["langgraph.thread"], "thread-node");
 });
 
 test("node-level fail-closed does not execute an unwrapped tool", async () => {
@@ -168,14 +222,39 @@ test("node-level fail-closed does not execute an unwrapped tool", async () => {
     return { ok: true };
   });
   const wrapped = guardToolNode(client, [mcp], { action: "mcp.invoked" });
-  const result = asDenial<LangGraphToolResult>(
-    await wrapped[0]!.func!({}, { configurable: { thread_id: "t" } }),
-  );
+  const result = asDenial<ArcjetDenialResult>(await wrapped[0]!.func!({}, threadConfig("t")));
   assert.equal(calls, 0);
   assert.equal(result.reason, "ERROR");
 });
 
-test("throws when the argument is neither a ToolNode nor a tools array", () => {
+test("node-level onGuardError allow still executes on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const mcp = createTool("mcp_search", async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  const wrapped = guardToolNode(client, [mcp], {
+    action: "mcp.invoked",
+    onGuardError: "allow",
+  });
+  const result = await wrapped[0]!.func!({}, threadConfig("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("node-level onDeny reshapes the denial", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const mcp = createTool("mcp_search", async () => ({ ok: true }));
+  const wrapped = guardToolNode(client, [mcp], {
+    action: "mcp.invoked",
+    onDeny: (decision) => ({ blocked: decision.reason }),
+  });
+  const result = await wrapped[0]!.func!({}, threadConfig("t"));
+  assert.deepEqual(result, { blocked: "PROMPT_INJECTION" });
+});
+
+test("throws when the argument is neither a node nor a tools array", () => {
   const { client } = stubClient(decisionAllow());
   assert.throws(
     () => guardToolNode(client, { name: "not-a-node" } as never),

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
@@ -50,10 +50,13 @@ export interface GuardToolNodePolicy {
  * Structural `ToolNode` surface this helper wraps. Matches
  * `@langchain/langgraph/prebuilt` `ToolNode` (`tools` + `invoke`) without
  * constructing one — CI must pass with the peer absent.
+ *
+ * `invoke` uses method syntax so a real `ToolNode`, whose `invoke` is
+ * generic, stays assignable; see the note on {@link LangGraphTool}.
  */
 export interface LangGraphToolNodeLike {
   tools: LangGraphTool[];
-  invoke: (input: unknown, config?: unknown) => unknown;
+  invoke?(input: unknown, config?: unknown): unknown;
 }
 
 function isToolNodeLike(value: unknown): value is LangGraphToolNodeLike {
@@ -106,28 +109,47 @@ function wrapUnbrandedTool(
   return guardTool(client, tool, policyForTool(tool, policy));
 }
 
-function ensureToolsGuarded(
+/**
+ * Replace every unguarded entry of `tools` with a guarded one, in place.
+ *
+ * In place is the whole point. `ToolNode`'s constructor registers
+ * `func: (input, config) => this.run(input, config)` — an arrow bound to the
+ * instance being constructed — and `run` reads `this.tools`. Assigning a new
+ * array to a copied node therefore changes nothing the node actually
+ * executes: the captured closure keeps reaching the original array. Mutating
+ * the array the node already holds is what the running graph observes, and it
+ * also means a caller holding the same node (or the same array) cannot
+ * bypass Guard through a stale reference.
+ */
+function guardToolsInPlace(
   client: ArcjetAgentClient,
   tools: LangGraphTool[],
   policy: GuardToolNodePolicy,
-): LangGraphTool[] {
-  let changed = false;
-  const next = tools.map((tool) => {
-    if (arcjetProtectedTool in tool) {
-      return tool;
+): void {
+  for (let index = 0; index < tools.length; index += 1) {
+    const tool = tools[index];
+    if (tool === undefined || arcjetProtectedTool in tool) {
+      continue;
     }
-    changed = true;
-    return wrapUnbrandedTool(client, tool, policy);
-  });
-  return changed ? next : tools;
+    tools[index] = guardTool(client, tool, policyForTool(tool, policy));
+  }
 }
 
 /**
- * Wraps a LangGraph `ToolNode` (or the tools you will pass to one) so MCP /
+ * Guards the tools a LangGraph `ToolNode` executes, so MCP /
  * runtime-discovered / unwrapped tools still hit Guard before execute.
  *
- * Already-branded tools (`guardTool`) are left alone so Guard is not
- * double-called. Wrapping a `ToolNode` that is already branded throws.
+ * Given a `ToolNode`, the node's tools are guarded **in place** and the same
+ * node is returned: `ToolNode` resolves tools through a closure captured at
+ * construction, so a copy with a fresh tools array would leave the original
+ * tools running unguarded. Mutating in place also means a caller still
+ * holding that node cannot bypass Guard. Given an array of tools, a new
+ * array of guarded tools is returned and the input array is left alone.
+ *
+ * Already-branded tools (`guardTool`) are left as they are, so Guard is not
+ * double-called. Wrapping a `ToolNode` that is already guarded throws. Tools
+ * appended after wrapping — MCP discovered mid-run — are guarded on the next
+ * `invoke`.
  *
  * Prefer this for tools that only run through `ToolNode`. Use `guardTool`
  * for authored tools invoked outside `ToolNode`.
@@ -184,44 +206,47 @@ export function guardToolNode(
     throw new Error("@arcjet/guard: guardToolNode() requires a ToolNode or an array of tools");
   }
 
-  if (arcjetProtectedTool in toolsOrNode) {
+  const node = toolsOrNode;
+
+  if (arcjetProtectedTool in node) {
     throw new Error(
       "@arcjet/guard: guardToolNode() cannot wrap a ToolNode that is already guarded; do not double-wrap with @arcjet/guard/langgraph/v1",
     );
   }
 
-  const originalInvoke = toolsOrNode.invoke;
+  // A frozen array cannot be guarded in place, and silently returning the
+  // node would leave every tool ungated. Fail at wrap time instead.
+  if (Object.isFrozen(node.tools)) {
+    throw new Error(
+      "@arcjet/guard: guardToolNode() cannot guard a ToolNode with a frozen tools array; pass the tools through guardToolNode() before constructing the ToolNode",
+    );
+  }
 
-  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
-  const proto = Object.getPrototypeOf(toolsOrNode) as object | null;
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
-  const wrapped = Object.defineProperties(
-    Object.create(proto),
-    Object.getOwnPropertyDescriptors(toolsOrNode),
-  ) as LangGraphToolNodeLike;
+  guardToolsInPlace(client, node.tools, policy);
 
-  wrapped.tools = ensureToolsGuarded(client, wrapped.tools, policy);
+  // oxlint-disable-next-line typescript/unbound-method -- deliberately unbound: it is re-applied to `node` below so the guarded tools array is the one it reads
+  const originalInvoke = node.invoke;
+  if (originalInvoke !== undefined) {
+    const ownInvoke = Object.getOwnPropertyDescriptor(node, "invoke");
+    const newInvoke = (input: unknown, config?: unknown): unknown => {
+      // Tools discovered after wrapping (MCP, runtime registration) are
+      // guarded here, before the node resolves the call.
+      guardToolsInPlace(client, node.tools, policy);
+      return originalInvoke.call(node, input, config);
+    };
+    Object.defineProperty(node, "invoke", {
+      value: newInvoke,
+      writable: true,
+      enumerable: ownInvoke?.enumerable ?? false,
+      configurable: true,
+    });
+  }
 
-  const newInvoke = (input: unknown, config?: unknown): unknown => {
-    wrapped.tools = ensureToolsGuarded(client, wrapped.tools, policy);
-    // Real ToolNode.runTool reads `this.tools`. Bind to the wrapped node so
-    // MCP tools added after wrap (and the replaced tools array) are the ones
-    // that execute.
-    return originalInvoke.call(wrapped, input, config);
-  };
-
-  Object.defineProperty(wrapped, "invoke", {
-    value: newInvoke,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
-
-  Object.defineProperty(wrapped, arcjetProtectedTool, {
+  Object.defineProperty(node, arcjetProtectedTool, {
     value: true,
     enumerable: false,
     configurable: true,
   });
 
-  return wrapped;
+  return node;
 }

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
@@ -1,0 +1,227 @@
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { guardTool } from "./guard-tool.ts";
+import type { GuardToolPolicy, LangGraphTool } from "./guard-tool.ts";
+
+/**
+ * Input passed to `rules` / `metadata` / `action` callbacks on
+ * `guardToolNode`. `input` is the tool's free-text args, not the opaque
+ * `tool_call_id`.
+ */
+export interface GuardToolNodeCall {
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Policy for `guardToolNode()` — how to guard unwrapped / MCP /
+ * runtime-discovered tools that execute through `ToolNode`.
+ *
+ * `createReactAgent` is deprecated in LangGraph JS v1; this helper wraps
+ * `ToolNode` from `@langchain/langgraph/prebuilt`, not that API. LangGraph
+ * `interrupt()` / `interrupt_before=["tools"]` is HITL, not a policy gate
+ * — there is no `guardInterrupt`.
+ */
+export interface GuardToolNodePolicy {
+  /**
+   * Guard label and capture action. Defaults to `"tool.invoked"`. May be a
+   * function of the tool name and args.
+   */
+  action?: string | ((call: GuardToolNodeCall) => string);
+  /**
+   * Rules to evaluate before an unwrapped tool runs. Omitting this still
+   * performs the guard call.
+   */
+  rules?: RuleWithInput[] | ((call: GuardToolNodeCall) => RuleWithInput[]);
+  /** Metadata merged over the derived LangGraph context. */
+  metadata?: ArcjetMetadata | ((call: GuardToolNodeCall) => ArcjetMetadata);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload the model sees for a real DENY decision.
+   * Unavailable guards take the `onUnavailable` path instead.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+/**
+ * Structural `ToolNode` surface this helper wraps. Matches
+ * `@langchain/langgraph/prebuilt` `ToolNode` (`tools` + `invoke`) without
+ * constructing one — CI must pass with the peer absent.
+ */
+export interface LangGraphToolNodeLike {
+  tools: LangGraphTool[];
+  invoke: (input: unknown, config?: unknown) => unknown;
+}
+
+function isToolNodeLike(value: unknown): value is LangGraphToolNodeLike {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "tools" in value &&
+    Array.isArray((value as { tools?: unknown }).tools) &&
+    "invoke" in value &&
+    typeof (value as { invoke?: unknown }).invoke === "function"
+  );
+}
+
+function resolveAction(policy: GuardToolNodePolicy, call: GuardToolNodeCall): string {
+  if (typeof policy.action === "function") {
+    return policy.action(call);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "tool.invoked";
+}
+
+function policyForTool(tool: LangGraphTool, policy: GuardToolNodePolicy): GuardToolPolicy<unknown> {
+  return {
+    action: (input) => resolveAction(policy, { toolName: tool.name, input }),
+    rules: (input) => {
+      const call = { toolName: tool.name, input };
+      return typeof policy.rules === "function" ? policy.rules(call) : (policy.rules ?? []);
+    },
+    metadata: (input) => {
+      const call = { toolName: tool.name, input };
+      return typeof policy.metadata === "function"
+        ? policy.metadata(call)
+        : (policy.metadata ?? {});
+    },
+    ...(policy.onGuardError !== undefined && { onGuardError: policy.onGuardError }),
+    ...(policy.onDeny !== undefined && { onDeny: policy.onDeny }),
+  };
+}
+
+function wrapUnbrandedTool(
+  client: ArcjetAgentClient,
+  tool: LangGraphTool,
+  policy: GuardToolNodePolicy,
+): LangGraphTool {
+  if (arcjetProtectedTool in tool) {
+    return tool;
+  }
+  return guardTool(client, tool, policyForTool(tool, policy));
+}
+
+function ensureToolsGuarded(
+  client: ArcjetAgentClient,
+  tools: LangGraphTool[],
+  policy: GuardToolNodePolicy,
+): LangGraphTool[] {
+  let changed = false;
+  const next = tools.map((tool) => {
+    if (arcjetProtectedTool in tool) {
+      return tool;
+    }
+    changed = true;
+    return wrapUnbrandedTool(client, tool, policy);
+  });
+  return changed ? next : tools;
+}
+
+/**
+ * Wraps a LangGraph `ToolNode` (or the tools you will pass to one) so MCP /
+ * runtime-discovered / unwrapped tools still hit Guard before execute.
+ *
+ * Already-branded tools (`guardTool`) are left alone so Guard is not
+ * double-called. Wrapping a `ToolNode` that is already branded throws.
+ *
+ * Prefer this for tools that only run through `ToolNode`. Use `guardTool`
+ * for authored tools invoked outside `ToolNode`.
+ *
+ * `interrupt()` / `interrupt_before=["tools"]` is HITL, not a policy gate.
+ * Graph hooks cannot enforce a deny — `ToolNode` (or `guardTool`) is the
+ * deny point.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardToolNode } from "@arcjet/guard/langgraph/v1";
+ * import { ToolNode } from "@langchain/langgraph/prebuilt";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const mcpLimit = tokenBucket({
+ *   refillRate: 20,
+ *   intervalSeconds: 60,
+ *   maxTokens: 20,
+ * });
+ *
+ * const tools = guardToolNode(
+ *   arcjet,
+ *   new ToolNode(mcpTools),
+ *   {
+ *     action: ({ toolName }) => `${toolName}.invoked`,
+ *     rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+ *   },
+ * );
+ * ```
+ */
+export function guardToolNode<T extends LangGraphToolNodeLike>(
+  client: ArcjetAgentClient,
+  node: T,
+  policy?: GuardToolNodePolicy,
+): T;
+export function guardToolNode<T extends LangGraphTool>(
+  client: ArcjetAgentClient,
+  tools: readonly T[],
+  policy?: GuardToolNodePolicy,
+): T[];
+export function guardToolNode(
+  client: ArcjetAgentClient,
+  toolsOrNode: LangGraphToolNodeLike | readonly LangGraphTool[],
+  policy: GuardToolNodePolicy = {},
+): LangGraphToolNodeLike | LangGraphTool[] {
+  if (Array.isArray(toolsOrNode)) {
+    const tools: readonly LangGraphTool[] = toolsOrNode;
+    return tools.map((tool) => wrapUnbrandedTool(client, tool, policy));
+  }
+
+  if (!isToolNodeLike(toolsOrNode)) {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error("@arcjet/guard: guardToolNode() requires a ToolNode or an array of tools");
+  }
+
+  if (arcjetProtectedTool in toolsOrNode) {
+    throw new Error(
+      "@arcjet/guard: guardToolNode() cannot wrap a ToolNode that is already guarded; do not double-wrap with @arcjet/guard/langgraph/v1",
+    );
+  }
+
+  const originalInvoke = toolsOrNode.invoke;
+
+  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
+  const proto = Object.getPrototypeOf(toolsOrNode) as object | null;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
+  const wrapped = Object.defineProperties(
+    Object.create(proto),
+    Object.getOwnPropertyDescriptors(toolsOrNode),
+  ) as LangGraphToolNodeLike;
+
+  wrapped.tools = ensureToolsGuarded(client, wrapped.tools, policy);
+
+  const newInvoke = (input: unknown, config?: unknown): unknown => {
+    wrapped.tools = ensureToolsGuarded(client, wrapped.tools, policy);
+    // Real ToolNode.runTool reads `this.tools`. Bind to the wrapped node so
+    // MCP tools added after wrap (and the replaced tools array) are the ones
+    // that execute.
+    return originalInvoke.call(wrapped, input, config);
+  };
+
+  Object.defineProperty(wrapped, "invoke", {
+    value: newInvoke,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(wrapped, arcjetProtectedTool, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return wrapped;
+}

--- a/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
@@ -1,4 +1,4 @@
-// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions -- test infrastructure and mocks
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions, typescript/unbound-method -- test infrastructure and mocks
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -13,7 +13,7 @@ import {
 } from "../../../test/_shared/stub-client.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
-import type { LangGraphToolResult } from "./denial.ts";
+import type { ArcjetDenialResult } from "./denial.ts";
 import type { LangGraphTool } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -54,8 +54,8 @@ function threadConfig(threadId: string) {
   return { configurable: { thread_id: threadId } };
 }
 
-function asToolResult(value: unknown): LangGraphToolResult {
-  return asDenial<LangGraphToolResult>(value);
+function asToolResult(value: unknown): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(value);
 }
 
 test("throws when the tool has no func or invoke", () => {
@@ -154,7 +154,7 @@ test("ALLOW → capture outcome is success and correlation comes from thread_id"
   );
 });
 
-test("DENY → func is not called and a status:error result is returned (no throw)", async () => {
+test("DENY → func is not called and a structured denial is returned (no throw)", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   let calls = 0;
   const tool = createLangGraphTool({
@@ -167,7 +167,7 @@ test("DENY → func is not called and a status:error result is returned (no thro
   const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
 
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
   assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
   assert.equal(result.retryable, false);
@@ -200,7 +200,7 @@ test("rules callback receives the tool input", async () => {
   assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
 });
 
-test("fail-closed unavailable → ERROR result, func not called", async () => {
+test("fail-closed unavailable → ERROR denial, func not called", async () => {
   const { client } = stubClient(decisionFailOpenAllow());
   let calls = 0;
   const tool = createLangGraphTool({
@@ -213,7 +213,7 @@ test("fail-closed unavailable → ERROR result, func not called", async () => {
   const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
 
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "ERROR");
 });
 
@@ -261,7 +261,7 @@ test("DENY + throwing onDeny still denies and does not throw", async () => {
 
   const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
 });
 
@@ -399,7 +399,7 @@ test("rules factory throw fail-closes and does not execute", async () => {
   });
   const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "ERROR");
 });
 
@@ -491,19 +491,29 @@ test("invoke-only tool (no func) is still gated", async () => {
   const wrapped = guardTool(client, tool, { action: "order.looked-up" });
   const result = asToolResult(await wrapped.invoke!({}, threadConfig("t")));
   assert.equal(calls, 0);
-  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
 });
 
-test("DENY invoke with a tool_call copies tool_call_id onto the result", async () => {
+test("DENY through a tool_call envelope returns the denial and scans only args", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
-  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  let scanned: unknown;
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: (input) => {
+      scanned = input;
+      return [];
+    },
+  });
   const result = asToolResult(
     await wrapped.invoke!(
       { name: "test-tool", args: { note: "x" }, id: "call-9", type: "tool_call" },
       threadConfig("t"),
     ),
   );
-  assert.equal(result.tool_call_id, "call-9");
-  assert.equal(result.status, "error");
+  // The opaque call id must not reach the detectors; ToolNode puts the id on
+  // the ToolMessage it builds from this denial.
+  assert.deepEqual(scanned, { note: "x" });
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
 });

--- a/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
@@ -1,0 +1,509 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionDenyRateLimit,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { DecisionDeny } from "../../types.ts";
+import type { LangGraphToolResult } from "./denial.ts";
+import type { LangGraphTool } from "./guard-tool.ts";
+import { guardTool } from "./guard-tool.ts";
+
+const HIDDEN = Symbol.for("langgraph.hidden");
+
+function createLangGraphTool<TInput = Record<string, unknown>>(overrides?: {
+  name?: string;
+  func?: (input: TInput, runtime?: unknown) => Promise<unknown>;
+  invoke?: (input: unknown, config?: unknown) => Promise<unknown>;
+}): LangGraphTool<TInput> {
+  const func = overrides?.func ?? overrides?.invoke ?? (async () => ({ ok: true }));
+  const tool: LangGraphTool<TInput> = {
+    name: overrides?.name ?? "test-tool",
+    description: "test tool",
+    func,
+    invoke:
+      overrides?.invoke ??
+      (async (input: unknown, config?: unknown) => {
+        const args =
+          input !== null &&
+          typeof input === "object" &&
+          "type" in input &&
+          (input as { type?: unknown }).type === "tool_call"
+            ? (input as unknown as { args: TInput }).args
+            : (input as TInput);
+        return func(args, config);
+      }),
+  };
+  Object.defineProperty(tool, HIDDEN, {
+    value: "keep-me",
+    enumerable: false,
+    configurable: true,
+  });
+  return tool;
+}
+
+function threadConfig(threadId: string) {
+  return { configurable: { thread_id: threadId } };
+}
+
+function asToolResult(value: unknown): LangGraphToolResult {
+  return asDenial<LangGraphToolResult>(value);
+}
+
+test("throws when the tool has no func or invoke", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = { name: "no-exec", description: "x" };
+  assert.throws(
+    () => guardTool(client, tool as LangGraphTool, { action: "test.executed" }),
+    /func or invoke/,
+  );
+});
+
+test("returned object is not the input tool and preserves non-enumerable markers", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createLangGraphTool();
+  const wrapped = guardTool(client, tool, { action: "test.executed" });
+
+  assert.notStrictEqual(wrapped, tool);
+  assert.equal((wrapped as any)[HIDDEN], "keep-me");
+});
+
+test("input tool.func and invoke are unchanged after wrapping", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createLangGraphTool();
+  const originalFunc = tool.func;
+  const originalInvoke = tool.invoke;
+  guardTool(client, tool, { action: "test.executed" });
+  assert.strictEqual(tool.func, originalFunc);
+  assert.strictEqual(tool.invoke, originalInvoke);
+});
+
+test("ALLOW → func called once with input and config by reference", async () => {
+  const { client } = stubClient(decisionAllow());
+  const input = { orderNumber: "A-1" };
+  const ctx = threadConfig("thread-1");
+  let calls = 0;
+  let capturedInput: unknown;
+  let capturedCtx: unknown;
+
+  const tool = createLangGraphTool({
+    func: async (inp, context) => {
+      calls += 1;
+      capturedInput = inp;
+      capturedCtx = context;
+      return { status: "shipped" };
+    },
+  });
+
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = await wrapped.func!(input, ctx);
+
+  assert.equal(calls, 1);
+  assert.strictEqual(capturedInput, input);
+  assert.strictEqual(capturedCtx, ctx);
+  assert.deepEqual(result, { status: "shipped" });
+});
+
+test("ALLOW → invoke with a tool_call uses args, not the opaque id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let captured: unknown;
+  const tool = createLangGraphTool<{ note: string }>({
+    func: async (input) => {
+      captured = input;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "note.read",
+    rules: (input) => {
+      assert.equal(input.note, "hello");
+      return [fakeRule];
+    },
+  });
+  await wrapped.invoke!(
+    { name: "test-tool", args: { note: "hello" }, id: "call-opaque", type: "tool_call" },
+    threadConfig("t"),
+  );
+  assert.deepEqual(captured, { note: "hello" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("ALLOW → capture outcome is success and correlation comes from thread_id", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool({
+    func: async () => ({ ok: true }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, threadConfig("thread-99"));
+
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "thread-99");
+  assert.equal(captureCalls.length, 1);
+  assert.equal(
+    recorded(captureCalls[0])["metadata"] &&
+      (recorded(captureCalls[0])["metadata"] as Record<string, unknown>)["outcome"],
+    "success",
+  );
+});
+
+test("DENY → func is not called and a status:error result is returned (no throw)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+  assert.equal(result.retryable, false);
+});
+
+test("RATE_LIMIT DENY → structured result is retryable", async () => {
+  const resetAt = Math.floor(Date.now() / 1000) + 12;
+  const { client } = stubClient(decisionDenyRateLimit(resetAt));
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+
+  assert.equal(result.retryable, true);
+  assert.ok(typeof result.retryAfterSeconds === "number");
+});
+
+test("rules callback receives the tool input", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool<{ id: string }>({
+    func: async () => ({ ok: true }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    rules: (input) => {
+      assert.equal(input.id, "xyz");
+      return [fakeRule];
+    },
+  });
+  await wrapped.func!({ id: "xyz" }, threadConfig("t"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("fail-closed unavailable → ERROR result, func not called", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+  assert.equal(result.reason, "ERROR");
+});
+
+test("onGuardError allow → func still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+  });
+  const result = await wrapped.func!({}, threadConfig("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("does not mint a correlation id when LangGraph provided none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, {});
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("DENY + throwing onDeny still denies and does not throw", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      throw new Error("onDeny exploded");
+    },
+  });
+
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("onDeny reshape is returned and func is not called", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let received: DecisionDeny | undefined;
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: (decision) => {
+      received = decision;
+      return { blocked: decision.reason };
+    },
+  });
+
+  const result = await wrapped.func!({}, threadConfig("t"));
+  assert.equal(received?.reason, "PROMPT_INJECTION");
+  assert.deepEqual(result, { blocked: "PROMPT_INJECTION" });
+});
+
+test("onDeny is not called on unavailable", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let onDenyCalls = 0;
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      onDenyCalls += 1;
+      return { blocked: true };
+    },
+  });
+
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(onDenyCalls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("guard throw with default fail-closed does not execute", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("omitted rules still submit an empty guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, threadConfig("t"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], []);
+});
+
+test("metadata callback is merged over derived context", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool<{ id: string }>({
+    func: async () => ({ ok: true }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: (input) => ({ "app.item": input.id }),
+  });
+  await wrapped.func!({ id: "item-9" }, threadConfig("thread-meta"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.item"], "item-9");
+  assert.equal(metadata["langgraph.tool"], "test-tool");
+});
+
+test("static metadata is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool({ name: "", func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: { "app.static": "yes" },
+  });
+  await wrapped.func!({}, threadConfig("t"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.static"], "yes");
+  assert.equal("langgraph.tool" in metadata, false);
+});
+
+test("rejects a second wrap (langgraph or vercel-ai brand)", async () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createLangGraphTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  assert.equal(arcjetProtectedTool in wrapped, true);
+  assert.throws(() => guardTool(client, wrapped, { action: "order.looked-up" }), /already guarded/);
+
+  const branded = createLangGraphTool();
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  assert.throws(() => guardTool(client, branded, { action: "order.looked-up" }), /already guarded/);
+});
+
+test("func throw is rethrown after capture", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool({
+    func: async (): Promise<{ ok: boolean }> => {
+      throw new Error("tool failed");
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await assert.rejects(async () => wrapped.func!({}, threadConfig("t")), /tool failed/);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "error");
+});
+
+test("non-object config does not mint an id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, "not-context");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("rules factory throw fail-closes and does not execute", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+  assert.equal(result.reason, "ERROR");
+});
+
+test("metadata factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    metadata: () => {
+      throw new Error("metadata exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("action factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: () => {
+      throw new Error("action exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("rules factory throw with onGuardError allow still executes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await wrapped.func!({}, threadConfig("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("invoke and func share one guard call (no double-call)", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let funcCalls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      funcCalls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.invoke!({ orderNumber: "A-1" }, threadConfig("t"));
+  assert.equal(funcCalls, 1);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("invoke-only tool (no func) is still gated", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool: LangGraphTool = {
+    name: "invoke-only",
+    invoke: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  };
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.status, "error");
+});
+
+test("DENY invoke with a tool_call copies tool_call_id onto the result", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const tool = createLangGraphTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(
+    await wrapped.invoke!(
+      { name: "test-tool", args: { note: "x" }, id: "call-9", type: "tool_call" },
+      threadConfig("t"),
+    ),
+  );
+  assert.equal(result.tool_call_id, "call-9");
+  assert.equal(result.status, "error");
+});

--- a/arcjet-guard/src/langgraph/v1/guard-tool.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.ts
@@ -6,15 +6,22 @@ import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
 import { langgraphAgentContext } from "./context.ts";
 import type { LangGraphContextSource } from "./context.ts";
-import { denialToolResult, unavailableToolResult } from "./denial.ts";
-import type { LangGraphToolResult } from "./denial.ts";
+import { denialResult, unavailableResult } from "./denial.ts";
 
 /**
  * Structural LangChain `tool()` / `StructuredTool` / `RunnableToolLike`.
  * Declared here so `guardTool` does not value-import `@langchain/core`.
  *
- * LangGraph Graph API tools are invoked via `invoke` (`ToolNode.runTool`)
- * and authored `tool()` wrappers also expose `func`. There is no `execute`.
+ * LangGraph Graph API tools are invoked through `invoke` (that is what
+ * `ToolNode.runTool` calls) and authored `tool()` wrappers also expose `func`.
+ * There is no `execute`.
+ *
+ * `invoke` and `func` are declared with method syntax, not as property types.
+ * Method parameters are bivariant, which is what lets a real
+ * `DynamicStructuredTool` — whose `invoke` is generic over
+ * `StructuredToolCallInput` — satisfy this interface. Written as property
+ * types they are contravariant under `strictFunctionTypes`, and every real
+ * LangChain tool is rejected at the call site.
  *
  * `createReactAgent` is deprecated in LangGraph JS v1 in favor of LangChain
  * `createAgent`. This helper targets Graph API tools, not that middleware.
@@ -22,8 +29,8 @@ import type { LangGraphToolResult } from "./denial.ts";
 export interface LangGraphTool<TInput = unknown> {
   name: string;
   description?: string;
-  invoke?: (input: unknown, config?: unknown) => unknown;
-  func?: (input: TInput, runtime?: unknown) => unknown;
+  invoke?(input: unknown, config?: unknown): unknown;
+  func?(input: TInput, runtime?: unknown): unknown;
 }
 
 /**
@@ -32,7 +39,7 @@ export interface LangGraphTool<TInput = unknown> {
  * the tool args (not opaque call ids).
  */
 export type LangGraphToolInput<TTool> = TTool extends {
-  func?: (input: infer TInput, runtime?: unknown) => unknown;
+  func?(input: infer TInput, runtime?: unknown): unknown;
 }
   ? TInput
   : unknown;
@@ -63,10 +70,13 @@ export interface GuardToolPolicy<TInput> {
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
   onGuardError?: OnGuardError;
   /**
-   * Reshape the denial payload the model sees for a real DENY decision.
-   * Return a `ToolMessage`-shaped object (`status: "error"` recommended) or
-   * a plain object. Unavailable guards take the `onUnavailable` path
-   * instead; this callback does not fire for outages.
+   * Reshape the denial payload the model sees for a real DENY decision. The
+   * value is returned to the caller as-is, so `ToolNode` treats it exactly
+   * as it treats the default denial: a non-message object becomes the
+   * content of the `ToolMessage` it builds. Unavailable guards take the
+   * `onUnavailable` path instead and return the fixed
+   * `{ reason: "ERROR", retryable: true, retryAfterSeconds: 5 }` result;
+   * this callback does not fire for outages.
    */
   onDeny?: (decision: DecisionDeny) => unknown;
 }
@@ -75,12 +85,7 @@ function isContextSource(value: unknown): value is LangGraphContextSource {
   return value !== null && typeof value === "object";
 }
 
-function isToolCall(input: unknown): input is {
-  args: unknown;
-  id?: string;
-  name?: string;
-  type: "tool_call";
-} {
+function isToolCall(input: unknown): input is { args: unknown; type: "tool_call" } {
   return (
     input !== null &&
     typeof input === "object" &&
@@ -90,15 +95,13 @@ function isToolCall(input: unknown): input is {
   );
 }
 
+/**
+ * The model-produced arguments. `ToolNode` invokes a tool with the whole
+ * `ToolCall`, so rules must see `args` rather than the envelope — scanning
+ * the envelope would feed an opaque `tool_call_id` to the detectors.
+ */
 function toolArgs(input: unknown): unknown {
   return isToolCall(input) ? input.args : input;
-}
-
-function toolCallId(input: unknown): string | undefined {
-  if (isToolCall(input) && typeof input.id === "string" && input.id.length > 0) {
-    return input.id;
-  }
-  return undefined;
 }
 
 /**
@@ -106,21 +109,22 @@ function toolCallId(input: unknown): string | undefined {
  * runs on DENY.
  *
  * Always runs `guard()` before the tool, submitting `policy.rules` or none;
- * on DENY the original function never executes and the model receives a
- * tool result with `status: "error"` (or the result of `policy.onDeny`).
- * This helper does not throw on DENY.
+ * on DENY the original function never executes and the model receives an
+ * `ArcjetDenialResult` (or the result of `policy.onDeny`). This helper does
+ * not throw on DENY. Through `ToolNode` the denial arrives as the content of
+ * a real `ToolMessage`; see {@link ArcjetDenialResult} for why the denial is
+ * in the payload rather than the message status.
  *
  * Guard API errors depend on `policy.onGuardError` (defaults to `"deny"`):
- * - `"deny"` (default): Tool does not execute; the model receives
- *   `status: "error"` with `reason: "ERROR"`.
+ * - `"deny"` (default): Tool does not execute; the model receives an
+ *   `ArcjetDenialResult` with `reason: "ERROR"`.
  * - `"allow"`: Tool still runs, with a warning gated on `ARCJET_LOG_LEVEL`.
  *
  * Correlation is read from the invoke `config` / `ToolRuntime`
  * (`configurable.thread_id`). No id is minted.
  *
- * Do not also wrap the same tool with `@arcjet/guard/vercel-ai/v7` or pass
- * it through `guardToolNode` after wrapping — the shared
- * `arcjetProtectedTool` brand throws on a second `guardTool` wrap.
+ * Do not also wrap the same tool with `@arcjet/guard/vercel-ai/v7`. The
+ * shared `arcjetProtectedTool` brand throws on a second `guardTool` wrap, and
  * `guardToolNode` skips already-branded tools so Guard is not double-called.
  *
  * This is Graph API (`StateGraph` + `ToolNode`). `createReactAgent` is
@@ -163,9 +167,11 @@ export function guardTool<TTool extends LangGraphTool<any>>(
   tool: TTool,
   policy: GuardToolPolicy<LangGraphToolInput<TTool>>,
 ): TTool {
-  const hasFunc = typeof tool.func === "function";
-  const hasInvoke = typeof tool.invoke === "function";
-  if (!hasFunc && !hasInvoke) {
+  // oxlint-disable-next-line typescript/unbound-method -- read to be bound to `tool` immediately below, which is the point
+  const func = typeof tool.func === "function" ? tool.func : undefined;
+  // oxlint-disable-next-line typescript/unbound-method -- read to be bound to `tool` immediately below, which is the point
+  const invoke = typeof tool.invoke === "function" ? tool.invoke : undefined;
+  if (func === undefined && invoke === undefined) {
     // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
     throw new Error("@arcjet/guard: guardTool() requires a tool with a func or invoke function");
   }
@@ -175,10 +181,13 @@ export function guardTool<TTool extends LangGraphTool<any>>(
     );
   }
 
-  const func = tool.func;
-  const invoke = tool.invoke;
-  const originalFunc = hasFunc && func !== undefined ? func.bind(tool) : undefined;
-  const originalInvoke = hasInvoke && invoke !== undefined ? invoke.bind(tool) : undefined;
+  // Bound to the original tool, so the guarded `invoke` below reaches the
+  // original `func` rather than the guarded one. That is what keeps a single
+  // call from evaluating the guard twice, without any shared re-entry state:
+  // `ToolNode` fans parallel tool calls out through `Promise.all`, and a
+  // shared flag would let one of those calls skip the guard entirely.
+  const originalFunc = func?.bind(tool);
+  const originalInvoke = invoke?.bind(tool);
 
   // Preserve class prototype and non-enumerable markers.
   // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
@@ -189,27 +198,11 @@ export function guardTool<TTool extends LangGraphTool<any>>(
     Object.getOwnPropertyDescriptors(tool),
   ) as TTool;
 
-  let inFlight = false;
-
-  const run = async (
-    input: unknown,
-    config: unknown,
-    execute: () => Promise<unknown>,
-  ): Promise<unknown> => {
-    if (inFlight) {
-      return execute();
-    }
-    inFlight = true;
-    try {
-      return await runGuardedTool(client, tool, policy, input, config, execute);
-    } finally {
-      inFlight = false;
-    }
-  };
-
   if (originalFunc !== undefined) {
-    const newFunc = (input: LangGraphToolInput<TTool>, runtime?: unknown): Promise<unknown> =>
-      run(input, runtime, () => Promise.resolve(originalFunc(input, runtime)));
+    const newFunc = (input: unknown, runtime?: unknown): Promise<unknown> =>
+      runGuardedTool(client, tool, policy, input, runtime, () =>
+        Promise.resolve(originalFunc(input, runtime)),
+      );
     Object.defineProperty(wrapped, "func", {
       value: newFunc,
       writable: true,
@@ -220,7 +213,9 @@ export function guardTool<TTool extends LangGraphTool<any>>(
 
   if (originalInvoke !== undefined) {
     const newInvoke = (input: unknown, config?: unknown): Promise<unknown> =>
-      run(input, config, () => Promise.resolve(originalInvoke(input, config)));
+      runGuardedTool(client, tool, policy, input, config, () =>
+        Promise.resolve(originalInvoke(input, config)),
+      );
     Object.defineProperty(wrapped, "invoke", {
       value: newInvoke,
       writable: true,
@@ -247,13 +242,6 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
   execute: () => Promise<unknown>,
 ): Promise<unknown> {
   const args = toolArgs(input);
-  const extras: { name: string; toolCallId?: string } = {
-    name: typeof tool.name === "string" ? tool.name : "",
-  };
-  const callId = toolCallId(input);
-  if (callId !== undefined) {
-    extras.toolCallId = callId;
-  }
 
   let action: string;
   let rules: RuleWithInput[] | undefined;
@@ -277,7 +265,7 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
     if (policy.onGuardError === "allow") {
       return execute();
     }
-    return Promise.resolve(unavailableToolResult(extras));
+    return Promise.resolve(unavailableResult());
   }
 
   const source = isContextSource(config) ? config : undefined;
@@ -298,9 +286,8 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
     onDeny: (decision: DecisionDeny) => {
-      const fallback = denialToolResult(decision, extras);
       if (policy.onDeny === undefined) {
-        return fallback;
+        return denialResult(decision);
       }
       try {
         return policy.onDeny(decision);
@@ -312,15 +299,11 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
             error,
           );
         }
-        return fallback;
+        return denialResult(decision);
       }
     },
-    onUnavailable: () => unavailableToolResult(extras),
+    onUnavailable: () => unavailableResult(),
     execute,
     onGuardError: policy.onGuardError ?? "deny",
   });
 }
-
-// oxlint-disable-next-line typescript/no-unused-vars -- keeps the async keyword so callers can await a rejected guard path
-
-export type { LangGraphToolResult };

--- a/arcjet-guard/src/langgraph/v1/guard-tool.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.ts
@@ -1,0 +1,326 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { langgraphAgentContext } from "./context.ts";
+import type { LangGraphContextSource } from "./context.ts";
+import { denialToolResult, unavailableToolResult } from "./denial.ts";
+import type { LangGraphToolResult } from "./denial.ts";
+
+/**
+ * Structural LangChain `tool()` / `StructuredTool` / `RunnableToolLike`.
+ * Declared here so `guardTool` does not value-import `@langchain/core`.
+ *
+ * LangGraph Graph API tools are invoked via `invoke` (`ToolNode.runTool`)
+ * and authored `tool()` wrappers also expose `func`. There is no `execute`.
+ *
+ * `createReactAgent` is deprecated in LangGraph JS v1 in favor of LangChain
+ * `createAgent`. This helper targets Graph API tools, not that middleware.
+ */
+export interface LangGraphTool<TInput = unknown> {
+  name: string;
+  description?: string;
+  invoke?: (input: unknown, config?: unknown) => unknown;
+  func?: (input: TInput, runtime?: unknown) => unknown;
+}
+
+/**
+ * Input type of a LangGraph / LangChain structured tool. Used so `guardTool`
+ * can keep the concrete tool type while still typing `policy.rules` against
+ * the tool args (not opaque call ids).
+ */
+export type LangGraphToolInput<TTool> = TTool extends {
+  func?: (input: infer TInput, runtime?: unknown) => unknown;
+}
+  ? TInput
+  : unknown;
+
+/**
+ * Policy for `guardTool()` — how to guard an authored LangChain `tool()` /
+ * `StructuredTool`.
+ *
+ * Specifies the guard action name, optional rules to evaluate, metadata
+ * context, and optional denial handler. Rules can be static or computed
+ * from the tool's free-text args. Do not scan opaque ids.
+ */
+export interface GuardToolPolicy<TInput> {
+  /**
+   * Guard label and capture action: `"resource.verb"`, past tense. A
+   * function is resolved per call from the tool args (used by
+   * `guardToolNode` so one policy can name many tools).
+   */
+  action: string | ((input: TInput) => string);
+  /**
+   * Rules to evaluate, static or computed from the tool's input. Omitting
+   * this, or returning `[]`, submits no rules — it does not skip the guard
+   * call, which still costs a round trip and returns a decision.
+   */
+  rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /** Metadata merged over the context's (object, or per-call function of the tool input). */
+  metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload the model sees for a real DENY decision.
+   * Return a `ToolMessage`-shaped object (`status: "error"` recommended) or
+   * a plain object. Unavailable guards take the `onUnavailable` path
+   * instead; this callback does not fire for outages.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+function isContextSource(value: unknown): value is LangGraphContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function isToolCall(input: unknown): input is {
+  args: unknown;
+  id?: string;
+  name?: string;
+  type: "tool_call";
+} {
+  return (
+    input !== null &&
+    typeof input === "object" &&
+    "type" in input &&
+    (input as { type?: unknown }).type === "tool_call" &&
+    "args" in input
+  );
+}
+
+function toolArgs(input: unknown): unknown {
+  return isToolCall(input) ? input.args : input;
+}
+
+function toolCallId(input: unknown): string | undefined {
+  if (isToolCall(input) && typeof input.id === "string" && input.id.length > 0) {
+    return input.id;
+  }
+  return undefined;
+}
+
+/**
+ * Wraps a LangChain `tool()` / `StructuredTool` so `func` / `invoke` never
+ * runs on DENY.
+ *
+ * Always runs `guard()` before the tool, submitting `policy.rules` or none;
+ * on DENY the original function never executes and the model receives a
+ * tool result with `status: "error"` (or the result of `policy.onDeny`).
+ * This helper does not throw on DENY.
+ *
+ * Guard API errors depend on `policy.onGuardError` (defaults to `"deny"`):
+ * - `"deny"` (default): Tool does not execute; the model receives
+ *   `status: "error"` with `reason: "ERROR"`.
+ * - `"allow"`: Tool still runs, with a warning gated on `ARCJET_LOG_LEVEL`.
+ *
+ * Correlation is read from the invoke `config` / `ToolRuntime`
+ * (`configurable.thread_id`). No id is minted.
+ *
+ * Do not also wrap the same tool with `@arcjet/guard/vercel-ai/v7` or pass
+ * it through `guardToolNode` after wrapping — the shared
+ * `arcjetProtectedTool` brand throws on a second `guardTool` wrap.
+ * `guardToolNode` skips already-branded tools so Guard is not double-called.
+ *
+ * This is Graph API (`StateGraph` + `ToolNode`). `createReactAgent` is
+ * deprecated in LangGraph JS v1; do not build on it. LangChain
+ * `createAgent` / `wrapToolCall` is a later adapter.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardTool } from "@arcjet/guard/langgraph/v1";
+ * import { tool } from "@langchain/core/tools";
+ * import { z } from "zod";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * export const lookupOrder = guardTool(
+ *   arcjet,
+ *   tool(
+ *     async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *     {
+ *       name: "lookup_order",
+ *       description: "Look up an order by number",
+ *       schema: z.object({ orderNumber: z.string() }),
+ *     },
+ *   ),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ * ```
+ */
+export function guardTool<TTool extends LangGraphTool<any>>(
+  client: ArcjetAgentClient,
+  tool: TTool,
+  policy: GuardToolPolicy<LangGraphToolInput<TTool>>,
+): TTool {
+  const hasFunc = typeof tool.func === "function";
+  const hasInvoke = typeof tool.invoke === "function";
+  if (!hasFunc && !hasInvoke) {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error("@arcjet/guard: guardTool() requires a tool with a func or invoke function");
+  }
+  if (arcjetProtectedTool in tool) {
+    throw new Error(
+      "@arcjet/guard: guardTool() cannot wrap a tool that is already guarded; do not double-wrap with @arcjet/guard/langgraph/v1 or @arcjet/guard/vercel-ai/v7",
+    );
+  }
+
+  const func = tool.func;
+  const invoke = tool.invoke;
+  const originalFunc = hasFunc && func !== undefined ? func.bind(tool) : undefined;
+  const originalInvoke = hasInvoke && invoke !== undefined ? invoke.bind(tool) : undefined;
+
+  // Preserve class prototype and non-enumerable markers.
+  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
+  const proto = Object.getPrototypeOf(tool) as object | null;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
+  const wrapped = Object.defineProperties(
+    Object.create(proto),
+    Object.getOwnPropertyDescriptors(tool),
+  ) as TTool;
+
+  let inFlight = false;
+
+  const run = async (
+    input: unknown,
+    config: unknown,
+    execute: () => Promise<unknown>,
+  ): Promise<unknown> => {
+    if (inFlight) {
+      return execute();
+    }
+    inFlight = true;
+    try {
+      return await runGuardedTool(client, tool, policy, input, config, execute);
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  if (originalFunc !== undefined) {
+    const newFunc = (input: LangGraphToolInput<TTool>, runtime?: unknown): Promise<unknown> =>
+      run(input, runtime, () => Promise.resolve(originalFunc(input, runtime)));
+    Object.defineProperty(wrapped, "func", {
+      value: newFunc,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  if (originalInvoke !== undefined) {
+    const newInvoke = (input: unknown, config?: unknown): Promise<unknown> =>
+      run(input, config, () => Promise.resolve(originalInvoke(input, config)));
+    Object.defineProperty(wrapped, "invoke", {
+      value: newInvoke,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  Object.defineProperty(wrapped, arcjetProtectedTool, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return wrapped;
+}
+
+function runGuardedTool<TTool extends LangGraphTool<any>>(
+  client: ArcjetAgentClient,
+  tool: TTool,
+  policy: GuardToolPolicy<LangGraphToolInput<TTool>>,
+  input: unknown,
+  config: unknown,
+  execute: () => Promise<unknown>,
+): Promise<unknown> {
+  const args = toolArgs(input);
+  const extras: { name: string; toolCallId?: string } = {
+    name: typeof tool.name === "string" ? tool.name : "",
+  };
+  const callId = toolCallId(input);
+  if (callId !== undefined) {
+    extras.toolCallId = callId;
+  }
+
+  let action: string;
+  let rules: RuleWithInput[] | undefined;
+  let policyMetadata: ArcjetMetadata | undefined;
+  try {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's structured input; policy factories are typed against it
+    const typedArgs = args as LangGraphToolInput<TTool>;
+    action = typeof policy.action === "function" ? policy.action(typedArgs) : policy.action;
+    rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
+    policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+  } catch (error) {
+    const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
+    if (shouldWarn()) {
+      console.warn(
+        '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+        actionLabel,
+        error,
+      );
+    }
+    if (policy.onGuardError === "allow") {
+      return execute();
+    }
+    return Promise.resolve(unavailableToolResult(extras));
+  }
+
+  const source = isContextSource(config) ? config : undefined;
+  const agentCtx = langgraphAgentContext(source);
+
+  const metadata: ArcjetMetadata = {
+    ...agentCtx.metadata,
+    ...(typeof tool.name === "string" &&
+      tool.name.length > 0 && {
+        "langgraph.tool": tool.name,
+      }),
+  };
+  const mergedMetadata = { ...metadata, ...policyMetadata };
+
+  return runGuarded<unknown>(client, {
+    action,
+    rules,
+    correlationId: agentCtx.correlationId,
+    metadata: mergedMetadata,
+    onDeny: (decision: DecisionDeny) => {
+      const fallback = denialToolResult(decision, extras);
+      if (policy.onDeny === undefined) {
+        return fallback;
+      }
+      try {
+        return policy.onDeny(decision);
+      } catch (error) {
+        if (shouldWarn()) {
+          console.warn(
+            '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+            action,
+            error,
+          );
+        }
+        return fallback;
+      }
+    },
+    onUnavailable: () => unavailableToolResult(extras),
+    execute,
+    onGuardError: policy.onGuardError ?? "deny",
+  });
+}
+
+// oxlint-disable-next-line typescript/no-unused-vars -- keeps the async keyword so callers can await a rejected guard path
+
+export type { LangGraphToolResult };

--- a/arcjet-guard/src/langgraph/v1/index.test.ts
+++ b/arcjet-guard/src/langgraph/v1/index.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import {
+  EXPECTED_CONDITIONS,
+  EXPECTED_ROOT_KEYS,
+  sortedKeys,
+} from "../../../test/_shared/source-scan.ts";
+import * as agentsBarrel from "../../agents/index.ts";
+import * as v7Namespace from "../../vercel-ai/v7/index.ts";
+import * as langgraphNamespace from "./index.ts";
+import type {
+  ArcjetDenialResult,
+  GuardToolNodePolicy,
+  GuardToolPolicy,
+  LangGraphAgentContext,
+} from "./index.ts";
+
+function verifyTypeExports(): void {
+  const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
+  const nodePolicy: GuardToolNodePolicy | undefined = undefined;
+  const denialResult: ArcjetDenialResult | undefined = undefined;
+  const agentContext: LangGraphAgentContext | undefined = undefined;
+  void [toolPolicy, nodePolicy, denialResult, agentContext];
+}
+
+verifyTypeExports();
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("exports the three own helpers as functions", () => {
+  const ownExports = ["langgraphAgentContext", "guardTool", "guardToolNode"] as const;
+
+  for (const funcName of ownExports) {
+    const func = (langgraphNamespace as Record<string, unknown>)[funcName];
+    assert.equal(
+      typeof func,
+      "function",
+      `@arcjet/guard/langgraph/v1 must export ${funcName} as a function`,
+    );
+  }
+});
+
+test("langgraph namespace exports the agnostic helpers", () => {
+  const requiredSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+  ] as const;
+
+  for (const symbol of requiredSymbols) {
+    const value = (langgraphNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/langgraph/v1 must export ${symbol}`);
+  }
+});
+
+test("agnostic exports have same identity across LangGraph and v7 namespaces", () => {
+  const agnosticSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+    "ArcjetGuardUnavailableError",
+  ] as const;
+
+  for (const symbol of agnosticSymbols) {
+    const langgraphValue = (langgraphNamespace as Record<string, unknown>)[symbol];
+    const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
+
+    assert.strictEqual(
+      langgraphValue,
+      v7Value,
+      `${symbol} must be the same object identity from both @arcjet/guard/langgraph/v1 and @arcjet/guard/vercel-ai/v7`,
+    );
+  }
+});
+
+test("LangGraph namespace is a strict superset of the agents barrel with same identity", () => {
+  const langgraphKeys = Object.keys(langgraphNamespace);
+  const agentKeys = Object.keys(agentsBarrel);
+
+  for (const key of agentKeys) {
+    assert.ok(
+      langgraphKeys.includes(key),
+      `agents barrel key "${key}" must be present in langgraph namespace`,
+    );
+    assert.strictEqual(
+      (langgraphNamespace as Record<string, unknown>)[key],
+      (agentsBarrel as Record<string, unknown>)[key],
+      `${key} must be the same object identity from both imports`,
+    );
+  }
+
+  const expectedAdditions = 3;
+  assert.equal(
+    langgraphKeys.length,
+    agentKeys.length + expectedAdditions,
+    `langgraph namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+  );
+
+  const langgraphOnlyKeys = langgraphKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["guardTool", "guardToolNode", "langgraphAgentContext"];
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const expectedOwnExports: readonly string[] = ownExportsArray.sort();
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const sorted: readonly string[] = langgraphOnlyKeys.sort();
+  assert.deepEqual(sorted, expectedOwnExports);
+});
+
+test("export map has no unversioned ./langgraph and no wildcard langgraph subpaths", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap, "package.json must have an exports field");
+
+  const exportKeys = Object.keys(exportsMap);
+
+  assert.ok(!exportKeys.includes("./langgraph"), 'export map must not have "./langgraph"');
+  assert.ok(exportKeys.includes("./langgraph/v1"), 'export map must have "./langgraph/v1"');
+
+  for (const key of exportKeys) {
+    if (key.startsWith("./langgraph/")) {
+      assert.equal(
+        key,
+        "./langgraph/v1",
+        `export map must not have wildcard langgraph subpaths; found "${key}"`,
+      );
+    }
+  }
+});
+
+test("does not export Eve / Mastra-only APIs onto the LangGraph namespace", () => {
+  const forbidden = [
+    "eveAgentContext",
+    "mastraAgentContext",
+    "guardInbound",
+    "guardApproval",
+    "guardInterrupt",
+    "guardProcessor",
+    "arcjetHooks",
+    "guardConnection",
+  ];
+  for (const key of forbidden) {
+    assert.equal(
+      (langgraphNamespace as Record<string, unknown>)[key],
+      undefined,
+      `langgraph namespace must not export "${key}"`,
+    );
+  }
+});
+
+test("export map must not have ./agents", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap);
+  assert.ok(!Object.keys(exportsMap).includes("./agents"));
+});
+
+test("root export map keys and runtime conditions are correct", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap);
+
+  assert.deepEqual(sortedKeys(exportsMap), EXPECTED_ROOT_KEYS);
+
+  const rootEntry = objectField(exportsMap, ".");
+  assert.ok(rootEntry);
+  assert.deepEqual(sortedKeys(rootEntry), EXPECTED_CONDITIONS);
+});

--- a/arcjet-guard/src/langgraph/v1/index.ts
+++ b/arcjet-guard/src/langgraph/v1/index.ts
@@ -23,12 +23,14 @@
  * Two surfaces, and three things this namespace does not build:
  *
  * - **An authored tool** (`tool()` / `StructuredTool`) → `guardTool()`.
- *   DENY returns a tool result with `status: "error"`; it does not throw.
+ *   DENY returns a structured `ArcjetDenialResult`; it does not throw.
+ *   `ToolNode` turns that into a real `ToolMessage` the model reads.
  * - **MCP / runtime-discovered / unwrapped tools** → `guardToolNode()`.
- *   Wraps `ToolNode` from `@langchain/langgraph/prebuilt` so execute still
- *   hits Guard. Already-branded tools are skipped (no double-call).
+ *   Guards the tools a `ToolNode` from `@langchain/langgraph/prebuilt`
+ *   executes, in place, so execute still hits Guard. Already-branded tools
+ *   are skipped (no double-call).
  * - **Correlation** → `langgraphAgentContext()` reads
- *   `configurable.thread_id`, then `checkpoint_ns`, then run id. It never
+ *   `configurable.thread_id`, then the run id, then `checkpoint_ns`. It never
  *   mints a new id.
  *
  * ## Screen inbound before `invoke` (or at the first graph node)
@@ -107,5 +109,5 @@ export type {
   GuardToolNodePolicy,
   LangGraphToolNodeLike,
 } from "./guard-tool-node.ts";
-export type { ArcjetDenialResult, LangGraphToolResult } from "./denial.ts";
+export type { ArcjetDenialResult } from "./denial.ts";
 export * from "../../agents/index.ts";

--- a/arcjet-guard/src/langgraph/v1/index.ts
+++ b/arcjet-guard/src/langgraph/v1/index.ts
@@ -1,0 +1,111 @@
+/**
+ * @packageDocumentation
+ *
+ * LangGraph namespace for Arcjet Guards.
+ *
+ * This module provides LangGraph Graph API helpers plus the
+ * framework-agnostic layer they build on, so a LangGraph agent needs one
+ * import path and no notion of layering.
+ *
+ * **Requires the optional peer dependencies `@langchain/langgraph` (`>=1 <2`)
+ * and `@langchain/core` (`>=1 <2`)**. Nothing in this module imports those
+ * packages at runtime: every LangGraph / LangChain type arrives through
+ * `import type`, so installing `@arcjet/guard` never pulls them in.
+ *
+ * **Note:** the version segment is `v1` because it names LangGraph's major.
+ * There is deliberately no unversioned `@arcjet/guard/langgraph` alias.
+ *
+ * This adapter is LangGraph Graph API (`StateGraph` + `ToolNode`), not
+ * LangChain `createAgent`. `createReactAgent` is deprecated in LangGraph JS
+ * v1 in favor of LangChain `createAgent` / `wrapToolCall` — do not build on
+ * it; that is a later adapter.
+ *
+ * Two surfaces, and three things this namespace does not build:
+ *
+ * - **An authored tool** (`tool()` / `StructuredTool`) → `guardTool()`.
+ *   DENY returns a tool result with `status: "error"`; it does not throw.
+ * - **MCP / runtime-discovered / unwrapped tools** → `guardToolNode()`.
+ *   Wraps `ToolNode` from `@langchain/langgraph/prebuilt` so execute still
+ *   hits Guard. Already-branded tools are skipped (no double-call).
+ * - **Correlation** → `langgraphAgentContext()` reads
+ *   `configurable.thread_id`, then `checkpoint_ns`, then run id. It never
+ *   mints a new id.
+ *
+ * ## Screen inbound before `invoke` (or at the first graph node)
+ *
+ * There is no first-class LangGraph channel for inbound screening, so there
+ * is no `guardInbound`. Put prompt-injection (and other inbound rules) in
+ * the application before `graph.invoke`, or in the graph's first node.
+ *
+ * ## `interrupt()` is not a policy gate
+ *
+ * `interrupt()` / `interrupt_before=["tools"]` is human-in-the-loop, not
+ * policy. Same trap as Mastra `requireApproval` and Claude `canUseTool`.
+ * There is no `guardInterrupt` and no `guardApproval`.
+ *
+ * ## `ToolNode` is the deny point for tools; hooks / HITL cannot enforce
+ *
+ * Unwrapped and MCP tools run inside `ToolNode`. Graph hooks and HITL
+ * pauses cannot stop `tool.invoke`. Use `guardToolNode` (or `guardTool` for
+ * authored tools you invoke yourself).
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardTool, guardToolNode, langgraphAgentContext } from "@arcjet/guard/langgraph/v1";
+ * import { StateGraph, MessagesAnnotation } from "@langchain/langgraph";
+ * import { ToolNode } from "@langchain/langgraph/prebuilt";
+ * import { tool } from "@langchain/core/tools";
+ * import { z } from "zod";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const lookupOrder = guardTool(
+ *   client,
+ *   tool(
+ *     async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *     {
+ *       name: "lookup_order",
+ *       description: "Look up an order",
+ *       schema: z.object({ orderNumber: z.string() }),
+ *     },
+ *   ),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ *
+ * const tools = guardToolNode(
+ *   client,
+ *   new ToolNode([lookupOrder, ...mcpTools]),
+ *   { action: ({ toolName }) => `${toolName}.invoked` },
+ * );
+ *
+ * // Screen inbound before invoke (or in the first graph node):
+ * const inbound = detectPromptInjection();
+ * const decision = await client.guard({
+ *   label: "message.received",
+ *   rules: [inbound(userText)],
+ *   ...langgraphAgentContext({ configurable: { thread_id: conversationId } }),
+ * });
+ * ```
+ */
+
+export { langgraphAgentContext } from "./context.ts";
+export type { LangGraphAgentContext, LangGraphContextSource } from "./context.ts";
+export { guardTool } from "./guard-tool.ts";
+export type { GuardToolPolicy, LangGraphTool, LangGraphToolInput } from "./guard-tool.ts";
+export { guardToolNode } from "./guard-tool-node.ts";
+export type {
+  GuardToolNodeCall,
+  GuardToolNodePolicy,
+  LangGraphToolNodeLike,
+} from "./guard-tool-node.ts";
+export type { ArcjetDenialResult, LangGraphToolResult } from "./denial.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/langgraph/v1/peer.test.ts
+++ b/arcjet-guard/src/langgraph/v1/peer.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("@langchain/langgraph and @langchain/core are optional peers and not dependencies", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+
+  const peerDependencies = objectField(packageJson, "peerDependencies");
+  assert.ok(peerDependencies);
+  assert.equal(peerDependencies["@langchain/langgraph"], ">=1 <2");
+  assert.equal(peerDependencies["@langchain/core"], ">=1 <2");
+
+  const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
+  assert.ok(peerDependenciesMeta);
+  const langgraphMeta = objectField(peerDependenciesMeta, "@langchain/langgraph");
+  assert.ok(langgraphMeta);
+  assert.equal(langgraphMeta["optional"], true);
+  const coreMeta = objectField(peerDependenciesMeta, "@langchain/core");
+  assert.ok(coreMeta);
+  assert.equal(coreMeta["optional"], true);
+
+  const dependencies = objectField(packageJson, "dependencies");
+  assert.ok(!(dependencies && "@langchain/langgraph" in dependencies));
+  assert.ok(!(dependencies && "@langchain/core" in dependencies));
+});

--- a/arcjet-guard/src/langgraph/v1/type-only.test.ts
+++ b/arcjet-guard/src/langgraph/v1/type-only.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+function isLangGraphPeer(specifier: string): boolean {
+  return (
+    specifier === "@langchain/langgraph" ||
+    specifier.startsWith("@langchain/langgraph/") ||
+    specifier === "@langchain/core" ||
+    specifier.startsWith("@langchain/core/")
+  );
+}
+
+test("type-only import scanner works on @langchain/langgraph fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of @langchain/langgraph",
+      content: 'import { StateGraph } from "@langchain/langgraph";\nvoid StateGraph;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of @langchain/langgraph",
+      content: 'import type { ToolNode } from "@langchain/langgraph/prebuilt";\nvoid 0;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content:
+        'import { type ToolNode, StateGraph } from "@langchain/langgraph";\nvoid StateGraph;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of @langchain/core",
+      content: 'export type { StructuredToolInterface } from "@langchain/core/tools";',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { handler } from "@langchain/openai";\nvoid handler;',
+      shouldHaveImport: false,
+    },
+    {
+      name: "detects dynamic import of @langchain/langgraph",
+      content: 'const graph = await import("@langchain/langgraph");\nvoid graph;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const peerImports = imports.filter((imp) => isLangGraphPeer(imp.specifier));
+
+    if (fixture.shouldHaveImport === false) {
+      assert.equal(peerImports.length, 0, `${fixture.name}: should not have langgraph imports`);
+    } else {
+      assert.equal(
+        peerImports.length,
+        1,
+        `${fixture.name}: should have exactly one langgraph/core import`,
+      );
+      assert.equal(
+        peerImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all @langchain/langgraph and @langchain/core imports in the langgraph namespace are type-only", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (isLangGraphPeer(imp.specifier) && !imp.typeOnly) {
+        errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+      }
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in langgraph namespace:\n${errors.join("\n")}`,
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-langgraph-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, 'import { StateGraph } from "@langchain/langgraph";\nvoid StateGraph;');
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const peerImports = imports.filter((imp) => isLangGraphPeer(imp.specifier));
+    assert.equal(peerImports.length, 1);
+    assert.equal(peerImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -291,6 +291,7 @@ export const EXPECTED_ROOT_KEYS = [
   ".",
   "./bun",
   "./fetch",
+  "./langgraph/v1",
   "./mastra/v1",
   "./node",
   // The in-memory client for application tests. Deliberately a single entry

--- a/arcjet-guard/test/langgraph/real-tool-node.test.ts
+++ b/arcjet-guard/test/langgraph/real-tool-node.test.ts
@@ -1,0 +1,267 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/unbound-method -- test fixtures built from the real SDK types
+/**
+ * Behaviour against the real `@langchain/langgraph` and `@langchain/core`
+ * classes, rather than hand-written fakes.
+ *
+ * Every assertion here corresponds to a bypass the fakes in
+ * `src/langgraph/v1/*.test.ts` could not see:
+ *
+ * - `ToolNode` resolves its tools through a closure captured in the
+ *   constructor (`func: (input, config) => this.run(input, config)`), so a
+ *   fake node written with `function` + `this.tools` reported success while
+ *   the real class ran the unguarded tools.
+ * - `ToolNode.run` fans parallel tool calls out through `Promise.all`, which
+ *   a fake invoking one tool at a time never exercises.
+ * - `ToolNode` decides whether to pass a tool result through with
+ *   `isBaseMessage`, so what the model finally reads is only observable with
+ *   the real class.
+ *
+ * This file value-imports the optional peers, so it lives outside
+ * `src/langgraph/` — that directory is globbed by the langgraph-absent CI job
+ * and scanned for type-only imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { AIMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { ToolNode } from "@langchain/langgraph/prebuilt";
+import { z } from "zod";
+
+import { guardToolNode } from "../../src/langgraph/v1/guard-tool-node.ts";
+import { guardTool } from "../../src/langgraph/v1/guard-tool.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+interface ToolRun {
+  calls: number;
+}
+
+function countingTool(name: string, run: ToolRun) {
+  return tool(
+    ({ note }: { note: string }) => {
+      run.calls += 1;
+      return `ran:${note}`;
+    },
+    {
+      name,
+      description: "real dependency test tool",
+      schema: z.object({ note: z.string() }),
+    },
+  );
+}
+
+function callMessage(name: string, notes: readonly string[]): AIMessage {
+  return new AIMessage({
+    content: "",
+    tool_calls: notes.map((note, index) => ({
+      name,
+      args: { note },
+      id: `call-${index}`,
+      type: "tool_call" as const,
+    })),
+  });
+}
+
+interface ToolMessageLike {
+  status?: string;
+  content?: unknown;
+  tool_call_id?: string;
+}
+
+async function runNode(node: ToolNode, message: AIMessage): Promise<ToolMessageLike[]> {
+  const output = await node.invoke({ messages: [message] });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolNode returns { messages: ToolMessage[] } for a messages-shaped input
+  const { messages } = output as { messages: ToolMessageLike[] };
+  return messages;
+}
+
+function denialFrom(message: ToolMessageLike): Record<string, unknown> {
+  // ToolNode JSON-stringifies a non-message tool result into the ToolMessage
+  // content, which is how the model reads an Arcjet denial.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- parsed from the content this namespace produced
+  return JSON.parse(String(message.content)) as Record<string, unknown>;
+}
+
+test("guardTool: DENY through a real ToolNode does not execute the tool", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const run: ToolRun = { calls: 0 };
+  const guarded = guardTool(client, countingTool("lookup", run), {
+    action: "order.looked-up",
+  });
+  const node = new ToolNode([guarded]);
+
+  const messages = await runNode(node, callMessage("lookup", ["hello"]));
+
+  assert.equal(run.calls, 0, "the tool must not run on DENY");
+  assert.equal(guardCalls.length, 1);
+  const denial = denialFrom(messages[0]!);
+  assert.equal(denial["arcjetDenied"], true);
+  assert.equal(denial["reason"], "PROMPT_INJECTION");
+  assert.equal(messages[0]?.tool_call_id, "call-0");
+});
+
+test("guardTool: ALLOW through a real ToolNode executes and returns the tool output", async () => {
+  const { client } = stubClient(decisionAllow());
+  const run: ToolRun = { calls: 0 };
+  const guarded = guardTool(client, countingTool("lookup", run), {
+    action: "order.looked-up",
+  });
+  const node = new ToolNode([guarded]);
+
+  const messages = await runNode(node, callMessage("lookup", ["hello"]));
+
+  assert.equal(run.calls, 1);
+  assert.equal(messages[0]?.content, "ran:hello");
+  assert.equal(messages[0]?.status, "success");
+});
+
+test("guardTool: rules see the model args, not the ToolCall envelope", async () => {
+  const { client } = stubClient(decisionAllow());
+  const run: ToolRun = { calls: 0 };
+  const seen: unknown[] = [];
+  const guarded = guardTool(client, countingTool("lookup", run), {
+    action: "order.looked-up",
+    rules: (input) => {
+      seen.push(input);
+      return [];
+    },
+  });
+
+  await runNode(new ToolNode([guarded]), callMessage("lookup", ["free text"]));
+
+  assert.deepEqual(seen, [{ note: "free text" }]);
+});
+
+test("guardTool: parallel calls to the same tool each evaluate the guard", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const run: ToolRun = { calls: 0 };
+  const guarded = guardTool(client, countingTool("lookup", run), {
+    action: "order.looked-up",
+  });
+  const node = new ToolNode([guarded]);
+
+  // ToolNode runs these through Promise.all. A shared re-entry flag used to
+  // let the second call skip the guard and execute on a DENY.
+  const messages = await runNode(node, callMessage("lookup", ["a", "b"]));
+
+  assert.equal(guardCalls.length, 2, "every tool call must reach the guard");
+  assert.equal(run.calls, 0, "no call may execute on DENY");
+  assert.equal(messages.length, 2);
+  for (const message of messages) {
+    assert.equal(denialFrom(message)["arcjetDenied"], true);
+  }
+});
+
+test("guardToolNode: guards a real ToolNode's unwrapped tools in place", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const run: ToolRun = { calls: 0 };
+  const node = new ToolNode([countingTool("mcp_search", run)]);
+
+  const guardedNode = guardToolNode(client, node, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+
+  // Same node: ToolNode's captured closure reads the array it was built with,
+  // so guarding a copy would leave the original tools running unguarded.
+  assert.equal(guardedNode, node);
+
+  const messages = await runNode(guardedNode, callMessage("mcp_search", ["hello"]));
+
+  assert.equal(run.calls, 0, "an unwrapped tool must not run on DENY");
+  assert.equal(guardCalls.length, 1);
+  assert.equal(denialFrom(messages[0]!)["reason"], "PROMPT_INJECTION");
+});
+
+test("guardToolNode: the original node reference cannot bypass Guard", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const run: ToolRun = { calls: 0 };
+  const node = new ToolNode([countingTool("mcp_search", run)]);
+
+  guardToolNode(client, node, { action: "mcp.invoked" });
+
+  // Deliberately invoke the pre-wrap reference a caller still holds.
+  await runNode(node, callMessage("mcp_search", ["hello"]));
+
+  assert.equal(run.calls, 0);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("guardToolNode: tools discovered after wrapping are guarded on the next invoke", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const run: ToolRun = { calls: 0 };
+  const node = new ToolNode([]);
+  const guardedNode = guardToolNode(client, node, { action: "late.invoked" });
+
+  guardedNode.tools.push(countingTool("late", run));
+  const messages = await runNode(guardedNode, callMessage("late", ["hello"]));
+
+  assert.equal(run.calls, 0);
+  assert.equal(guardCalls.length, 1);
+  assert.equal(denialFrom(messages[0]!)["arcjetDenied"], true);
+});
+
+test("guardToolNode: an authored guardTool tool is not guarded twice", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const run: ToolRun = { calls: 0 };
+  const authored = guardTool(client, countingTool("authored", run), {
+    action: "order.looked-up",
+  });
+  const guardedNode = guardToolNode(client, new ToolNode([authored]), {
+    action: "node.invoked",
+  });
+
+  await runNode(guardedNode, callMessage("authored", ["hello"]));
+
+  assert.equal(run.calls, 1);
+  assert.equal(guardCalls.length, 1, "the tool must not be guarded by both helpers");
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub records the guard options
+  const first = guardCalls[0] as { label?: string };
+  assert.equal(first.label, "order.looked-up");
+});
+
+test("guardToolNode: ALLOW still executes every tool through the real node", async () => {
+  const { client } = stubClient(decisionAllow());
+  const run: ToolRun = { calls: 0 };
+  const guardedNode = guardToolNode(client, new ToolNode([countingTool("mcp_search", run)]), {
+    action: "mcp.invoked",
+  });
+
+  const messages = await runNode(guardedNode, callMessage("mcp_search", ["hello"]));
+
+  assert.equal(run.calls, 1);
+  assert.equal(messages[0]?.content, "ran:hello");
+});
+
+test("guardToolNode: refuses a frozen tools array rather than silently ungating", () => {
+  const { client } = stubClient(decisionAllow());
+  const run: ToolRun = { calls: 0 };
+  const node = new ToolNode([countingTool("mcp_search", run)]);
+  Object.freeze(node.tools);
+
+  assert.throws(() => guardToolNode(client, node, { action: "mcp.invoked" }), /frozen tools array/);
+});
+
+test("correlation comes from the graph thread id and is never minted", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const run: ToolRun = { calls: 0 };
+  const guarded = guardTool(client, countingTool("lookup", run), {
+    action: "order.looked-up",
+  });
+  const node = new ToolNode([guarded]);
+
+  await node.invoke(
+    { messages: [callMessage("lookup", ["hello"])] },
+    {
+      configurable: { thread_id: "thread-real" },
+    },
+  );
+  await runNode(node, callMessage("lookup", ["hello"]));
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub records the guard options
+  const [withThread, withoutThread] = guardCalls as Array<{ correlationId?: string }>;
+  assert.equal(withThread?.correlationId, "thread-real");
+  assert.ok(
+    withoutThread !== undefined && !("correlationId" in withoutThread),
+    "no thread id must leave the call uncorrelated rather than minting one",
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,6 +185,8 @@
       },
       "devDependencies": {
         "@ai-sdk/provider-utils": "5.0.13",
+        "@langchain/core": "1.2.8",
+        "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.58.0",
         "@types/node": "22.20.1",
         "ai": "7.0.38",
@@ -199,12 +201,20 @@
       },
       "peerDependencies": {
         "@ai-sdk/provider-utils": ">=5 <6",
+        "@langchain/core": ">=1 <2",
+        "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
         "ai": ">=7 <8",
         "eve": ">=0.25.1 <1"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/provider-utils": {
+          "optional": true
+        },
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
           "optional": true
         },
         "@mastra/core": {
@@ -1569,6 +1579,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@clack/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
@@ -1776,7 +1793,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1794,7 +1810,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1812,7 +1827,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1830,7 +1844,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1848,7 +1861,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1866,7 +1878,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1884,7 +1895,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1902,7 +1912,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1920,7 +1929,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1938,7 +1946,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1956,7 +1963,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1974,7 +1980,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1992,7 +1997,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2010,7 +2014,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2028,7 +2031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2046,7 +2048,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2064,7 +2065,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2082,7 +2082,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2100,7 +2099,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2118,7 +2116,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2136,7 +2133,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,7 +2150,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2172,7 +2167,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2190,7 +2184,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2208,7 +2201,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2226,7 +2218,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2989,6 +2980,136 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-ppi2UaCYKqM4LEY8NWQ/JZ0Of0MAngHRvclceVeEQklcD/M6QKanlHPWblDnLO2m4vz7987b1Z4r33Ps6lf/ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@langchain/core/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.10.tgz",
+      "integrity": "sha512-QBNbbIWDp3pcyvaINGEYHdekGYSQm6ZYuC9/h7arEAZckAl5mRLaoRGw5t61V4Bf+rspEj2VcylqNAN3fcdBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.1.3",
+        "@langchain/langgraph-sdk": "~1.9.29",
+        "@langchain/protocol": "^0.0.18",
+        "@standard-schema/spec": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "zod": "^3.25.32 || ^4.2.0"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
+      "integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.9.29",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.29.tgz",
+      "integrity": "sha512-W+ccugM5EzBHvaOieyYxlSbhAy6HWF8Tyn6b/BlTWuFd8xtcnQOz2WuFyofcAc9+aQHE+6yHJfIywGOvjxS+bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/protocol": "^0.0.18",
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
+      "integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -4967,6 +5088,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -6015,6 +6143,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.0",
@@ -7993,6 +8142,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -8109,6 +8268,77 @@
       "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/langsmith": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.11.tgz",
+      "integrity": "sha512-dNKtyEiNS6L10qsRGKExQVHoMsRGBJt+xiBHn6G8JxslapedUhXVkvcDkhi00EuiIMeil+RevAVG8k6VM0B9ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/langsmith/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/langsmith/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/light-my-request": {
       "version": "6.6.0",
@@ -9469,6 +9699,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.17",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
@@ -10122,6 +10362,16 @@
         "vite-plus": {
           "optional": true
         }
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {

--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,13 @@
       "matchPackageNames": ["@mastra/core"],
       "automerge": false,
       "allowedVersions": "<2"
+    },
+    {
+      "description": "Never automerge @langchain/langgraph or @langchain/core majors. `@arcjet/guard/langgraph/v1` types against ToolNode, StructuredTool, and RunnableConfig. A green typecheck is necessary but not sufficient. Keep the range on 1.x; langgraph/v2 is added deliberately, not by a bump.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@langchain/langgraph", "@langchain/core"],
+      "automerge": false,
+      "allowedVersions": "<2"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a LangGraph integration for `@arcjet/guard` under the versioned subpath `@arcjet/guard/langgraph/v1`, alongside the existing `vercel-ai/v7`, `vercel-eve/v0`, and `mastra/v1` namespaces.

This targets the LangGraph **Graph API** — `StateGraph` plus `ToolNode` from `@langchain/langgraph/prebuilt`. It is deliberately not a LangChain `createAgent` / `wrapToolCall` adapter (that is a separate integration), and it does not build on `createReactAgent`, which is deprecated in LangGraph JS v1 in favour of `createAgent`.

## What's new

- **`guardTool`** — wraps a LangChain `tool()` / `StructuredTool` so `func` / `invoke` never runs on DENY. The model receives a structured `ArcjetDenialResult`; the helper does not throw. Rules see the model's args, not the opaque `tool_call_id`, because `ToolNode` invokes tools with the whole `ToolCall`.
- **`guardToolNode`** — guards the tools a `ToolNode` executes, so MCP / runtime-discovered / unwrapped tools still hit Guard. Accepts either an existing node or a tools array. Already-guarded tools are skipped so Guard is not called twice, and a second wrap of the same node throws on the shared `arcjetProtectedTool` brand.
- **`langgraphAgentContext`** — correlation from `configurable.thread_id`, then the run id, then `configurable.checkpoint_ns`. Never mints an id: with nothing valid present the call is left uncorrelated rather than joined to an id nobody has.

There is no `guardInbound` (LangGraph has no first-class inbound channel — screen before `graph.invoke` or in the first node), and no `guardApproval` / `guardInterrupt`: `interrupt()` and `interrupt_before=["tools"]` are human-in-the-loop, not policy gates. Same trap as Mastra `requireApproval` and Claude `canUseTool`.

## Two behaviours worth reviewing

**`guardToolNode` guards the node's tools in place and returns the same node.** `ToolNode`'s constructor captures `func: (input, config) => this.run(input, config)` — an arrow bound to the instance being constructed — and `run` reads `this.tools`. A copy holding a fresh tools array therefore changes nothing the node executes, so guarding in place is the only approach that works against the real class. It also closes a stale-reference bypass: a caller still holding the pre-wrap node cannot route around Guard. A frozen tools array throws at wrap time rather than silently leaving every tool ungated. The tools-array form returns guarded copies and leaves the input array alone.

**A denial is a plain `ArcjetDenialResult`, not a fabricated `ToolMessage`.** `ToolNode` passes a tool result through only when `isBaseMessage(output)` holds, which checks for a `_getType` method; anything that satisfies it is then handed to `messagesStateReducer`, which assigns `m.lc_kwargs.id` and would crash the graph on a duck-typed message. Constructing a real `ToolMessage` would need a value import of `@langchain/core`, which this namespace must not have. So the denial stays a plain object and `ToolNode` wraps it into a genuine `ToolMessage` carrying the tool call id. Because the tool did not throw, that message's `status` is `success` — the denial rides in the payload (`arcjetDenied: true`), and the docs say so rather than promising a status the design cannot deliver without throwing.

## Packaging

- `@langchain/langgraph` and `@langchain/core` (`>=1 <2`) are added as **optional** peers, plus devDependencies for tests. Nothing in the namespace value-imports either one — enforced by a static type-only scan and by a new `Unit tests with langgraph absent` CI job that runs the namespace's tests with both packages deleted from `node_modules`.
- Export map adds `./langgraph/v1` only; there is deliberately no unversioned `./langgraph` alias or wildcard, asserted by a test.
- Renovate keeps both packages on 1.x and never automerges majors, following the `@mastra/core` rule.
- `package-lock.json` regenerated with the repo's pinned npm 12.

## Docs and skill

- README gains a LangGraph usage section, the three H2s (screen inbound before `invoke`; `interrupt()` is not a policy gate; `ToolNode` is the deny point), a peer-install block, and a fail-closed table row.
- Adds `skills/integrate-arcjet-guard-langgraph/SKILL.md`.
- CONTRIBUTING records why this namespace's surfaces differ from the other vendors'.
- The `langgraph-agent` example belongs in [`arcjet/examples`](https://github.com/arcjet/examples) (follow-up on https://github.com/arcjet/examples/pull/193), not `examples/` in this repo, per #6217.

## Tests

Unit suites cover context derivation, denial shape, the tool wrapper (deny / allow / unavailable, fail-closed, no-throw on DENY, double-wrap rejection, policy-factory throws fail-closing, correlation never minted), the node wrapper, the index barrel and export map, the optional-peer configuration, and the type-only import scan.

Separately, `test/langgraph/real-tool-node.test.ts` drives the helpers through the **real** `ToolNode`, `tool()`, and `AIMessage` rather than fakes. That suite was added after fakes hid two fail-opens during development — a copied node left the original tools running unguarded, and a shared re-entry flag let parallel calls to the same tool skip the guard entirely (`ToolNode.run` fans tool calls out with `Promise.all`). Its assertions are the numbers those bugs got wrong, so they cannot regress silently. It value-imports the peers, so it lives outside `src/langgraph/` — which the absent-peer job globs and the type-only scan covers — and is wired into `test-unit`, with a comment in `guard.yml` recording why.

`assignability.test.ts` asserts a real `DynamicStructuredTool` and `ToolNode` compile at the call site with no casts. `invoke` / `func` are declared as methods rather than property types for this reason: as properties their parameters are contravariant under `strictFunctionTypes`, and every real LangChain tool was rejected unless the caller wrote `as never`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adc12bdd-2aee-4afd-aab3-5162790be852?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adc12bdd-2aee-4afd-aab3-5162790be852&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

