### PR TITLE
docs(protocol): document ArcjetDecision.ttl as seconds

### DIFF
--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -1238,7 +1238,7 @@ interface ArcjetDecisionInitAbstract {
   results: ArcjetRuleResult[];
 
   /**
-   * Duration in milliseconds this decision should be considered valid.
+   * Duration in seconds this decision should be considered valid.
    */
   ttl: number;
 
@@ -1279,7 +1279,7 @@ export abstract class ArcjetDecision {
   id: string;
 
   /**
-   * Duration in milliseconds this decision should be considered valid, also
+   * Duration in seconds this decision should be considered valid, also
    * known as time-to-live.
    */
   ttl: number;

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -841,6 +841,20 @@ test("convert", async (t) => {
         }),
       );
     });
+
+    await t.test("should pass decision TTL through as seconds, not milliseconds", () => {
+      const proto = ArcjetDecisionToProtocol(
+        new ArcjetDenyDecision({
+          id: "deny-ttl",
+          ip: new ArcjetIpDetails(),
+          reason: new ArcjetReason(),
+          results: [],
+          ttl: 60,
+        }),
+      );
+
+      assert.equal(proto.ttl, 60);
+    });
   });
 
   await t.test("ArcjetDecisionFromProtocol", async (t) => {
@@ -874,6 +888,15 @@ test("convert", async (t) => {
 
       assert.ok(decision instanceof ArcjetDenyDecision);
       assert.equal(decision.conclusion, "DENY");
+    });
+
+    await t.test("should pass protocol TTL through as seconds, not milliseconds", () => {
+      const decision = ArcjetDecisionFromProtocol(
+        create(DecisionSchema, { conclusion: Conclusion.DENY, ttl: 60 }),
+      );
+
+      assert.ok(decision instanceof ArcjetDenyDecision);
+      assert.equal(decision.ttl, 60);
     });
 
     await t.test(

--- a/protocol/test/protocol.test.ts
+++ b/protocol/test/protocol.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  ArcjetAllowDecision,
+  ArcjetDenyDecision,
+  ArcjetReason,
+  ArcjetRuleResult,
+} from "../dist/index.js";
 
 test("@arcjet/protocol", async function (t) {
   await t.test("should expose the public api", async function () {
@@ -42,6 +50,46 @@ test("protocol", async (t) => {
       });
 
       assert.equal(result.isDenied(), false);
+    });
+  });
+
+  await t.test("ArcjetDecision.ttl is in seconds", async (t) => {
+    await t.test("should store a deny TTL of 60 as 60 seconds, not milliseconds", () => {
+      const result = new ArcjetRuleResult({
+        conclusion: "DENY",
+        fingerprint: "fingerprint",
+        reason: new ArcjetReason(),
+        ruleId: "rule-id",
+        state: "RUN",
+        ttl: 60,
+      });
+
+      const decision = new ArcjetDenyDecision({
+        reason: result.reason,
+        results: [result],
+        ttl: result.ttl,
+      });
+
+      assert.equal(result.ttl, 60);
+      assert.equal(decision.ttl, 60);
+      assert.equal(decision.ttl, result.ttl);
+    });
+
+    await t.test("should store an allow TTL of 0 seconds", () => {
+      const decision = new ArcjetAllowDecision({
+        reason: new ArcjetReason(),
+        results: [],
+        ttl: 0,
+      });
+
+      assert.equal(decision.ttl, 0);
+    });
+
+    await t.test("should document decision TTL as seconds in published types", () => {
+      const dts = readFileSync(fileURLToPath(new URL("../dist/index.d.ts", import.meta.url)), "utf8");
+
+      assert.match(dts, /Duration in seconds this decision should be considered valid/);
+      assert.doesNotMatch(dts, /Duration in milliseconds this decision should be considered valid/);
     });
   });
 });

--- a/protocol/test/protocol.test.ts
+++ b/protocol/test/protocol.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-
 import { readFileSync } from "node:fs";
+import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -85,11 +84,17 @@ test("protocol", async (t) => {
       assert.equal(decision.ttl, 0);
     });
 
-    await t.test("should document decision TTL as seconds in published types", () => {
-      const dts = readFileSync(fileURLToPath(new URL("../dist/index.d.ts", import.meta.url)), "utf8");
+    await t.test("should document decision TTL as seconds in source types", () => {
+      const source = readFileSync(
+        fileURLToPath(new URL("../src/index.ts", import.meta.url)),
+        "utf8",
+      );
 
-      assert.match(dts, /Duration in seconds this decision should be considered valid/);
-      assert.doesNotMatch(dts, /Duration in milliseconds this decision should be considered valid/);
+      assert.match(source, /Duration in seconds this decision should be considered valid/);
+      assert.doesNotMatch(
+        source,
+        /Duration in milliseconds this decision should be considered valid/,
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Before

`ArcjetDecision.ttl` was documented as milliseconds:

```ts
/**
 * Duration in milliseconds this decision should be considered valid, also
 * known as time-to-live.
 */
ttl: number;
```

## After

The comments now say **seconds**, matching `ArcjetRuleResult.ttl`, the cache, and the other SDKs:

```ts
/**
 * Duration in seconds this decision should be considered valid, also
 * known as time-to-live.
 */
ttl: number;
```

## Why

This is documentation-only, but the old unit was wrong. Evidence:

- `ArcjetRuleResult.ttl` is already documented as seconds
- Deny decisions copy `result.ttl` straight through (`new ArcjetDenyDecision({ ttl: result.ttl })`)
- `MemoryCache` is seconds-based (`expiresAt = nowInSeconds() + ttl`)
- Local denies use `ttl: 60` (60 seconds), same as Python and Go

Anyone porting between SDKs or writing a custom `Cache` would have cached for 1000× too long.

## Tests

- Decision TTL of `60` is stored as `60` (same unit as the rule result)
- Protocol convert passes TTL through as seconds in both directions
- Source comments in `protocol/src/index.ts` document seconds and no longer say milliseconds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a1e8ac4-6d45-4b50-9d54-b63a227b27ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a1e8ac4-6d45-4b50-9d54-b63a227b27ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

