### PR TITLE
feat!: remove deprecated detectPromptInjection threshold and score

### DIFF
--- a/arcjet-astro/src/index.ts
+++ b/arcjet-astro/src/index.ts
@@ -152,6 +152,8 @@ const validateProtectSignupOptions = z
   })
   .strict();
 
+// `.strict()` rejects leftover `threshold` at config time. The core SDK
+// ignores that deprecated option; Astro users must drop it on upgrade.
 const validateDetectPromptInjectionOptions = z
   .object({
     mode: validateMode.optional(),

--- a/arcjet-astro/src/index.ts
+++ b/arcjet-astro/src/index.ts
@@ -155,7 +155,6 @@ const validateProtectSignupOptions = z
 const validateDetectPromptInjectionOptions = z
   .object({
     mode: validateMode.optional(),
-    threshold: z.number().optional(),
   })
   .strict();
 

--- a/arcjet-astro/test/index.test.ts
+++ b/arcjet-astro/test/index.test.ts
@@ -892,6 +892,48 @@ test("validateEmail", async function (t) {
   });
 });
 
+test("detectPromptInjection", async function (t) {
+  await t.test("should work w/o options", async function () {
+    const rule = detectPromptInjection();
+
+    assert.equal(rule.type, "detectPromptInjection");
+    assert.deepEqual(rule.options, {});
+
+    arcjet({ rules: [rule] });
+  });
+
+  await t.test("should work w/ valid `mode`", async function () {
+    const rule = detectPromptInjection({ mode: "LIVE" });
+
+    assert.equal(rule.type, "detectPromptInjection");
+    assert.deepEqual(rule.options, { mode: "LIVE" });
+
+    arcjet({ rules: [rule] });
+  });
+
+  await t.test("should fail w/ invalid `mode`", async function () {
+    const rule = detectPromptInjection({
+      // @ts-expect-error: test runtime behavior.
+      mode: "INVALID",
+    });
+
+    assert.throws(function () {
+      arcjet({ rules: [rule] });
+    }, /LIVE.*DRY_RUN/);
+  });
+
+  await t.test("should fail w/ removed `threshold`", async function () {
+    const rule = detectPromptInjection({
+      // @ts-expect-error: threshold was removed.
+      threshold: 0.5,
+    });
+
+    assert.throws(function () {
+      arcjet({ rules: [rule] });
+    }, /unrecognized_keys|threshold/);
+  });
+});
+
 test("@arcjet/astro", async function (t) {
   await t.test("should create an integration that injects the configured rules", async function () {
     const rule = filter({

--- a/arcjet/src/index.ts
+++ b/arcjet/src/index.ts
@@ -989,10 +989,7 @@ function validateDetectPromptInjectionOptions(
 ): asserts value is DetectPromptInjectionOptions {
   validateInterface(value, {
     name: "detectPromptInjection",
-    validations: [
-      { key: "mode", required: false, validate: validateMode },
-      { key: "threshold", required: false, validate: validateNumber },
-    ],
+    validations: [{ key: "mode", required: false, validate: validateMode }],
   });
 }
 
@@ -3093,18 +3090,6 @@ export type DetectPromptInjectionOptions = {
    * `"LIVE"` will block requests when prompt injection is detected.
    */
   mode?: ArcjetMode;
-
-  /**
-   * The score threshold above which a request is considered a prompt injection
-   * attempt (default: `0.5`) e.g. anything over `0.5` is malicious.
-   *
-   * Must be in the range (0.0, 1.0) exclusive.
-   *
-   * @deprecated
-   *   This option is no longer respected by the server and will be removed in
-   *   a future release.
-   */
-  threshold?: number;
 };
 
 /**
@@ -3236,20 +3221,11 @@ export function detectPromptInjection(
   const type = "PROMPT_INJECTION_DETECTION";
   const version = 0;
   const mode = options.mode === "LIVE" ? "LIVE" : "DRY_RUN";
-  const threshold = options.threshold ?? 0.5;
-
-  // Validate threshold range: must be in (0.0, 1.0) exclusive
-  if (threshold <= 0.0 || threshold >= 1.0) {
-    throw new Error(
-      "`detectPromptInjection` options error: `threshold` must be between 0.0 and 1.0 (exclusive)",
-    );
-  }
 
   return [
     {
       type,
       version,
-      threshold,
       priority: Priority.DetectPromptInjection,
       mode,
       validate(
@@ -3290,7 +3266,6 @@ export function detectPromptInjection(
           hasher.string("type", type),
           hasher.uint32("version", version),
           hasher.string("mode", mode),
-          hasher.float64("threshold", threshold),
         );
 
         const { fingerprint } = context;
@@ -3317,7 +3292,6 @@ export function detectPromptInjection(
           conclusion: "ALLOW",
           reason: new ArcjetPromptInjectionReason({
             injectionDetected: false,
-            score: 0.0,
           }),
         });
       },

--- a/arcjet/test/detect-prompt-injection.test.ts
+++ b/arcjet/test/detect-prompt-injection.test.ts
@@ -204,27 +204,30 @@ test("detectPromptInjection", async function (t) {
     assert.equal(rule.version, 0);
   });
 
-  await t.test("should generate the same rule ID regardless of leftover threshold", async function () {
-    const rule1: ArcjetPromptInjectionDetectionRule = detectPromptInjection({
-      // @ts-expect-error: threshold was removed and must not affect identity.
-      threshold: 0.5,
-    })[0];
-    const rule2: ArcjetPromptInjectionDetectionRule = detectPromptInjection({
-      // @ts-expect-error: threshold was removed and must not affect identity.
-      threshold: 0.7,
-    })[0];
-    const context = createContext();
-    const details = createRequest();
-    details.extra.detectPromptInjectionMessage = "Test";
+  await t.test(
+    "should generate the same rule ID regardless of leftover threshold",
+    async function () {
+      const rule1: ArcjetPromptInjectionDetectionRule = detectPromptInjection({
+        // @ts-expect-error: threshold was removed and must not affect identity.
+        threshold: 0.5,
+      })[0];
+      const rule2: ArcjetPromptInjectionDetectionRule = detectPromptInjection({
+        // @ts-expect-error: threshold was removed and must not affect identity.
+        threshold: 0.7,
+      })[0];
+      const context = createContext();
+      const details = createRequest();
+      details.extra.detectPromptInjectionMessage = "Test";
 
-    rule1.validate(context, details);
-    rule2.validate(context, details);
+      rule1.validate(context, details);
+      rule2.validate(context, details);
 
-    const result1 = await rule1.protect(context, details);
-    const result2 = await rule2.protect(context, details);
+      const result1 = await rule1.protect(context, details);
+      const result2 = await rule2.protect(context, details);
 
-    assert.equal(result1.ruleId, result2.ruleId);
-  });
+      assert.equal(result1.ruleId, result2.ruleId);
+    },
+  );
 
   await t.test("should generate different rule IDs for different modes", async function () {
     const rule1: ArcjetPromptInjectionDetectionRule = detectPromptInjection({

--- a/arcjet/test/detect-prompt-injection.test.ts
+++ b/arcjet/test/detect-prompt-injection.test.ts
@@ -19,7 +19,7 @@ test("detectPromptInjection", async function (t) {
   await t.test("should use defaults when no options provided", async function () {
     const [rule] = detectPromptInjection();
     assert.equal(rule.mode, "DRY_RUN");
-    assert.equal(rule.threshold, 0.5);
+    assert.equal("threshold" in rule, false);
   });
 
   await t.test("should accept valid mode", async function () {
@@ -36,57 +36,19 @@ test("detectPromptInjection", async function (t) {
     }, /`detectPromptInjection` options error: invalid value for `mode` - expected one of 'LIVE', 'DRY_RUN'/);
   });
 
-  await t.test("should use default threshold when not provided", async function () {
+  await t.test("should not expose a threshold on the rule", async function () {
     const [rule] = detectPromptInjection({ mode: "LIVE" });
-    assert.equal(rule.threshold, 0.5);
+    assert.equal("threshold" in rule, false);
   });
 
-  await t.test("should accept valid threshold", async function () {
-    const [rule] = detectPromptInjection({ threshold: 0.7 });
-    assert.equal(rule.threshold, 0.7);
-  });
-
-  await t.test("should fail if threshold is not a number", async function () {
-    assert.throws(function () {
-      detectPromptInjection({
-        // @ts-expect-error: test runtime behavior of invalid threshold.
-        threshold: "0.5",
-      });
-    }, /invalid type for `threshold` - expected number/);
-  });
-
-  await t.test("should fail if threshold is exactly 0.0", async function () {
-    assert.throws(function () {
-      detectPromptInjection({ threshold: 0.0 });
-    }, /`detectPromptInjection` options error: `threshold` must be between 0.0 and 1.0 \(exclusive\)/);
-  });
-
-  await t.test("should fail if threshold is exactly 1.0", async function () {
-    assert.throws(function () {
-      detectPromptInjection({ threshold: 1.0 });
-    }, /`detectPromptInjection` options error: `threshold` must be between 0.0 and 1.0 \(exclusive\)/);
-  });
-
-  await t.test("should fail if threshold is negative", async function () {
-    assert.throws(function () {
-      detectPromptInjection({ threshold: -0.5 });
-    }, /`detectPromptInjection` options error: `threshold` must be between 0.0 and 1.0 \(exclusive\)/);
-  });
-
-  await t.test("should fail if threshold is greater than 1.0", async function () {
-    assert.throws(function () {
-      detectPromptInjection({ threshold: 1.5 });
-    }, /`detectPromptInjection` options error: `threshold` must be between 0.0 and 1.0 \(exclusive\)/);
-  });
-
-  await t.test("should accept threshold near minimum", async function () {
-    const [rule] = detectPromptInjection({ threshold: 0.01 });
-    assert.equal(rule.threshold, 0.01);
-  });
-
-  await t.test("should accept threshold near maximum", async function () {
-    const [rule] = detectPromptInjection({ threshold: 0.99 });
-    assert.equal(rule.threshold, 0.99);
+  await t.test("should ignore a leftover threshold option", async function () {
+    const [rule] = detectPromptInjection({
+      mode: "LIVE",
+      // @ts-expect-error: threshold was removed; leftover callers must not throw.
+      threshold: 0,
+    });
+    assert.equal(rule.mode, "LIVE");
+    assert.equal("threshold" in rule, false);
   });
 
   await t.test("should throw if detectPromptInjectionMessage is missing", async function () {
@@ -173,7 +135,7 @@ test("detectPromptInjection", async function (t) {
     assert.equal(result.conclusion, "ALLOW");
     assert.ok(result.reason instanceof ArcjetPromptInjectionReason);
     assert.equal(result.reason.injectionDetected, false);
-    assert.equal(result.reason.score, 0.0);
+    assert.equal("score" in result.reason, false);
   });
 
   await t.test("should return NOT_RUN in DRY_RUN mode", async function () {
@@ -212,7 +174,6 @@ test("detectPromptInjection", async function (t) {
         conclusion: "DENY",
         reason: new ArcjetPromptInjectionReason({
           injectionDetected: true,
-          score: 0.95,
         }),
       },
       60,
@@ -225,7 +186,7 @@ test("detectPromptInjection", async function (t) {
     assert.equal(result2.conclusion, "DENY");
     assert.ok(result2.reason instanceof ArcjetPromptInjectionReason);
     assert.equal((result2.reason as ArcjetPromptInjectionReason).injectionDetected, true);
-    assert.equal((result2.reason as ArcjetPromptInjectionReason).score, 0.95);
+    assert.equal("score" in result2.reason, false);
   });
 
   await t.test("should have correct priority", async function () {
@@ -243,11 +204,13 @@ test("detectPromptInjection", async function (t) {
     assert.equal(rule.version, 0);
   });
 
-  await t.test("should generate different rule IDs for different thresholds", async function () {
+  await t.test("should generate the same rule ID regardless of leftover threshold", async function () {
     const rule1: ArcjetPromptInjectionDetectionRule = detectPromptInjection({
+      // @ts-expect-error: threshold was removed and must not affect identity.
       threshold: 0.5,
     })[0];
     const rule2: ArcjetPromptInjectionDetectionRule = detectPromptInjection({
+      // @ts-expect-error: threshold was removed and must not affect identity.
       threshold: 0.7,
     })[0];
     const context = createContext();
@@ -260,7 +223,7 @@ test("detectPromptInjection", async function (t) {
     const result1 = await rule1.protect(context, details);
     const result2 = await rule2.protect(context, details);
 
-    assert.notEqual(result1.ruleId, result2.ruleId);
+    assert.equal(result1.ruleId, result2.ruleId);
   });
 
   await t.test("should generate different rule IDs for different modes", async function () {
@@ -292,7 +255,6 @@ test("integration with arcjet client", async function (t) {
           ttl: 300,
           reason: new ArcjetPromptInjectionReason({
             injectionDetected: true,
-            score: 0.92,
           }),
           results: [],
         });
@@ -303,7 +265,7 @@ test("integration with arcjet client", async function (t) {
     const key = "test-key";
     const aj = arcjet({
       key,
-      rules: [detectPromptInjection({ mode: "LIVE", threshold: 0.8 })],
+      rules: [detectPromptInjection({ mode: "LIVE" })],
       client,
       log: createTestLogger(),
     });
@@ -330,7 +292,7 @@ test("integration with arcjet client", async function (t) {
     assert.equal(decision.conclusion, "DENY");
     assert.ok(decision.reason instanceof ArcjetPromptInjectionReason);
     assert.equal((decision.reason as ArcjetPromptInjectionReason).injectionDetected, true);
-    assert.equal((decision.reason as ArcjetPromptInjectionReason).score, 0.92);
+    assert.equal("score" in decision.reason, false);
   });
 
   await t.test("should handle server returning ALLOW", async function () {
@@ -340,7 +302,6 @@ test("integration with arcjet client", async function (t) {
           ttl: 0,
           reason: new ArcjetPromptInjectionReason({
             injectionDetected: false,
-            score: 0.15,
           }),
           results: [],
         });
@@ -351,7 +312,7 @@ test("integration with arcjet client", async function (t) {
     const key = "test-key";
     const aj = arcjet({
       key,
-      rules: [detectPromptInjection({ mode: "LIVE", threshold: 0.5 })],
+      rules: [detectPromptInjection({ mode: "LIVE" })],
       client,
       log: createTestLogger(),
     });
@@ -378,7 +339,7 @@ test("integration with arcjet client", async function (t) {
     assert.equal(decision.conclusion, "ALLOW");
     assert.ok(decision.reason instanceof ArcjetPromptInjectionReason);
     assert.equal((decision.reason as ArcjetPromptInjectionReason).injectionDetected, false);
-    assert.equal((decision.reason as ArcjetPromptInjectionReason).score, 0.15);
+    assert.equal("score" in decision.reason, false);
   });
 
   await t.test(
@@ -393,7 +354,6 @@ test("integration with arcjet client", async function (t) {
             ttl: 0,
             reason: new ArcjetPromptInjectionReason({
               injectionDetected: false,
-              score: 0.1,
             }),
             results: [],
           });

--- a/protocol/src/convert.ts
+++ b/protocol/src/convert.ts
@@ -282,7 +282,6 @@ export function ArcjetReasonFromProtocol(proto?: Reason): ArcjetReason {
       const reason = proto.reason.value;
       return new ArcjetPromptInjectionReason({
         injectionDetected: reason.injectionDetected,
-        score: reason.score,
       });
     }
     case "bot": {
@@ -414,7 +413,6 @@ export function ArcjetReasonToProtocol(reason: ArcjetReason): Reason {
         case: "promptInjection",
         value: create(PromptInjectionReasonSchema, {
           injectionDetected: reason.injectionDetected,
-          score: reason.score ?? 0.0,
         }),
       },
     });
@@ -768,7 +766,6 @@ export function ArcjetRuleToProtocol<Props extends { [key: string]: unknown }>(
         case: "promptInjectionDetection",
         value: {
           mode: ArcjetModeToProtocol(rule.mode),
-          threshold: rule.threshold ?? 0.5,
           version: rule.version,
         },
       },

--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -285,15 +285,6 @@ interface ArcjetPromptInjectionReasonInit {
    * Whether a prompt injection attempt was detected in the input.
    */
   injectionDetected?: boolean | undefined;
-
-  /**
-   * The prompt injection confidence score, scaled to [0, 1].
-   *
-   * @deprecated
-   *   This field is no longer respected by the server and will be removed in
-   *   a future release.
-   */
-  score?: number | undefined;
 }
 
 /**
@@ -311,15 +302,6 @@ export class ArcjetPromptInjectionReason extends ArcjetReason {
   injectionDetected: boolean;
 
   /**
-   * The prompt injection confidence score.
-   *
-   * @deprecated
-   *   This field is no longer respected by the server and will be removed in
-   *   a future release.
-   */
-  score?: number;
-
-  /**
    * Create a prompt injection reason.
    *
    * @param init
@@ -331,7 +313,6 @@ export class ArcjetPromptInjectionReason extends ArcjetReason {
     super();
 
     this.injectionDetected = init.injectionDetected ?? false;
-    this.score = init.score ?? 0.0;
   }
 }
 
@@ -1838,16 +1819,6 @@ export interface ArcjetPromptInjectionDetectionRule extends ArcjetRule<{
    * Kind.
    */
   type: "PROMPT_INJECTION_DETECTION";
-
-  /**
-   * The score threshold above which a request is considered a prompt
-   * injection attempt.
-   *
-   * @deprecated
-   *   This field is no longer respected by the server and will be removed in
-   *   a future release.
-   */
-  threshold?: number;
 }
 
 /**

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -40,6 +40,8 @@ import {
   ArcjetErrorReason,
   ArcjetFilterReason,
   ArcjetIpDetails,
+  type ArcjetPromptInjectionDetectionRule,
+  ArcjetPromptInjectionReason,
   ArcjetRateLimitReason,
   ArcjetReason,
   ArcjetRuleResult,
@@ -565,6 +567,22 @@ test("convert", async (t) => {
       assert.equal(reason.shieldTriggered, false);
     });
 
+    await t.test("should create a prompt injection reason without score", () => {
+      const reason = ArcjetReasonFromProtocol(
+        create(ReasonSchema, {
+          reason: {
+            case: "promptInjection",
+            value: { injectionDetected: true, score: 0.995 },
+          },
+        }),
+      );
+
+      assert.ok(reason instanceof ArcjetPromptInjectionReason);
+      assert.equal(reason.type, "PROMPT_INJECTION_DETECTION");
+      assert.equal(reason.injectionDetected, true);
+      assert.equal("score" in reason, false);
+    });
+
     await t.test("should create an anonymous reason w/ an unknown `case` proto", () => {
       // Note: creating a reason using `create` with an unknown `case` will
       // turn it into `undefined` instead:
@@ -743,6 +761,16 @@ test("convert", async (t) => {
           reason: { case: "shield", value: { shieldTriggered: true } },
         }),
       );
+    });
+
+    await t.test("should create a protocol reason from a prompt injection reason without score", () => {
+      const proto = ArcjetReasonToProtocol(
+        new ArcjetPromptInjectionReason({ injectionDetected: true }),
+      );
+
+      assert.equal(proto.reason.case, "promptInjection");
+      assert.equal(proto.reason.value?.injectionDetected, true);
+      assert.equal(proto.reason.value?.score, 0);
     });
 
     await t.test("should create a protocol reason from an arcjet email reason", () => {
@@ -1258,6 +1286,35 @@ test("convert", async (t) => {
         }),
       );
       assert.equal(rule.rule.case, "filter");
+    });
+
+    await t.test("should create a prompt injection protocol rule without threshold", () => {
+      const rule = ArcjetRuleToProtocol({
+        mode: "LIVE",
+        priority: 1,
+        protect() {
+          assert.fail("should not call `protect`");
+        },
+        type: "PROMPT_INJECTION_DETECTION",
+        validate() {
+          assert.fail("should not call `validate`");
+        },
+        version: 0,
+      } as ArcjetPromptInjectionDetectionRule);
+
+      assert.deepEqual(
+        rule,
+        create(RuleSchema, {
+          rule: {
+            case: "promptInjectionDetection",
+            value: { mode: Mode.LIVE },
+          },
+        }),
+      );
+      assert.equal(rule.rule.case, "promptInjectionDetection");
+      if (rule.rule.case === "promptInjectionDetection") {
+        assert.equal(rule.rule.value.threshold, undefined);
+      }
     });
 
     await t.test("should create a sensitive info protocol rule", () => {

--- a/protocol/test/convert.test.ts
+++ b/protocol/test/convert.test.ts
@@ -763,15 +763,17 @@ test("convert", async (t) => {
       );
     });
 
-    await t.test("should create a protocol reason from a prompt injection reason without score", () => {
-      const proto = ArcjetReasonToProtocol(
-        new ArcjetPromptInjectionReason({ injectionDetected: true }),
-      );
+    await t.test(
+      "should create a protocol reason from a prompt injection reason without score",
+      () => {
+        const proto = ArcjetReasonToProtocol(
+          new ArcjetPromptInjectionReason({ injectionDetected: true }),
+        );
 
-      assert.equal(proto.reason.case, "promptInjection");
-      assert.equal(proto.reason.value?.injectionDetected, true);
-      assert.equal(proto.reason.value?.score, 0);
-    });
+        assert.equal(proto.reason.case, "promptInjection");
+        assert.equal(proto.reason.value?.injectionDetected, true);
+      },
+    );
 
     await t.test("should create a protocol reason from an arcjet email reason", () => {
       assert.deepEqual(

--- a/protocol/test/protocol.test.ts
+++ b/protocol/test/protocol.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
+import { ArcjetPromptInjectionReason, ArcjetReason, ArcjetRuleResult } from "../dist/index.js";
 
 test("@arcjet/protocol", async function (t) {
   await t.test("should expose the public api", async function () {
@@ -42,6 +42,23 @@ test("protocol", async (t) => {
       });
 
       assert.equal(result.isDenied(), false);
+    });
+  });
+
+  await t.test("ArcjetPromptInjectionReason", async (t) => {
+    await t.test("should default injectionDetected to false and omit score", () => {
+      const reason = new ArcjetPromptInjectionReason({});
+
+      assert.equal(reason.type, "PROMPT_INJECTION_DETECTION");
+      assert.equal(reason.injectionDetected, false);
+      assert.equal("score" in reason, false);
+    });
+
+    await t.test("should record injectionDetected without a score", () => {
+      const reason = new ArcjetPromptInjectionReason({ injectionDetected: true });
+
+      assert.equal(reason.injectionDetected, true);
+      assert.equal("score" in reason, false);
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Before

`detectPromptInjection({ threshold })` was `@deprecated` and ignored by the server, but JS still validated and sent it. `threshold: 0` threw in JS and was accepted in Python. `ArcjetPromptInjectionReason.score` was likewise deprecated.

```ts
detectPromptInjection({ mode: "LIVE", threshold: 0.8 });
// throws if threshold is 0 or 1 (exclusive range)
decision.reason.score; // deprecated, unused
```

## After

The option and `score` are gone, matching Go. Only `mode` remains. Leftover `threshold` is ignored by the core SDK and no longer changes the rule id.

```ts
detectPromptInjection({ mode: "LIVE" });
decision.reason.injectionDetected; // binary verdict
```

## Breaking (Astro)

`@arcjet/astro` validates rule options with Zod `.strict()`. Existing Astro apps that still pass `threshold` will throw at startup instead of silently ignoring the option (core SDK behavior). Remove `threshold` from the integration config on upgrade.

## Why

The server ignores `threshold` (binary model). Reconciling JS/Python ranges is wasted work. Go already removed it. Same for `score`.

This is the JS repo only — Python needs a matching change in that SDK.

## Tests

- Rule no longer exposes `threshold`; leftover `threshold: 0` does not throw in core
- Rule ids no longer vary by leftover threshold
- Reason omits `score`
- Protocol convert drops `threshold` on the rule and `score` on the reason
- Astro options schema rejects `threshold` and accepts mode-only config

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a1e8ac4-6d45-4b50-9d54-b63a227b27ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a1e8ac4-6d45-4b50-9d54-b63a227b27ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

