### PR TITLE
fix(guard): name missing AI peers and Eve's Node 24 floor

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -180,10 +180,13 @@ jobs:
           node --test 'arcjet-guard/src/mastra/**/*.test.ts'
         working-directory: ${{ github.workspace }}
 
-      # The vercel-eve namespace imports eve for types only, which is what lets
-      # guard support Node 22 at all — eve declares engines.node ">=24". A static
-      # scan proves the imports are written `import type`; this proves the
-      # consequence, catching a build step that re-emits one as a value import.
+      # The vercel-eve namespace imports eve for types only so installing
+      # @arcjet/guard never pulls Eve in. Eve's own engines.node is ">=24";
+      # importing the namespace throws "needs Node 24" below that floor rather
+      # than leaving npm's generic EBADENGINE warning as the only signal. A
+      # static scan proves the imports are written `import type`; this proves
+      # the consequence, catching a build step that re-emits one as a value
+      # import.
       #
       # Runs on every leg of the matrix rather than just Node 22, because the
       # criterion is about all three. Runs last because it deletes a

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1261,12 +1261,13 @@ importing only core guards are not forced to install unneeded packages:
 
 - **`@arcjet/guard`** (core) has no peer dependencies.
 - **`@arcjet/guard/vercel-ai/v7`** requires `ai` and `@ai-sdk/provider-utils`
-  (optional peers — the package will not be installed automatically, but the
-  imports will fail clearly if the peers are missing).
+  (optional peers — the package will not be installed automatically). Importing
+  the namespace without them throws `install ai and @ai-sdk/provider-utils.`
 - **`@arcjet/guard/vercel-eve/v0`** requires `eve` (optional peer, installed
   only to use `@arcjet/guard/vercel-eve/v0`). **Eve requires Node.js >= 24**,
-  which is higher than `@arcjet/guard`'s own floor of >= 22. If you are using
-  Eve, ensure your deployment environment and CI both run Node 24 or later.
+  which is higher than `@arcjet/guard`'s own floor of >= 22. Importing this
+  namespace on an older engine throws `needs Node 24.` rather than a generic
+  engine warning.
 - **`@arcjet/guard/mastra/v1`** requires `@mastra/core` (optional peer,
   installed only to use `@arcjet/guard/mastra/v1`). The peer range is `>=1 <2`.
 - **`@arcjet/guard/claude-agent-sdk/v0`** requires

--- a/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
@@ -38,8 +38,10 @@ Ask only what you cannot infer from the code; suggest defaults.
 ## Step 1: Install and find the guard client
 
 Install `@arcjet/guard` (required), plus `ai` and `@ai-sdk/provider-utils`
-(optional peers, needed only for `@arcjet/guard/vercel-ai/v7`). Every agent
-helper lives on that one path. Always use explicit versions:
+(optional peers, needed only for `@arcjet/guard/vercel-ai/v7`). Importing
+`@arcjet/guard/vercel-ai/v7` without those peers throws
+`install ai and @ai-sdk/provider-utils.` Every agent helper lives on that
+one path. Always use explicit versions:
 `@arcjet/guard/vercel-ai/v7` resolves, but `@arcjet/guard/vercel-ai` does not —
 omitting the version is deliberate (it prevents silent API breaking changes
 when a new major version is supported). Attempting to import from an

--- a/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
@@ -103,8 +103,9 @@ npm install @arcjet/guard eve
 ```
 
 **Note:** Eve requires Node.js >= 24. `@arcjet/guard` supports Node >= 22, but
-the Eve integration does not. Verify the agent's `engines` declares `">=24"` or
-note the floor in deployment docs.
+the Eve integration does not. Importing `@arcjet/guard/vercel-eve/v0` on an
+older engine throws `needs Node 24.` Verify the agent's `engines` declares
+`">=24"` or note the floor in deployment docs.
 
 If the agent has no guard client yet, launch one **once at module scope**:
 

--- a/arcjet-guard/src/vercel-ai/v7/guard-tool.ts
+++ b/arcjet-guard/src/vercel-ai/v7/guard-tool.ts
@@ -1,7 +1,9 @@
-import { jsonSchema } from "ai";
 import type { InferToolInput, InferToolOutput, Tool } from "ai";
 
 import { shouldWarn } from "../../agents/capture.ts";
+import { importAi } from "./peers.ts";
+
+const { jsonSchema } = await importAi();
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { ArcjetAgentContext } from "../../agents/context.ts";
 import { retryAfterSeconds } from "../../agents/denial.ts";

--- a/arcjet-guard/src/vercel-ai/v7/index.test.ts
+++ b/arcjet-guard/src/vercel-ai/v7/index.test.ts
@@ -1,13 +1,10 @@
+import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { test } from "node:test";
-import assert from "node:assert/strict";
 
-import * as v7Namespace from "./index.ts";
-import * as agentsBarrel from "../../agents/index.ts";
 import type { Tool } from "ai";
 
-import type { ArcjetDenialResult, GuardToolPolicy } from "./index.ts";
 import {
   collectTsFiles,
   extractImportSpecifiers,
@@ -15,6 +12,9 @@ import {
   EXPECTED_ROOT_KEYS,
   EXPECTED_CONDITIONS,
 } from "../../../test/_shared/source-scan.ts";
+import * as agentsBarrel from "../../agents/index.ts";
+import * as v7Namespace from "./index.ts";
+import type { ArcjetDenialResult, GuardToolPolicy } from "./index.ts";
 
 // `Object.keys` on a namespace import never lists type-only exports, so assert
 // them at type level instead: this stops compiling if the barrel drops one.
@@ -28,7 +28,11 @@ verifyTypeExports();
 
 // AC1.3: Namespace exports guardTool and aiToolsContext as functions
 test("AC1.3: exports guardTool and aiToolsContext", () => {
-  assert.equal(typeof v7Namespace.guardTool, "function", "guardTool must be exported as a function");
+  assert.equal(
+    typeof v7Namespace.guardTool,
+    "function",
+    "guardTool must be exported as a function",
+  );
   assert.equal(
     typeof v7Namespace.aiToolsContext,
     "function",
@@ -39,7 +43,13 @@ test("AC1.3: exports guardTool and aiToolsContext", () => {
 // AC1.4: Proxy identity — shared exports have same function identity
 test("AC1.4: shared exports have same function identity", () => {
   // These shared exports must be the same function objects, not wrappers
-  const sharedExports = ["guardAction", "captureAction", "securityMetadata", "createAgentContext", "ArcjetDeniedError"] as const;
+  const sharedExports = [
+    "guardAction",
+    "captureAction",
+    "securityMetadata",
+    "createAgentContext",
+    "ArcjetDeniedError",
+  ] as const;
 
   for (const exportName of sharedExports) {
     const v7Value = (v7Namespace as Record<string, unknown>)[exportName];
@@ -84,10 +94,7 @@ test("AC1.2: v7 namespace exports the agnostic helpers", () => {
 
   for (const symbol of requiredSymbols) {
     const value = (v7Namespace as Record<string, unknown>)[symbol];
-    assert.ok(
-      value !== undefined,
-      `@arcjet/guard/vercel-ai/v7 must export ${symbol}`,
-    );
+    assert.ok(value !== undefined, `@arcjet/guard/vercel-ai/v7 must export ${symbol}`);
   }
 });
 
@@ -148,10 +155,7 @@ test("AC1.5 and AC1.6: export map has correct subpaths", () => {
   }
 
   // Must have ./vercel-ai/v7
-  assert.ok(
-    exportKeys.includes("./vercel-ai/v7"),
-    'export map must have "./vercel-ai/v7"',
-  );
+  assert.ok(exportKeys.includes("./vercel-ai/v7"), 'export map must have "./vercel-ai/v7"');
 
   // ./agents must NOT exist. The agnostic layer is internal: it reaches users
   // only through a vendor namespace until it has been proven against more than
@@ -206,22 +210,20 @@ test("AC1.1: root barrel exports launchArcjet and rule builders", async () => {
 
   for (const funcName of requiredFunctions) {
     const func = (rootBarrel as Record<string, unknown>)[funcName];
-    assert.equal(
-      typeof func,
-      "function",
-      `root barrel must export ${funcName} as a function`,
-    );
+    assert.equal(typeof func, "function", `root barrel must export ${funcName} as a function`);
   }
 });
 
-// AC2.3: Static precondition — guard-tool.ts and tools-context.ts import from ai/@ai-sdk/provider-utils
-test("AC2.3: guard-tool and tools-context have ai SDK dependencies (static check)", () => {
+// AC2.3: Static precondition — peers.ts loads ai and @ai-sdk/provider-utils so a
+// miss can throw the install line; tools-context.ts still types against
+// provider-utils; guard-tool.ts still types against ai.
+test("AC2.3: guard-tool, tools-context, and peers have ai SDK dependencies (static check)", () => {
   const guardToolPath = resolve(import.meta.dirname, "./guard-tool.ts");
   const toolsContextPath = resolve(import.meta.dirname, "./tools-context.ts");
+  const peersPath = resolve(import.meta.dirname, "./peers.ts");
 
   const errors: string[] = [];
 
-  // Read guard-tool.ts and verify it imports from ai
   let guardToolContent: string;
   try {
     guardToolContent = readFileSync(guardToolPath, "utf-8");
@@ -235,7 +237,6 @@ test("AC2.3: guard-tool and tools-context have ai SDK dependencies (static check
     errors.push("guard-tool.ts must import from 'ai'");
   }
 
-  // Read tools-context.ts and verify it imports from @ai-sdk/provider-utils
   let toolsContextContent: string;
   try {
     toolsContextContent = readFileSync(toolsContextPath, "utf-8");
@@ -247,6 +248,25 @@ test("AC2.3: guard-tool and tools-context have ai SDK dependencies (static check
   const toolsContextImports = extractImportSpecifiers(toolsContextContent);
   if (!toolsContextImports.includes("@ai-sdk/provider-utils")) {
     errors.push("tools-context.ts must import from '@ai-sdk/provider-utils'");
+  }
+
+  let peersContent: string;
+  try {
+    peersContent = readFileSync(peersPath, "utf-8");
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    assert.fail(`Failed to read peers.ts: ${message}`);
+  }
+
+  const peersImports = extractImportSpecifiers(peersContent);
+  if (!peersImports.includes("ai")) {
+    errors.push("peers.ts must import 'ai'");
+  }
+  if (!peersImports.includes("@ai-sdk/provider-utils")) {
+    errors.push("peers.ts must import '@ai-sdk/provider-utils'");
+  }
+  if (!peersContent.includes("install ai and @ai-sdk/provider-utils.")) {
+    errors.push("peers.ts must tell the user to install both peers");
   }
 
   assert.equal(

--- a/arcjet-guard/src/vercel-ai/v7/index.ts
+++ b/arcjet-guard/src/vercel-ai/v7/index.ts
@@ -11,6 +11,9 @@
  * - `ai@^7.0.36`
  * - `@ai-sdk/provider-utils@^5.0.12`
  *
+ * Missing peers throw `install ai and @ai-sdk/provider-utils.` rather than
+ * Node's generic `ERR_MODULE_NOT_FOUND`.
+ *
  * **Exports:** `guardTool` and `aiToolsContext`, plus the agnostic helpers —
  * context, metadata vocabulary, `guardAction`, `captureAction`, and the error
  * types. The agnostic layer has no export map entry of its own; this is the

--- a/arcjet-guard/src/vercel-ai/v7/peers.test.ts
+++ b/arcjet-guard/src/vercel-ai/v7/peers.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { AI_PEERS_INSTALL_MESSAGE, importAi, missingAiPeersError } from "./peers.ts";
+
+test("missing ai names both packages", () => {
+  assert.equal(
+    missingAiPeersError().message,
+    `@arcjet/guard/vercel-ai/v7: ${AI_PEERS_INSTALL_MESSAGE}`,
+  );
+  assert.equal(AI_PEERS_INSTALL_MESSAGE, "install ai and @ai-sdk/provider-utils.");
+});
+
+test("importAi returns the ai module when the peers are installed", async () => {
+  const ai = await importAi();
+  assert.equal(typeof ai.jsonSchema, "function");
+});
+
+test("importing the v7 namespace without ai peers throws the install line", () => {
+  const dir = mkdtempSync(join(tmpdir(), "arcjet-ai-peers-"));
+  try {
+    const hookPath = join(dir, "hook.mjs");
+    const registerPath = join(dir, "register.mjs");
+    writeFileSync(
+      hookPath,
+      `
+export async function resolve(specifier, context, nextResolve) {
+  if (
+    specifier === "ai" ||
+    specifier.startsWith("ai/") ||
+    specifier === "@ai-sdk/provider-utils" ||
+    specifier.startsWith("@ai-sdk/provider-utils/")
+  ) {
+    const error = new Error("Cannot find package '" + specifier + "'");
+    error.code = "ERR_MODULE_NOT_FOUND";
+    throw error;
+  }
+  return nextResolve(specifier, context);
+}
+`,
+    );
+    writeFileSync(
+      registerPath,
+      `
+import { register } from "node:module";
+register(new URL("./hook.mjs", import.meta.url));
+`,
+    );
+
+    const namespaceUrl = pathToFileURL(join(import.meta.dirname, "index.ts")).href;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(registerPath).href,
+        "--input-type=module",
+        "-e",
+        `
+try {
+  await import(${JSON.stringify(namespaceUrl)});
+  console.error("expected the v7 namespace import to fail");
+  process.exit(1);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!message.includes("install ai and @ai-sdk/provider-utils.")) {
+    console.error(error);
+    process.exit(2);
+  }
+}
+`,
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/src/vercel-ai/v7/peers.ts
+++ b/arcjet-guard/src/vercel-ai/v7/peers.ts
@@ -1,0 +1,28 @@
+/**
+ * Load the Vercel AI SDK peers, or throw a single install line.
+ *
+ * A static `import { jsonSchema } from "ai"` fails at link time with Node's
+ * generic `ERR_MODULE_NOT_FOUND` and names only the specifier that happened
+ * to resolve first. Both `ai` and `@ai-sdk/provider-utils` are required, so
+ * the load is deferred and any miss becomes one sentence.
+ */
+
+export const AI_PEERS_INSTALL_MESSAGE: string = "install ai and @ai-sdk/provider-utils.";
+
+export function missingAiPeersError(cause?: unknown): Error {
+  if (cause === undefined) {
+    return new Error(`@arcjet/guard/vercel-ai/v7: ${AI_PEERS_INSTALL_MESSAGE}`);
+  }
+  return new Error(`@arcjet/guard/vercel-ai/v7: ${AI_PEERS_INSTALL_MESSAGE}`, {
+    cause,
+  });
+}
+
+export async function importAi(): Promise<typeof import("ai")> {
+  try {
+    const [ai] = await Promise.all([import("ai"), import("@ai-sdk/provider-utils")]);
+    return ai;
+  } catch (error) {
+    throw missingAiPeersError(error);
+  }
+}

--- a/arcjet-guard/src/vercel-eve/v0/engine.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/engine.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { EVE_NODE_ENGINE_MESSAGE, assertEveEngine, eveEngineError, nodeMajor } from "./engine.ts";
+
+test("Eve engine error is needs Node 24", () => {
+  assert.equal(eveEngineError().message, `@arcjet/guard/vercel-eve/v0: ${EVE_NODE_ENGINE_MESSAGE}`);
+  assert.equal(EVE_NODE_ENGINE_MESSAGE, "needs Node 24.");
+});
+
+test("nodeMajor reads the leading segment", () => {
+  assert.equal(nodeMajor({ node: "22.21.0" }), 22);
+  assert.equal(nodeMajor({ node: "24.5.0" }), 24);
+  assert.equal(nodeMajor({ node: "26.0.0" }), 26);
+  assert.equal(nodeMajor({ node: "" }), undefined);
+  assert.equal(nodeMajor(undefined), undefined);
+});
+
+test("assertEveEngine accepts Node 24 and above", () => {
+  assert.doesNotThrow(() => {
+    assertEveEngine({ node: "24.0.0" });
+  });
+  assert.doesNotThrow(() => {
+    assertEveEngine({ node: "24.5.0" });
+  });
+  assert.doesNotThrow(() => {
+    assertEveEngine({ node: "26.3.1" });
+  });
+});
+
+test("assertEveEngine fails below Node 24 with needs Node 24", () => {
+  assert.throws(() => {
+    assertEveEngine({ node: "22.21.0" });
+  }, /needs Node 24/);
+  assert.throws(() => {
+    assertEveEngine({ node: "23.11.0" });
+  }, /needs Node 24/);
+  assert.throws(() => {
+    assertEveEngine(undefined);
+  }, /needs Node 24/);
+});

--- a/arcjet-guard/src/vercel-eve/v0/engine.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/engine.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { EVE_NODE_ENGINE_MESSAGE, assertEveEngine, eveEngineError, nodeMajor } from "./engine.ts";
+import {
+  EVE_NODE_ENGINE_MESSAGE,
+  assertEveEngine,
+  currentNodeMajor,
+  eveEngineError,
+  nodeMajor,
+} from "./engine.ts";
 
 test("Eve engine error is needs Node 24", () => {
   assert.equal(eveEngineError().message, `@arcjet/guard/vercel-eve/v0: ${EVE_NODE_ENGINE_MESSAGE}`);
@@ -13,7 +19,7 @@ test("nodeMajor reads the leading segment", () => {
   assert.equal(nodeMajor({ node: "24.5.0" }), 24);
   assert.equal(nodeMajor({ node: "26.0.0" }), 26);
   assert.equal(nodeMajor({ node: "" }), undefined);
-  assert.equal(nodeMajor(undefined), undefined);
+  assert.equal(nodeMajor({}), undefined);
 });
 
 test("assertEveEngine accepts Node 24 and above", () => {
@@ -28,6 +34,19 @@ test("assertEveEngine accepts Node 24 and above", () => {
   });
 });
 
+test("assertEveEngine reads the running process when no versions are passed", () => {
+  const major = currentNodeMajor();
+  if (major !== undefined && major >= 24) {
+    assert.doesNotThrow(() => {
+      assertEveEngine();
+    });
+    return;
+  }
+  assert.throws(() => {
+    assertEveEngine();
+  }, /needs Node 24/);
+});
+
 test("assertEveEngine fails below Node 24 with needs Node 24", () => {
   assert.throws(() => {
     assertEveEngine({ node: "22.21.0" });
@@ -36,6 +55,6 @@ test("assertEveEngine fails below Node 24 with needs Node 24", () => {
     assertEveEngine({ node: "23.11.0" });
   }, /needs Node 24/);
   assert.throws(() => {
-    assertEveEngine(undefined);
+    assertEveEngine({});
   }, /needs Node 24/);
 });

--- a/arcjet-guard/src/vercel-eve/v0/engine.ts
+++ b/arcjet-guard/src/vercel-eve/v0/engine.ts
@@ -19,9 +19,7 @@ export function eveEngineError(): Error {
   return new Error(`@arcjet/guard/vercel-eve/v0: ${EVE_NODE_ENGINE_MESSAGE}`);
 }
 
-export function nodeMajor(
-  versions: NodeVersions | undefined = readNodeVersions(),
-): number | undefined {
+export function nodeMajor(versions: NodeVersions | undefined): number | undefined {
   const node = versions?.node;
   if (typeof node !== "string" || node === "") {
     return undefined;
@@ -33,8 +31,12 @@ export function nodeMajor(
   return major;
 }
 
-export function assertEveEngine(versions: NodeVersions | undefined = readNodeVersions()): void {
-  const major = nodeMajor(versions);
+export function currentNodeMajor(): number | undefined {
+  return nodeMajor(readNodeVersions());
+}
+
+export function assertEveEngine(versions?: NodeVersions): void {
+  const major = nodeMajor(versions ?? readNodeVersions());
   if (major === undefined || major < 24) {
     throw eveEngineError();
   }
@@ -53,6 +55,5 @@ function readNodeVersions(): NodeVersions | undefined {
   if (typeof versions !== "object" || versions === null) {
     return undefined;
   }
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- object-and-null guard above
-  return versions as NodeVersions;
+  return versions;
 }

--- a/arcjet-guard/src/vercel-eve/v0/engine.ts
+++ b/arcjet-guard/src/vercel-eve/v0/engine.ts
@@ -1,0 +1,58 @@
+/**
+ * Eve's own floor is Node 24 — higher than `@arcjet/guard`.
+ *
+ * npm reports a mismatch as `EBADENGINE` plus a raw range. Importing this
+ * namespace throws the same fact in one sentence instead.
+ */
+
+export const EVE_NODE_ENGINE_MESSAGE: string = "needs Node 24.";
+
+/**
+ * The `process.versions` slice this check reads. Injected in tests so the
+ * branches do not depend on the runner's engine.
+ */
+export type NodeVersions = {
+  readonly node?: string;
+};
+
+export function eveEngineError(): Error {
+  return new Error(`@arcjet/guard/vercel-eve/v0: ${EVE_NODE_ENGINE_MESSAGE}`);
+}
+
+export function nodeMajor(
+  versions: NodeVersions | undefined = readNodeVersions(),
+): number | undefined {
+  const node = versions?.node;
+  if (typeof node !== "string" || node === "") {
+    return undefined;
+  }
+  const major = Number(node.split(".")[0]);
+  if (!Number.isFinite(major)) {
+    return undefined;
+  }
+  return major;
+}
+
+export function assertEveEngine(versions: NodeVersions | undefined = readNodeVersions()): void {
+  const major = nodeMajor(versions);
+  if (major === undefined || major < 24) {
+    throw eveEngineError();
+  }
+}
+
+function readNodeVersions(): NodeVersions | undefined {
+  const g: unknown = globalThis;
+  if (typeof g !== "object" || g === null || !("process" in g)) {
+    return undefined;
+  }
+  const proc = g.process;
+  if (typeof proc !== "object" || proc === null || !("versions" in proc)) {
+    return undefined;
+  }
+  const versions = proc.versions;
+  if (typeof versions !== "object" || versions === null) {
+    return undefined;
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- object-and-null guard above
+  return versions as NodeVersions;
+}

--- a/arcjet-guard/src/vercel-eve/v0/index.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/index.test.ts
@@ -14,7 +14,7 @@ import * as agentsBarrel from "../../agents/index.ts";
 // story covered by AC2.2, which applies only to Eve's own files. AC1.2 requires
 // cross-namespace assertions that can only be verified when ai is available.
 import * as v7Namespace from "../../vercel-ai/v7/index.ts";
-import { nodeMajor } from "./engine.ts";
+import { currentNodeMajor } from "./engine.ts";
 import type {
   ArcjetHookFamily,
   ArcjetHooksOptions,
@@ -53,8 +53,7 @@ function verifyTypeExports(): void {
 
 verifyTypeExports();
 
-const eveSupported = (nodeMajor() ?? 0) >= 24;
-const testOnEveEngine = eveSupported ? test : test.skip;
+const eveSupported = (currentNodeMajor() ?? 0) >= 24;
 
 test("importing the Eve namespace below Node 24 fails with needs Node 24", async (t) => {
   if (eveSupported) {
@@ -98,7 +97,11 @@ function objectField(
 
 // AC1.1: Each of the five own exports (eveAgentContext, guardApproval, guardTool,
 // guardInbound, arcjetHooks) must be a function.
-testOnEveEngine("AC1.1: exports the five own helpers as functions", async () => {
+test("AC1.1: exports the five own helpers as functions", async (t) => {
+  if (!eveSupported) {
+    t.skip("Eve namespace needs Node 24");
+    return;
+  }
   const eveNamespace = await import("./index.ts");
   const ownExports = [
     "eveAgentContext",
@@ -120,7 +123,11 @@ testOnEveEngine("AC1.1: exports the five own helpers as functions", async () => 
 
 // The agnostic helpers reach users through this namespace and no other,
 // so the public path is what must carry them.
-testOnEveEngine("eve namespace exports the agnostic helpers", async () => {
+test("eve namespace exports the agnostic helpers", async (t) => {
+  if (!eveSupported) {
+    t.skip("Eve namespace needs Node 24");
+    return;
+  }
   const eveNamespace = await import("./index.ts");
   const requiredSymbols = [
     "createAgentContext",
@@ -138,90 +145,89 @@ testOnEveEngine("eve namespace exports the agnostic helpers", async () => {
 
 // AC1.2: For each agnostic symbol, the value imported from Eve namespace must
 // be the same object identity as the value from vercel-ai/v7 namespace.
-testOnEveEngine(
-  "AC1.2: agnostic exports have same identity across Eve and v7 namespaces",
-  async () => {
-    const eveNamespace = await import("./index.ts");
-    const agnosticSymbols = [
-      "createAgentContext",
-      "securityMetadata",
-      "guardAction",
-      "captureAction",
-      "ArcjetDeniedError",
-      "ArcjetGuardUnavailableError",
-    ] as const;
+test("AC1.2: agnostic exports have same identity across Eve and v7 namespaces", async (t) => {
+  if (!eveSupported) {
+    t.skip("Eve namespace needs Node 24");
+    return;
+  }
+  const eveNamespace = await import("./index.ts");
+  const agnosticSymbols = [
+    "createAgentContext",
+    "securityMetadata",
+    "guardAction",
+    "captureAction",
+    "ArcjetDeniedError",
+    "ArcjetGuardUnavailableError",
+  ] as const;
 
-    for (const symbol of agnosticSymbols) {
-      const eveValue = (eveNamespace as Record<string, unknown>)[symbol];
-      const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
+  for (const symbol of agnosticSymbols) {
+    const eveValue = (eveNamespace as Record<string, unknown>)[symbol];
+    const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
 
-      assert.strictEqual(
-        eveValue,
-        v7Value,
-        `${symbol} must be the same object identity from both @arcjet/guard/vercel-eve/v0 and @arcjet/guard/vercel-ai/v7`,
-      );
-    }
-  },
-);
+    assert.strictEqual(
+      eveValue,
+      v7Value,
+      `${symbol} must be the same object identity from both @arcjet/guard/vercel-eve/v0 and @arcjet/guard/vercel-ai/v7`,
+    );
+  }
+});
 
 // Proxy identity — shared exports have same function identity
-testOnEveEngine(
-  "Eve namespace is a strict superset of the agents barrel with same identity for shared exports",
-  async () => {
-    const eveNamespace = await import("./index.ts");
-    const eveKeys = Object.keys(eveNamespace);
-    const agentKeys = Object.keys(agentsBarrel);
+test("Eve namespace is a strict superset of the agents barrel with same identity for shared exports", async (t) => {
+  if (!eveSupported) {
+    t.skip("Eve namespace needs Node 24");
+    return;
+  }
+  const eveNamespace = await import("./index.ts");
+  const eveKeys = Object.keys(eveNamespace);
+  const agentKeys = Object.keys(agentsBarrel);
 
-    // Verify all agents barrel keys are present in eve namespace
-    for (const key of agentKeys) {
-      assert.ok(
-        eveKeys.includes(key),
-        `agents barrel key "${key}" must be present in eve namespace`,
-      );
+  // Verify all agents barrel keys are present in eve namespace
+  for (const key of agentKeys) {
+    assert.ok(eveKeys.includes(key), `agents barrel key "${key}" must be present in eve namespace`);
 
-      // Verify the exported value is the exact same object, not a wrapper
-      const eveValue = (eveNamespace as Record<string, unknown>)[key];
-      const agentValue = (agentsBarrel as Record<string, unknown>)[key];
+    // Verify the exported value is the exact same object, not a wrapper
+    const eveValue = (eveNamespace as Record<string, unknown>)[key];
+    const agentValue = (agentsBarrel as Record<string, unknown>)[key];
 
-      assert.strictEqual(
-        eveValue,
-        agentValue,
-        `${key} must be the same object identity from both imports`,
-      );
-    }
-
-    // eve has exactly the agents keys plus five own exports: eveAgentContext,
-    // guardApproval, guardTool, guardInbound, arcjetHooks.
-    // Type-only exports (GuardApprovalPolicy, GuardApprovalResponsePolicy, GuardToolPolicy, GuardInboundOptions,
-    // InboundVerdict, ArcjetHookFamily, ArcjetHooksOptions, ArcjetDenialResult)
-    // do not appear at runtime.
-    const expectedAdditions = 5;
-    assert.equal(
-      eveKeys.length,
-      agentKeys.length + expectedAdditions,
-      `eve namespace must have agents barrel exports plus ${expectedAdditions} own exports (eve has ${eveKeys.length}, agents has ${agentKeys.length}, expected ${agentKeys.length + expectedAdditions})`,
+    assert.strictEqual(
+      eveValue,
+      agentValue,
+      `${key} must be the same object identity from both imports`,
     );
+  }
 
-    // Verify the extra keys are exactly the five own exports
-    const eveOnlyKeys = eveKeys.filter((key) => !agentKeys.includes(key));
-    const ownExportsArray = [
-      "arcjetHooks",
-      "eveAgentContext",
-      "guardApproval",
-      "guardInbound",
-      "guardTool",
-    ];
-    // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-    const expectedOwnExports: readonly string[] = ownExportsArray.sort();
-    // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-    const sorted: readonly string[] = eveOnlyKeys.sort();
-    assert.deepEqual(
-      sorted,
-      expectedOwnExports,
-      `eve namespace's own exports must be exactly [${expectedOwnExports.join(", ")}]`,
-    );
-  },
-);
+  // eve has exactly the agents keys plus five own exports: eveAgentContext,
+  // guardApproval, guardTool, guardInbound, arcjetHooks.
+  // Type-only exports (GuardApprovalPolicy, GuardApprovalResponsePolicy, GuardToolPolicy, GuardInboundOptions,
+  // InboundVerdict, ArcjetHookFamily, ArcjetHooksOptions, ArcjetDenialResult)
+  // do not appear at runtime.
+  const expectedAdditions = 5;
+  assert.equal(
+    eveKeys.length,
+    agentKeys.length + expectedAdditions,
+    `eve namespace must have agents barrel exports plus ${expectedAdditions} own exports (eve has ${eveKeys.length}, agents has ${agentKeys.length}, expected ${agentKeys.length + expectedAdditions})`,
+  );
+
+  // Verify the extra keys are exactly the five own exports
+  const eveOnlyKeys = eveKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = [
+    "arcjetHooks",
+    "eveAgentContext",
+    "guardApproval",
+    "guardInbound",
+    "guardTool",
+  ];
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const expectedOwnExports: readonly string[] = ownExportsArray.sort();
+  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+  const sorted: readonly string[] = eveOnlyKeys.sort();
+  assert.deepEqual(
+    sorted,
+    expectedOwnExports,
+    `eve namespace's own exports must be exactly [${expectedOwnExports.join(", ")}]`,
+  );
+});
 
 // AC1.3: Ensure no unversioned or other-versioned vercel-eve keys exist
 test("AC1.3: export map has no unversioned ./vercel-eve or unsupported ./vercel-eve/v1", () => {

--- a/arcjet-guard/src/vercel-eve/v0/index.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/index.test.ts
@@ -14,7 +14,7 @@ import * as agentsBarrel from "../../agents/index.ts";
 // story covered by AC2.2, which applies only to Eve's own files. AC1.2 requires
 // cross-namespace assertions that can only be verified when ai is available.
 import * as v7Namespace from "../../vercel-ai/v7/index.ts";
-import * as eveNamespace from "./index.ts";
+import { nodeMajor } from "./engine.ts";
 import type {
   ArcjetHookFamily,
   ArcjetHooksOptions,
@@ -53,6 +53,24 @@ function verifyTypeExports(): void {
 
 verifyTypeExports();
 
+const eveSupported = (nodeMajor() ?? 0) >= 24;
+const testOnEveEngine = eveSupported ? test : test.skip;
+
+test("importing the Eve namespace below Node 24 fails with needs Node 24", async (t) => {
+  if (eveSupported) {
+    t.skip("this engine already meets Eve's floor");
+    return;
+  }
+  await assert.rejects(
+    () => import("./index.ts"),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /needs Node 24/);
+      return true;
+    },
+  );
+});
+
 /**
  * Read a JSON file as a plain record. `JSON.parse` is untyped by definition, so
  * the boundary is asserted once here rather than at each call site.
@@ -80,7 +98,8 @@ function objectField(
 
 // AC1.1: Each of the five own exports (eveAgentContext, guardApproval, guardTool,
 // guardInbound, arcjetHooks) must be a function.
-test("AC1.1: exports the five own helpers as functions", () => {
+testOnEveEngine("AC1.1: exports the five own helpers as functions", async () => {
+  const eveNamespace = await import("./index.ts");
   const ownExports = [
     "eveAgentContext",
     "guardApproval",
@@ -101,7 +120,8 @@ test("AC1.1: exports the five own helpers as functions", () => {
 
 // The agnostic helpers reach users through this namespace and no other,
 // so the public path is what must carry them.
-test("eve namespace exports the agnostic helpers", () => {
+testOnEveEngine("eve namespace exports the agnostic helpers", async () => {
+  const eveNamespace = await import("./index.ts");
   const requiredSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -118,79 +138,90 @@ test("eve namespace exports the agnostic helpers", () => {
 
 // AC1.2: For each agnostic symbol, the value imported from Eve namespace must
 // be the same object identity as the value from vercel-ai/v7 namespace.
-test("AC1.2: agnostic exports have same identity across Eve and v7 namespaces", () => {
-  const agnosticSymbols = [
-    "createAgentContext",
-    "securityMetadata",
-    "guardAction",
-    "captureAction",
-    "ArcjetDeniedError",
-    "ArcjetGuardUnavailableError",
-  ] as const;
+testOnEveEngine(
+  "AC1.2: agnostic exports have same identity across Eve and v7 namespaces",
+  async () => {
+    const eveNamespace = await import("./index.ts");
+    const agnosticSymbols = [
+      "createAgentContext",
+      "securityMetadata",
+      "guardAction",
+      "captureAction",
+      "ArcjetDeniedError",
+      "ArcjetGuardUnavailableError",
+    ] as const;
 
-  for (const symbol of agnosticSymbols) {
-    const eveValue = (eveNamespace as Record<string, unknown>)[symbol];
-    const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
+    for (const symbol of agnosticSymbols) {
+      const eveValue = (eveNamespace as Record<string, unknown>)[symbol];
+      const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
 
-    assert.strictEqual(
-      eveValue,
-      v7Value,
-      `${symbol} must be the same object identity from both @arcjet/guard/vercel-eve/v0 and @arcjet/guard/vercel-ai/v7`,
-    );
-  }
-});
+      assert.strictEqual(
+        eveValue,
+        v7Value,
+        `${symbol} must be the same object identity from both @arcjet/guard/vercel-eve/v0 and @arcjet/guard/vercel-ai/v7`,
+      );
+    }
+  },
+);
 
 // Proxy identity — shared exports have same function identity
-test("Eve namespace is a strict superset of the agents barrel with same identity for shared exports", () => {
-  const eveKeys = Object.keys(eveNamespace);
-  const agentKeys = Object.keys(agentsBarrel);
+testOnEveEngine(
+  "Eve namespace is a strict superset of the agents barrel with same identity for shared exports",
+  async () => {
+    const eveNamespace = await import("./index.ts");
+    const eveKeys = Object.keys(eveNamespace);
+    const agentKeys = Object.keys(agentsBarrel);
 
-  // Verify all agents barrel keys are present in eve namespace
-  for (const key of agentKeys) {
-    assert.ok(eveKeys.includes(key), `agents barrel key "${key}" must be present in eve namespace`);
+    // Verify all agents barrel keys are present in eve namespace
+    for (const key of agentKeys) {
+      assert.ok(
+        eveKeys.includes(key),
+        `agents barrel key "${key}" must be present in eve namespace`,
+      );
 
-    // Verify the exported value is the exact same object, not a wrapper
-    const eveValue = (eveNamespace as Record<string, unknown>)[key];
-    const agentValue = (agentsBarrel as Record<string, unknown>)[key];
+      // Verify the exported value is the exact same object, not a wrapper
+      const eveValue = (eveNamespace as Record<string, unknown>)[key];
+      const agentValue = (agentsBarrel as Record<string, unknown>)[key];
 
-    assert.strictEqual(
-      eveValue,
-      agentValue,
-      `${key} must be the same object identity from both imports`,
+      assert.strictEqual(
+        eveValue,
+        agentValue,
+        `${key} must be the same object identity from both imports`,
+      );
+    }
+
+    // eve has exactly the agents keys plus five own exports: eveAgentContext,
+    // guardApproval, guardTool, guardInbound, arcjetHooks.
+    // Type-only exports (GuardApprovalPolicy, GuardApprovalResponsePolicy, GuardToolPolicy, GuardInboundOptions,
+    // InboundVerdict, ArcjetHookFamily, ArcjetHooksOptions, ArcjetDenialResult)
+    // do not appear at runtime.
+    const expectedAdditions = 5;
+    assert.equal(
+      eveKeys.length,
+      agentKeys.length + expectedAdditions,
+      `eve namespace must have agents barrel exports plus ${expectedAdditions} own exports (eve has ${eveKeys.length}, agents has ${agentKeys.length}, expected ${agentKeys.length + expectedAdditions})`,
     );
-  }
 
-  // eve has exactly the agents keys plus five own exports: eveAgentContext,
-  // guardApproval, guardTool, guardInbound, arcjetHooks.
-  // Type-only exports (GuardApprovalPolicy, GuardApprovalResponsePolicy, GuardToolPolicy, GuardInboundOptions,
-  // InboundVerdict, ArcjetHookFamily, ArcjetHooksOptions, ArcjetDenialResult)
-  // do not appear at runtime.
-  const expectedAdditions = 5;
-  assert.equal(
-    eveKeys.length,
-    agentKeys.length + expectedAdditions,
-    `eve namespace must have agents barrel exports plus ${expectedAdditions} own exports (eve has ${eveKeys.length}, agents has ${agentKeys.length}, expected ${agentKeys.length + expectedAdditions})`,
-  );
-
-  // Verify the extra keys are exactly the five own exports
-  const eveOnlyKeys = eveKeys.filter((key) => !agentKeys.includes(key));
-  const ownExportsArray = [
-    "arcjetHooks",
-    "eveAgentContext",
-    "guardApproval",
-    "guardInbound",
-    "guardTool",
-  ];
-  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-  const expectedOwnExports: readonly string[] = ownExportsArray.sort();
-  // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-  const sorted: readonly string[] = eveOnlyKeys.sort();
-  assert.deepEqual(
-    sorted,
-    expectedOwnExports,
-    `eve namespace's own exports must be exactly [${expectedOwnExports.join(", ")}]`,
-  );
-});
+    // Verify the extra keys are exactly the five own exports
+    const eveOnlyKeys = eveKeys.filter((key) => !agentKeys.includes(key));
+    const ownExportsArray = [
+      "arcjetHooks",
+      "eveAgentContext",
+      "guardApproval",
+      "guardInbound",
+      "guardTool",
+    ];
+    // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+    const expectedOwnExports: readonly string[] = ownExportsArray.sort();
+    // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
+    const sorted: readonly string[] = eveOnlyKeys.sort();
+    assert.deepEqual(
+      sorted,
+      expectedOwnExports,
+      `eve namespace's own exports must be exactly [${expectedOwnExports.join(", ")}]`,
+    );
+  },
+);
 
 // AC1.3: Ensure no unversioned or other-versioned vercel-eve keys exist
 test("AC1.3: export map has no unversioned ./vercel-eve or unsupported ./vercel-eve/v1", () => {

--- a/arcjet-guard/src/vercel-eve/v0/index.ts
+++ b/arcjet-guard/src/vercel-eve/v0/index.ts
@@ -8,7 +8,9 @@
  * layering.
  *
  * **Requires the optional peer dependency `eve@>=0.34.0 <1`**, and Eve's own
- * Node floor of 24 — higher than `@arcjet/guard`'s. Nothing in this module
+ * Node floor of 24 — higher than `@arcjet/guard`'s. Importing this namespace
+ * below Node 24 throws `needs Node 24.` rather than leaving npm's
+ * generic `EBADENGINE` warning as the only signal. Nothing in this module
  * imports `eve` at runtime: every Eve type arrives through `import type`, so
  * installing `@arcjet/guard` never pulls Eve in.
  *
@@ -81,6 +83,10 @@
  * }
  * ```
  */
+
+import { assertEveEngine } from "./engine.ts";
+
+assertEveEngine();
 
 export { eveAgentContext } from "./context.ts";
 export { guardApproval } from "./guard-approval.ts";

--- a/arcjet-guard/test/runtime/node.test.ts
+++ b/arcjet-guard/test/runtime/node.test.ts
@@ -217,6 +217,28 @@ describe("Package boundary: the exports map is the public API", () => {
     }
   });
 
+  test("@arcjet/guard/vercel-ai/v7 loads when the ai peers are installed", async () => {
+    const v7 = await import("@arcjet/guard/vercel-ai/v7");
+    assert.equal(typeof v7.guardTool, "function");
+  });
+
+  test("@arcjet/guard/vercel-eve/v0 names Node 24 when the engine is below it", async () => {
+    const major = Number(process.versions.node.split(".")[0]);
+    if (major >= 24) {
+      const eve = await import("@arcjet/guard/vercel-eve/v0");
+      assert.equal(typeof eve.guardTool, "function");
+      return;
+    }
+    await assert.rejects(
+      () => import("@arcjet/guard/vercel-eve/v0"),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /needs Node 24/);
+        return true;
+      },
+    );
+  });
+
   test("internal modules are unreachable through the package boundary", async () => {
     // The seams the registry and test client share with the client — the
     // fail-open decision, capture normalization, the diagnostics symbol — are


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Missing Vercel AI SDK peers and Eve on an older Node currently fail with generic resolver/engine output. This names the actual fix.

- Importing `@arcjet/guard/vercel-ai/v7` without `ai` / `@ai-sdk/provider-utils` throws `install ai and @ai-sdk/provider-utils.` instead of Node's `ERR_MODULE_NOT_FOUND`.
- Importing `@arcjet/guard/vercel-eve/v0` below Node 24 throws `needs Node 24.` instead of relying on npm's `EBADENGINE` warning.
- Implementation helpers stay importable on Node 22 so type-only and unit tests still run; only the public Eve barrel enforces the floor.

## Changes

- Load `ai` and `@ai-sdk/provider-utils` dynamically in the v7 namespace so a miss can be rewritten.
- Check `process.versions.node` when the Eve barrel loads.
- Cover both messages in unit tests (including a module hook that hides the AI peers) and a Node runtime package-boundary test.

## Test plan

- `arcjet-guard` unit tests, including new `peers.test.ts` and `engine.test.ts`
- Eve barrel import on Node 22 must throw `needs Node 24`
- Eve barrel import on Node 24+ still exports `guardTool`
- v7 import with a hook that hides `ai` / `@ai-sdk/provider-utils` must throw the install line
- Runtime Node package-boundary tests for both subpaths

## Verification

On Node 22.22.2:

- `npm run test-unit` in `arcjet-guard`: 1158 tests, 1154 pass, 4 skipped (Eve barrel identity tests, which need Node 24), 0 fail
- `npm run lint` and `npm run typecheck` pass
- Direct imports:

[not used](https://cursor.com/agents/bc-90391b1c-aad7-4bb2-9699-f44ffa0e5644/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpeer_engine_error_messages.log)

Actual messages:

- `@arcjet/guard/vercel-eve/v0: needs Node 24.`
- `@arcjet/guard/vercel-ai/v7: install ai and @ai-sdk/provider-utils.`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90391b1c-aad7-4bb2-9699-f44ffa0e5644?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90391b1c-aad7-4bb2-9699-f44ffa0e5644&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

