### PR TITLE
feat(guard): add Eve 0.34+ request/response approval support

### DIFF
--- a/arcjet-guard/CHANGELOG.md
+++ b/arcjet-guard/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 🚀 New Features
 
+* **guard:** add Eve 0.34+ request/response approval support
 * **guard:** graduate moderateContent from experimental
 
 

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -121,8 +121,8 @@
     "@langchain/langgraph": "1.4.10",
     "@mastra/core": "1.58.0",
     "@types/node": "22.20.1",
-    "ai": "7.0.38",
-    "eve": "0.31.0",
+    "ai": "7.0.58",
+    "eve": "0.39.0",
     "miniflare": "4.20260708.1",
     "oxlint-tsgolint": "0.24.0",
     "tsdown": "0.22.7",
@@ -135,7 +135,7 @@
     "@langchain/langgraph": ">=1 <2",
     "@mastra/core": ">=1 <2",
     "ai": ">=7 <8",
-    "eve": ">=0.25.1 <1"
+    "eve": ">=0.34.0 <1"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/provider-utils": {

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -115,7 +115,7 @@
     "@connectrpc/connect-web": "2.1.2"
   },
   "devDependencies": {
-    "@ai-sdk/provider-utils": "5.0.13",
+    "@ai-sdk/provider-utils": "5.0.25",
     "@anthropic-ai/claude-agent-sdk": "0.3.221",
     "@langchain/core": "1.2.8",
     "@langchain/langgraph": "1.4.10",

--- a/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
@@ -2,7 +2,7 @@
 name: integrate-arcjet-guard-eve
 description: Integrate Arcjet security into a Vercel Eve agent using @arcjet/guard — add guard gates to tools and connections, screen inbound messages, and record agent lifecycle events correlated to the session. Use when asked to add Arcjet to an Eve agent, rate limit its tools, guard connection access, or screen inbound messages.
 license: Apache-2.0
-compatibility: Requires the target app to use Vercel Eve (eve >= 0.25.1 < 1) on Node.js >= 24.
+compatibility: Requires the target app to use Vercel Eve (eve >= 0.34.0 < 1) on Node.js >= 24.
 metadata:
   author: arcjet
 ---
@@ -68,9 +68,15 @@ State plainly why each applies to Eve, not other frameworks:
    helpers call it themselves; `guardInbound` runs before the session exists,
    so it takes an explicit `correlationId` instead.
 
-4. **`approval` is one function per tool or connection.** There is no composition
-   with `always()`/`once()`/`never()` from `eve/tools/approval`. To require a
-   human _in addition_ to the guard check, use `onAllow: "user-approval"`.
+4. **`approval` is one field per tool or connection.** It can be a function
+   (request-time only) or `{ request, response }`. You still cannot assign
+   `always()`/`once()`/`never()` from `eve/tools/approval` *alongside*
+   `guardApproval` — the slot holds one value. `onAllow: "user-approval"` is
+   how you require a human after the request-time gate. The optional `response`
+   policy is how you authorize who may approve the parked request. A rejected
+   response leaves the approval pending; it does not deny the tool. HITL
+   clients answer with `cancel`, not `deny`. Request-time denials are still
+   `{ type: "denied" }`.
 
 5. **`defineDynamic` tools are not covered.** Eve's compiler hoists a dynamic
    tool's inline `execute` to a module-scope step function, so a wrapper is not
@@ -155,8 +161,9 @@ export default guardTool(
 
 **Tool-only:** `guardTool` is called at tool invocation time and observes the
 outcome. If you only need to gate the tool without observing its result, use
-`guardApproval()` instead — it is simpler and can be composed with Eve's native
-`approval` field if the tool ever needs human sign-off.
+`guardApproval()` instead. To require a human after the request-time gate,
+set `onAllow: "user-approval"` and, when you need to authorize the responder,
+add a `response` policy.
 
 ## Step 3: Gate connection operations
 
@@ -180,6 +187,11 @@ export default defineOpenAPIConnection({
   approval: guardApproval(arcjet, {
     action: "orders-api.read",
     rules: (ctx) => [apiLimit({ key: ctx.session.id, requested: 1 })],
+    onAllow: "user-approval",
+    response: {
+      action: "orders-api.approved",
+      rules: (ctx) => [apiLimit({ key: ctx.responder.principalId, requested: 1 })],
+    },
   }),
   operations: {
     allow: ["GetOrder"],
@@ -187,10 +199,16 @@ export default defineOpenAPIConnection({
 });
 ```
 
-- The `approval` callback receives the `ApprovalContext` which carries
+- The request-time callback receives the `ApprovalContext` which carries
   `session.id`, so you can key limits per user/session.
-- On DENY the operation is blocked; Eve returns a `denied` status the model can
-  read and adapt to. Contrast `guardTool`, which throws.
+- On request-time DENY the operation is blocked; Eve returns a `denied` status
+  the model can read and adapt to. Contrast `guardTool`, which throws.
+- `onAllow: "user-approval"` parks the call for a human. HITL clients answer
+  with `cancel` (not `deny`). A request-time denial is still
+  `{ type: "denied" }`.
+- The optional `response` policy authorizes the responder. ALLOW returns
+  `{ status: "allowed" }`. DENY returns `{ status: "rejected", reason }` and
+  leaves the approval pending.
 - This gate is the only way to protect connection operations — there is no
   middleware or hook alternative.
 

--- a/arcjet-guard/src/vercel-eve/v0/assignability.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/assignability.test.ts
@@ -1,7 +1,9 @@
 /**
- * Compile-time assignability test: `guardApproval` returns an `Approval` function
- * assignable to Eve's three approval slots — `ToolDefinition.approval`,
- * `OpenAPIConnectionDefinition.approval`, and `McpClientConnectionDefinition.approval`.
+ * Compile-time assignability test: `guardApproval` returns Eve's `Approval`
+ * — a function (`ApprovalPolicy`) or `{ request, response }`
+ * (`ApprovalConfiguration`) — assignable to Eve's three approval slots:
+ * `ToolDefinition.approval`, `OpenAPIConnectionDefinition.approval`, and
+ * `McpClientConnectionDefinition.approval`.
  *
  * Verifies AC4.1: the design's central claim that one helper covers authored tools,
  * OpenAPI connections and MCP connections. Type-level tests are the right instrument
@@ -27,7 +29,7 @@ import type { ToolDefinition } from "eve/tools";
 import { decisionAllow, stubClient } from "../../../test/_shared/stub-client.ts";
 import { guardApproval } from "./guard-approval.ts";
 
-test("AC4.1: guardApproval is assignable to all three Eve approval slots", () => {
+test("AC4.1: guardApproval function form is assignable to all three Eve approval slots", () => {
   const { client } = stubClient(decisionAllow());
 
   // Tool slot: parameterised as Approval<ApprovalContextInput<TInput>>, unlike
@@ -49,5 +51,26 @@ test("AC4.1: guardApproval is assignable to all three Eve approval slots", () =>
   });
 
   // Suppress unused variable warnings and ensure values are evaluated at runtime
+  void [forTool, forOpenAPI, forMcp];
+});
+
+test("AC4.1: guardApproval { request, response } form is assignable to all three Eve approval slots", () => {
+  const { client } = stubClient(decisionAllow());
+
+  const forTool: NonNullable<ToolDefinition<{ id: string }>["approval"]> = guardApproval(client, {
+    action: "thing.read",
+    response: { action: "thing.approved" },
+  });
+
+  const forOpenAPI: NonNullable<OpenAPIConnectionDefinition["approval"]> = guardApproval(client, {
+    action: "thing.read",
+    response: { action: "thing.approved" },
+  });
+
+  const forMcp: NonNullable<McpClientConnectionDefinition["approval"]> = guardApproval(client, {
+    action: "thing.read",
+    response: { action: "thing.approved" },
+  });
+
   void [forTool, forOpenAPI, forMcp];
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { ApprovalContext } from "eve/tools";
+import type { ApprovalContext, ApprovalResponseContext } from "eve/tools";
 
 import { recorded } from "../../../test/_shared/source-scan.ts";
 import {
@@ -46,6 +46,44 @@ function createApprovalContext(overrides?: Partial<ApprovalContext>): ApprovalCo
     getSkill: mockSessionContext.getSkill,
     ...overrides,
   } as any as ApprovalContext;
+}
+
+// Factory for creating approval response contexts with overrides
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test infrastructure
+function createApprovalResponseContext(
+  overrides?: Partial<ApprovalResponseContext>,
+): ApprovalResponseContext {
+  // oxlint-disable-next-line typescript/no-explicit-any -- test infrastructure
+  const mockAuth: any = {
+    getToken: async () => ({ token: "t" }),
+    requireAuth: () => {
+      throw new Error("requireAuth");
+    },
+  };
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test infrastructure
+  return {
+    auth: mockAuth,
+    request: {
+      callId: "call_abc",
+      requestId: "req_xyz",
+      toolName: "test.tool",
+      toolInput: { id: "123" },
+    },
+    response: { decision: "approve" },
+    responder: {
+      attributes: {},
+      authenticator: "test",
+      principalId: "approver_789",
+      principalType: "user",
+    },
+    session: {
+      id: "ses_123",
+      initiator: null,
+      turn: { id: "turn_789", sequence: 1 },
+    },
+    ...overrides,
+  } as any as ApprovalResponseContext;
 }
 
 test("AC4.1: ALLOW → default resolved value is exactly 'not-applicable'", async () => {
@@ -673,6 +711,327 @@ test("last-resort catch emits warning when onDeny throws with onGuardError: allo
     assert.ok(
       warning,
       `Expected a warning with "resource.read", got: ${warnings.map((w) => w.format).join(", ")}`,
+    );
+    assert.ok(
+      /fail(ing|ed) open/.test(warning.format),
+      `Expected warning to match /fail(ing|ed) open/, got: ${warning.format}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+    if (oldLogLevel === undefined) {
+      delete process.env.ARCJET_LOG_LEVEL;
+    } else {
+      process.env.ARCJET_LOG_LEVEL = oldLogLevel;
+    }
+  }
+});
+
+test("omitting response returns Eve's function form", () => {
+  const { client } = stubClient(decisionAllow());
+  const approval = guardApproval(client, { action: "resource.read" });
+
+  assert.equal(typeof approval, "function");
+});
+
+test("setting response returns Eve's { request, response } form", () => {
+  const { client } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  assert.equal(typeof approval, "object");
+  assert.ok(approval !== null);
+  assert.equal(typeof approval.request, "function");
+  assert.equal(typeof approval.response, "function");
+});
+
+test("response ALLOW → { status: 'allowed' }", async () => {
+  const { client } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  const result = await approval.response(createApprovalResponseContext());
+
+  assert.deepEqual(result, { status: "allowed" });
+});
+
+test("response DENY → { status: 'rejected', reason } and does not throw", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  const result = await approval.response(createApprovalResponseContext());
+
+  assert.equal(result.status, "rejected");
+  assert.ok(result.status === "rejected" && result.reason.includes("PROMPT_INJECTION"));
+});
+
+test("response fail-closed unavailable → { status: 'rejected', reason }", async () => {
+  const { client } = stubClient(new Error("boom"));
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved", onGuardError: "deny" },
+  });
+
+  const result = await approval.response(createApprovalResponseContext());
+
+  assert.equal(result.status, "rejected");
+  assert.ok(result.status === "rejected" && result.reason.includes("could not be completed"));
+});
+
+test("response fail-open unavailable → { status: 'allowed' }", async () => {
+  const oldLogLevel = process.env.ARCJET_LOG_LEVEL;
+  process.env.ARCJET_LOG_LEVEL = "warn";
+  const originalWarn = console.warn;
+  const warnings: Array<{ format: string; args: unknown[] }> = [];
+  // oxlint-disable-next-line typescript/no-explicit-any -- test infrastructure
+  console.warn = (format: string, ...args: any[]) => {
+    warnings.push({ format, args });
+  };
+
+  try {
+    const { client } = stubClient(new Error("boom"));
+    const approval = guardApproval(client, {
+      action: "resource.read",
+      response: { action: "resource.approved", onGuardError: "allow" },
+    });
+
+    const result = await approval.response(createApprovalResponseContext());
+
+    assert.deepEqual(result, { status: "allowed" });
+    const failOpenWarning = warnings.find((w) => /fail(ing|ed) open/.test(w.format));
+    assert.ok(
+      failOpenWarning,
+      `Expected a fail(ing|ed) open warning, got: ${warnings.map((w) => w.format).join(", ")}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+    if (oldLogLevel === undefined) {
+      delete process.env.ARCJET_LOG_LEVEL;
+    } else {
+      process.env.ARCJET_LOG_LEVEL = oldLogLevel;
+    }
+  }
+});
+
+test("response rules callback throw → reject unavailable, not throw", async () => {
+  const { client } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: {
+      action: "resource.approved",
+      rules: () => {
+        throw new Error("rule computation failed");
+      },
+      onGuardError: "deny",
+    },
+  });
+
+  const result = await approval.response(createApprovalResponseContext());
+
+  assert.equal(result.status, "rejected");
+});
+
+test("response metadata callback throw → reject unavailable, not throw", async () => {
+  const { client } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: {
+      action: "resource.approved",
+      metadata: () => {
+        throw new Error("metadata computation failed");
+      },
+      onGuardError: "deny",
+    },
+  });
+
+  const result = await approval.response(createApprovalResponseContext());
+
+  assert.equal(result.status, "rejected");
+});
+
+test("response rules callback throw with onGuardError: allow → { status: 'allowed' }", async () => {
+  const { client } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: {
+      action: "resource.approved",
+      rules: () => {
+        throw new Error("rule computation failed");
+      },
+      onGuardError: "allow",
+    },
+  });
+
+  const result = await approval.response(createApprovalResponseContext());
+
+  assert.deepEqual(result, { status: "allowed" });
+});
+
+test("response capture carries eve.phase: 'approval-response' on all outcomes", async () => {
+  const { client: allowClient, captureCalls: allowCaptures } = stubClient(decisionAllow());
+  const { client: denyClient, captureCalls: denyCaptures } = stubClient(
+    decisionDenyPromptInjection(),
+  );
+  const { client: unavailableClient, captureCalls: unavailableCaptures } =
+    stubClient(decisionAllow());
+
+  const allowApproval = guardApproval(allowClient, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+  const denyApproval = guardApproval(denyClient, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+  const unavailableApproval = guardApproval(unavailableClient, {
+    action: "resource.read",
+    response: {
+      action: "resource.approved",
+      rules: () => {
+        throw new Error("rules callback failed");
+      },
+      onGuardError: "deny",
+    },
+  });
+
+  const ctx = createApprovalResponseContext();
+
+  await allowApproval.response(ctx);
+  await denyApproval.response(ctx);
+  await unavailableApproval.response(ctx);
+
+  for (const captures of [allowCaptures, denyCaptures, unavailableCaptures]) {
+    assert.equal(captures.length, 1);
+    const capture = recorded(captures[0]);
+    const metadata = recorded(capture.metadata);
+    assert.equal(metadata["eve.phase"], "approval-response");
+  }
+});
+
+test("response guard call uses responder as actor and session as correlation", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  await approval.response(createApprovalResponseContext());
+
+  assert.equal(guardCalls.length, 1);
+  const call = recorded(guardCalls[0]);
+  assert.equal(call.label, "resource.approved");
+  assert.equal(call.correlationId, "ses_123");
+  const metadata = recorded(call.metadata);
+  assert.equal(metadata["user"], "approver_789");
+  assert.equal(metadata["eve.session"], "ses_123");
+  assert.equal(metadata["eve.tool"], "test.tool");
+  assert.equal(metadata["eve.call"], "call_abc");
+  assert.equal(metadata["eve.request"], "req_xyz");
+  assert.equal(metadata["eve.phase"], "approval-response");
+});
+
+test("response rules function receives ApprovalResponseContext", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: {
+      action: "resource.approved",
+      rules: (ctx) => {
+        assert.equal(ctx.responder.principalId, "approver_789");
+        assert.equal(ctx.request.toolName, "test.tool");
+        assert.ok(ctx.request.toolInput);
+        return [fakeRule];
+      },
+    },
+  });
+
+  await approval.response(createApprovalResponseContext());
+
+  const call = recorded(guardCalls[0]);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test infrastructure
+  const rules = call.rules as Array<{ type: string }>;
+  assert.equal(rules.length, 1);
+  assert.deepEqual(rules[0], fakeRule);
+});
+
+test("response empty toolName/callId/requestId omitted from metadata", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  await approval.response(
+    createApprovalResponseContext({
+      request: { callId: "", requestId: "", toolName: "" },
+    }),
+  );
+
+  const call = recorded(guardCalls[0]);
+  const metadata = recorded(call.metadata);
+  assert.equal("eve.tool" in metadata, false);
+  assert.equal("eve.call" in metadata, false);
+  assert.equal("eve.request" in metadata, false);
+});
+
+test("response missing session → guard still called, does not throw", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test infrastructure
+  const ctx = {
+    request: { callId: "call_abc", requestId: "req_xyz", toolName: "test.tool" },
+    response: { decision: "approve" },
+    responder: { principalId: "approver_789" },
+  } as unknown as ApprovalResponseContext;
+
+  const result = await approval.response(ctx);
+
+  assert.ok(result !== undefined);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("response last-resort catch fails open when extra evaluation throws with onGuardError: allow", async () => {
+  const oldLogLevel = process.env.ARCJET_LOG_LEVEL;
+  process.env.ARCJET_LOG_LEVEL = "warn";
+  const originalWarn = console.warn;
+  const warnings: Array<{ format: string; args: unknown[] }> = [];
+  // oxlint-disable-next-line typescript/no-explicit-any -- test infrastructure
+  console.warn = (format: string, ...args: any[]) => {
+    warnings.push({ format, args });
+  };
+
+  try {
+    const { client } = stubClient(decisionAllow());
+    const approval = guardApproval(client, {
+      action: "resource.read",
+      response: { action: "resource.approved", onGuardError: "allow" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any -- test infrastructure
+    const ctx: any = createApprovalResponseContext();
+    Object.defineProperty(ctx, "request", {
+      get() {
+        throw new Error("request getter threw unexpectedly");
+      },
+    });
+
+    const result = await approval.response(ctx);
+
+    assert.deepEqual(result, { status: "allowed" });
+    const warning = warnings.find((w) => w.args.includes("resource.approved"));
+    assert.ok(
+      warning,
+      `Expected a warning with "resource.approved", got: ${warnings.map((w) => w.format).join(", ")}`,
     );
     assert.ok(
       /fail(ing|ed) open/.test(warning.format),

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { ApprovalContext, ApprovalResponseContext } from "eve/tools";
+import type { ApprovalContext, ApprovalResponseContext, ApprovalResponsePolicy } from "eve/tools";
 
 import { recorded } from "../../../test/_shared/source-scan.ts";
 import {
@@ -55,7 +55,7 @@ function createApprovalResponseContext(
 ): ApprovalResponseContext {
   // oxlint-disable-next-line typescript/no-explicit-any -- test infrastructure
   const mockAuth: any = {
-    getToken: async () => ({ token: "t" }),
+    getToken: () => Promise.resolve({ token: "t" }),
     requireAuth: () => {
       throw new Error("requireAuth");
     },
@@ -84,6 +84,16 @@ function createApprovalResponseContext(
     },
     ...overrides,
   } as any as ApprovalResponseContext;
+}
+
+/** Eve types `ApprovalConfiguration.response` as optional; our helper always sets it. */
+function requireResponse<TInput>(approval: {
+  response?: ApprovalResponsePolicy<TInput>;
+}): ApprovalResponsePolicy<TInput> {
+  assert.equal(typeof approval.response, "function");
+  const response = approval.response;
+  assert.ok(response);
+  return response;
 }
 
 test("AC4.1: ALLOW → default resolved value is exactly 'not-applicable'", async () => {
@@ -753,7 +763,7 @@ test("response ALLOW → { status: 'allowed' }", async () => {
     response: { action: "resource.approved" },
   });
 
-  const result = await approval.response(createApprovalResponseContext());
+  const result = await requireResponse(approval)(createApprovalResponseContext());
 
   assert.deepEqual(result, { status: "allowed" });
 });
@@ -765,7 +775,7 @@ test("response DENY → { status: 'rejected', reason } and does not throw", asyn
     response: { action: "resource.approved" },
   });
 
-  const result = await approval.response(createApprovalResponseContext());
+  const result = await requireResponse(approval)(createApprovalResponseContext());
 
   assert.equal(result.status, "rejected");
   assert.ok(result.status === "rejected" && result.reason.includes("PROMPT_INJECTION"));
@@ -778,7 +788,7 @@ test("response fail-closed unavailable → { status: 'rejected', reason }", asyn
     response: { action: "resource.approved", onGuardError: "deny" },
   });
 
-  const result = await approval.response(createApprovalResponseContext());
+  const result = await requireResponse(approval)(createApprovalResponseContext());
 
   assert.equal(result.status, "rejected");
   assert.ok(result.status === "rejected" && result.reason.includes("could not be completed"));
@@ -801,7 +811,7 @@ test("response fail-open unavailable → { status: 'allowed' }", async () => {
       response: { action: "resource.approved", onGuardError: "allow" },
     });
 
-    const result = await approval.response(createApprovalResponseContext());
+    const result = await requireResponse(approval)(createApprovalResponseContext());
 
     assert.deepEqual(result, { status: "allowed" });
     const failOpenWarning = warnings.find((w) => /fail(ing|ed) open/.test(w.format));
@@ -832,7 +842,7 @@ test("response rules callback throw → reject unavailable, not throw", async ()
     },
   });
 
-  const result = await approval.response(createApprovalResponseContext());
+  const result = await requireResponse(approval)(createApprovalResponseContext());
 
   assert.equal(result.status, "rejected");
 });
@@ -850,7 +860,7 @@ test("response metadata callback throw → reject unavailable, not throw", async
     },
   });
 
-  const result = await approval.response(createApprovalResponseContext());
+  const result = await requireResponse(approval)(createApprovalResponseContext());
 
   assert.equal(result.status, "rejected");
 });
@@ -868,7 +878,7 @@ test("response rules callback throw with onGuardError: allow → { status: 'allo
     },
   });
 
-  const result = await approval.response(createApprovalResponseContext());
+  const result = await requireResponse(approval)(createApprovalResponseContext());
 
   assert.deepEqual(result, { status: "allowed" });
 });
@@ -902,9 +912,9 @@ test("response capture carries eve.phase: 'approval-response' on all outcomes", 
 
   const ctx = createApprovalResponseContext();
 
-  await allowApproval.response(ctx);
-  await denyApproval.response(ctx);
-  await unavailableApproval.response(ctx);
+  await requireResponse(allowApproval)(ctx);
+  await requireResponse(denyApproval)(ctx);
+  await requireResponse(unavailableApproval)(ctx);
 
   for (const captures of [allowCaptures, denyCaptures, unavailableCaptures]) {
     assert.equal(captures.length, 1);
@@ -921,7 +931,7 @@ test("response guard call uses responder as actor and session as correlation", a
     response: { action: "resource.approved" },
   });
 
-  await approval.response(createApprovalResponseContext());
+  await requireResponse(approval)(createApprovalResponseContext());
 
   assert.equal(guardCalls.length, 1);
   const call = recorded(guardCalls[0]);
@@ -951,7 +961,7 @@ test("response rules function receives ApprovalResponseContext", async () => {
     },
   });
 
-  await approval.response(createApprovalResponseContext());
+  await requireResponse(approval)(createApprovalResponseContext());
 
   const call = recorded(guardCalls[0]);
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test infrastructure
@@ -967,7 +977,7 @@ test("response empty toolName/callId/requestId omitted from metadata", async () 
     response: { action: "resource.approved" },
   });
 
-  await approval.response(
+  await requireResponse(approval)(
     createApprovalResponseContext({
       request: { callId: "", requestId: "", toolName: "" },
     }),
@@ -994,7 +1004,7 @@ test("response missing session → guard still called, does not throw", async ()
     responder: { principalId: "approver_789" },
   } as unknown as ApprovalResponseContext;
 
-  const result = await approval.response(ctx);
+  const result = await requireResponse(approval)(ctx);
 
   assert.ok(result !== undefined);
   assert.equal(guardCalls.length, 1);
@@ -1025,7 +1035,7 @@ test("response last-resort catch fails open when extra evaluation throws with on
       },
     });
 
-    const result = await approval.response(ctx);
+    const result = await requireResponse(approval)(ctx);
 
     assert.deepEqual(result, { status: "allowed" });
     const warning = warnings.find((w) => w.args.includes("resource.approved"));

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -1010,6 +1010,30 @@ test("response missing session → guard still called, does not throw", async ()
 
   assert.ok(result !== undefined);
   assert.equal(guardCalls.length, 1);
+  const call = recorded(guardCalls[0]);
+  assert.notEqual(call.correlationId, "");
+  assert.ok(typeof call.correlationId === "string" && call.correlationId.length > 0);
+  const metadata = recorded(call.metadata);
+  assert.notEqual(metadata["eve.session"], "");
+  assert.equal(metadata["eve.session"], undefined);
+});
+
+test("response empty session id is omitted from correlation and eve.session", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    response: { action: "resource.approved" },
+  });
+
+  await requireResponse(approval)(createApprovalResponseContext({ session: { id: "" } }));
+
+  assert.equal(guardCalls.length, 1);
+  const call = recorded(guardCalls[0]);
+  assert.notEqual(call.correlationId, "");
+  assert.ok(typeof call.correlationId === "string" && call.correlationId.length > 0);
+  const metadata = recorded(call.metadata);
+  assert.notEqual(metadata["eve.session"], "");
+  assert.equal(metadata["eve.session"], undefined);
 });
 
 test("response last-resort catch fails open when extra evaluation throws with onGuardError: allow", async () => {
@@ -1031,6 +1055,8 @@ test("response last-resort catch fails open when extra evaluation throws with on
 
     // oxlint-disable-next-line typescript/no-explicit-any -- test infrastructure
     const ctx: any = createApprovalResponseContext();
+    // Throws from `responsePhaseMetadata` via `options.extraMetadata()` when
+    // that helper reads `ctx.request`.
     Object.defineProperty(ctx, "request", {
       get() {
         throw new Error("request getter threw unexpectedly");

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -1025,7 +1025,11 @@ test("response empty session id is omitted from correlation and eve.session", as
     response: { action: "resource.approved" },
   });
 
-  await requireResponse(approval)(createApprovalResponseContext({ session: { id: "" } }));
+  await requireResponse(approval)(
+    createApprovalResponseContext({
+      session: { id: "", initiator: null, turn: { id: "turn_789", sequence: 1 } },
+    }),
+  );
 
   assert.equal(guardCalls.length, 1);
   const call = recorded(guardCalls[0]);

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -751,7 +751,7 @@ test("setting response returns Eve's { request, response } form", () => {
   });
 
   assert.equal(typeof approval, "object");
-  assert.ok(approval !== null);
+  assert.ok(approval !== undefined);
   assert.equal(typeof approval.request, "function");
   assert.equal(typeof approval.response, "function");
 });
@@ -955,6 +955,8 @@ test("response rules function receives ApprovalResponseContext", async () => {
       rules: (ctx) => {
         assert.equal(ctx.responder.principalId, "approver_789");
         assert.equal(ctx.request.toolName, "test.tool");
+        assert.equal(ctx.request.callId, "call_abc");
+        assert.equal(ctx.request.requestId, "req_xyz");
         assert.ok(ctx.request.toolInput);
         return [fakeRule];
       },

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -145,11 +145,19 @@ export function guardApproval<TInput = Record<string, unknown>>(
   };
 }
 
+function allowedResponse(): ApprovalResponseDecision {
+  return { status: "allowed" };
+}
+
+function rejectedResponse(reason: string): ApprovalResponseDecision {
+  return { status: "rejected", reason };
+}
+
 function createRequestApproval<TInput>(
   client: ArcjetAgentClient,
   policy: GuardApprovalPolicy<TInput>,
 ): ApprovalPolicy<TInput> {
-  return async (ctx: ApprovalContext<TInput>): Promise<ApprovalStatus> => {
+  return (ctx: ApprovalContext<TInput>): Promise<ApprovalStatus> => {
     const allowStatus = (): ApprovalStatus => policy.onAllow ?? "not-applicable";
 
     return evaluateApprovalPolicy(client, policy, ctx, {
@@ -171,26 +179,20 @@ function createResponseApproval<TInput>(
   client: ArcjetAgentClient,
   policy: GuardApprovalResponsePolicy<TInput>,
 ): ApprovalResponsePolicy<TInput> {
-  return async (ctx: ApprovalResponseContext<TInput>): Promise<ApprovalResponseDecision> => {
-    const allowStatus = (): ApprovalResponseDecision => ({ status: "allowed" });
-    const rejectStatus = (reason: string): ApprovalResponseDecision => ({
-      status: "rejected",
-      reason,
-    });
-
+  return (ctx: ApprovalResponseContext<TInput>): Promise<ApprovalResponseDecision> => {
     return evaluateApprovalPolicy(client, policy, ctx, {
       deriveAgentContext: () => responseAgentContext(ctx),
       extraMetadata: () => responsePhaseMetadata(ctx),
-      onAllow: allowStatus,
-      onDeny: (decision) => rejectStatus(deniedReason(decision)),
+      onAllow: allowedResponse,
+      onDeny: (decision) => rejectedResponse(deniedReason(decision)),
       onUnavailable: () =>
-        policy.onGuardError === "allow" ? allowStatus() : rejectStatus(unavailableReason()),
+        policy.onGuardError === "allow" ? allowedResponse() : rejectedResponse(unavailableReason()),
       warnKind: "approval-response",
     });
   };
 }
 
-function requestPhaseMetadata(ctx: ApprovalContext): ArcjetMetadata {
+function requestPhaseMetadata<TInput>(ctx: ApprovalContext<TInput>): ArcjetMetadata {
   return {
     "eve.phase": "approval",
     ...(typeof ctx?.toolName === "string" &&
@@ -199,7 +201,7 @@ function requestPhaseMetadata(ctx: ApprovalContext): ArcjetMetadata {
   };
 }
 
-function responsePhaseMetadata(ctx: ApprovalResponseContext): ArcjetMetadata {
+function responsePhaseMetadata<TInput>(ctx: ApprovalResponseContext<TInput>): ArcjetMetadata {
   const request = ctx?.request;
   return {
     "eve.phase": "approval-response",
@@ -218,26 +220,31 @@ function responsePhaseMetadata(ctx: ApprovalResponseContext): ArcjetMetadata {
  * `user` metadata field and session correlation apply to the person answering
  * the parked request rather than the original caller.
  */
-function responseAgentContext(ctx: ApprovalResponseContext): ReturnType<typeof eveAgentContext> {
-  return eveAgentContext({
-    session: {
-      id: ctx?.session?.id,
-      auth: {
-        current: ctx?.responder ?? null,
-        initiator: ctx?.session?.initiator ?? null,
-      },
-      turn: ctx?.session?.turn,
-      parent: ctx?.session?.parent,
+function responseAgentContext<TInput>(
+  ctx: ApprovalResponseContext<TInput>,
+): ReturnType<typeof eveAgentContext> {
+  // ApprovalResponseContext is not a SessionContext. Map the responder onto
+  // auth.current so eveAgentContext's existing `user` / session correlation
+  // apply to the person answering the parked request.
+  const session: SessionContext["session"] = {
+    id: typeof ctx?.session?.id === "string" ? ctx.session.id : "",
+    auth: {
+      current: ctx?.responder ?? null,
+      initiator: ctx?.session?.initiator ?? null,
     },
+    turn: ctx?.session?.turn ?? { id: "", sequence: 0 },
+    ...(ctx?.session?.parent === undefined ? {} : { parent: ctx.session.parent }),
+  };
+  const sessionContext: SessionContext = {
+    session,
     getSandbox() {
-      return Promise.reject(
-        new Error("@arcjet/guard: approval response context has no sandbox"),
-      );
+      return Promise.reject(new Error("@arcjet/guard: approval response context has no sandbox"));
     },
     getSkill() {
       throw new Error("@arcjet/guard: approval response context has no skill");
     },
-  } as SessionContext);
+  };
+  return eveAgentContext(sessionContext);
 }
 
 async function evaluateApprovalPolicy<TCtx, TResult>(

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -235,19 +235,18 @@ function responseAgentContext<TInput>(
   // auth.current so eveAgentContext's existing `user` / session correlation
   // apply to the person answering the parked request.
   //
-  // SessionContext requires `id: string`. Keep that shape, but omit a missing
-  // or empty id so eveAgentContext generates a ULID and does not capture
-  // `eve.session: ""` or `correlationId: ""`.
+  // SessionContext requires `id: string`. Keep that shape for the helper, but
+  // do not pass a missing or empty id through as `eve.session` / correlation.
   const sessionId = responseSessionId(ctx);
-  const session = {
-    ...(sessionId === undefined ? {} : { id: sessionId }),
+  const session: SessionContext["session"] = {
+    id: sessionId ?? "",
     auth: {
       current: ctx?.responder ?? null,
       initiator: ctx?.session?.initiator ?? null,
     },
     turn: ctx?.session?.turn ?? { id: "", sequence: 0 },
     ...(ctx?.session?.parent === undefined ? {} : { parent: ctx.session.parent }),
-  } as SessionContext["session"];
+  };
   // eveAgentContext is expected not to invoke getSandbox / getSkill during
   // metadata derivation. If that helper later starts calling them, this
   // response-time adapter would throw.
@@ -260,7 +259,26 @@ function responseAgentContext<TInput>(
       throw new Error("@arcjet/guard: approval response context has no skill");
     },
   };
-  return eveAgentContext(sessionContext);
+  return omitBlankSessionCapture(eveAgentContext(sessionContext), sessionId);
+}
+
+function omitBlankSessionCapture(
+  agent: ReturnType<typeof eveAgentContext>,
+  sessionId: string | undefined,
+): ReturnType<typeof eveAgentContext> {
+  if (sessionId !== undefined) {
+    return agent;
+  }
+  const metadata = agent.metadata;
+  if (metadata === undefined || metadata["eve.session"] !== "") {
+    return agent;
+  }
+  const rest: ArcjetMetadata = { ...metadata };
+  delete rest["eve.session"];
+  return {
+    correlationId: agent.correlationId,
+    ...(Object.keys(rest).length > 0 ? { metadata: rest } : {}),
+  };
 }
 
 type ApprovalPolicyOptions<TResult> = {

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -1,4 +1,14 @@
-import type { Approval, ApprovalContext, ApprovalStatus } from "eve/tools";
+import type { SessionContext } from "eve/context";
+import type {
+  Approval,
+  ApprovalConfiguration,
+  ApprovalContext,
+  ApprovalPolicy,
+  ApprovalResponseContext,
+  ApprovalResponseDecision,
+  ApprovalResponsePolicy,
+  ApprovalStatus,
+} from "eve/tools";
 
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
@@ -13,6 +23,9 @@ import { runGate } from "./gate.ts";
  *
  * Specifies the action label, optional rules, metadata context, and optional handlers
  * for allowing or denying. Rules can be static or computed from the approval context.
+ *
+ * Set `response` to also authorize who may approve a parked HITL request. Omitting
+ * it keeps the returned value as Eve's function form (`ApprovalPolicy`).
  */
 export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
   /** Guard label and capture action: `"resource.verb"`, past tense. */
@@ -27,15 +40,41 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
   onAllow?: ApprovalStatus;
   /** Reshape the status returned on DENY. */
   onDeny?: (decision: DecisionDeny) => ApprovalStatus;
+  /**
+   * Optional response-time policy. When set, `guardApproval` returns Eve's
+   * `{ request, response }` form so the same slot can authorize the responder
+   * after `onAllow: "user-approval"` parks the call.
+   */
+  response?: GuardApprovalResponsePolicy<TInput>;
+}
+
+/**
+ * Policy evaluated against Eve's `ApprovalResponseContext` — who may approve a
+ * parked HITL request. A rejection leaves the approval pending; it does not
+ * deny the tool.
+ */
+export interface GuardApprovalResponsePolicy<TInput = Record<string, unknown>> {
+  /** Guard label and capture action: `"resource.verb"`, past tense. */
+  action: string;
+  /** Rules to evaluate, static or computed from the response context. */
+  rules?: RuleWithInput[] | ((ctx: ApprovalResponseContext<TInput>) => RuleWithInput[]);
+  /** Metadata merged over the session-derived context's. */
+  metadata?: ArcjetMetadata | ((ctx: ApprovalResponseContext<TInput>) => ArcjetMetadata);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
 }
 
 /**
  * Gate for Eve tool and connection calls using Arcjet guard policies.
  *
- * Returns an `Approval` function assignable to `ToolDefinition.approval`,
+ * Returns an Eve `Approval` assignable to `ToolDefinition.approval`,
  * `OpenAPIConnectionDefinition.approval`, or `McpClientConnectionDefinition.approval`.
  *
- * The returned function:
+ * When `policy.response` is omitted, the return value is Eve's function form
+ * (`ApprovalPolicy`). When `response` is set, the return value is
+ * `{ request, response }` (`ApprovalConfiguration`).
+ *
+ * The request-time function:
  * 1. Derives context from the Eve `ApprovalContext`
  * 2. Resolves rules and metadata (each may be a function of ctx)
  * 3. Calls the guard with merged metadata including `eve.phase: "approval"`, `eve.tool`, and `eve.call`
@@ -44,6 +83,12 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
  * 6. On unavailable (guard threw or failed open with `onGuardError: "deny"`), resolves to
  *    a denial status or `policy.onAllow` depending on the mode
  * 7. Never throws, for any input
+ *
+ * The optional response-time function authorizes the responder of a parked
+ * HITL request. ALLOW resolves to `{ status: "allowed" }`; DENY or
+ * unavailable-with-deny resolves to `{ status: "rejected", reason }` (the
+ * approval stays pending). Capture metadata uses `eve.phase: "approval-response"`
+ * and the responder as the actor. It also never throws.
  *
  * @example
  * ```ts
@@ -57,9 +102,10 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
  *
  * // A connection's tools have no local `execute` to wrap, so the approval
  * // gate is the only enforcement point that reaches them. `onAllow` still
- * // requires a human after the policy passes — Eve allows one `approval`
- * // function per connection, so there is nowhere to compose `once()` or
- * // `always()` from `eve/tools/approval` alongside this.
+ * // requires a human after the policy passes. The optional `response` policy
+ * // authorizes who may approve the parked request. Eve still allows one
+ * // `approval` field per connection; it can be this function or the
+ * // `{ request, response }` object `guardApproval` returns when `response` is set.
  * const weather: OpenAPIConnectionDefinition = defineOpenAPIConnection({
  *   description: "Weather API",
  *   spec: "https://api.example.com/openapi.json",
@@ -67,6 +113,10 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
  *     action: "weather.fetched",
  *     rules: (ctx) => [callLimit({ key: ctx.session.id, requested: 1 })],
  *     onAllow: "user-approval",
+ *     response: {
+ *       action: "weather.approved",
+ *       rules: (ctx) => [callLimit({ key: ctx.responder.principalId, requested: 1 })],
+ *     },
  *   }),
  * });
  *
@@ -75,96 +125,236 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
  */
 export function guardApproval<TInput = Record<string, unknown>>(
   client: ArcjetAgentClient,
+  policy: GuardApprovalPolicy<TInput> & { response: GuardApprovalResponsePolicy<TInput> },
+): ApprovalConfiguration<TInput>;
+export function guardApproval<TInput = Record<string, unknown>>(
+  client: ArcjetAgentClient,
+  policy: GuardApprovalPolicy<TInput>,
+): ApprovalPolicy<TInput>;
+export function guardApproval<TInput = Record<string, unknown>>(
+  client: ArcjetAgentClient,
   policy: GuardApprovalPolicy<TInput>,
 ): Approval<TInput> {
-  return async (ctx: ApprovalContext<TInput>): Promise<ApprovalStatus> => {
-    const allowStatus = (): ApprovalStatus => policy.onAllow ?? "not-applicable";
-
-    try {
-      // Derive context from the Eve SessionContext
-      const agentCtx = eveAgentContext(ctx);
-
-      // Create base metadata with derived context and eve-specific keys
-      // eve.phase is written by guardApproval, not by runGate (which is shared with guardInbound)
-      let metadata: ArcjetMetadata = {
-        ...agentCtx.metadata,
-        "eve.phase": "approval",
-        ...(typeof ctx.toolName === "string" &&
-          ctx.toolName.length > 0 && { "eve.tool": ctx.toolName }),
-        ...(typeof ctx.callId === "string" && ctx.callId.length > 0 && { "eve.call": ctx.callId }),
-      };
-
-      // Resolve rules — may be a function.
-      // A throwing rules callback is a caller defect; treat as unavailable.
-      let ruleResolutionFailed = false;
-      let ruleResolutionError: unknown;
-      let rules: RuleWithInput[] | undefined;
-      try {
-        rules = typeof policy.rules === "function" ? policy.rules(ctx) : policy.rules;
-      } catch (error) {
-        ruleResolutionFailed = true;
-        ruleResolutionError = error;
-      }
-
-      // Resolve metadata — may be a function.
-      // A throwing metadata callback is a caller defect; treat as unavailable.
-      let metadataResolutionFailed = false;
-      let metadataResolutionError: unknown;
-      try {
-        const policyMetadata =
-          typeof policy.metadata === "function" ? policy.metadata(ctx) : policy.metadata;
-        metadata = { ...metadata, ...policyMetadata };
-      } catch (error) {
-        metadataResolutionFailed = true;
-        metadataResolutionError = error;
-      }
-
-      // If a callback threw, treat as unavailable rather than guarding
-      if (ruleResolutionFailed || metadataResolutionFailed) {
-        const failClosed = policy.onGuardError !== "allow";
-        const correlation =
-          agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
-        const error = ruleResolutionFailed ? ruleResolutionError : metadataResolutionError;
-        warnCallbackFailure(policy.action, failClosed, error);
-        captureEvent(client, {
-          action: policy.action,
-          ...correlation,
-          metadata: { ...metadata, outcome: "unavailable" },
-        });
-        return failClosed ? { type: "denied", reason: unavailableReason() } : allowStatus();
-      }
-
-      // Call runGate with the appropriate handlers
-      return await runGate(client, {
-        action: policy.action,
-        rules,
-        correlationId: agentCtx.correlationId,
-        metadata,
-        onAllow: allowStatus,
-        onDeny: (decision) =>
-          policy.onDeny?.(decision) ?? { type: "denied", reason: deniedReason(decision) },
-        onUnavailable: () =>
-          policy.onGuardError === "allow"
-            ? allowStatus()
-            : { type: "denied", reason: unavailableReason() },
-        onGuardError: policy.onGuardError ?? "deny",
-      });
-    } catch (error) {
-      // Last resort: should never reach here if runGate never throws,
-      // but if something unforeseen happens, fail closed by default
-      const failClosed = policy.onGuardError !== "allow";
-      warnCallbackFailure(policy.action, failClosed, error);
-      return failClosed ? { type: "denied", reason: unavailableReason() } : allowStatus();
-    }
+  const request = createRequestApproval(client, policy);
+  if (policy.response === undefined) {
+    return request;
+  }
+  return {
+    request,
+    response: createResponseApproval(client, policy.response),
   };
 }
 
-function warnCallbackFailure(action: string, failClosed: boolean, error?: unknown): void {
+function createRequestApproval<TInput>(
+  client: ArcjetAgentClient,
+  policy: GuardApprovalPolicy<TInput>,
+): ApprovalPolicy<TInput> {
+  return async (ctx: ApprovalContext<TInput>): Promise<ApprovalStatus> => {
+    const allowStatus = (): ApprovalStatus => policy.onAllow ?? "not-applicable";
+
+    return evaluateApprovalPolicy(client, policy, ctx, {
+      deriveAgentContext: () => eveAgentContext(ctx),
+      extraMetadata: () => requestPhaseMetadata(ctx),
+      onAllow: allowStatus,
+      onDeny: (decision) =>
+        policy.onDeny?.(decision) ?? { type: "denied", reason: deniedReason(decision) },
+      onUnavailable: () =>
+        policy.onGuardError === "allow"
+          ? allowStatus()
+          : { type: "denied", reason: unavailableReason() },
+      warnKind: "approval",
+    });
+  };
+}
+
+function createResponseApproval<TInput>(
+  client: ArcjetAgentClient,
+  policy: GuardApprovalResponsePolicy<TInput>,
+): ApprovalResponsePolicy<TInput> {
+  return async (ctx: ApprovalResponseContext<TInput>): Promise<ApprovalResponseDecision> => {
+    const allowStatus = (): ApprovalResponseDecision => ({ status: "allowed" });
+    const rejectStatus = (reason: string): ApprovalResponseDecision => ({
+      status: "rejected",
+      reason,
+    });
+
+    return evaluateApprovalPolicy(client, policy, ctx, {
+      deriveAgentContext: () => responseAgentContext(ctx),
+      extraMetadata: () => responsePhaseMetadata(ctx),
+      onAllow: allowStatus,
+      onDeny: (decision) => rejectStatus(deniedReason(decision)),
+      onUnavailable: () =>
+        policy.onGuardError === "allow" ? allowStatus() : rejectStatus(unavailableReason()),
+      warnKind: "approval-response",
+    });
+  };
+}
+
+function requestPhaseMetadata(ctx: ApprovalContext): ArcjetMetadata {
+  return {
+    "eve.phase": "approval",
+    ...(typeof ctx?.toolName === "string" &&
+      ctx.toolName.length > 0 && { "eve.tool": ctx.toolName }),
+    ...(typeof ctx?.callId === "string" && ctx.callId.length > 0 && { "eve.call": ctx.callId }),
+  };
+}
+
+function responsePhaseMetadata(ctx: ApprovalResponseContext): ArcjetMetadata {
+  const request = ctx?.request;
+  return {
+    "eve.phase": "approval-response",
+    ...(typeof request?.toolName === "string" &&
+      request.toolName.length > 0 && { "eve.tool": request.toolName }),
+    ...(typeof request?.callId === "string" &&
+      request.callId.length > 0 && { "eve.call": request.callId }),
+    ...(typeof request?.requestId === "string" &&
+      request.requestId.length > 0 && { "eve.request": request.requestId }),
+  };
+}
+
+/**
+ * Map Eve's response-time context onto the session shape `eveAgentContext`
+ * already understands. The responder is `auth.current`, so the existing
+ * `user` metadata field and session correlation apply to the person answering
+ * the parked request rather than the original caller.
+ */
+function responseAgentContext(ctx: ApprovalResponseContext): ReturnType<typeof eveAgentContext> {
+  return eveAgentContext({
+    session: {
+      id: ctx?.session?.id,
+      auth: {
+        current: ctx?.responder ?? null,
+        initiator: ctx?.session?.initiator ?? null,
+      },
+      turn: ctx?.session?.turn,
+      parent: ctx?.session?.parent,
+    },
+    getSandbox() {
+      return Promise.reject(
+        new Error("@arcjet/guard: approval response context has no sandbox"),
+      );
+    },
+    getSkill() {
+      throw new Error("@arcjet/guard: approval response context has no skill");
+    },
+  } as SessionContext);
+}
+
+async function evaluateApprovalPolicy<TCtx, TResult>(
+  client: ArcjetAgentClient,
+  policy: {
+    action: string;
+    rules?: RuleWithInput[] | ((ctx: TCtx) => RuleWithInput[]);
+    metadata?: ArcjetMetadata | ((ctx: TCtx) => ArcjetMetadata);
+    onGuardError?: OnGuardError;
+  },
+  ctx: TCtx,
+  options: {
+    deriveAgentContext: () => ReturnType<typeof eveAgentContext>;
+    extraMetadata: () => ArcjetMetadata;
+    onAllow: () => TResult;
+    onDeny: (decision: DecisionDeny) => TResult;
+    onUnavailable: () => TResult;
+    warnKind: "approval" | "approval-response";
+  },
+): Promise<TResult> {
+  try {
+    const agentCtx = options.deriveAgentContext();
+
+    // Create base metadata with derived context and eve-specific keys.
+    // eve.phase is written by guardApproval, not by runGate (which is shared with guardInbound).
+    let metadata: ArcjetMetadata = {
+      ...agentCtx.metadata,
+      ...options.extraMetadata(),
+    };
+
+    // Resolve rules — may be a function.
+    // A throwing rules callback is a caller defect; treat as unavailable.
+    let ruleResolutionFailed = false;
+    let ruleResolutionError: unknown;
+    let rules: RuleWithInput[] | undefined;
+    try {
+      rules = typeof policy.rules === "function" ? policy.rules(ctx) : policy.rules;
+    } catch (error) {
+      ruleResolutionFailed = true;
+      ruleResolutionError = error;
+    }
+
+    // Resolve metadata — may be a function.
+    // A throwing metadata callback is a caller defect; treat as unavailable.
+    let metadataResolutionFailed = false;
+    let metadataResolutionError: unknown;
+    try {
+      const policyMetadata =
+        typeof policy.metadata === "function" ? policy.metadata(ctx) : policy.metadata;
+      metadata = { ...metadata, ...policyMetadata };
+    } catch (error) {
+      metadataResolutionFailed = true;
+      metadataResolutionError = error;
+    }
+
+    // If a callback threw, treat as unavailable rather than guarding
+    if (ruleResolutionFailed || metadataResolutionFailed) {
+      const failClosed = policy.onGuardError !== "allow";
+      const correlation =
+        agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
+      const error = ruleResolutionFailed ? ruleResolutionError : metadataResolutionError;
+      warnCallbackFailure(options.warnKind, policy.action, failClosed, error);
+      captureEvent(client, {
+        action: policy.action,
+        ...correlation,
+        metadata: { ...metadata, outcome: "unavailable" },
+      });
+      return failClosed ? options.onUnavailable() : options.onAllow();
+    }
+
+    // Call runGate with the appropriate handlers
+    return await runGate(client, {
+      action: policy.action,
+      rules,
+      correlationId: agentCtx.correlationId,
+      metadata,
+      onAllow: options.onAllow,
+      onDeny: options.onDeny,
+      onUnavailable: options.onUnavailable,
+      onGuardError: policy.onGuardError ?? "deny",
+    });
+  } catch (error) {
+    // Last resort: should never reach here if runGate never throws,
+    // but if something unforeseen happens, fail closed by default
+    const failClosed = policy.onGuardError !== "allow";
+    warnCallbackFailure(options.warnKind, policy.action, failClosed, error);
+    return failClosed ? options.onUnavailable() : options.onAllow();
+  }
+}
+
+function warnCallbackFailure(
+  kind: "approval" | "approval-response",
+  action: string,
+  failClosed: boolean,
+  error?: unknown,
+): void {
   if (!shouldWarn()) {
     return;
   }
   // Constant format string: `action` must not be interpolated into the first argument
   // (Semgrep requirement for actionable log messages).
+  if (kind === "approval-response") {
+    if (failClosed) {
+      console.warn(
+        '@arcjet/guard: approval response policy for "%s" could not be evaluated; failing closed:',
+        action,
+        error,
+      );
+    } else {
+      console.warn(
+        '@arcjet/guard: approval response policy for "%s" could not be evaluated; failing open:',
+        action,
+        error,
+      );
+    }
+    return;
+  }
   if (failClosed) {
     console.warn(
       '@arcjet/guard: approval policy for "%s" could not be evaluated; failing closed:',

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -214,6 +214,14 @@ function responsePhaseMetadata<TInput>(ctx: ApprovalResponseContext<TInput>): Ar
   };
 }
 
+function responseSessionId<TInput>(ctx: ApprovalResponseContext<TInput>): string | undefined {
+  const id = ctx?.session?.id;
+  if (typeof id !== "string" || id === "") {
+    return undefined;
+  }
+  return id;
+}
+
 /**
  * Map Eve's response-time context onto the session shape `eveAgentContext`
  * already understands. The responder is `auth.current`, so the existing
@@ -226,15 +234,23 @@ function responseAgentContext<TInput>(
   // ApprovalResponseContext is not a SessionContext. Map the responder onto
   // auth.current so eveAgentContext's existing `user` / session correlation
   // apply to the person answering the parked request.
-  const session: SessionContext["session"] = {
-    id: typeof ctx?.session?.id === "string" ? ctx.session.id : "",
+  //
+  // SessionContext requires `id: string`. Keep that shape, but omit a missing
+  // or empty id so eveAgentContext generates a ULID and does not capture
+  // `eve.session: ""` or `correlationId: ""`.
+  const sessionId = responseSessionId(ctx);
+  const session = {
+    ...(sessionId === undefined ? {} : { id: sessionId }),
     auth: {
       current: ctx?.responder ?? null,
       initiator: ctx?.session?.initiator ?? null,
     },
     turn: ctx?.session?.turn ?? { id: "", sequence: 0 },
     ...(ctx?.session?.parent === undefined ? {} : { parent: ctx.session.parent }),
-  };
+  } as SessionContext["session"];
+  // eveAgentContext is expected not to invoke getSandbox / getSkill during
+  // metadata derivation. If that helper later starts calling them, this
+  // response-time adapter would throw.
   const sessionContext: SessionContext = {
     session,
     getSandbox() {
@@ -247,80 +263,104 @@ function responseAgentContext<TInput>(
   return eveAgentContext(sessionContext);
 }
 
+type ApprovalPolicyOptions<TResult> = {
+  deriveAgentContext: () => ReturnType<typeof eveAgentContext>;
+  extraMetadata: () => ArcjetMetadata;
+  onAllow: () => TResult;
+  onDeny: (decision: DecisionDeny) => TResult;
+  onUnavailable: () => TResult;
+  warnKind: "approval" | "approval-response";
+};
+
+type ApprovalPolicyConfig<TCtx> = {
+  action: string;
+  rules?: RuleWithInput[] | ((ctx: TCtx) => RuleWithInput[]);
+  metadata?: ArcjetMetadata | ((ctx: TCtx) => ArcjetMetadata);
+  onGuardError?: OnGuardError;
+};
+
+type CallbackResolution<TResult> =
+  | { status: "resolved"; rules: RuleWithInput[] | undefined; metadata: ArcjetMetadata }
+  | { status: "failed"; result: TResult };
+
+function resolveApprovalCallbacks<TCtx, TResult>(
+  client: ArcjetAgentClient,
+  policy: ApprovalPolicyConfig<TCtx>,
+  ctx: TCtx,
+  options: ApprovalPolicyOptions<TResult>,
+  agentCtx: ReturnType<typeof eveAgentContext>,
+  metadata: ArcjetMetadata,
+): CallbackResolution<TResult> {
+  // Resolve both callbacks independently so a throw in one cannot skip
+  // the other. Merge extra metadata only when the metadata callback resolves.
+  let ruleResolutionFailed = false;
+  let ruleResolutionError: unknown;
+  let rules: RuleWithInput[] | undefined;
+  try {
+    rules = typeof policy.rules === "function" ? policy.rules(ctx) : policy.rules;
+  } catch (error) {
+    ruleResolutionFailed = true;
+    ruleResolutionError = error;
+  }
+
+  let metadataResolutionFailed = false;
+  let metadataResolutionError: unknown;
+  let resolvedMetadata = metadata;
+  try {
+    const policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(ctx) : policy.metadata;
+    resolvedMetadata = { ...metadata, ...policyMetadata };
+  } catch (error) {
+    metadataResolutionFailed = true;
+    metadataResolutionError = error;
+  }
+
+  if (ruleResolutionFailed || metadataResolutionFailed) {
+    const failClosed = policy.onGuardError !== "allow";
+    const correlation =
+      agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
+    const error = ruleResolutionFailed ? ruleResolutionError : metadataResolutionError;
+    warnCallbackFailure(options.warnKind, policy.action, failClosed, error);
+    captureEvent(client, {
+      action: policy.action,
+      ...correlation,
+      metadata: { ...resolvedMetadata, outcome: "unavailable" },
+    });
+    return {
+      status: "failed",
+      result: failClosed ? options.onUnavailable() : options.onAllow(),
+    };
+  }
+
+  return { status: "resolved", rules, metadata: resolvedMetadata };
+}
+
 async function evaluateApprovalPolicy<TCtx, TResult>(
   client: ArcjetAgentClient,
-  policy: {
-    action: string;
-    rules?: RuleWithInput[] | ((ctx: TCtx) => RuleWithInput[]);
-    metadata?: ArcjetMetadata | ((ctx: TCtx) => ArcjetMetadata);
-    onGuardError?: OnGuardError;
-  },
+  policy: ApprovalPolicyConfig<TCtx>,
   ctx: TCtx,
-  options: {
-    deriveAgentContext: () => ReturnType<typeof eveAgentContext>;
-    extraMetadata: () => ArcjetMetadata;
-    onAllow: () => TResult;
-    onDeny: (decision: DecisionDeny) => TResult;
-    onUnavailable: () => TResult;
-    warnKind: "approval" | "approval-response";
-  },
+  options: ApprovalPolicyOptions<TResult>,
 ): Promise<TResult> {
   try {
     const agentCtx = options.deriveAgentContext();
 
     // Create base metadata with derived context and eve-specific keys.
     // eve.phase is written by guardApproval, not by runGate (which is shared with guardInbound).
-    let metadata: ArcjetMetadata = {
+    const metadata: ArcjetMetadata = {
       ...agentCtx.metadata,
       ...options.extraMetadata(),
     };
 
-    // Resolve rules — may be a function.
-    // A throwing rules callback is a caller defect; treat as unavailable.
-    let ruleResolutionFailed = false;
-    let ruleResolutionError: unknown;
-    let rules: RuleWithInput[] | undefined;
-    try {
-      rules = typeof policy.rules === "function" ? policy.rules(ctx) : policy.rules;
-    } catch (error) {
-      ruleResolutionFailed = true;
-      ruleResolutionError = error;
+    const resolved = resolveApprovalCallbacks(client, policy, ctx, options, agentCtx, metadata);
+    if (resolved.status === "failed") {
+      return resolved.result;
     }
 
-    // Resolve metadata — may be a function.
-    // A throwing metadata callback is a caller defect; treat as unavailable.
-    let metadataResolutionFailed = false;
-    let metadataResolutionError: unknown;
-    try {
-      const policyMetadata =
-        typeof policy.metadata === "function" ? policy.metadata(ctx) : policy.metadata;
-      metadata = { ...metadata, ...policyMetadata };
-    } catch (error) {
-      metadataResolutionFailed = true;
-      metadataResolutionError = error;
-    }
-
-    // If a callback threw, treat as unavailable rather than guarding
-    if (ruleResolutionFailed || metadataResolutionFailed) {
-      const failClosed = policy.onGuardError !== "allow";
-      const correlation =
-        agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
-      const error = ruleResolutionFailed ? ruleResolutionError : metadataResolutionError;
-      warnCallbackFailure(options.warnKind, policy.action, failClosed, error);
-      captureEvent(client, {
-        action: policy.action,
-        ...correlation,
-        metadata: { ...metadata, outcome: "unavailable" },
-      });
-      return failClosed ? options.onUnavailable() : options.onAllow();
-    }
-
-    // Call runGate with the appropriate handlers
     return await runGate(client, {
       action: policy.action,
-      rules,
+      rules: resolved.rules,
       correlationId: agentCtx.correlationId,
-      metadata,
+      metadata: resolved.metadata,
       onAllow: options.onAllow,
       onDeny: options.onDeny,
       onUnavailable: options.onUnavailable,

--- a/arcjet-guard/src/vercel-eve/v0/index.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/index.test.ts
@@ -19,6 +19,7 @@ import type {
   ArcjetHookFamily,
   ArcjetHooksOptions,
   GuardApprovalPolicy,
+  GuardApprovalResponsePolicy,
   GuardInboundOptions,
   GuardToolPolicy,
   InboundVerdict,
@@ -31,6 +32,7 @@ import type {
  */
 function verifyTypeExports(): void {
   const approvalPolicy: GuardApprovalPolicy | undefined = undefined;
+  const approvalResponsePolicy: GuardApprovalResponsePolicy | undefined = undefined;
   const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
   const inboundOptions: GuardInboundOptions | undefined = undefined;
   const inboundVerdict: InboundVerdict | undefined = undefined;
@@ -39,6 +41,7 @@ function verifyTypeExports(): void {
   const denialResult: ArcjetDenialResult | undefined = undefined;
   void [
     approvalPolicy,
+    approvalResponsePolicy,
     toolPolicy,
     inboundOptions,
     inboundVerdict,
@@ -159,7 +162,7 @@ test("Eve namespace is a strict superset of the agents barrel with same identity
 
   // eve has exactly the agents keys plus five own exports: eveAgentContext,
   // guardApproval, guardTool, guardInbound, arcjetHooks.
-  // Type-only exports (GuardApprovalPolicy, GuardToolPolicy, GuardInboundOptions,
+  // Type-only exports (GuardApprovalPolicy, GuardApprovalResponsePolicy, GuardToolPolicy, GuardInboundOptions,
   // InboundVerdict, ArcjetHookFamily, ArcjetHooksOptions, ArcjetDenialResult)
   // do not appear at runtime.
   const expectedAdditions = 5;

--- a/arcjet-guard/src/vercel-eve/v0/index.ts
+++ b/arcjet-guard/src/vercel-eve/v0/index.ts
@@ -7,7 +7,7 @@
  * layer they build on, so an Eve agent needs one import path and no notion of
  * layering.
  *
- * **Requires the optional peer dependency `eve@>=0.25.1 <1`**, and Eve's own
+ * **Requires the optional peer dependency `eve@>=0.34.0 <1`**, and Eve's own
  * Node floor of 24 — higher than `@arcjet/guard`'s. Nothing in this module
  * imports `eve` at runtime: every Eve type arrives through `import type`, so
  * installing `@arcjet/guard` never pulls Eve in.
@@ -84,7 +84,7 @@
 
 export { eveAgentContext } from "./context.ts";
 export { guardApproval } from "./guard-approval.ts";
-export type { GuardApprovalPolicy } from "./guard-approval.ts";
+export type { GuardApprovalPolicy, GuardApprovalResponsePolicy } from "./guard-approval.ts";
 export { guardTool } from "./guard-tool.ts";
 export type { GuardToolPolicy } from "./guard-tool.ts";
 export { guardInbound } from "./guard-inbound.ts";

--- a/arcjet-guard/src/vercel-eve/v0/peer.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/peer.test.ts
@@ -32,12 +32,18 @@ function objectField(
 test("AC1.5: eve is an optional peer and not a dependency", () => {
   const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
 
-  // Static assertion 1: peerDependencies.eve is exactly ">=0.25.1 <1"
+  // Static assertion 1: peerDependencies.eve is exactly ">=0.34.0 <1"
   const peerDependencies = objectField(packageJson, "peerDependencies");
   assert.ok(peerDependencies, "package.json must have peerDependencies");
 
   const eveVersion = peerDependencies["eve"];
-  assert.equal(eveVersion, ">=0.25.1 <1", 'peerDependencies.eve must be exactly ">=0.25.1 <1"');
+  assert.equal(eveVersion, ">=0.34.0 <1", 'peerDependencies.eve must be exactly ">=0.34.0 <1"');
+
+  // The assignability tests compile against this pin; keep it on a 0.34+ release
+  // that exports Approval as ApprovalPolicy | ApprovalConfiguration.
+  const devDependencies = objectField(packageJson, "devDependencies");
+  assert.ok(devDependencies, "package.json must have devDependencies");
+  assert.equal(devDependencies["eve"], "0.39.0", 'devDependencies.eve must be pinned to "0.39.0"');
 
   // Static assertion 2: peerDependenciesMeta.eve.optional is true
   const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,7 @@
         "@connectrpc/connect-web": "2.1.2"
       },
       "devDependencies": {
-        "@ai-sdk/provider-utils": "5.0.13",
+        "@ai-sdk/provider-utils": "5.0.25",
         "@anthropic-ai/claude-agent-sdk": "0.3.221",
         "@langchain/core": "1.2.8",
         "@langchain/langgraph": "1.4.10",
@@ -645,26 +645,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
-      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.7",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8",
-        "undici": "^7.28.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/provider": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
@@ -679,16 +659,17 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.13.tgz",
-      "integrity": "sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==",
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
+      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider": "4.0.7",
         "@standard-schema/spec": "^1.1.0",
         "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=22"
@@ -779,6 +760,19 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-v5": {
@@ -6193,26 +6187,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
-      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.7",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8",
-        "undici": "^7.28.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,8 +190,8 @@
         "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.58.0",
         "@types/node": "22.20.1",
-        "ai": "7.0.38",
-        "eve": "0.31.0",
+        "ai": "7.0.58",
+        "eve": "0.39.0",
         "miniflare": "4.20260708.1",
         "oxlint-tsgolint": "0.24.0",
         "tsdown": "0.22.7",
@@ -207,7 +207,7 @@
         "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
         "ai": ">=7 <8",
-        "eve": ">=0.25.1 <1"
+        "eve": ">=0.34.0 <1"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/provider-utils": {
@@ -615,15 +615,48 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "4.0.29",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.29.tgz",
-      "integrity": "sha512-x63ILOnzMjbavVb55ckuoQLZB8KTdrJFzk3nSt1QbecokLac4FGEYQDUKQSvRV93lFWol+8tr0ZR+IHWhGtmJw==",
+      "version": "4.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.46.tgz",
+      "integrity": "sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.4",
-        "@ai-sdk/provider-utils": "5.0.13",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.25",
         "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
+      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=22"
@@ -6132,15 +6165,48 @@
       }
     },
     "node_modules/ai": {
-      "version": "7.0.38",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.38.tgz",
-      "integrity": "sha512-14biRrfd9lGNBT1rNw3QkQs4VDI6u7iBaw6TesP7r09GH4FFY+l22qkza5gQzzSNp/+nn8AM0+q8br0W72nLhQ==",
+      "version": "7.0.58",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.58.tgz",
+      "integrity": "sha512-GfgO90CQQ0yYuoxJAUOeQ6tviyYw1BUIDygSZ1q3Ce6kSc93tYmB5eltKY/NxC0YOouAax7JvDqVnYxvIAr04Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "4.0.29",
-        "@ai-sdk/provider": "4.0.4",
-        "@ai-sdk/provider-utils": "5.0.13"
+        "@ai-sdk/gateway": "4.0.46",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.25"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
+      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=22"
@@ -7694,9 +7760,9 @@
       }
     },
     "node_modules/eve": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/eve/-/eve-0.31.0.tgz",
-      "integrity": "sha512-9zFS0JH/uTKQe9if/PQKhfv7vGmIv/RWqcVAbTLQR9G6+Gh6b/vzYfqPFNmNdjwWc2mK0YiLkwls0BH9Bo0BFA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/eve/-/eve-0.39.0.tgz",
+      "integrity": "sha512-AbpCNmAHEJn2/BhFxu0FNlhQ3MsN0Sl//VgoPg+c8NMambPDs0jncfE9zOvIquW5AAMPOTj6a/erLdKIINm56A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7711,7 +7777,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "ai": "^7.0.38",
+        "ai": "^7.0.58",
         "braintrust": "^3.0.0",
         "just-bash": "^3.0.0",
         "microsandbox": "^0.5.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Eve 0.34 made `approval` a function or `{ request, response }`. This stays on `@arcjet/guard/vercel-eve/v0` and raises the peer to `eve >=0.34.0 <1` so `guardApproval` can authorize both the tool call and who may approve a parked HITL request.

```ts
import { guardApproval } from "@arcjet/guard/vercel-eve/v0";

approval: guardApproval(arcjet, {
  action: "refund.issued",
  rules: (ctx) => [refundLimit({ key: ctx.session.id, requested: 1 })],
  onAllow: "user-approval",
  response: {
    action: "refund.approved",
    rules: (ctx) => [refundLimit({ key: ctx.responder.principalId, requested: 1 })],
  },
})
```

Request-time tests still pass; assignability and response-policy unit tests cover both forms.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4e26813-e2f0-40f4-ae9a-96951e1af2d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4e26813-e2f0-40f4-ae9a-96951e1af2d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

