### PR TITLE
fix(guard): export package.json from @arcjet/guard

### DIFF
--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -91,7 +91,8 @@
     "./openai-agents/v0": {
       "types": "./dist/openai-agents/v0/index.d.ts",
       "import": "./dist/openai-agents/v0/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/arcjet-guard/src/testing/index.test.ts
+++ b/arcjet-guard/src/testing/index.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { afterEach, describe, test } from "node:test";
 
@@ -197,6 +198,18 @@ describe("the ./testing subpath", () => {
     assert.doesNotMatch(targets, /dist\/client\./);
     assert.doesNotMatch(targets, /dist\/diagnostics\./);
     assert.doesNotMatch(targets, /dist\/symbol\./);
+  });
+});
+
+describe("the ./package.json subpath", () => {
+  test("is exported", () => {
+    assert.equal(exportsMap()["./package.json"], "./package.json");
+  });
+
+  test("resolves through the package boundary", () => {
+    const require = createRequire(import.meta.url);
+    const pkg = require("@arcjet/guard/package.json") as { name: string };
+    assert.equal(pkg.name, "@arcjet/guard");
   });
 });
 

--- a/arcjet-guard/src/testing/index.test.ts
+++ b/arcjet-guard/src/testing/index.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { afterEach, describe, test } from "node:test";
 
@@ -204,12 +203,6 @@ describe("the ./testing subpath", () => {
 describe("the ./package.json subpath", () => {
   test("is exported", () => {
     assert.equal(exportsMap()["./package.json"], "./package.json");
-  });
-
-  test("resolves through the package boundary", () => {
-    const require = createRequire(import.meta.url);
-    const pkg = require("@arcjet/guard/package.json") as { name: string };
-    assert.equal(pkg.name, "@arcjet/guard");
   });
 });
 

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -296,6 +296,7 @@ export const EXPECTED_ROOT_KEYS = [
   "./mastra/v1",
   "./node",
   "./openai-agents/v0",
+  "./package.json",
   // The in-memory client for application tests. Deliberately a single entry
   // rather than a runtime-conditional one: it has no transport, so there is
   // nothing for a condition to select.

--- a/arcjet-guard/test/runtime/node.test.ts
+++ b/arcjet-guard/test/runtime/node.test.ts
@@ -203,6 +203,14 @@ describe("Package boundary: the exports map is the public API", () => {
     assert.equal(typeof testing.registerTestClient, "function");
   });
 
+  test("@arcjet/guard/package.json is exported", async () => {
+    const pkg = await import("@arcjet/guard/package.json", {
+      with: { type: "json" },
+    });
+
+    assert.equal(pkg.default.name, "@arcjet/guard");
+  });
+
   test("the registered test client receives the free calls", async () => {
     const { registerTestClient } = await import("@arcjet/guard/testing");
     const { capture: freeCapture } = await import("@arcjet/guard");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Every other workspace package already exposes `./package.json` through its `exports` map. `@arcjet/guard` did not, so `import "@arcjet/guard/package.json"` (or `require("@arcjet/guard/package.json")`) failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

This adds the same export and updates the guard export-map tests so the new key is part of the expected public surface.

## Changes

- Add `"./package.json": "./package.json"` to `@arcjet/guard` exports
- Include `./package.json` in `EXPECTED_ROOT_KEYS`
- Assert the subpath is declared and that Node can import it through the package boundary

## Test plan

- Unit tests: `@arcjet/guard` export-map checks (including `EXPECTED_ROOT_KEYS`)
- Runtime Node test: `import "@arcjet/guard/package.json"` with `{ type: "json" }`
- Manual resolve: `import` and `require` of `@arcjet/guard/package.json` both return `{ name: "@arcjet/guard", version: "1.10.0" }`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-812c6108-6e7b-4ebb-84c6-91cc7d288901?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-812c6108-6e7b-4ebb-84c6-91cc7d288901&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

