### PR TITLE
feat(guard): add OpenAI Agents support as @arcjet/guard/openai-agents/v0

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -149,9 +149,10 @@ jobs:
       # the consequence, catching a build step that re-emits one as a value
       # import.
       #
-      # Only `src/openai-agents` is globbed. The suite that exercises the real
-      # `tool()` value-imports the peer, so it lives in `test/openai-agents`
-      # and runs in the unit-test step above, where the peer is installed.
+      # Only `src/openai-agents` is globbed. The suites that exercise the real
+      # `tool()` and the real `run()` loop value-import the peer, so they live
+      # in `test/openai-agents` and run in the unit-test step above, where the
+      # peer is installed.
       #
       # Runs before the eve-absent step because that one deletes a different
       # optional peer. Typecheck legitimately fails without the peer.

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -144,6 +144,26 @@ jobs:
           node --test 'arcjet-guard/src/langgraph/**/*.test.ts'
         working-directory: ${{ github.workspace }}
 
+      # The openai-agents namespace imports @openai/agents for types only. A
+      # static scan proves the imports are written `import type`; this proves
+      # the consequence, catching a build step that re-emits one as a value
+      # import.
+      #
+      # Only `src/openai-agents` is globbed. The suite that exercises the real
+      # `tool()` value-imports the peer, so it lives in `test/openai-agents`
+      # and runs in the unit-test step above, where the peer is installed.
+      #
+      # Runs before the eve-absent step because that one deletes a different
+      # optional peer. Typecheck legitimately fails without the peer.
+      - name: Unit tests with openai-agents absent
+        run: |
+          rm -rf node_modules/@openai/agents arcjet-guard/node_modules/@openai/agents
+          node -e "try { require.resolve('@openai/agents', { paths: ['arcjet-guard/src/openai-agents/v0'] }); console.error('openai-agents still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
+          count=$(find arcjet-guard/src/openai-agents -name '*.test.ts' | wc -l)
+          test "$count" -ge 5 || { echo "only $count openai-agents test files matched; the glob has gone stale" >&2; exit 1; }
+          node --test 'arcjet-guard/src/openai-agents/**/*.test.ts'
+        working-directory: ${{ github.workspace }}
+
       # The mastra namespace imports @mastra/core for types only. A static scan
       # proves the imports are written `import type`; this proves the
       # consequence, catching a build step that re-emits one as a value import.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ change them:
   are `guardTool`, unwrapped / MCP tools go through `guardToolNode`, and
   `interrupt()` is HITL not policy. `createReactAgent` is deprecated; do not
   build on it or on LangChain `createAgent`.
+  `openai-agents/v0` is text `Agent` + `run()` / `Runner` + authored
+  `tool({ execute })`: the runner-facing deny point is `FunctionTool.invoke`
+  (the SDK closes over `execute`), inbound is screened before `run()`
+  (SDK `inputGuardrails` are not Arcjet), and `needsApproval` is HITL not
+  policy. There is no ToolNode, no `guardInbound`, no `guardApproval`, and
+  no `guardHooks` — hosted tools, MCP, handoffs, and `agent.asTool()` skip
+  the authored-`execute` path. `RunContext` has no session / conversation
+  id; correlation is a field the integrator puts on `runContext.context`.
 - **Flat** — a single level under `@arcjet/guard`, no further nesting.
 - **Explicitly versioned, with no unversioned alias.** `@arcjet/guard/vercel-ai`
   does not resolve, and neither does a wildcard `./vercel-ai/*`. An alias would

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1201,6 +1201,14 @@ real messages.
     rules: [inbound(userText)],
     ...openaiAgentsContext({ context: appContext, conversationId }),
   });
+
+  if (decision.conclusion === "DENY") {
+    throw new Error("message blocked");
+  }
+  // `guard()` fails open, so an ALLOW is not proof the rules ran. Gate on
+  // `decision.hasFailedOpen()` here if this call site must fail closed; the
+  // agent helpers below already default to that.
+  await run(agent, userText, { context: appContext });
   ```
 
 #### Screen inbound before `run()` (SDK `inputGuardrails` are not Arcjet)

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1142,6 +1142,90 @@ the denial and build your own `ToolMessage`; do not push the denial object
 straight into `messages`, because the graph's message reducer only accepts
 real messages.
 
+- **`@arcjet/guard/openai-agents/v0`** — OpenAI Agents text `Agent` +
+  `run()` / `Runner` integration. Exports `guardTool` and
+  `openaiAgentsContext`. This is **not** Realtime, Sandbox, hosted tools,
+  computer / shell / apply_patch, MCP, or `agent.asTool()`. There is no
+  `guardInbound` (screen before `run()`; SDK `inputGuardrails` are not
+  Arcjet), no `guardApproval` (`needsApproval` is human HITL, not
+  policy), and no `guardHooks` / `guardToolNode` (there is no ToolNode;
+  hosted / MCP / handoffs skip authored `execute`).
+
+  On DENY a guarded tool does not run and does not throw: it returns a
+  structured `ArcjetDenialResult`. The runner stringifies that object
+  onto a `function_call_result` with `status: "completed"` — the denial
+  is in the payload (`arcjetDenied: true`), not a fabricated envelope.
+  Throwing would hit the SDK `errorFunction` (a generic string, or
+  `ToolCallError` when `outputSchema` / `errorFunction: null`).
+  `RunContext` has no session / conversation id; put the id you already
+  have on `run(..., { context })`:
+
+  ```ts
+  import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+  import { guardTool, openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
+  import { Agent, run, tool } from "@openai/agents";
+  import { z } from "zod";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const lookupOrder = guardTool(
+    arcjet,
+    tool({
+      name: "lookup_order",
+      description: "Look up an order",
+      parameters: z.object({ orderNumber: z.string() }),
+      execute: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+    }),
+    {
+      action: "order.looked-up",
+      onGuardError: "deny",
+      rules: (input: { orderNumber: string }) => [limit({ key: input.orderNumber, requested: 1 })],
+    },
+  );
+
+  const agent = new Agent({
+    name: "support-agent",
+    instructions: "Help the user.",
+    tools: [lookupOrder],
+  });
+
+  const appContext = { sessionId: conversationId };
+  const inbound = detectPromptInjection();
+  const decision = await arcjet.guard({
+    label: "message.received",
+    rules: [inbound(userText)],
+    ...openaiAgentsContext({ context: appContext, conversationId }),
+  });
+  ```
+
+#### Screen inbound before `run()` (SDK `inputGuardrails` are not Arcjet)
+
+OpenAI Agents has no first-class inbound channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `run()`. SDK `inputGuardrails` / `outputGuardrails` /
+`defineToolInputGuardrail` / `defineToolOutputGuardrail` are the SDK's
+own tripwires, not this policy gate.
+
+#### `needsApproval` is not a policy gate
+
+`needsApproval` / `requireApproval` / `onApproval` is human-in-the-loop,
+not policy. The run pauses; `result.state.approve` / `reject`. Same trap
+as Mastra `requireApproval`, Claude `canUseTool`, and LangGraph
+`interrupt()`. There is no `guardApproval`.
+
+#### `tool()` execute is the deny point; hosted, MCP, and handoffs are not on that path
+
+The runner executes authored function tools in `toolExecution.ts` via
+`invoke`. Hosted tools, handoffs, computer / shell / apply_patch, and
+MCP (`mcpServers` → `mcpToFunctionTool`) skip that authored-`execute`
+path. `agent_tool_start` / `agent_tool_end` are void observe-only hooks;
+they are not a deny. There is no `guardHooks` and no `guardToolNode`.
+
 ### Naming and versions
 
 Integration paths are `@arcjet/guard/<vendor-sdk>/v<major>` — the SDK being
@@ -1183,6 +1267,9 @@ importing only core guards are not forced to install unneeded packages:
 - **`@arcjet/guard/langgraph/v1`** requires `@langchain/langgraph` and
   `@langchain/core` (optional peers, installed only to use
   `@arcjet/guard/langgraph/v1`). The peer range is `>=1 <2` for both.
+- **`@arcjet/guard/openai-agents/v0`** requires `@openai/agents` (optional
+  peer, installed only to use `@arcjet/guard/openai-agents/v0`). The peer
+  range is `>=0.17.0 <1`. Zod is their peer, not ours.
 
 **pnpm caveat**: pnpm does not reliably honour
 `peerDependenciesMeta.*.optional` (pnpm#5152, #8142), especially with
@@ -1218,6 +1305,11 @@ pnpm install @langchain/langgraph @langchain/core
 ```
 
 ```sh
+# @arcjet/guard/openai-agents/v0
+pnpm install @openai/agents
+```
+
+```sh
 # or skip the peer install and relax the check:
 pnpm install --no-strict-peer-dependencies
 ```
@@ -1230,8 +1322,9 @@ they import reaches `ai`. They are published on each vendor namespace, so there
 is one path to learn and no layering to reason about.
 
 `@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`,
-`@arcjet/guard/mastra/v1`, `@arcjet/guard/claude-agent-sdk/v0`, and
-`@arcjet/guard/langgraph/v1` now export these helpers. The open next step is
+`@arcjet/guard/mastra/v1`, `@arcjet/guard/claude-agent-sdk/v0`,
+`@arcjet/guard/langgraph/v1`, and `@arcjet/guard/openai-agents/v0` now export
+these helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
 agnostic layer without installing a vendor peer. That change is a follow-up
 with its own ADR; there is still no public `@arcjet/guard/agents`.
@@ -1253,6 +1346,7 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 | Mastra `guardProcessor` / `guardHooks`  | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Claude `guardTool` / `guardHooks`       | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | LangGraph `guardTool` / `guardToolNode` | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| OpenAI Agents `guardTool`               | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -1604,6 +1698,8 @@ For an example with Mastra, see [`mastra-agent`](https://github.com/arcjet/examp
 
 For an example with LangGraph, see [`langgraph-agent`](https://github.com/arcjet/examples/tree/main/examples/langgraph-agent) (follow-up on that same PR): inbound screening before `invoke`, `guardTool` / `guardToolNode` (deny, PII on args, rate limit, fail-closed), and `thread_id` correlation. `interrupt()` is HITL, not a policy gate; `ToolNode` is the deny point for tools.
 
+For an example with OpenAI Agents, see [`openai-agent`](https://github.com/arcjet/examples/tree/main/examples/openai-agent) (follow-up on that same PR): inbound screening before `run()`, `guardTool` (deny, PII on args, rate limit, fail-closed), and a caller-owned id on `run(..., { context })`. `needsApproval` is HITL, not a policy gate; authored `tool()` `invoke` is the deny point.
+
 ## Agent skill
 
 For integration help in Claude Code or other AI coding agents, a skill file per integration is packaged with `@arcjet/guard`:
@@ -1659,6 +1755,16 @@ ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-langgrap
 ```
 
 In Claude Code, use `/integrate-arcjet-guard-langgraph` to start an integration session.
+
+**For OpenAI Agents:**
+
+```bash
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-openai-agents ~/.claude/skills/
+# or
+ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-openai-agents ~/.claude/skills/
+```
+
+In Claude Code, use `/integrate-arcjet-guard-openai-agents` to start an integration session.
 
 Each skill guides you through wrapping tools, screening inbound messages, and recording lifecycle events joined by correlation ID.
 

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -87,6 +87,10 @@
     "./langgraph/v1": {
       "types": "./dist/langgraph/v1/index.d.ts",
       "import": "./dist/langgraph/v1/index.js"
+    },
+    "./openai-agents/v0": {
+      "types": "./dist/openai-agents/v0/index.d.ts",
+      "import": "./dist/openai-agents/v0/index.js"
     }
   },
   "publishConfig": {
@@ -99,7 +103,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts'",
+    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts'",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
     "test-runtime-deno": "npm run build && deno test --no-check --allow-all test/runtime/deno.test.ts",
@@ -120,6 +124,7 @@
     "@langchain/core": "1.2.8",
     "@langchain/langgraph": "1.4.10",
     "@mastra/core": "1.58.0",
+    "@openai/agents": "0.17.0",
     "@types/node": "22.20.1",
     "ai": "7.0.58",
     "eve": "0.39.0",
@@ -134,6 +139,7 @@
     "@langchain/core": ">=1 <2",
     "@langchain/langgraph": ">=1 <2",
     "@mastra/core": ">=1 <2",
+    "@openai/agents": ">=0.17.0 <1",
     "ai": ">=7 <8",
     "eve": ">=0.34.0 <1"
   },
@@ -157,6 +163,9 @@
       "optional": true
     },
     "@langchain/langgraph": {
+      "optional": true
+    },
+    "@openai/agents": {
       "optional": true
     }
   },

--- a/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: integrate-arcjet-guard-openai-agents
+description: Integrate Arcjet security into an OpenAI Agents text Agent using @arcjet/guard — wrap tool({ execute }), screen inbound before run(), and read a caller-owned id from runContext.context. Use when asked to add Arcjet to @openai/agents, rate limit its tools, screen inbound messages, or block prompt injection / PII.
+license: Apache-2.0
+compatibility: Requires the target app to use OpenAI Agents (@openai/agents >=0.17.0 <1) on Node.js >= 22. This is text Agent + run() / Runner, not Realtime, not Sandbox, not hosted / MCP / asTool.
+metadata:
+  author: arcjet
+---
+
+# Integrate Arcjet Guard into an OpenAI Agents app
+
+`@arcjet/guard`'s OpenAI Agents v0 namespace wraps the agent's existing
+Arcjet client. It never talks to the Arcjet API itself. Two surfaces, one
+decision rule:
+
+- **An authored tool** (`tool({ execute })`) → `guardTool()`. After
+  `tool()` the object is a `FunctionTool`; the runner calls `invoke`.
+  DENY returns a structured `ArcjetDenialResult`. Do not throw.
+- **Correlation** → `openaiAgentsContext()` reads a field the integrator
+  put on `runContext.context` (then documented copies: `conversationId`,
+  `groupId`, already-resolved `sessionId`). It never mints a new id.
+  It never calls `session.getSessionId()`.
+
+This namespace is text **`Agent` + `run()` / `Runner`**. Not Realtime,
+not Sandbox, not hosted tools, not computer / shell / apply_patch, not
+MCP, not `agent.asTool()`.
+
+## Screen inbound before `run()` (SDK `inputGuardrails` are not Arcjet)
+
+There is no first-class inbound channel, so there is no `guardInbound`.
+Put prompt-injection (and other inbound rules) in the application before
+`run()`. SDK `inputGuardrails` / `outputGuardrails` /
+`defineToolInputGuardrail` / `defineToolOutputGuardrail` are the SDK's
+own tripwires, not this policy gate. Do not wrap them as Guard.
+
+## `needsApproval` is not a policy gate
+
+`needsApproval` / `requireApproval` / `onApproval` is human-in-the-loop.
+The run pauses; `result.state.approve` / `reject`. Same trap as Mastra
+`requireApproval`, Claude `canUseTool`, and LangGraph `interrupt()`.
+There is no `guardApproval`. Do not wrap them as Guard.
+
+## `tool()` execute is the deny point; hosted, MCP, and handoffs are not
+
+The runner executes authored function tools in `toolExecution.ts` via
+`invoke`. Hosted tools, handoffs, computer / shell / apply_patch, and
+MCP (`mcpServers` → `mcpToFunctionTool`) skip that authored-`execute`
+path. `agent_tool_start` / `agent_tool_end` are void observe-only
+hooks; they are not a deny. There is no `guardHooks` and no
+`guardToolNode` (there is no ToolNode).
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those get `guardTool`. Hosted / MCP / handoffs
+   are out of v0 scope.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. Put the
+   conversation / session id you already have on
+   `run(..., { context: { sessionId } })`. That id is the correlation id,
+   not the user.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound screening before
+   `run()`: failing closed there means the agent does not run for the
+   duration of the outage, so `"allow"` is a routine and legitimate
+   choice at that one call site.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection before
+   `run()`. SDK input/output guardrails are not Arcjet.
+2. **`needsApproval` is not a policy gate.** It is HITL. Use `guardTool`.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/openai-agents/v0`. `@arcjet/guard/openai-agents` does
+   not resolve.
+4. **Correlation is read, never minted.** Do not call `createAgentContext`
+   inside a run callback — that generates a second id and splits the
+   Sequence. `RunContext` has no session / conversation id of its own.
+   Put the id you already chose on `run(..., { context })`. Do not call
+   `session.getSessionId()` from the helper: `MemorySession` mints a UUID
+   when constructed without `sessionId`. Do not use `traceId` (the SDK
+   mints one when omitted).
+5. **Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.** `guardTool`
+   throws if the tool already carries the Arcjet protection brand.
+6. **A denial from `guardTool` is a structured object, not a throw.**
+   Throwing would hit the SDK `errorFunction` (a generic string, or
+   `ToolCallError` when `outputSchema` / `errorFunction: null`). The
+   runner stringifies the object onto a `function_call_result` with
+   `status: "completed"` — the denial is in the payload
+   (`arcjetDenied: true`). If `onDeny` throws, the tool still does not
+   run and the model still receives the default denial.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `@openai/agents` (optional peer,
+needed for `@arcjet/guard/openai-agents/v0`). Always use the versioned
+path: `@arcjet/guard/openai-agents/v0` resolves;
+`@arcjet/guard/openai-agents` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+Zod is the OpenAI Agents peer, not ours — install `zod` only if the app
+already uses it for `tool({ parameters })`.
+
+```sh
+npm install @arcjet/guard @openai/agents
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate authored tools
+
+```ts
+import { tool } from "@openai/agents";
+import { z } from "zod";
+import { guardTool } from "@arcjet/guard/openai-agents/v0";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  bucket: "lookups",
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+// Factory then text — same shape as `detectPromptInjection()(text)`.
+// Scan free-text args (a note, reason, body). An opaque `orderId` will
+// not trip EMAIL / phone / card / IP, so do not pass it here.
+const detectPii = localDetectSensitiveInfo();
+
+export const lookupOrder = guardTool(
+  arcjet,
+  tool({
+    name: "lookup_order",
+    description: "Look up an order by ID",
+    parameters: z.object({
+      orderId: z.string(),
+      note: z.string(),
+    }),
+    execute: async ({ orderId, note }) => ({ orderId, note, status: "shipped" }),
+  }),
+  {
+    action: "order.looked-up",
+    rules: (input: { orderId: string; note: string }) => [
+      lookupLimit({ key: input.orderId, requested: 1 }),
+      detectPii(input.note),
+    ],
+  },
+);
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the closed-over `execute` never runs. The model receives
+  `{ arcjetDenied: true, reason, message, retryable }` as the tool
+  result (stringified by the runner).
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+
+## Step 3: Screen inbound before run
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
+
+import { arcjet } from "./arcjet.js";
+
+const appContext = { sessionId: conversationId };
+const inbound = detectPromptInjection();
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...openaiAgentsContext({ context: appContext, conversationId }),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+
+await run(agent, userText, { context: appContext });
+```
+
+There is no `guardInbound`.
+
+## Step 4: Correlation
+
+Put the id you already have on the app context you pass to `run()`:
+
+```ts
+const appContext = { sessionId: conversationId };
+await run(agent, userText, { context: appContext });
+```
+
+`MemorySession({ sessionId })` and `OpenAIConversationsSession({
+conversationId })` already exist. Resolve the id yourself
+(`await session.getSessionId()` only after you passed that id in) and
+copy it onto `context`. `openaiAgentsContext` reads it; it never calls
+`createAgentContext` and never calls `getSessionId()`.
+
+Preference order: `context.correlationId`, then `context.sessionId`,
+then `context.conversationId`, then `context.groupId`, then the
+envelope copies (`conversationId`, `groupId`, already-resolved
+`sessionId`). If none is a valid 1–256 printable-ASCII string, the call
+is uncorrelated rather than joined to a generated id nobody has.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI (before run), a tool deny, PII on args, a rate
+   limit, and fail-closed (an unreachable guard).
+3. Confirm in the Arcjet dashboard that decisions share the session /
+   conversation id as their correlation id.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo will land in
+[`arcjet/examples` `openai-agent`](https://github.com/arcjet/examples/tree/main/examples/openai-agent)
+with [arcjet/examples#193](https://github.com/arcjet/examples/pull/193).
+Do not add an example under `examples/` in the JS SDK repo.
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
@@ -161,6 +161,10 @@ export const lookupOrder = guardTool(
   `{ arcjetDenied: true, reason, message, retryable }` as the tool
   result (stringified by the runner).
 - Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+- The runner treats the denial as the tool's output. If the tool sets
+  `timeoutMs`, that race now covers the guard round trip too, so leave
+  headroom for it; if it sets `outputGuardrails` or `customDataExtractor`,
+  those receive the denial object and must not assume the tool's own shape.
 
 ## Step 3: Screen inbound before run
 

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -8,9 +8,9 @@
  * users re-exported from a vendor namespace — `@arcjet/guard/vercel-ai/v7`,
  * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`,
  * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langgraph/v1`, and
- * `@arcjet/guard/openai-agents/v0`. The layer
- * stays agnostic so multiple vendor namespaces can share the same code. A
- * public `@arcjet/guard/agents` path is still a follow-up with its own ADR.
+ * `@arcjet/guard/openai-agents/v0`. The layer stays agnostic so multiple
+ * vendor namespaces can share the same code. A public `@arcjet/guard/agents`
+ * path is still a follow-up with its own ADR.
  */
 
 export { createAgentContext } from "./context.ts";

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -6,9 +6,9 @@
  *
  * @internal This barrel has no export map entry. Every symbol below reaches
  * users re-exported from a vendor namespace — `@arcjet/guard/vercel-ai/v7`,
- * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`, and
- * `@arcjet/guard/claude-agent-sdk/v0`, and `@arcjet/guard/langgraph/v1`. The
- * layer
+ * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`,
+ * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langgraph/v1`, and
+ * `@arcjet/guard/openai-agents/v0`. The layer
  * stays agnostic so multiple vendor namespaces can share the same code. A
  * public `@arcjet/guard/agents` path is still a follow-up with its own ADR.
  */
@@ -23,11 +23,7 @@ export {
   captureAction,
   guardAction,
 } from "./guard-action.ts";
-export type {
-  CaptureActionOptions,
-  GuardActionPolicy,
-  OnGuardError,
-} from "./guard-action.ts";
+export type { CaptureActionOptions, GuardActionPolicy, OnGuardError } from "./guard-action.ts";
 export type { ArcjetAgentClient } from "./capture.ts";
 // Re-exported from the root so a caller building a `captureAction()` payload
 // does not need a second import.

--- a/arcjet-guard/src/openai-agents/v0/assignability.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/assignability.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Compile-time assignability: the helpers accept the values an OpenAI
+ * Agents app actually has, with no casts at the call site.
+ *
+ * The declarations are types only (`declare const`, never executed) so this
+ * suite still runs in the openai-agents-absent CI job, where the peer is
+ * gone and the type-only import scan applies. Runtime behaviour against
+ * the real `tool()` lives in `test/openai-agents/real-tool.test.ts`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { FunctionTool } from "@openai/agents";
+
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { guardTool } from "./guard-tool.ts";
+
+declare const client: ArcjetAgentClient;
+declare const authoredTool: FunctionTool;
+
+// Never called: the declarations above have no runtime value. Typecheck is
+// the assertion.
+function typeProbe(): void {
+  const guarded: FunctionTool = guardTool(client, authoredTool, {
+    action: "order.looked-up",
+    rules: (input: { orderNumber: string }) => {
+      void input.orderNumber;
+      return [];
+    },
+  });
+
+  void guarded;
+}
+
+test("helpers accept a real FunctionTool without casts", () => {
+  assert.equal(typeof typeProbe, "function");
+});

--- a/arcjet-guard/src/openai-agents/v0/context.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/context.test.ts
@@ -1,0 +1,249 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { openaiAgentsContext } from "./context.ts";
+
+test("prefers a field the integrator put on runContext.context", () => {
+  const result = openaiAgentsContext({
+    context: { sessionId: "sess-app", conversationId: "conv-app", groupId: "group-app" },
+    conversationId: "conv-envelope",
+    groupId: "group-envelope",
+    sessionId: "sess-envelope",
+  });
+
+  assert.equal(result.correlationId, "sess-app");
+  assert.equal(result.metadata?.["openai-agents.session"], "sess-app");
+  assert.equal(result.metadata?.["openai-agents.conversation"], "conv-app");
+  assert.equal(result.metadata?.["openai-agents.group"], "group-app");
+});
+
+test("prefers context.correlationId over context.sessionId", () => {
+  const result = openaiAgentsContext({
+    context: { correlationId: "corr-1", sessionId: "sess-1" },
+  });
+
+  assert.equal(result.correlationId, "corr-1");
+  assert.equal(result.metadata?.["openai-agents.session"], "sess-1");
+});
+
+test("falls back to context.conversationId when sessionId is absent", () => {
+  const result = openaiAgentsContext({
+    context: { conversationId: "conv-1", groupId: "group-1" },
+  });
+
+  assert.equal(result.correlationId, "conv-1");
+  assert.equal(result.metadata?.["openai-agents.conversation"], "conv-1");
+  assert.equal(result.metadata?.["openai-agents.group"], "group-1");
+});
+
+test("falls back to context.groupId when session and conversation are absent", () => {
+  const result = openaiAgentsContext({
+    context: { groupId: "group-only" },
+  });
+
+  assert.equal(result.correlationId, "group-only");
+  assert.equal(result.metadata?.["openai-agents.group"], "group-only");
+});
+
+test("reads documented envelope copies when context has no id", () => {
+  const result = openaiAgentsContext({
+    context: { user: "alice" },
+    conversationId: "conv-opt",
+    groupId: "group-cfg",
+  });
+
+  assert.equal(result.correlationId, "conv-opt");
+  assert.equal(result.metadata?.["openai-agents.conversation"], "conv-opt");
+  assert.equal(result.metadata?.["openai-agents.group"], "group-cfg");
+});
+
+test("accepts a bare app context object", () => {
+  const result = openaiAgentsContext({ sessionId: "direct-sess" });
+  assert.equal(result.correlationId, "direct-sess");
+  assert.equal(result.metadata?.["openai-agents.session"], "direct-sess");
+});
+
+test("init.sessionId is a last-resort caller-owned fallback", () => {
+  const result = openaiAgentsContext({ context: { user: "alice" } }, { sessionId: "policy-sess" });
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["openai-agents.session"], "policy-sess");
+});
+
+test("never mints an id when nothing valid is present", () => {
+  const result = openaiAgentsContext({});
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+});
+
+test("never mints an id when the only candidate is invalid", () => {
+  const result = openaiAgentsContext({ context: { sessionId: "" } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("openai-agents.session" in (result.metadata ?? {}), false);
+});
+
+test("skips an invalid context session id and uses the next candidate", () => {
+  const result = openaiAgentsContext({
+    context: { sessionId: "" },
+    conversationId: "conv-ok",
+  });
+
+  assert.equal(result.correlationId, "conv-ok");
+});
+
+test("rejects a session id over 256 characters and does not mint", () => {
+  const longId = "x".repeat(257);
+  const result = openaiAgentsContext({ context: { sessionId: longId } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["openai-agents.session"], longId);
+});
+
+test("never reads traceId, even when it is the only string present", () => {
+  const result = openaiAgentsContext({
+    context: { traceId: "trace-minted-by-sdk" },
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- asserting we do not invent a traceId field on the source
+    ...({ traceId: "envelope-trace" } as Record<string, unknown>),
+  });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("does not call getSessionId on a session-shaped object", () => {
+  let called = 0;
+  const result = openaiAgentsContext({
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- session is not a documented source field
+    ...({
+      session: {
+        getSessionId: () => {
+          called += 1;
+          return "minted-or-async";
+        },
+      },
+    } as Record<string, unknown>),
+  });
+
+  assert.equal(called, 0);
+  assert.equal(result.correlationId, undefined);
+});
+
+test("a null context does not throw and does not mint", () => {
+  const result = openaiAgentsContext({ context: null });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("caller metadata overrides derived keys", () => {
+  const result = openaiAgentsContext(
+    { context: { sessionId: "sess-1" } },
+    { metadata: { "openai-agents.session": "override" } },
+  );
+
+  assert.equal(result.metadata?.["openai-agents.session"], "override");
+});
+
+test("derived metadata keys match /^[A-Za-z0-9._-]+$/", () => {
+  const result = openaiAgentsContext({
+    context: { sessionId: "sess-1", conversationId: "conv-1", groupId: "group-1" },
+  });
+
+  assert.ok(result.metadata);
+  const validKeyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const key of Object.keys(result.metadata)) {
+    assert.ok(
+      validKeyPattern.test(key),
+      `derived key "${key}" must match the metadata character class`,
+    );
+  }
+});
+
+test("encoder round-trip produces no AJ1017 warnings", () => {
+  const result = openaiAgentsContext({
+    context: { sessionId: "sess-1", conversationId: "conv-1", groupId: "group-1" },
+  });
+
+  assert.ok(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
+  assert.ok(metadataJson["openai-agents.session"]);
+  assert.ok(metadataJson["openai-agents.conversation"]);
+  assert.ok(metadataJson["openai-agents.group"]);
+});
+
+test("undefined source does not throw and does not mint", () => {
+  const result = openaiAgentsContext();
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("null and primitive sources do not mint", () => {
+  assert.equal("correlationId" in openaiAgentsContext(null as never), false);
+  assert.equal("correlationId" in openaiAgentsContext("sess" as never), false);
+  assert.equal("correlationId" in openaiAgentsContext(12 as never), false);
+});
+
+test("non-string candidates are skipped", () => {
+  const result = openaiAgentsContext({
+    context: { sessionId: 99, conversationId: { id: "nope" } },
+  });
+  assert.equal(result.correlationId, undefined);
+});
+
+test("non-printable session id is rejected and does not mint", () => {
+  const result = openaiAgentsContext({ context: { sessionId: "bad\nid" } });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["openai-agents.session"], "bad\nid");
+});
+
+test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "info";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    openaiAgentsContext({ context: { sessionId: "" } });
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /rejected/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("does not warn when a later candidate is valid", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const result = openaiAgentsContext({
+      context: { sessionId: "" },
+      conversationId: "conv-ok",
+    });
+    assert.equal(result.correlationId, "conv-ok");
+    assert.equal(warnings.length, 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/openai-agents/v0/context.ts
+++ b/arcjet-guard/src/openai-agents/v0/context.ts
@@ -1,0 +1,195 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `openaiAgentsContext` can read.
+ *
+ * `RunContext` itself has no session / conversation / thread id. Its public
+ * fields are `context` (the app object from `run(..., { context })`),
+ * `usage`, and `toolInput` (asTool only). This helper never reads a
+ * fabricated `runContext.conversationId`, and never reads `traceId`
+ * (the SDK mints one when omitted).
+ *
+ * Accepts:
+ * - a `RunContext`-shaped object (`{ context: app }`)
+ * - the app context object itself
+ * - run options / `RunConfig` copies (`conversationId`, `groupId`,
+ *   already-resolved `sessionId`)
+ *
+ * Do not pass a `Session` and expect `getSessionId()` to be called:
+ * `MemorySession` mints a UUID when constructed without `sessionId`.
+ * Resolve the id you already chose (`await session.getSessionId()`) and
+ * put that string on `context` or on this source.
+ */
+export interface OpenAIAgentsContextSource {
+  context?: unknown;
+  conversationId?: unknown;
+  groupId?: unknown;
+  sessionId?: unknown;
+  correlationId?: unknown;
+}
+
+/**
+ * Context derived from an OpenAI Agents run. `correlationId` is omitted
+ * when nothing valid was present — this helper never mints one.
+ */
+export interface OpenAIAgentsAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asContextSource(source: unknown): OpenAIAgentsContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+function asAppContext(value: unknown): OpenAIAgentsContextSource | undefined {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * The integrator-owned app object. On a `RunContext` / run-options envelope
+ * that is `source.context`. On a bare app object it is the source itself.
+ */
+function readAppContext(
+  source: OpenAIAgentsContextSource | undefined,
+): OpenAIAgentsContextSource | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  const nested = asAppContext(source.context);
+  if (nested !== undefined) {
+    return nested;
+  }
+  return source;
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function firstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Derive correlation and metadata from an OpenAI Agents `RunContext`, app
+ * context, or run-options copy. Never mints a new id. Never calls
+ * `createAgentContext`. Never calls `session.getSessionId()`.
+ *
+ * Preference order for `correlationId`:
+ * 1. Fields the integrator put on `runContext.context` (or a bare app
+ *    object): `correlationId`, then `sessionId`, then `conversationId`,
+ *    then `groupId`
+ * 2. Documented copies on the envelope: run option `conversationId`,
+ *    `RunConfig.groupId`, already-resolved `sessionId`
+ * 3. `init.sessionId` / `init.correlationId` (a caller-owned fallback)
+ *
+ * `traceId` is never read. An invalid candidate is skipped (and warned
+ * when `ARCJET_LOG_LEVEL` asks for warnings). If nothing valid remains,
+ * `correlationId` is omitted so the decision is uncorrelated rather than
+ * joined to a generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
+ *
+ * const appContext = { sessionId: conversationId };
+ * export function beforeRun() {
+ *   return openaiAgentsContext({ context: appContext, conversationId });
+ * }
+ * ```
+ */
+export function openaiAgentsContext(
+  source?: OpenAIAgentsContextSource,
+  init?: { sessionId?: string; correlationId?: string; metadata?: ArcjetMetadata },
+): OpenAIAgentsAgentContext {
+  const envelope = asContextSource(source);
+  const app = readAppContext(envelope);
+
+  const fromApp = {
+    correlationId: app?.correlationId,
+    sessionId: app?.sessionId,
+    conversationId: app?.conversationId,
+    groupId: app?.groupId,
+  };
+  const fromEnvelope = {
+    conversationId: envelope?.conversationId,
+    groupId: envelope?.groupId,
+    sessionId: envelope?.sessionId,
+    correlationId: envelope?.correlationId,
+  };
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: fromApp.correlationId, label: "context.correlationId" },
+    { value: fromApp.sessionId, label: "context.sessionId" },
+    { value: fromApp.conversationId, label: "context.conversationId" },
+    { value: fromApp.groupId, label: "context.groupId" },
+    { value: fromEnvelope.conversationId, label: "conversationId" },
+    { value: fromEnvelope.groupId, label: "groupId" },
+    { value: fromEnvelope.sessionId, label: "sessionId" },
+    { value: fromEnvelope.correlationId, label: "correlationId" },
+    { value: init?.correlationId, label: "init.correlationId" },
+    { value: init?.sessionId, label: "init.sessionId" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: OpenAI Agents ${rejected} rejected; no valid session/conversation/group id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const session = firstString([fromApp.sessionId, fromEnvelope.sessionId, init?.sessionId]);
+  if (session !== undefined) {
+    derivedMetadata["openai-agents.session"] = session;
+  }
+
+  const conversation = firstString([fromApp.conversationId, fromEnvelope.conversationId]);
+  if (conversation !== undefined) {
+    derivedMetadata["openai-agents.conversation"] = conversation;
+  }
+
+  const group = firstString([fromApp.groupId, fromEnvelope.groupId]);
+  if (group !== undefined) {
+    derivedMetadata["openai-agents.group"] = group;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: OpenAIAgentsAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/openai-agents/v0/denial.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/denial.test.ts
@@ -70,7 +70,13 @@ describe("openai-agents/v0/denial", () => {
     assert.match(deniedReason(decision), /Do not retry/);
   });
 
-  test("a denial does not pretend to be an SDK tool message", () => {
+  // `type` is the load-bearing one here. Without an `outputSchema` the runner
+  // passes the tool output through `normalizeStructuredToolOutputs`, which
+  // reinterprets any object carrying `type: "text"` (or another content type)
+  // as a structured content item. A denial that grew a `type` field would be
+  // rewritten into content instead of being stringified, losing the payload
+  // the model is meant to read.
+  test("a denial does not pretend to be an SDK tool message or content item", () => {
     const results: Array<Record<string, unknown>> = [
       { ...denialResult(decisionDenyPromptInjection()) },
       { ...unavailableResult() },

--- a/arcjet-guard/src/openai-agents/v0/denial.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/denial.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  decisionDenyError,
+  decisionDenyPromptInjection,
+  decisionDenyPromptInjectionWithReset,
+  decisionDenyRateLimit,
+  decisionDenyRateLimitNoReset,
+} from "../../../test/_shared/stub-client.ts";
+import {
+  denialResult,
+  deniedReason,
+  unavailableReason,
+  unavailableResult,
+  UNAVAILABLE_RETRY_AFTER_SECONDS,
+} from "./denial.ts";
+
+describe("openai-agents/v0/denial", () => {
+  test("rate-limit denial is retryable and may carry retry-after", () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 30;
+    const decision = decisionDenyRateLimit(resetAt);
+    const result = denialResult(decision);
+
+    assert.equal(result.arcjetDenied, true);
+    assert.equal(result.reason, "RATE_LIMIT");
+    assert.equal(result.retryable, true);
+    assert.ok(typeof result.retryAfterSeconds === "number");
+    assert.match(deniedReason(decision), /RATE_LIMIT/);
+  });
+
+  test("prompt-injection denial is not retryable", () => {
+    const decision = decisionDenyPromptInjection();
+    const result = denialResult(decision);
+
+    assert.equal(result.retryable, false);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(result.message, /Do not retry/);
+  });
+
+  test("unavailable result is retryable with a fixed backoff", () => {
+    const result = unavailableResult();
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, true);
+    assert.equal(result.retryAfterSeconds, UNAVAILABLE_RETRY_AFTER_SECONDS);
+    assert.equal(result.message, unavailableReason());
+  });
+
+  test("RATE_LIMIT without reset is retryable without retryAfterSeconds", () => {
+    const decision = decisionDenyRateLimitNoReset();
+    const result = denialResult(decision);
+    assert.equal(result.retryable, true);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(deniedReason(decision), /retried later/);
+  });
+
+  test("non-rate-limit denial ignores a co-occurring reset time", () => {
+    const decision = decisionDenyPromptInjectionWithReset(Math.floor(Date.now() / 1000) + 30);
+    const result = denialResult(decision);
+    assert.equal(result.retryable, false);
+    assert.equal(result.retryAfterSeconds, undefined);
+    assert.match(deniedReason(decision), /Do not retry/);
+  });
+
+  test("ERROR denial is not treated as unavailable", () => {
+    const decision = decisionDenyError();
+    const result = denialResult(decision);
+    assert.equal(result.reason, "ERROR");
+    assert.equal(result.retryable, false);
+    assert.match(deniedReason(decision), /Do not retry/);
+  });
+
+  test("a denial does not pretend to be an SDK tool message", () => {
+    const results: Array<Record<string, unknown>> = [
+      { ...denialResult(decisionDenyPromptInjection()) },
+      { ...unavailableResult() },
+    ];
+
+    for (const result of results) {
+      for (const messageField of ["_getType", "getType", "status", "type", "callId"]) {
+        assert.equal(
+          messageField in result,
+          false,
+          `a denial must not carry the message field "${messageField}"`,
+        );
+      }
+    }
+  });
+
+  test("a denial is JSON-serializable, which is how the runner surfaces it", () => {
+    const decoded: unknown = JSON.parse(
+      JSON.stringify(denialResult(decisionDenyPromptInjection())),
+    );
+    assert.deepEqual(decoded, {
+      arcjetDenied: true,
+      reason: "PROMPT_INJECTION",
+      message: deniedReason(decisionDenyPromptInjection()),
+      retryable: false,
+    });
+  });
+});

--- a/arcjet-guard/src/openai-agents/v0/denial.ts
+++ b/arcjet-guard/src/openai-agents/v0/denial.ts
@@ -1,0 +1,97 @@
+import { retryAfterSeconds } from "../../agents/denial.ts";
+import type { DecisionDeny } from "../../types.ts";
+
+/**
+ * Structured tool result returned to the model when a call is denied.
+ *
+ * Intentionally structurally identical to `vercel-ai/v7`'s, `mastra/v1`'s,
+ * and `langgraph/v1`'s ArcjetDenialResult so the model trained on denial
+ * objects sees the same shape regardless of which integration is in use.
+ * Each declaration exists separately to avoid putting another vendor's SDK
+ * in this namespace's import graph.
+ *
+ * **Why this is not a throw.** `tool({ execute })` without an `outputSchema`
+ * installs a default `errorFunction` that turns a throw into
+ * `"An error occurred while running the tool. Please try again. Error: …"`.
+ * With an `outputSchema`, or with `errorFunction: null`, the throw is
+ * rethrown as `ToolCallError` and the run dies. Neither path is a policy
+ * denial the model can inspect. Returning a plain object is what `execute`
+ * already does: the runner's `getToolCallOutputItem` stringifies it
+ * (`toSmartString` / `JSON.stringify`) onto a `function_call_result` with
+ * `status: "completed"`. The denial is in the payload
+ * (`arcjetDenied: true`), not a fabricated envelope.
+ */
+export interface ArcjetDenialResult {
+  arcjetDenied: true;
+  /** Denial reason, e.g. `"RATE_LIMIT"` or `"PROMPT_INJECTION"`. */
+  reason: string;
+  /** Human/model-readable explanation of the denial. */
+  message: string;
+  /** Whether retrying later can succeed (true for rate limits). */
+  retryable: boolean;
+  /** Seconds until a rate-limited call may be retried. */
+  retryAfterSeconds?: number;
+}
+
+/** Model- and user-readable explanation of a denial. */
+export function deniedReason(decision: DecisionDeny): string {
+  const isRateLimit = decision.reason === "RATE_LIMIT";
+  let message: string;
+
+  if (isRateLimit) {
+    const retryAfter = retryAfterSeconds(decision);
+    message =
+      `Arcjet denied this call (${decision.reason}). It may be retried` +
+      (retryAfter === undefined ? " later." : ` after ${retryAfter} seconds.`);
+  } else {
+    message = `Arcjet denied this call (${decision.reason}). Do not retry; explain the denial to the user or try a different approach.`;
+  }
+
+  return message;
+}
+
+/** Explanation used when the policy could not be evaluated. */
+export function unavailableReason(): string {
+  return "Arcjet security check could not be completed; please retry later.";
+}
+
+/**
+ * Backoff hint returned to the model when the guard is unavailable.
+ *
+ * A rate-limit denial derives its hint from the denying rule's
+ * `resetAtUnixSeconds`. This path has nothing to derive from. Five seconds
+ * paces a model's retry loop.
+ */
+export const UNAVAILABLE_RETRY_AFTER_SECONDS: number = 5;
+
+export function denialResult(decision: DecisionDeny): ArcjetDenialResult {
+  const isRateLimit = decision.reason === "RATE_LIMIT";
+  let retryAfterSecs: number | undefined;
+
+  if (isRateLimit) {
+    retryAfterSecs = retryAfterSeconds(decision);
+  }
+
+  const result: ArcjetDenialResult = {
+    arcjetDenied: true,
+    reason: decision.reason,
+    message: deniedReason(decision),
+    retryable: isRateLimit,
+  };
+
+  if (isRateLimit && retryAfterSecs !== undefined) {
+    result.retryAfterSeconds = retryAfterSecs;
+  }
+
+  return result;
+}
+
+export function unavailableResult(): ArcjetDenialResult {
+  return {
+    arcjetDenied: true,
+    reason: "ERROR",
+    message: unavailableReason(),
+    retryable: true,
+    retryAfterSeconds: UNAVAILABLE_RETRY_AFTER_SECONDS,
+  };
+}

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
@@ -477,6 +477,100 @@ test("policy.sessionId is used when runContext.context has none", async () => {
   assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
 });
 
+test("an already-parsed object input is scanned as-is", async () => {
+  const { client } = stubClient(decisionAllow());
+  let scanned: unknown;
+  const tool = createFunctionTool();
+  const wrapped = guardTool<{ note: string }>(client, tool, {
+    action: "note.read",
+    rules: (input) => {
+      scanned = input;
+      return [];
+    },
+  });
+  // The runner always passes `toolCall.arguments` as a JSON string, but a
+  // caller invoking the tool directly may hand over the parsed object.
+  await wrapped.invoke(runContext("t"), { note: "hello" } as unknown as string);
+  assert.deepEqual(scanned, { note: "hello" });
+});
+
+test("a non-string, non-object input is scanned as empty rather than coerced", async () => {
+  const { client } = stubClient(decisionAllow());
+  let scanned: unknown;
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, {
+    action: "note.read",
+    rules: (input) => {
+      scanned = input;
+      return [];
+    },
+  });
+  await wrapped.invoke(runContext("t"), undefined as unknown as string);
+  assert.deepEqual(scanned, {});
+});
+
+test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client } = stubClient(decisionDenyPromptInjection());
+    const tool = createFunctionTool();
+    const wrapped = guardTool(client, tool, {
+      action: "order.looked-up",
+      onDeny: () => {
+        throw new Error("onDeny exploded");
+      },
+    });
+    const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+    assert.equal(result.arcjetDenied, true);
+    assert.ok(warnings.length > 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("policy factory throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client } = stubClient(decisionAllow());
+    const tool = createFunctionTool();
+    const wrapped = guardTool(client, tool, {
+      action: "order.looked-up",
+      rules: () => {
+        throw new Error("rules exploded");
+      },
+    });
+    const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+    assert.equal(result.reason, "ERROR");
+    assert.ok(warnings.length > 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
 test("wraps invoke when the descriptor is non-writable", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   let calls = 0;

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
@@ -509,6 +509,43 @@ test("a non-string, non-object input is scanned as empty rather than coerced", a
   assert.deepEqual(scanned, {});
 });
 
+test("an input shape the runner cannot produce warns instead of silently scanning nothing", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client } = stubClient(decisionAllow());
+    const tool = createFunctionTool();
+    const wrapped = guardTool(client, tool, { action: "note.read" });
+
+    // A JSON string is the runner's shape and must stay quiet, including when
+    // the model produced malformed JSON.
+    await wrapped.invoke(runContext("t"), "not-json");
+    assert.equal(warnings.length, 0);
+
+    await wrapped.invoke(runContext("t"), 12 as unknown as string);
+    assert.equal(warnings.length, 1);
+    assert.match(String(warnings[0]?.[0]), /no arguments were scanned/);
+    assert.equal(warnings[0]?.[2], "number");
+
+    await wrapped.invoke(runContext("t"), null as unknown as string);
+    assert.equal(warnings.length, 2);
+    assert.equal(warnings[1]?.[2], "null");
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
 test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
   const previous = process.env["ARCJET_LOG_LEVEL"];
   process.env["ARCJET_LOG_LEVEL"] = "warn";

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
@@ -1,0 +1,499 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions, typescript/unbound-method -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionDenyRateLimit,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { DecisionDeny } from "../../types.ts";
+import type { ArcjetDenialResult } from "./denial.ts";
+import type { OpenAIAgentsTool } from "./guard-tool.ts";
+import { guardTool } from "./guard-tool.ts";
+
+const HIDDEN = Symbol.for("openai-agents.hidden");
+
+function createFunctionTool(overrides?: {
+  name?: string;
+  invoke?: (runContext: unknown, input: string, details?: unknown) => Promise<unknown>;
+  execute?: (args: unknown, runContext?: unknown, details?: unknown) => Promise<unknown>;
+}): OpenAIAgentsTool & {
+  execute?: (args: unknown, runContext?: unknown, details?: unknown) => Promise<unknown>;
+} {
+  const execute = overrides?.execute ?? (async () => ({ ok: true }));
+  const invoke =
+    overrides?.invoke ??
+    (async (_runContext: unknown, input: string, details?: unknown) => {
+      let args: unknown = {};
+      try {
+        args = JSON.parse(input) as unknown;
+      } catch {
+        args = {};
+      }
+      return execute(args, _runContext, details);
+    });
+  const tool: OpenAIAgentsTool & { execute?: typeof execute } = {
+    name: overrides?.name ?? "test-tool",
+    description: "test tool",
+    type: "function",
+    invoke,
+    execute,
+  };
+  Object.defineProperty(tool, HIDDEN, {
+    value: "keep-me",
+    enumerable: false,
+    configurable: true,
+  });
+  return tool;
+}
+
+function runContext(sessionId: string) {
+  return { context: { sessionId } };
+}
+
+function asToolResult(value: unknown): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(value);
+}
+
+test("throws when the tool has no invoke", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = { name: "no-invoke", description: "x" };
+  assert.throws(
+    () => guardTool(client, tool as OpenAIAgentsTool, { action: "test.executed" }),
+    /invoke/,
+  );
+});
+
+test("returned object is not the input tool and preserves non-enumerable markers", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "test.executed" });
+
+  assert.notStrictEqual(wrapped, tool);
+  assert.equal((wrapped as any)[HIDDEN], "keep-me");
+});
+
+test("input tool.invoke is unchanged after wrapping", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const originalInvoke = tool.invoke;
+  guardTool(client, tool, { action: "test.executed" });
+  assert.strictEqual(tool.invoke, originalInvoke);
+});
+
+test("ALLOW → invoke called once with runContext, input, and details by reference", async () => {
+  const { client } = stubClient(decisionAllow());
+  const ctx = runContext("sess-1");
+  const details = { toolCall: { callId: "call-opaque" } };
+  const input = JSON.stringify({ orderNumber: "A-1" });
+  let calls = 0;
+  let capturedCtx: unknown;
+  let capturedInput: unknown;
+  let capturedDetails: unknown;
+
+  const tool = createFunctionTool({
+    invoke: async (runCtx, inp, det) => {
+      calls += 1;
+      capturedCtx = runCtx;
+      capturedInput = inp;
+      capturedDetails = det;
+      return { status: "shipped" };
+    },
+  });
+
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = await wrapped.invoke(ctx, input, details);
+
+  assert.equal(calls, 1);
+  assert.strictEqual(capturedCtx, ctx);
+  assert.strictEqual(capturedInput, input);
+  assert.strictEqual(capturedDetails, details);
+  assert.deepEqual(result, { status: "shipped" });
+});
+
+test("ALLOW → rules see parsed args, not the opaque call id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let captured: unknown;
+  const tool = createFunctionTool({
+    execute: async (args) => {
+      captured = args;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool<{ note: string }>(client, tool, {
+    action: "note.read",
+    rules: (input) => {
+      assert.equal(input.note, "hello");
+      return [fakeRule];
+    },
+  });
+  await wrapped.invoke(runContext("t"), JSON.stringify({ note: "hello" }), {
+    toolCall: { callId: "call-opaque" },
+  });
+  assert.deepEqual(captured, { note: "hello" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("ALLOW → capture outcome is success and correlation comes from context.sessionId", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.invoke(runContext("sess-99"), "{}");
+
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-99");
+  assert.equal(captureCalls.length, 1);
+  assert.equal(
+    recorded(captureCalls[0])["metadata"] &&
+      (recorded(captureCalls[0])["metadata"] as Record<string, unknown>)["outcome"],
+    "success",
+  );
+});
+
+test("DENY → execute is not called and a structured denial is returned (no throw)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+  assert.equal(result.retryable, false);
+});
+
+test("RATE_LIMIT DENY → structured result is retryable", async () => {
+  const resetAt = Math.floor(Date.now() / 1000) + 12;
+  const { client } = stubClient(decisionDenyRateLimit(resetAt));
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+
+  assert.equal(result.retryable, true);
+  assert.ok(typeof result.retryAfterSeconds === "number");
+});
+
+test("fail-closed unavailable → ERROR denial, execute not called", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("onGuardError allow → execute still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+  });
+  const result = await wrapped.invoke(runContext("t"), "{}");
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("does not mint a correlation id when the run provided none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.invoke({ context: {} }, "{}");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("DENY + throwing onDeny still denies and does not throw", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      throw new Error("onDeny exploded");
+    },
+  });
+
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("onDeny reshape is returned and execute is not called", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let received: DecisionDeny | undefined;
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: (decision) => {
+      received = decision;
+      return { blocked: decision.reason };
+    },
+  });
+
+  const result = await wrapped.invoke(runContext("t"), "{}");
+  assert.equal(received?.reason, "PROMPT_INJECTION");
+  assert.deepEqual(result, { blocked: "PROMPT_INJECTION" });
+});
+
+test("onDeny is not called on unavailable", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let onDenyCalls = 0;
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      onDenyCalls += 1;
+      return { blocked: true };
+    },
+  });
+
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(onDenyCalls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("guard throw with default fail-closed does not execute", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("omitted rules still submit an empty guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.invoke(runContext("t"), "{}");
+  assert.deepEqual(recorded(guardCalls[0])["rules"], []);
+});
+
+test("metadata callback is merged over derived context", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool<{ id: string }>(client, tool, {
+    action: "thing.read",
+    metadata: (input) => ({ "app.item": input.id }),
+  });
+  await wrapped.invoke(runContext("sess-meta"), JSON.stringify({ id: "item-9" }));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.item"], "item-9");
+  assert.equal(metadata["openai-agents.tool"], "test-tool");
+  assert.equal(metadata["openai-agents.session"], "sess-meta");
+});
+
+test("static metadata is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool({ name: "" });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: { "app.static": "yes" },
+  });
+  await wrapped.invoke(runContext("t"), "{}");
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.static"], "yes");
+  assert.equal("openai-agents.tool" in metadata, false);
+});
+
+test("rejects a second wrap", async () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  assert.equal(arcjetProtectedTool in wrapped, true);
+  assert.throws(() => guardTool(client, wrapped, { action: "order.looked-up" }), /already guarded/);
+
+  const branded = createFunctionTool();
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  assert.throws(() => guardTool(client, branded, { action: "order.looked-up" }), /already guarded/);
+});
+
+test("execute throw is rethrown after capture", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool({
+    execute: async (): Promise<{ ok: boolean }> => {
+      throw new Error("tool failed");
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await assert.rejects(async () => wrapped.invoke(runContext("t"), "{}"), /tool failed/);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "error");
+});
+
+test("non-object runContext does not mint an id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.invoke("not-context", "{}");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("rules factory throw fail-closes and does not execute", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("metadata factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    metadata: () => {
+      throw new Error("metadata exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("sessionId factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: () => {
+      throw new Error("sessionId exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("rules factory throw with onGuardError allow still executes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await wrapped.invoke(runContext("t"), "{}");
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("malformed JSON args are not treated as free text and do not scan a call id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let scanned: unknown;
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: (input) => {
+      scanned = input;
+      return [];
+    },
+  });
+  await wrapped.invoke(runContext("t"), "not-json", {
+    toolCall: { callId: "call-9" },
+  });
+  assert.deepEqual(scanned, {});
+  assert.deepEqual(recorded(guardCalls[0])["rules"], []);
+});
+
+test("policy.sessionId is used when runContext.context has none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: "policy-sess",
+  });
+  await wrapped.invoke({ context: {} }, "{}");
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("wraps invoke when the descriptor is non-writable", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  Object.defineProperty(tool, "invoke", {
+    value: tool.invoke,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+});

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.ts
@@ -1,0 +1,293 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { openaiAgentsContext } from "./context.ts";
+import type { OpenAIAgentsContextSource } from "./context.ts";
+import { denialResult, unavailableResult } from "./denial.ts";
+
+/**
+ * Structural `tool()` / `FunctionTool`. Declared here so `guardTool` does
+ * not value-import `@openai/agents`.
+ *
+ * After `tool({ execute })` the authored `execute` is closed over inside
+ * `invoke`. The runner (`toolExecution.ts`) calls `invoke(runContext,
+ * argumentsJson, details)` — there is no `execute` on the returned object
+ * and no ToolNode. `invoke` is declared with method syntax so a real
+ * `FunctionTool` (whose `invoke` is a property typed against `RunContext`)
+ * is assignable under `strictFunctionTypes`.
+ */
+export interface OpenAIAgentsTool {
+  name: string;
+  description?: string;
+  type?: string;
+  invoke(runContext: unknown, input: string, details?: unknown): unknown;
+}
+
+/**
+ * Policy for `guardTool()` — how to guard an authored `tool({ execute })`.
+ *
+ * Specifies the guard action name, optional rules to evaluate, metadata
+ * context, and optional denial handler. Rules can be static or computed
+ * from the tool's parsed free-text args. Do not scan opaque call ids.
+ */
+export interface GuardToolPolicy<TInput> {
+  /** Guard label and capture action: `"resource.verb"`, past tense. */
+  action: string;
+  /**
+   * Rules to evaluate, static or computed from the tool's parsed args.
+   * Omitting this, or returning `[]`, submits no rules — it does not skip
+   * the guard call, which still costs a round trip and returns a decision.
+   */
+  rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /** Metadata merged over the context's (object, or per-call function of the tool input). */
+  metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
+  /**
+   * Fallback session id when `runContext.context` does not carry one.
+   * Prefer putting the id you already chose on `run(..., { context })`.
+   * Never mint a new id here. Never pass `session.getSessionId()` as a
+   * factory that would run against a MemorySession constructed without
+   * `sessionId` — that class mints a UUID.
+   */
+  sessionId?: string | ((input: TInput) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload the model sees for a real DENY decision.
+   * The value is returned from `invoke` as-is, which is what `execute`
+   * already does; the runner stringifies it onto a `function_call_result`.
+   * Unavailable guards take the `onUnavailable` path instead and return
+   * the fixed `{ reason: "ERROR", retryable: true, retryAfterSeconds: 5 }`
+   * result; this callback does not fire for outages.
+   *
+   * **Warning:** A tool created with `outputSchema` validates `execute`'s
+   * return. This wrapper returns from `invoke` (after `tool()` closed over
+   * `execute`), so a default denial is not schema-checked. Prefer omitting
+   * `outputSchema` on guarded tools, or verify the schema accepts
+   * `ArcjetDenialResult` / your `onDeny` shape.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+function isContextSource(value: unknown): value is OpenAIAgentsContextSource {
+  return value !== null && typeof value === "object";
+}
+
+/**
+ * The model-produced arguments. The runner invokes with
+ * `toolCall.arguments` (a JSON string). Scan the parsed args, not
+ * `details.toolCall.callId`.
+ */
+function toolArgs(input: unknown): unknown {
+  if (typeof input === "string") {
+    try {
+      return JSON.parse(input) as unknown;
+    } catch {
+      return {};
+    }
+  }
+  if (input !== null && typeof input === "object") {
+    return input;
+  }
+  return {};
+}
+
+function resolveSessionId<TInput>(
+  policy: GuardToolPolicy<TInput>,
+  input: TInput,
+): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(input);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+/**
+ * Wraps a `tool()` / `FunctionTool` so the closed-over `execute` never
+ * runs on DENY.
+ *
+ * After `tool({ execute })` the runner calls `invoke`, not `execute`.
+ * This helper replaces `invoke` (via `Object.defineProperty`, so a
+ * non-writable descriptor still gets the wrap) and always runs `guard()`
+ * before the original `invoke`. On DENY the original `invoke` — and
+ * therefore `execute` — never runs. The model receives an
+ * `ArcjetDenialResult` (or the result of `policy.onDeny`). This helper
+ * does not throw on DENY: a throw would hit the SDK `errorFunction`
+ * (generic string, or `ToolCallError` when `outputSchema` /
+ * `errorFunction: null`).
+ *
+ * Guard API errors depend on `policy.onGuardError` (defaults to `"deny"`):
+ * - `"deny"` (default): `execute` does not run; the model receives an
+ *   `ArcjetDenialResult` with `reason: "ERROR"`.
+ * - `"allow"`: `execute` still runs, with a warning gated on
+ *   `ARCJET_LOG_LEVEL`.
+ *
+ * Correlation is read from `runContext.context` (and documented copies
+ * on the envelope). No id is minted. `session.getSessionId()` is never
+ * called.
+ *
+ * Hosted tools, MCP (`mcpToFunctionTool`), handoffs, `agent.asTool()`,
+ * and computer / shell / apply_patch are not on this path. Do not also
+ * wrap the same tool with `@arcjet/guard/vercel-ai/v7`. The shared
+ * `arcjetProtectedTool` brand throws on a second `guardTool` wrap.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardTool } from "@arcjet/guard/openai-agents/v0";
+ * import { tool } from "@openai/agents";
+ * import { z } from "zod";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * export const lookupOrder = guardTool(
+ *   arcjet,
+ *   tool({
+ *     name: "lookup_order",
+ *     description: "Look up an order by number",
+ *     parameters: z.object({ orderNumber: z.string() }),
+ *     execute: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *   }),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input: { orderNumber: string }) => [
+ *       lookupLimit({ key: input.orderNumber, requested: 1 }),
+ *     ],
+ *   },
+ * );
+ * ```
+ */
+export function guardTool<TInput = unknown, TTool extends OpenAIAgentsTool = OpenAIAgentsTool>(
+  client: ArcjetAgentClient,
+  tool: TTool,
+  policy: GuardToolPolicy<TInput>,
+): TTool {
+  // oxlint-disable-next-line typescript/unbound-method -- read to be bound to `tool` immediately below, which is the point
+  if (typeof tool.invoke !== "function") {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error(
+      "@arcjet/guard: guardTool() requires a FunctionTool from tool() (invoke). Pass the result of tool({ execute }), not the options object.",
+    );
+  }
+  if (arcjetProtectedTool in tool) {
+    throw new Error(
+      "@arcjet/guard: guardTool() cannot wrap a tool that is already guarded; do not double-wrap with @arcjet/guard/openai-agents/v0 or @arcjet/guard/vercel-ai/v7",
+    );
+  }
+
+  const originalInvoke = tool.invoke.bind(tool);
+
+  // Preserve own descriptors (needsApproval, inputGuardrails, …). Those
+  // surfaces are not policy gates and are copied, not wrapped.
+  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
+  const proto = Object.getPrototypeOf(tool) as object | null;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
+  const wrapped = Object.defineProperties(
+    Object.create(proto),
+    Object.getOwnPropertyDescriptors(tool),
+  ) as TTool;
+
+  const newInvoke = (runContext: unknown, input: string, details?: unknown): Promise<unknown> =>
+    runGuardedTool(client, tool, policy, runContext, input, () =>
+      Promise.resolve(originalInvoke(runContext, input, details)),
+    );
+
+  Object.defineProperty(wrapped, "invoke", {
+    value: newInvoke,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(wrapped, arcjetProtectedTool, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return wrapped;
+}
+
+function runGuardedTool<TInput>(
+  client: ArcjetAgentClient,
+  tool: OpenAIAgentsTool,
+  policy: GuardToolPolicy<TInput>,
+  runContext: unknown,
+  input: unknown,
+  execute: () => Promise<unknown>,
+): Promise<unknown> {
+  const args = toolArgs(input);
+
+  let sessionId: string | undefined;
+  let rules: RuleWithInput[] | undefined;
+  let policyMetadata: ArcjetMetadata | undefined;
+  try {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
+    const typedArgs = args as TInput;
+    sessionId = resolveSessionId(policy, typedArgs);
+    rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
+    policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+  } catch (error) {
+    if (shouldWarn()) {
+      console.warn(
+        '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+        policy.action,
+        error,
+      );
+    }
+    if (policy.onGuardError === "allow") {
+      return execute();
+    }
+    return Promise.resolve(unavailableResult());
+  }
+
+  const source = isContextSource(runContext) ? runContext : undefined;
+  const agentCtx = openaiAgentsContext(source, sessionId === undefined ? undefined : { sessionId });
+
+  const metadata: ArcjetMetadata = {
+    ...agentCtx.metadata,
+    ...(typeof tool.name === "string" &&
+      tool.name.length > 0 && {
+        "openai-agents.tool": tool.name,
+      }),
+  };
+  const mergedMetadata = { ...metadata, ...policyMetadata };
+
+  return runGuarded<unknown>(client, {
+    action: policy.action,
+    rules,
+    correlationId: agentCtx.correlationId,
+    metadata: mergedMetadata,
+    onDeny: (decision: DecisionDeny) => {
+      if (policy.onDeny === undefined) {
+        return denialResult(decision);
+      }
+      try {
+        return policy.onDeny(decision);
+      } catch (error) {
+        if (shouldWarn()) {
+          console.warn(
+            '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+            policy.action,
+            error,
+          );
+        }
+        return denialResult(decision);
+      }
+    },
+    onUnavailable: () => unavailableResult(),
+    execute,
+    onGuardError: policy.onGuardError ?? "deny",
+  });
+}

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.ts
@@ -84,9 +84,10 @@ function isContextSource(value: unknown): value is OpenAIAgentsContextSource {
  * `parameters: undefined` at construction even though the type admits it — so
  * a parse failure means malformed model output, not a free-text tool whose
  * arguments were dropped. Rules see `{}` for it, and the original `invoke`
- * then raises the SDK's own invalid-input failure.
+ * then raises the SDK's own invalid-input failure. Anything that is neither a
+ * string nor an object cannot come from the runner at all, so it warns.
  */
-function toolArgs(input: unknown): unknown {
+function toolArgs(input: unknown, action: string): unknown {
   if (typeof input === "string") {
     try {
       return JSON.parse(input) as unknown;
@@ -96,6 +97,16 @@ function toolArgs(input: unknown): unknown {
   }
   if (input !== null && typeof input === "object") {
     return input;
+  }
+  // The runner never invokes with this shape, so it means a caller invoked the
+  // tool directly with something unexpected. Rules would silently see `{}` and
+  // scan nothing, which is worth saying out loud.
+  if (shouldWarn()) {
+    console.warn(
+      '@arcjet/guard: guardTool() for "%s" was invoked with a %s input; expected the JSON string the runner passes, so no arguments were scanned.',
+      action,
+      input === null ? "null" : typeof input,
+    );
   }
   return {};
 }
@@ -215,6 +226,13 @@ export function guardTool<TInput = unknown, TTool extends OpenAIAgentsTool = Ope
       Promise.resolve(originalInvoke(runContext, input, details)),
     );
 
+  // Writable and configurable, matching the descriptors `tool()` produces for
+  // its own object literal, so a spy or tracing wrapper can still re-wrap
+  // `invoke` and `Object.defineProperties` copies of the guarded tool keep
+  // working. Freezing these (and the brand below) would not buy protection:
+  // anything holding a reference in this process already closed over the
+  // unguarded original, so the brand is a double-wrap guard rather than a
+  // security boundary. Do not tighten it without replacing the guarantee.
   Object.defineProperty(wrapped, "invoke", {
     value: newInvoke,
     writable: true,
@@ -239,7 +257,7 @@ function runGuardedTool<TInput>(
   input: unknown,
   execute: () => Promise<unknown>,
 ): Promise<unknown> {
-  const args = toolArgs(input);
+  const args = toolArgs(input, policy.action);
 
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.ts
@@ -63,10 +63,10 @@ export interface GuardToolPolicy<TInput> {
    * result; this callback does not fire for outages.
    *
    * **Warning:** A tool created with `outputSchema` validates `execute`'s
-   * return. This wrapper returns from `invoke` (after `tool()` closed over
-   * `execute`), so a default denial is not schema-checked. Prefer omitting
-   * `outputSchema` on guarded tools, or verify the schema accepts
-   * `ArcjetDenialResult` / your `onDeny` shape.
+   * return. That validation lives inside the `invoke` this wrapper replaces,
+   * so a denial is not schema-checked. Prefer omitting `outputSchema` on
+   * guarded tools, or verify the schema accepts `ArcjetDenialResult` / your
+   * `onDeny` shape.
    */
   onDeny?: (decision: DecisionDeny) => unknown;
 }
@@ -79,6 +79,12 @@ function isContextSource(value: unknown): value is OpenAIAgentsContextSource {
  * The model-produced arguments. The runner invokes with
  * `toolCall.arguments` (a JSON string). Scan the parsed args, not
  * `details.toolCall.callId`.
+ *
+ * Every tool from `tool()` has an object parameter schema — `tool()` rejects
+ * `parameters: undefined` at construction even though the type admits it — so
+ * a parse failure means malformed model output, not a free-text tool whose
+ * arguments were dropped. Rules see `{}` for it, and the original `invoke`
+ * then raises the SDK's own invalid-input failure.
  */
 function toolArgs(input: unknown): unknown {
   if (typeof input === "string") {
@@ -130,6 +136,13 @@ function resolveSessionId<TInput>(
  * Correlation is read from `runContext.context` (and documented copies
  * on the envelope). No id is minted. `session.getSessionId()` is never
  * called.
+ *
+ * The runner treats whatever this returns as the tool's output, so two
+ * per-tool options see a denial as they would any other result: a
+ * `timeoutMs` race covers the guard round trip as well as `execute`, and
+ * `outputGuardrails` / `customDataExtractor` receive the denial object.
+ * Keep `timeoutMs` wide enough for a guard call, and do not assume your own
+ * output shape in those callbacks.
  *
  * Hosted tools, MCP (`mcpToFunctionTool`), handoffs, `agent.asTool()`,
  * and computer / shell / apply_patch are not on this path. Do not also

--- a/arcjet-guard/src/openai-agents/v0/index.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/index.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import {
+  EXPECTED_CONDITIONS,
+  EXPECTED_ROOT_KEYS,
+  sortedKeys,
+} from "../../../test/_shared/source-scan.ts";
+import * as agentsBarrel from "../../agents/index.ts";
+import * as v7Namespace from "../../vercel-ai/v7/index.ts";
+import * as openaiAgentsNamespace from "./index.ts";
+import type { ArcjetDenialResult, GuardToolPolicy, OpenAIAgentsAgentContext } from "./index.ts";
+
+function verifyTypeExports(): void {
+  const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
+  const denialResult: ArcjetDenialResult | undefined = undefined;
+  const agentContext: OpenAIAgentsAgentContext | undefined = undefined;
+  void [toolPolicy, denialResult, agentContext];
+}
+
+verifyTypeExports();
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("exports the two own helpers as functions", () => {
+  const ownExports = ["openaiAgentsContext", "guardTool"] as const;
+
+  for (const funcName of ownExports) {
+    const func = (openaiAgentsNamespace as Record<string, unknown>)[funcName];
+    assert.equal(
+      typeof func,
+      "function",
+      `@arcjet/guard/openai-agents/v0 must export ${funcName} as a function`,
+    );
+  }
+});
+
+test("openai-agents namespace exports the agnostic helpers", () => {
+  const requiredSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+  ] as const;
+
+  for (const symbol of requiredSymbols) {
+    const value = (openaiAgentsNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/openai-agents/v0 must export ${symbol}`);
+  }
+});
+
+test("agnostic exports have same identity across OpenAI Agents and v7 namespaces", () => {
+  const agnosticSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+    "ArcjetGuardUnavailableError",
+  ] as const;
+
+  for (const symbol of agnosticSymbols) {
+    const openaiAgentsValue = (openaiAgentsNamespace as Record<string, unknown>)[symbol];
+    const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
+
+    assert.strictEqual(
+      openaiAgentsValue,
+      v7Value,
+      `${symbol} must be the same object identity from both @arcjet/guard/openai-agents/v0 and @arcjet/guard/vercel-ai/v7`,
+    );
+  }
+});
+
+test("OpenAI Agents namespace is a strict superset of the agents barrel with same identity", () => {
+  const openaiAgentsKeys = Object.keys(openaiAgentsNamespace);
+  const agentKeys = Object.keys(agentsBarrel);
+
+  for (const key of agentKeys) {
+    assert.ok(
+      openaiAgentsKeys.includes(key),
+      `agents barrel key "${key}" must be present in openai-agents namespace`,
+    );
+    assert.strictEqual(
+      (openaiAgentsNamespace as Record<string, unknown>)[key],
+      (agentsBarrel as Record<string, unknown>)[key],
+      `${key} must be the same object identity from both imports`,
+    );
+  }
+
+  const expectedAdditions = 2;
+  assert.equal(
+    openaiAgentsKeys.length,
+    agentKeys.length + expectedAdditions,
+    `openai-agents namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+  );
+
+  const openaiAgentsOnlyKeys = openaiAgentsKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["guardTool", "openaiAgentsContext"];
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const expectedOwnExports: readonly string[] = ownExportsArray.sort();
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const sorted: readonly string[] = openaiAgentsOnlyKeys.sort();
+  assert.deepEqual(sorted, expectedOwnExports);
+});
+
+test("export map has no unversioned ./openai-agents and no wildcard subpaths", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap, "package.json must have an exports field");
+
+  const exportKeys = Object.keys(exportsMap);
+
+  assert.ok(!exportKeys.includes("./openai-agents"), 'export map must not have "./openai-agents"');
+  assert.ok(exportKeys.includes("./openai-agents/v0"), 'export map must have "./openai-agents/v0"');
+
+  for (const key of exportKeys) {
+    if (key.startsWith("./openai-agents/")) {
+      assert.equal(
+        key,
+        "./openai-agents/v0",
+        `export map must not have wildcard openai-agents subpaths; found "${key}"`,
+      );
+    }
+  }
+});
+
+test("does not export Eve / Mastra / Claude / LangGraph-only APIs", () => {
+  const forbidden = [
+    "eveAgentContext",
+    "mastraAgentContext",
+    "claudeAgentContext",
+    "langgraphAgentContext",
+    "guardInbound",
+    "guardApproval",
+    "guardInterrupt",
+    "guardHooks",
+    "guardToolNode",
+    "guardProcessor",
+    "arcjetHooks",
+    "guardConnection",
+    "guardCanUseTool",
+  ];
+  for (const key of forbidden) {
+    assert.equal(
+      (openaiAgentsNamespace as Record<string, unknown>)[key],
+      undefined,
+      `openai-agents namespace must not export "${key}"`,
+    );
+  }
+});
+
+test("export map must not have ./agents", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap);
+  assert.ok(!Object.keys(exportsMap).includes("./agents"));
+});
+
+test("root export map keys and runtime conditions are correct", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+  const exportsMap = objectField(packageJson, "exports");
+  assert.ok(exportsMap);
+
+  assert.deepEqual(sortedKeys(exportsMap), EXPECTED_ROOT_KEYS);
+
+  const rootEntry = objectField(exportsMap, ".");
+  assert.ok(rootEntry);
+  assert.deepEqual(sortedKeys(rootEntry), EXPECTED_CONDITIONS);
+});

--- a/arcjet-guard/src/openai-agents/v0/index.ts
+++ b/arcjet-guard/src/openai-agents/v0/index.ts
@@ -1,0 +1,117 @@
+/**
+ * @packageDocumentation
+ *
+ * OpenAI Agents namespace for Arcjet Guards.
+ *
+ * This module provides OpenAI Agents helpers plus the framework-agnostic
+ * layer they build on, so an OpenAI Agents app needs one import path and
+ * no notion of layering.
+ *
+ * **Requires the optional peer dependency `@openai/agents`
+ * (`>=0.17.0 <1`)**. Nothing in this module imports that package at
+ * runtime: every OpenAI Agents type arrives through `import type`, so
+ * installing `@arcjet/guard` never pulls it in. Zod is their peer, not
+ * ours.
+ *
+ * **Note:** the version segment is `v0` because `@openai/agents` is
+ * pre-1.0. There is deliberately no unversioned
+ * `@arcjet/guard/openai-agents` alias. A `v1` namespace is added when the
+ * SDK reaches 1.0; the segment names the SDK's major, not this
+ * integration's iteration. 0.x minors can break.
+ *
+ * v0 is text `Agent` + `run()` / `Runner` + authored `tool()`. Not
+ * Realtime, not Sandbox, not hosted tools, not computer / shell /
+ * apply_patch, not MCP, not `agent.asTool()`.
+ *
+ * Two surfaces, and the things this namespace does not build:
+ *
+ * - **An authored tool** (`tool({ execute })`) → `guardTool()`. After
+ *   `tool()` the object is a `FunctionTool` whose runner-facing method is
+ *   `invoke`. DENY returns a structured `ArcjetDenialResult`; it does not
+ *   throw.
+ * - **Correlation** → `openaiAgentsContext()` reads a field the
+ *   integrator put on `runContext.context` (and documented copies:
+ *   `conversationId`, `groupId`, already-resolved `sessionId`). It never
+ *   mints a new id. It never calls `session.getSessionId()` —
+ *   `MemorySession` mints a UUID when constructed without `sessionId`.
+ *
+ * ## Screen inbound before `run()` (SDK `inputGuardrails` are not Arcjet)
+ *
+ * There is no first-class inbound channel, so there is no `guardInbound`.
+ * Put prompt-injection (and other inbound rules) in the application
+ * before `run()`. SDK `inputGuardrails` / `outputGuardrails` /
+ * `defineToolInputGuardrail` / `defineToolOutputGuardrail` are the SDK's
+ * own tripwires, not this policy gate.
+ *
+ * ## `needsApproval` is not a policy gate
+ *
+ * `needsApproval` / `requireApproval` / `onApproval` is human-in-the-loop.
+ * The run pauses; `result.state.approve` / `reject`. Same trap as Mastra
+ * `requireApproval`, Claude `canUseTool`, and LangGraph `interrupt()`.
+ * There is no `guardApproval`.
+ *
+ * ## `tool()` execute is the deny point; hosted, MCP, and handoffs are not
+ *
+ * The runner executes authored function tools in `toolExecution.ts` via
+ * `invoke`. Hosted tools, handoffs, computer / shell / apply_patch, and
+ * MCP (`mcpServers` → `mcpToFunctionTool`) skip that authored-`execute`
+ * path. `agent_tool_start` / `agent_tool_end` are void observe-only
+ * hooks; they are not a deny. There is no `guardHooks` and no
+ * `guardToolNode` (there is no ToolNode).
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardTool, openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
+ * import { Agent, run, tool } from "@openai/agents";
+ * import { z } from "zod";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const lookupOrder = guardTool(
+ *   client,
+ *   tool({
+ *     name: "lookup_order",
+ *     description: "Look up an order",
+ *     parameters: z.object({ orderNumber: z.string() }),
+ *     execute: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *   }),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input: { orderNumber: string }) => [
+ *       lookupLimit({ key: input.orderNumber, requested: 1 }),
+ *     ],
+ *   },
+ * );
+ *
+ * const agent = new Agent({
+ *   name: "support-agent",
+ *   instructions: "Help the user.",
+ *   tools: [lookupOrder],
+ * });
+ *
+ * const appContext = { sessionId: conversationId };
+ * const inbound = detectPromptInjection();
+ * const decision = await client.guard({
+ *   label: "message.received",
+ *   rules: [inbound(userText)],
+ *   ...openaiAgentsContext({ context: appContext, conversationId }),
+ * });
+ * if (decision.conclusion === "DENY") {
+ *   throw new Error("message blocked");
+ * }
+ * await run(agent, userText, { context: appContext });
+ * ```
+ */
+
+export { openaiAgentsContext } from "./context.ts";
+export type { OpenAIAgentsAgentContext, OpenAIAgentsContextSource } from "./context.ts";
+export { guardTool } from "./guard-tool.ts";
+export type { GuardToolPolicy, OpenAIAgentsTool } from "./guard-tool.ts";
+export type { ArcjetDenialResult } from "./denial.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/openai-agents/v0/peer.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/peer.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("@openai/agents is an optional peer and not a dependency", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+
+  const peerDependencies = objectField(packageJson, "peerDependencies");
+  assert.ok(peerDependencies);
+  assert.equal(peerDependencies["@openai/agents"], ">=0.17.0 <1");
+
+  const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
+  assert.ok(peerDependenciesMeta);
+  const openaiAgentsMeta = objectField(peerDependenciesMeta, "@openai/agents");
+  assert.ok(openaiAgentsMeta);
+  assert.equal(openaiAgentsMeta["optional"], true);
+
+  const dependencies = objectField(packageJson, "dependencies");
+  assert.ok(!(dependencies && "@openai/agents" in dependencies));
+
+  const peers = objectField(packageJson, "peerDependencies");
+  assert.ok(!(peers && "zod" in (peers ?? {})));
+});

--- a/arcjet-guard/src/openai-agents/v0/peer.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/peer.test.ts
@@ -36,6 +36,8 @@ test("@openai/agents is an optional peer and not a dependency", () => {
   const dependencies = objectField(packageJson, "dependencies");
   assert.ok(!(dependencies && "@openai/agents" in dependencies));
 
-  const peers = objectField(packageJson, "peerDependencies");
-  assert.ok(!(peers && "zod" in (peers ?? {})));
+  // Zod is the OpenAI Agents peer, not ours: nothing in this namespace types
+  // against it, and adding it would force it on every `@arcjet/guard` user.
+  assert.ok(!("zod" in peerDependencies));
+  assert.ok(!(dependencies && "zod" in dependencies));
 });

--- a/arcjet-guard/src/openai-agents/v0/type-only.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/type-only.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+function isOpenAIAgentsPeer(specifier: string): boolean {
+  return specifier === "@openai/agents" || specifier.startsWith("@openai/agents/");
+}
+
+test("type-only import scanner works on @openai/agents fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of @openai/agents",
+      content: 'import { Agent, run } from "@openai/agents";\nvoid Agent;\nvoid run;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of @openai/agents",
+      content: 'import type { FunctionTool } from "@openai/agents";\nvoid 0;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content: 'import { type FunctionTool, tool } from "@openai/agents";\nvoid tool;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of @openai/agents",
+      content: 'export type { FunctionTool } from "@openai/agents";',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { OpenAI } from "openai";\nvoid OpenAI;',
+      shouldHaveImport: false,
+    },
+    {
+      name: "detects dynamic import of @openai/agents",
+      content: 'const agents = await import("@openai/agents");\nvoid agents;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const peerImports = imports.filter((imp) => isOpenAIAgentsPeer(imp.specifier));
+
+    if (fixture.shouldHaveImport === false) {
+      assert.equal(peerImports.length, 0, `${fixture.name}: should not have openai-agents imports`);
+    } else {
+      assert.equal(
+        peerImports.length,
+        1,
+        `${fixture.name}: should have exactly one openai-agents import`,
+      );
+      assert.equal(
+        peerImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all @openai/agents imports in the openai-agents namespace are type-only", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (isOpenAIAgentsPeer(imp.specifier) && !imp.typeOnly) {
+        errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+      }
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in openai-agents namespace:\n${errors.join("\n")}`,
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-openai-agents-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, 'import { Agent } from "@openai/agents";\nvoid Agent;');
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const peerImports = imports.filter((imp) => isOpenAIAgentsPeer(imp.specifier));
+    assert.equal(peerImports.length, 1);
+    assert.equal(peerImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -295,6 +295,7 @@ export const EXPECTED_ROOT_KEYS = [
   "./langgraph/v1",
   "./mastra/v1",
   "./node",
+  "./openai-agents/v0",
   // The in-memory client for application tests. Deliberately a single entry
   // rather than a runtime-conditional one: it has no transport, so there is
   // nothing for a condition to select.

--- a/arcjet-guard/test/openai-agents/real-run.test.ts
+++ b/arcjet-guard/test/openai-agents/real-run.test.ts
@@ -1,0 +1,176 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unsafe-member-access, typescript/no-unsafe-type-assertion, typescript/require-await, eslint/require-await -- test fixtures built from the real SDK types
+/**
+ * End-to-end behaviour through the real `Runner` / `Agent` / `run()` loop,
+ * driven by the SDK's own `ScriptedModel` so no network is involved.
+ *
+ * `real-tool.test.ts` calls `invoke` directly, which cannot see two things:
+ *
+ * - Whether the runner actually reaches the guarded tool. `guardTool`
+ *   returns a copy, so anything that rebuilt or re-registered tools between
+ *   `new Agent({ tools })` and `executeFunctionToolCalls` would run the
+ *   unguarded original while a direct-invoke test still passed.
+ * - What the model is finally shown. The claim documented on
+ *   `ArcjetDenialResult` — that the denial rides in the payload of a
+ *   `function_call_result` with `status: "completed"`, rather than an error
+ *   envelope — is a property of `getToolCallOutputItem`, not of this
+ *   package. Here it is asserted against the item the next model call
+ *   actually receives.
+ *
+ * This file value-imports the optional peer, so it lives outside
+ * `src/openai-agents/` — that directory is globbed by the openai-agents-absent
+ * CI job and scanned for type-only imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Agent, Runner, tool } from "@openai/agents";
+import { assistantMessage, functionCall, ScriptedModel } from "@openai/agents/testing";
+
+import type { ArcjetDenialResult } from "../../src/openai-agents/v0/denial.ts";
+import { guardTool } from "../../src/openai-agents/v0/guard-tool.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+const parameters = {
+  type: "object" as const,
+  properties: { note: { type: "string" as const } },
+  required: ["note"] as Array<"note">,
+  additionalProperties: false as const,
+};
+
+const CALL_ID = "call-e2e-1";
+
+interface ToolResultItem {
+  type: string;
+  callId?: string;
+  status?: string;
+  output?: { type: string; text: string };
+}
+
+/**
+ * The `function_call_result` the model is shown on its second turn. That is
+ * the only place the denial's model-visible shape is observable.
+ */
+function resultItemFromSecondCall(model: ScriptedModel): ToolResultItem {
+  assert.ok(model.calls.length >= 2, "the runner must call the model again after the tool");
+  const { input } = model.calls[1].request;
+  assert.ok(Array.isArray(input), "the second turn carries history, not a bare string");
+  const items = input as ToolResultItem[];
+  const resultItem = items.find(
+    (item) => item.type === "function_call_result" && item.callId === CALL_ID,
+  );
+  assert.ok(resultItem, "the model must be shown a function_call_result for the tool call");
+  return resultItem;
+}
+
+function scriptedRun(guardedTool: ReturnType<typeof tool>) {
+  const model = new ScriptedModel([
+    [functionCall("lookup_order", { note: "hello" }, { callId: CALL_ID })],
+    [assistantMessage("done")],
+  ]);
+  const agent = new Agent({
+    name: "support-agent",
+    instructions: "Help the user.",
+    tools: [guardedTool],
+  });
+  // A scripted model plus disabled tracing keeps the loop entirely local.
+  const runner = new Runner({ model, tracingDisabled: true });
+  return { model, agent, runner };
+}
+
+test("DENY through the real run() loop: execute never runs and the model sees the denial", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const guarded = guardTool(
+    client,
+    tool({
+      name: "lookup_order",
+      description: "real dependency test tool",
+      parameters,
+      execute: () => {
+        calls += 1;
+        return "must not run";
+      },
+    }),
+    { action: "order.looked-up" },
+  );
+
+  const { model, agent, runner } = scriptedRun(guarded);
+  const result = await runner.run(agent, "look up my order", {
+    context: { sessionId: "sess-e2e" },
+  });
+
+  assert.equal(calls, 0);
+  assert.equal(result.finalOutput, "done");
+
+  const resultItem = resultItemFromSecondCall(model);
+  // Not an error envelope: the tool did not throw, so `errorFunction` was
+  // never involved and the item completed normally.
+  assert.equal(resultItem.status, "completed");
+  assert.equal(resultItem.output?.type, "text");
+
+  const denial = JSON.parse(resultItem.output?.text ?? "") as ArcjetDenialResult;
+  assert.equal(denial.arcjetDenied, true);
+  assert.equal(denial.reason, "PROMPT_INJECTION");
+  assert.equal(denial.retryable, false);
+  assert.match(denial.message, /Do not retry/);
+});
+
+test("ALLOW through the real run() loop: execute runs and its own output reaches the model", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const guarded = guardTool(
+    client,
+    tool({
+      name: "lookup_order",
+      description: "real dependency test tool",
+      parameters,
+      execute: (input) => {
+        calls += 1;
+        const { note } = input as { note: string };
+        return `ran:${note}`;
+      },
+    }),
+    { action: "order.looked-up" },
+  );
+
+  const { model, agent, runner } = scriptedRun(guarded);
+  const result = await runner.run(agent, "look up my order", {
+    context: { sessionId: "sess-e2e" },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.finalOutput, "done");
+  assert.equal(guardCalls.length, 1);
+
+  const resultItem = resultItemFromSecondCall(model);
+  assert.equal(resultItem.status, "completed");
+  assert.equal(resultItem.output?.text, "ran:hello");
+});
+
+test("the runner reaches the guarded copy, not the tool passed to guardTool", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    parameters,
+    execute: () => {
+      calls += 1;
+      return "must not run";
+    },
+  });
+  const guarded = guardTool(client, authored, { action: "order.looked-up" });
+
+  // The unguarded original is still a working tool. Registering the guarded
+  // copy must be what decides whether `execute` runs.
+  assert.notStrictEqual(guarded, authored);
+
+  const { model, agent, runner } = scriptedRun(guarded);
+  await runner.run(agent, "look up my order", { context: { sessionId: "sess-e2e" } });
+
+  assert.equal(calls, 0);
+  const denial = JSON.parse(
+    resultItemFromSecondCall(model).output?.text ?? "",
+  ) as ArcjetDenialResult;
+  assert.equal(denial.arcjetDenied, true);
+});

--- a/arcjet-guard/test/openai-agents/real-tool.test.ts
+++ b/arcjet-guard/test/openai-agents/real-tool.test.ts
@@ -1,0 +1,102 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/no-unsafe-type-assertion, typescript/unbound-method, typescript/require-await, eslint/require-await -- test fixtures built from the real SDK types
+/**
+ * Behaviour against the real `@openai/agents` `tool()` / `FunctionTool`,
+ * rather than hand-written fakes.
+ *
+ * Every assertion here corresponds to a bypass the fakes in
+ * `src/openai-agents/v0/*.test.ts` could not see:
+ *
+ * - `tool({ execute })` closes over `execute` inside `invoke`. The returned
+ *   object has no `execute`. Wrapping a property named `execute` on that
+ *   object would report success in a fake that kept both, while the real
+ *   class ran the unguarded body.
+ * - The runner calls `invoke(runContext, argumentsJson, details)`. A fake
+ *   that invoked `execute` directly never exercises that path.
+ *
+ * This file value-imports the optional peer, so it lives outside
+ * `src/openai-agents/` — that directory is globbed by the openai-agents-absent
+ * CI job and scanned for type-only imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { RunContext, tool } from "@openai/agents";
+
+import type { ArcjetDenialResult } from "../../src/openai-agents/v0/denial.ts";
+import { guardTool } from "../../src/openai-agents/v0/guard-tool.ts";
+import { asDenial, recorded } from "../_shared/source-scan.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+const parameters = {
+  type: "object" as const,
+  properties: { note: { type: "string" as const } },
+  required: ["note"] as Array<"note">,
+  additionalProperties: false as const,
+};
+
+test("real tool() has invoke and no execute; wrapping invoke gates execute", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    parameters,
+    execute: (input) => {
+      calls += 1;
+      const { note } = input as { note: string };
+      return `ran:${note}`;
+    },
+  });
+
+  assert.equal(typeof authored.invoke, "function");
+  assert.equal("execute" in authored, false);
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const result = asDenial<ArcjetDenialResult>(
+    await wrapped.invoke(new RunContext({ sessionId: "sess-1" }), '{"note":"hello"}'),
+  );
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("real tool() ALLOW still reaches execute through invoke", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    parameters,
+    execute: (input) => {
+      calls += 1;
+      const { note } = input as { note: string };
+      return { note, status: "shipped" };
+    },
+  });
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const result = await wrapped.invoke(new RunContext({ sessionId: "sess-real" }), '{"note":"n1"}');
+
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { note: "n1", status: "shipped" });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-real");
+});
+
+test("real tool() DENY does not throw (errorFunction is not the deny path)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    parameters,
+    execute: () => {
+      throw new Error("should not run");
+    },
+  });
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const result = asDenial<ArcjetDenialResult>(
+    await wrapped.invoke(new RunContext({}), '{"note":"x"}'),
+  );
+  assert.equal(result.arcjetDenied, true);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,7 @@
         "@langchain/core": "1.2.8",
         "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.58.0",
+        "@openai/agents": "0.17.0",
         "@types/node": "22.20.1",
         "ai": "7.0.58",
         "eve": "0.39.0",
@@ -206,6 +207,7 @@
         "@langchain/core": ">=1 <2",
         "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
+        "@openai/agents": ">=0.17.0 <1",
         "ai": ">=7 <8",
         "eve": ">=0.34.0 <1"
       },
@@ -223,6 +225,9 @@
           "optional": true
         },
         "@mastra/core": {
+          "optional": true
+        },
+        "@openai/agents": {
           "optional": true
         },
         "ai": {
@@ -3427,6 +3432,26 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
@@ -3745,6 +3770,77 @@
       },
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/@openai/agents": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.17.0.tgz",
+      "integrity": "sha512-yzJ3tfHLO/6um9wsZ5IzEAQDaY7VcDBMxOPq7IgBaJkEPHrGX0vIXWGL0aqyreikHW4OpVmWwCaBBIOxxILXlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.17.0",
+        "@openai/agents-openai": "0.17.0",
+        "@openai/agents-realtime": "0.17.0",
+        "debug": "^4.4.0",
+        "openai": "^7.2.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.17.0.tgz",
+      "integrity": "sha512-lyoF860313ypeKSPRsdmyNK1ypF8/ocShN2EwCcKUpF4VvRWa5AUVKL6VXO/keQMwNPZw5SACAf1siU9uMvUNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "debug": "^4.4.0",
+        "openai": "^7.2.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.17.0.tgz",
+      "integrity": "sha512-pMqXK7YtNI3U9KLAZIt+WzB9AReOWt/kiY8nhc9eXWcIZIpkmrzFd6dQgBpGLKWPfvEfgRCDeIVfHpWoXr7hEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.17.0",
+        "debug": "^4.4.0",
+        "openai": "^7.2.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.17.0.tgz",
+      "integrity": "sha512-spHgDIaWQIOJjwowjBTo0X9Jn3+CGX9fWgsyRUilsQ8SsnNrAre2km6sr8HwFnRiyQC0XpmTccieyfuXmzMfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.17.0",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.21.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -5428,6 +5524,16 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -7794,7 +7900,6 @@
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -11221,6 +11326,40 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/openai": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.5.0.tgz",
+      "integrity": "sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ora": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
@@ -11584,7 +11723,6 @@
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }

--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,13 @@
       "matchPackageNames": ["@langchain/langgraph", "@langchain/core"],
       "automerge": false,
       "allowedVersions": "<2"
+    },
+    {
+      "description": "Never automerge @openai/agents. It is pre-1.0, so a minor release may break. `@arcjet/guard/openai-agents/v0` types against FunctionTool, tool({ execute }), RunContext, and run() / Runner. A green typecheck is necessary but not sufficient. Keep the range below 1.0; openai-agents/v1 is added deliberately, not by a bump. This rule is last in packageRules so it wins over the devDependencies and patch automerge rules above.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@openai/agents"],
+      "automerge": false,
+      "allowedVersions": "<1"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an OpenAI Agents integration for `@arcjet/guard` under the versioned subpath `@arcjet/guard/openai-agents/v0`, alongside the existing `vercel-ai/v7`, `vercel-eve/v0`, `mastra/v1`, `claude-agent-sdk/v0`, and `langgraph/v1` namespaces.

Scope is text `Agent` + `run()` / `Runner` + authored `tool({ execute })`. Not Realtime, not Sandbox, not hosted tools, not computer / shell / apply_patch, not MCP, not `agent.asTool()`.

## What's new

Two helpers: `guardTool` and `openaiAgentsContext`.

```ts
import { detectPromptInjection, launchArcjet, tokenBucket } from "@arcjet/guard";
import { guardTool, openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
import { Agent, run, tool } from "@openai/agents";
import { z } from "zod";

const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
const lookupLimit = tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 10 });

const lookupOrder = guardTool(
  arcjet,
  tool({
    name: "lookup_order",
    description: "Look up an order by number",
    parameters: z.object({ orderNumber: z.string() }),
    execute: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
  }),
  {
    action: "order.looked-up",
    rules: (input: { orderNumber: string }) => [
      lookupLimit({ key: input.orderNumber, requested: 1 }),
    ],
  },
);

const agent = new Agent({
  name: "support-agent",
  instructions: "Help the user.",
  tools: [lookupOrder],
});

// No first-class inbound channel, so screen before run(). The id you put on
// `context` is what openaiAgentsContext reads as the correlation id.
const appContext = { sessionId: conversationId };
const inbound = detectPromptInjection();
const decision = await arcjet.guard({
  label: "message.received",
  rules: [inbound(userText)],
  ...openaiAgentsContext({ context: appContext, conversationId }),
});
if (decision.conclusion === "DENY") {
  throw new Error("message blocked");
}

await run(agent, userText, { context: appContext });
```

## Three decisions worth reviewing

**`guardTool` wraps `invoke`, not `execute`.** After `tool({ execute })` the authored function is closed over inside `invoke` and there is no `execute` on the returned object; the runner calls `invoke` from `toolExecution.ts`. Wrapping a property named `execute` would look correct against a fake that kept both and run the unguarded body against the real thing. The wrapper is installed with `Object.defineProperty` so a non-writable descriptor still gets it, and the tool is copied descriptor-for-descriptor so the input tool is left untouched and SDK internals (including symbol-keyed ones such as the output validator) survive.

**A denial is a plain object, not a throw and not an error envelope.** Throwing would hit the SDK `errorFunction`: a generic model-visible string, or a rethrow when `outputSchema` / `errorFunction: null` is set. Neither is a policy denial the model can inspect. Returning an object is what `execute` already does, so `getToolCallOutputItem` stringifies it onto a `function_call_result` with `status: "completed"` and the denial rides in the payload (`arcjetDenied: true`). Because the runner treats that return as the tool's output, a per-tool `timeoutMs` now races the guard round trip too, and `outputGuardrails` / `customDataExtractor` receive the denial object — both documented on `guardTool`.

**Correlation is read, never minted.** `RunContext` has no session / conversation / thread id of its own, so `openaiAgentsContext` reads a field the integrator put on `runContext.context` (`correlationId`, then `sessionId`, then `conversationId`, then `groupId`), then the documented copies (`conversationId`, `groupId`, an already-resolved `sessionId`). It never reads `traceId`, which the SDK mints when omitted, and never calls `session.getSessionId()`, because `MemorySession` mints a UUID when constructed without one. With nothing valid present the call is left uncorrelated rather than joined to an id nobody has.

## Deliberately absent

No `guardInbound` (screen before `run()`; SDK `inputGuardrails` / `outputGuardrails` / `defineToolInputGuardrail` / `defineToolOutputGuardrail` are the SDK's own tripwires, not this gate). No `guardApproval` (`needsApproval` / `onApproval` is human-in-the-loop — the same trap as Mastra `requireApproval`, Claude `canUseTool`, and LangGraph `interrupt()`). No `guardHooks`: `agent_tool_start` / `agent_tool_end` are void and observe-only, so they cannot deny. No `guardToolNode`, because there is no ToolNode. Hosted tools, handoffs, computer / shell / apply_patch, and MCP (`mcpServers` → `mcpToFunctionTool`, synthesized at list time) all skip the authored-`execute` path and are out of scope for v0.

## Packaging

- `@openai/agents` (`>=0.17.0 <1`) is an **optional** peer plus a devDependency for tests. Zod is their peer, not ours. Nothing in the namespace value-imports the SDK — enforced by a static type-only scan and by a new `Unit tests with openai-agents absent` CI job that runs the namespace's tests with the package deleted from `node_modules`.
- Export map adds `./openai-agents/v0` only. There is deliberately no unversioned `./openai-agents` alias and no wildcard, asserted by a test.
- Renovate never automerges `@openai/agents` and holds it below 1.0; `openai-agents/v1` is added deliberately, not by a bump.
- `package-lock.json` regenerated with the repo's pinned npm 12.

## Docs and skill

README gains a usage section, the three H2s (screen inbound before `run()`; `needsApproval` is not a policy gate; `tool()` execute is the deny point), a peer-install block, and a fail-closed table row. Adds `skills/integrate-arcjet-guard-openai-agents/SKILL.md`. CONTRIBUTING records why this namespace's surfaces differ from the other vendors'. The `openai-agent` example belongs in [`arcjet/examples`](https://github.com/arcjet/examples) (follow-up on https://github.com/arcjet/examples/pull/193), not `examples/` in this repo, per #6217.

## Tests

1148 passing, with the `openai-agents/v0` namespace at 100% line, branch, and function coverage. Unit suites cover context derivation, denial shape, the tool wrapper (deny / allow / unavailable, fail-closed, no-throw on DENY, double-wrap rejection, policy-factory throws failing closed, correlation never minted), the index barrel and export map, the optional-peer configuration, and the type-only import scan.

Two suites use the real dependency and so live outside `src/openai-agents/`, which the absent-peer job globs. `test/openai-agents/real-tool.test.ts` proves against the real `tool()` that there is no `execute` on the result and that wrapping `invoke` gates it. `test/openai-agents/real-run.test.ts` drives a real `Runner` / `Agent` / `run()` with the SDK's own `ScriptedModel`, so it can assert the two things a direct `invoke` call cannot see: that the runner reaches the guarded copy rather than the original, and what the model is finally shown — the denial in the payload of a `function_call_result` with `status: "completed"`. Reverting the wrapper fails all three of its cases.

`assignability.test.ts` asserts a real `FunctionTool` compiles at the call site with no casts. `invoke` is declared with method syntax rather than as a property type for that reason: as a property its parameters are contravariant under `strictFunctionTypes` and every real `FunctionTool` is rejected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-456df488-15eb-43dd-9297-0af365fdcbd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-456df488-15eb-43dd-9297-0af365fdcbd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

