### PR TITLE
ci: drop Bun from the Windows test matrix

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -16,16 +16,19 @@ jobs:
     timeout-minutes: 15
     defaults:
       run:
-        # Git Bash on Windows so `&&` matches Linux/macOS.
+        # Explicit so `pipefail` is on, matching the other jobs here.
         shell: bash
     strategy:
       fail-fast: false
       matrix:
+        # No windows-latest: Bun cannot migrate `package-lock.json`, so
+        # `bun install` resolves every package from the registry, and Windows
+        # harden-runner's DNS proxy drops those lookups (`no upstream DNS
+        # servers available` for registry.npmjs.org, then `ConnectionRefused`
+        # on each tarball). Re-add it once that proxy is reliable on Windows.
         include:
           - os: ubuntu-latest
             bun-asset: bun-linux-x64.zip
-          - os: windows-latest
-            bun-asset: bun-windows-x64.zip
           - os: macos-latest
             bun-asset: bun-darwin-aarch64.zip
     permissions:
@@ -47,11 +50,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      # Windows harden-runner's DNS proxy can still be coming up when the next
-      # step runs, which makes setup-bun's GitHub API fetch fail immediately.
-      - name: Wait for Windows DNS proxy
-        if: runner.os == 'Windows'
-        run: sleep 5
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
           bun-version: 1.2.19


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `windows-latest` from the `bun-test` matrix in `reusable-test.yml`. `arcjet-bun`'s tests keep running on Ubuntu and macOS. Deno and Node keep their Windows legs untouched.

## Why

Bun cannot migrate `package-lock.json` (`InvalidNPMLockfile: failed to migrate lockfile`), so `bun install` resolves every package straight from the registry rather than a lockfile. That makes this the most network-dependent job in the matrix, and Windows harden-runner's DNS proxy does not hold up under it:

```
level=WARN msg="upstream DNS query failed" domain=registry.npmjs.org. error="no upstream DNS servers available"
level=WARN msg="skipping adapter due to error" adapter="Ethernet 4"
  error="Set-DnsClientServerAddress : No MSFT_DNSClientServerAddress objects found ..."
```

With lookups dropped, the install fails on ~20 packages with `ConnectionRefused` (`fontkitten`, `binaryen`, `@bytecodealliance/jco`, `srvx`, …) and ends in `failed to resolve`. The existing `Wait for Windows DNS proxy` sleep was an earlier attempt at the same problem and is not sufficient.

This failed repeatedly on PRs whose changes had nothing to do with Bun — [#6240](https://github.com/arcjet/arcjet-js/pull/6240) hit it twice and had to be force merged, and `david/cursor/export-guard-package-json-8901` hit the identical failure. Ubuntu and macOS pass consistently.

The `Wait for Windows DNS proxy` step is removed along with it: its `if: runner.os == 'Windows'` can never be true in this job now. The `defaults.run.shell` comment referenced Windows Git Bash, so it is reworded — `shell: bash` stays, because it keeps `pipefail` on and matches the sibling jobs.

A comment on the matrix records why Windows is excluded and what would have to change to re-add it, so it is not restored blindly.

## Branch protection

Unaffected. The required check is the aggregate `Run tests / Bun`, which gates on `needs.bun-test.result`; only a matrix leg is removed, not a check name.

## Test plan

- [x] `actionlint 1.7.12` (the version pinned in `dev/mise.toml`) passes on all workflows
- [x] `zizmor 1.24.1` at `--min-severity=medium` reports no findings
- [x] Parsed the workflow to confirm `bun-test` now resolves to `ubuntu-latest` + `macos-latest`, the dead DNS-wait step is gone, and Deno/Node still list all three OSes
- [x] CI on this PR has no `Run tests / Bun (OS: windows-latest)` job; `Run tests / Bun (required)`, `Bun (OS: ubuntu-latest)`, and `Bun (OS: macos-latest)` are all green
- [x] `Lint workflows / actionlint + zizmor` green in CI, matching the local runs above
- [x] Required checks: 0 failed, 0 pending

The one red check is `StepSecurity Harden-Runner` ("⚠️ Unexpected network calls from CI/CD runners"), which is advisory and not required. It failed on all three runs of [#6240](https://github.com/arcjet/arcjet-js/pull/6240) too, before this workflow change existed, so it predates this PR. Triaging it needs the StepSecurity dashboard; the runner logs do not enumerate the flagged calls (the only domain harden-runner logged on the Windows Deno leg was `github.com`, which is already allowlisted).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48194cf4-42bf-4ed5-afb4-9cabc3608a55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48194cf4-42bf-4ed5-afb4-9cabc3608a55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

