### PR TITLE
fix: default Decide API timeout to 2s for cold starts

### DIFF
--- a/arcjet-astro/src/index.ts
+++ b/arcjet-astro/src/index.ts
@@ -634,7 +634,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number | undefined;
 };

--- a/arcjet-astro/src/internal.ts
+++ b/arcjet-astro/src/internal.ts
@@ -3,7 +3,7 @@ import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 import core from "arcjet";
 import type {
@@ -112,7 +112,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -127,7 +127,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions) {
   const url = options?.baseUrl ?? baseUrl(env);
-  const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-bun/src/index.ts
+++ b/arcjet-bun/src/index.ts
@@ -20,7 +20,7 @@ import { readBodyWeb } from "@arcjet/body";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 import type { Server } from "bun";
 import { env } from "bun";
@@ -90,7 +90,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -105,7 +105,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions): ReturnType<typeof createClient> {
   const url = options?.baseUrl ?? baseUrl(env);
-  const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-bun/test/index.test.ts
+++ b/arcjet-bun/test/index.test.ts
@@ -75,6 +75,13 @@ test("`@arcjet/bun`: should expose the public api", async function () {
   ]);
 });
 
+test("`createRemoteClient`: should default timeout to 2 seconds", async function () {
+  const remoteClient = createRemoteClient();
+
+  assert.equal(typeof remoteClient.decide, "function");
+  assert.equal(typeof remoteClient.report, "function");
+});
+
 test("`createRemoteClient`: should create a client", async function () {
   const remoteClient = createRemoteClient({ timeout: 4 });
 

--- a/arcjet-deno/src/index.ts
+++ b/arcjet-deno/src/index.ts
@@ -20,7 +20,7 @@ export type { ProxyService } from "@arcjet/ip";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 
 /** SDK version. Updated by the release process. */
@@ -88,7 +88,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -105,7 +105,7 @@ export function createRemoteClient(options?: RemoteClientOptions): ReturnType<ty
   // We technically build this twice but they happen at startup.
   const env = Deno.env.toObject();
   const url = options?.baseUrl ?? baseUrl(env);
-  const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-deno/test/index.test.ts
+++ b/arcjet-deno/test/index.test.ts
@@ -87,6 +87,13 @@ test("`@arcjet/deno`", async function (t) {
 });
 
 test("`createRemoteClient`", async function (t) {
+  await t.test("should default timeout to 2 seconds", async function () {
+    const remoteClient = createRemoteClient();
+
+    assert.equal(typeof remoteClient.decide, "function");
+    assert.equal(typeof remoteClient.report, "function");
+  });
+
   await t.test("should create a client", async function () {
     const remoteClient = createRemoteClient({ timeout: 4 });
 

--- a/arcjet-fastify/src/index.ts
+++ b/arcjet-fastify/src/index.ts
@@ -5,7 +5,7 @@ import { ArcjetHeaders } from "@arcjet/headers";
 import { type Cidr, findIp, parseProxies, type ProxyService } from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
 // TODO(@wooorm-arcjet): use export maps to hide file extensions and lock down API.
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 import type {
   ArcjetDecision,
@@ -63,7 +63,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -86,7 +86,7 @@ export function createRemoteClient(
     baseUrl,
     sdkStack: "FASTIFY",
     sdkVersion: VERSION,
-    timeout: settings.timeout ?? (isDevelopment(process.env) ? 1000 : 500),
+    timeout: resolveClientTimeout(settings.timeout),
     transport: createTransport(baseUrl),
   });
 }

--- a/arcjet-fastify/test/index.test.ts
+++ b/arcjet-fastify/test/index.test.ts
@@ -68,6 +68,13 @@ test("`@arcjet/fastify`", async function (t) {
 });
 
 test("`createRemoteClient`", async function (t) {
+  await t.test("should default timeout to 2 seconds", async function () {
+    const remoteClient = createRemoteClient();
+
+    assert.equal(typeof remoteClient.decide, "function");
+    assert.equal(typeof remoteClient.report, "function");
+  });
+
   await t.test("`createRemoteClient`: should create a client", async function () {
     const remoteClient = createRemoteClient({ timeout: 4 });
 

--- a/arcjet-nest/src/index.ts
+++ b/arcjet-nest/src/index.ts
@@ -23,7 +23,7 @@ import { readBody } from "@arcjet/body";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 import { Inject, SetMetadata } from "@nestjs/common";
 import type {
@@ -103,7 +103,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -118,7 +118,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions): ReturnType<typeof createClient> {
   const url = options?.baseUrl ?? baseUrl(process.env);
-  const timeout = options?.timeout ?? (isDevelopment(process.env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-next/src/index.ts
+++ b/arcjet-next/src/index.ts
@@ -25,7 +25,7 @@ export type { ProxyService } from "@arcjet/ip";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 
 /** SDK version. Updated by the release process. */
@@ -114,7 +114,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -129,7 +129,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions): ReturnType<typeof createClient> {
   const url = options?.baseUrl ?? baseUrl(process.env);
-  const timeout = options?.timeout ?? (isDevelopment(process.env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-node/src/index.ts
+++ b/arcjet-node/src/index.ts
@@ -20,7 +20,7 @@ import type { Env } from "@arcjet/env";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 
 /** SDK version. Updated by the release process. */
@@ -121,7 +121,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -136,7 +136,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions): ReturnType<typeof createClient> {
   const url = options?.baseUrl ?? baseUrl(env);
-  const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-node/test/index.test.ts
+++ b/arcjet-node/test/index.test.ts
@@ -68,6 +68,13 @@ test("`@arcjet/node`", async function (t) {
 });
 
 test("`createRemoteClient`", async function (t) {
+  await t.test("should default timeout to 2 seconds", async function () {
+    const remoteClient = createRemoteClient();
+
+    assert.equal(typeof remoteClient.decide, "function");
+    assert.equal(typeof remoteClient.report, "function");
+  });
+
   await t.test("should create a client", async function () {
     const remoteClient = createRemoteClient({ timeout: 4 });
 

--- a/arcjet-nuxt/src/internal.ts
+++ b/arcjet-nuxt/src/internal.ts
@@ -3,7 +3,7 @@ import { baseUrl as baseUrlFromEnvironment, isDevelopment, logLevel, platform } 
 import { ArcjetHeaders } from "@arcjet/headers";
 import { type Cidr, findIp, parseProxies, type ProxyService } from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
-import { type Client, createClient } from "@arcjet/protocol/client.js";
+import { type Client, createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 import arcjetCore, {
   type ArcjetAdapterContext,
@@ -224,7 +224,7 @@ export interface RemoteClientOptions {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number | null | undefined;
 }
@@ -381,7 +381,7 @@ export function createRemoteClient(options?: RemoteClientOptions | null | undefi
     baseUrl,
     sdkStack: "NUXT",
     sdkVersion: VERSION,
-    timeout: settings.timeout ?? (isDevelopment(process.env) ? 1000 : 500),
+    timeout: resolveClientTimeout(settings.timeout),
     transport: createTransport(baseUrl),
   });
 }

--- a/arcjet-react-router/src/index.ts
+++ b/arcjet-react-router/src/index.ts
@@ -3,7 +3,7 @@ import { baseUrl as baseUrlFromEnvironment, isDevelopment, logLevel, platform } 
 import { ArcjetHeaders } from "@arcjet/headers";
 import { type Cidr, findIp, parseProxies, type ProxyService } from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
-import { type Client, createClient } from "@arcjet/protocol/client.js";
+import { type Client, createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 import arcjetCore, {
   type ArcjetAdapterContext,
@@ -155,7 +155,7 @@ export interface RemoteClientOptions {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number | null | undefined;
 }
@@ -306,7 +306,7 @@ export function createRemoteClient(options?: RemoteClientOptions | null | undefi
     baseUrl,
     sdkStack: "REACT_ROUTER",
     sdkVersion: VERSION,
-    timeout: settings.timeout ?? (isDevelopment(process.env) ? 1000 : 500),
+    timeout: resolveClientTimeout(settings.timeout),
     transport: createTransport(baseUrl),
   });
 }

--- a/arcjet-react-router/test/index.test.ts
+++ b/arcjet-react-router/test/index.test.ts
@@ -57,6 +57,13 @@ test("@arcjet/react-router", async function (t) {
 });
 
 test("`createRemoteClient`", async function (t) {
+  await t.test("should default timeout to 2 seconds", async function () {
+    const remoteClient = createRemoteClient();
+
+    assert.equal(typeof remoteClient.decide, "function");
+    assert.equal(typeof remoteClient.report, "function");
+  });
+
   await t.test("should create a client", async function () {
     const remoteClient = createRemoteClient({ timeout: 4 });
 

--- a/arcjet-remix/src/index.ts
+++ b/arcjet-remix/src/index.ts
@@ -19,7 +19,7 @@ export type { ProxyService } from "@arcjet/ip";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 
 /** SDK version. Updated by the release process. */
@@ -87,7 +87,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -102,7 +102,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions): ReturnType<typeof createClient> {
   const url = options?.baseUrl ?? baseUrl(process.env);
-  const timeout = options?.timeout ?? (isDevelopment(process.env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/arcjet-sveltekit/src/index.ts
+++ b/arcjet-sveltekit/src/index.ts
@@ -20,7 +20,7 @@ import { env } from "$env/dynamic/private";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
 import { Logger } from "@arcjet/logger";
-import { createClient } from "@arcjet/protocol/client.js";
+import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
 
 /** SDK version. Updated by the release process. */
@@ -88,7 +88,7 @@ export type RemoteClientOptions = {
   /**
    * Timeout in milliseconds for the Decide API (optional).
    *
-   * Defaults to `500` in production and `1000` in development.
+   * Defaults to `2000` (2 seconds) to allow for API cold starts.
    */
   timeout?: number;
 };
@@ -103,7 +103,7 @@ export type RemoteClientOptions = {
  */
 export function createRemoteClient(options?: RemoteClientOptions): ReturnType<typeof createClient> {
   const url = options?.baseUrl ?? baseUrl(env);
-  const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
+  const timeout = resolveClientTimeout(options?.timeout);
 
   // Transport is the HTTP client that the client uses to make requests.
   const transport = createTransport(url);

--- a/protocol/src/client.ts
+++ b/protocol/src/client.ts
@@ -105,6 +105,26 @@ export type ClientOptions = {
 };
 
 /**
+ * Default timeout for Decide API requests, in milliseconds.
+ *
+ * Sized to allow for API cold starts while remaining short enough that a
+ * hung request still fails open quickly.
+ */
+export const DEFAULT_CLIENT_TIMEOUT_MS = 2_000;
+
+/**
+ * Resolve the Decide API timeout.
+ *
+ * @param timeout
+ *   Explicit timeout in milliseconds. `null` and `undefined` use the default.
+ * @returns
+ *   Timeout in milliseconds.
+ */
+export function resolveClientTimeout(timeout?: number | null): number {
+  return timeout ?? DEFAULT_CLIENT_TIMEOUT_MS;
+}
+
+/**
  * Compute the timeout for a `Decide` request based on the configured rules.
  *
  * @internal Exported for testing only.

--- a/protocol/src/client.ts
+++ b/protocol/src/client.ts
@@ -115,8 +115,14 @@ export const DEFAULT_CLIENT_TIMEOUT_MS = 2_000;
 /**
  * Resolve the Decide API timeout.
  *
+ * Any non-nullish value is used as-is, including `0`. A timeout of `0`
+ * expires immediately, so Decide requests fail open. Negative values are
+ * not validated here; callers should pass a positive number of milliseconds
+ * or omit the option to use the default.
+ *
  * @param timeout
- *   Explicit timeout in milliseconds. `null` and `undefined` use the default.
+ *   Explicit timeout in milliseconds. `null` and `undefined` use
+ *   {@link DEFAULT_CLIENT_TIMEOUT_MS}.
  * @returns
  *   Timeout in milliseconds.
  */

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -965,12 +965,17 @@ test("decideTimeout", async (t) => {
     assert.equal(decideTimeout(DEFAULT_CLIENT_TIMEOUT_MS, [{ ...baseRule, type: "EMAIL" }]), 4_000);
   });
 
-  await t.test("should keep the 2s default for prompt injection (already above the 1s floor)", () => {
-    assert.equal(
-      decideTimeout(DEFAULT_CLIENT_TIMEOUT_MS, [{ ...baseRule, type: "PROMPT_INJECTION_DETECTION" }]),
-      2_000,
-    );
-  });
+  await t.test(
+    "should keep the 2s default for prompt injection (already above the 1s floor)",
+    () => {
+      assert.equal(
+        decideTimeout(DEFAULT_CLIENT_TIMEOUT_MS, [
+          { ...baseRule, type: "PROMPT_INJECTION_DETECTION" },
+        ]),
+        2_000,
+      );
+    },
+  );
 
   await t.test("should return the timeout as-is with unrelated rules", () => {
     assert.equal(decideTimeout(500, [{ ...baseRule, type: "RATE_LIMIT" }]), 500);

--- a/protocol/test/client.test.ts
+++ b/protocol/test/client.test.ts
@@ -5,7 +5,13 @@ import type { Cache } from "@arcjet/cache";
 import { create } from "@bufbuild/protobuf";
 import { createRouterTransport } from "@connectrpc/connect";
 
-import { type ClientOptions, createClient, decideTimeout } from "../dist/client.js";
+import {
+  type ClientOptions,
+  createClient,
+  decideTimeout,
+  DEFAULT_CLIENT_TIMEOUT_MS,
+  resolveClientTimeout,
+} from "../dist/client.js";
 import {
   type ArcjetCacheEntry,
   type ArcjetConclusion,
@@ -102,6 +108,33 @@ const exampleDetails = {
   query: "",
 };
 
+test("DEFAULT_CLIENT_TIMEOUT_MS", () => {
+  assert.equal(DEFAULT_CLIENT_TIMEOUT_MS, 2_000);
+});
+
+test("resolveClientTimeout", async (t) => {
+  await t.test("should default to 2 seconds when timeout is omitted", () => {
+    assert.equal(resolveClientTimeout(), 2_000);
+  });
+
+  await t.test("should default to 2 seconds when timeout is undefined", () => {
+    assert.equal(resolveClientTimeout(undefined), 2_000);
+  });
+
+  await t.test("should default to 2 seconds when timeout is null", () => {
+    assert.equal(resolveClientTimeout(null), 2_000);
+  });
+
+  await t.test("should return an explicit timeout", () => {
+    assert.equal(resolveClientTimeout(500), 500);
+    assert.equal(resolveClientTimeout(4), 4);
+  });
+
+  await t.test("should treat 0 as an explicit timeout", () => {
+    assert.equal(resolveClientTimeout(0), 0);
+  });
+});
+
 test("createClient", async (t) => {
   await t.test("should work", () => {
     const client = createClient(exampleClientOptions);
@@ -128,6 +161,33 @@ test("createClient", async (t) => {
             assert.ok(typeof ms === "number");
             assert.ok(ms > 9000);
             assert.ok(ms < 10000);
+            return create(DecideResponseSchema);
+          },
+        });
+      }),
+    });
+
+    await client.decide(exampleContext, exampleDetails, []);
+
+    assert.equal(calls, 1);
+  });
+
+  await t.test("should use the 2s default timeout when resolved", async () => {
+    let calls = 0;
+
+    const client = createClient({
+      ...exampleClientOptions,
+      timeout: resolveClientTimeout(),
+      transport: createRouterTransport(function ({ service }) {
+        service(DecideService, {
+          decide(_, handlerContext) {
+            assert.equal(calls, 0);
+            calls++;
+
+            const ms = handlerContext.timeoutMs();
+            assert.ok(typeof ms === "number");
+            assert.ok(ms > 1_500);
+            assert.ok(ms < 2_100);
             return create(DecideResponseSchema);
           },
         });
@@ -895,6 +955,21 @@ test("decideTimeout", async (t) => {
 
   await t.test("should return the timeout as-is with no rules", () => {
     assert.equal(decideTimeout(500, []), 500);
+  });
+
+  await t.test("should return the 2s default timeout as-is with no rules", () => {
+    assert.equal(decideTimeout(DEFAULT_CLIENT_TIMEOUT_MS, []), 2_000);
+  });
+
+  await t.test("should double the 2s default if there is an email rule", () => {
+    assert.equal(decideTimeout(DEFAULT_CLIENT_TIMEOUT_MS, [{ ...baseRule, type: "EMAIL" }]), 4_000);
+  });
+
+  await t.test("should keep the 2s default for prompt injection (already above the 1s floor)", () => {
+    assert.equal(
+      decideTimeout(DEFAULT_CLIENT_TIMEOUT_MS, [{ ...baseRule, type: "PROMPT_INJECTION_DETECTION" }]),
+      2_000,
+    );
   });
 
   await t.test("should return the timeout as-is with unrelated rules", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Before

Adapter clients used a **500ms** Decide API timeout in production and **1000ms** in development. Short defaults fail during API cold starts, especially for slower rules.

```ts
const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);
```

## After

Every adapter defaults to **2000ms**, matching Guard. A shared `resolveClientTimeout()` in `@arcjet/protocol/client` is the single source of truth. Explicit `timeout` still wins. Email doubling and the prompt-injection 1s floor are unchanged.

```ts
import { resolveClientTimeout } from "@arcjet/protocol/client.js";

const timeout = resolveClientTimeout(options?.timeout); // 2000 unless set
```

## Why

Cold starts on the Decide API can exceed 500–1000ms. A 2s default gives those requests time to complete without changing fail-open behavior for callers who set their own timeout.

## Tests

- `resolveClientTimeout()` defaults, `null`/`undefined`, explicit values, and `0`
- `createClient` uses the resolved 2s timeout on the wire
- `decideTimeout` keeps email doubling (2s → 4s) and the prompt-injection 1s floor
- Adapter `createRemoteClient()` smoke tests with no timeout

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a1e8ac4-6d45-4b50-9d54-b63a227b27ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a1e8ac4-6d45-4b50-9d54-b63a227b27ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

