### PR TITLE
ci(guard): consolidate optional-peer absent unit tests

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -77,7 +77,7 @@ jobs:
       # installing, so a floor below what package.json advertises fails here
       # rather than in a user's project.
       #
-      # Runs before the eve-absent step because that one deletes eve outright.
+      # Runs before the peer-absent step because that one deletes eve outright.
       - name: Unit tests at the lowest supported eve
         run: |
           floor=$(node -e "
@@ -108,116 +108,22 @@ jobs:
           node --test 'arcjet-guard/src/vercel-eve/**/*.test.ts'
         working-directory: ${{ github.workspace }}
 
-      # The claude-agent-sdk namespace imports the SDK for types only. A static
-      # scan proves the imports are written `import type`; this proves the
-      # consequence, catching a build step that re-emits one as a value import.
-      #
-      # Runs before the eve-absent step because that one deletes a different
-      # optional peer. Typecheck legitimately fails without the SDK.
-      - name: Unit tests with claude-agent-sdk absent
-        run: |
-          rm -rf node_modules/@anthropic-ai/claude-agent-sdk arcjet-guard/node_modules/@anthropic-ai/claude-agent-sdk
-          node -e "try { require.resolve('@anthropic-ai/claude-agent-sdk', { paths: ['arcjet-guard/src/claude-agent-sdk/v0'] }); console.error('claude-agent-sdk still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          count=$(find arcjet-guard/src/claude-agent-sdk -name '*.test.ts' | wc -l)
-          test "$count" -ge 5 || { echo "only $count claude-agent-sdk test files matched; the glob has gone stale" >&2; exit 1; }
-          node --test 'arcjet-guard/src/claude-agent-sdk/**/*.test.ts'
-        working-directory: ${{ github.workspace }}
-
-      # The langgraph namespace imports @langchain/langgraph and
-      # @langchain/core for types only. A static scan proves the imports are
-      # written `import type`; this proves the consequence, catching a build
-      # step that re-emits one as a value import.
-      #
-      # Only `src/langgraph` is globbed. The suite that exercises the real
-      # ToolNode value-imports both peers, so it lives in `test/langgraph`
-      # and runs in the unit-test step above, where the peers are installed.
-      #
-      # Runs before the eve-absent step because that one deletes a different
-      # optional peer. Typecheck legitimately fails without the peers.
-      - name: Unit tests with langgraph absent
-        run: |
-          rm -rf node_modules/@langchain/langgraph node_modules/@langchain/core arcjet-guard/node_modules/@langchain/langgraph arcjet-guard/node_modules/@langchain/core
-          node -e "try { require.resolve('@langchain/langgraph', { paths: ['arcjet-guard/src/langgraph/v1'] }); console.error('langgraph still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          node -e "try { require.resolve('@langchain/core', { paths: ['arcjet-guard/src/langgraph/v1'] }); console.error('langchain core still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          count=$(find arcjet-guard/src/langgraph -name '*.test.ts' | wc -l)
-          test "$count" -ge 5 || { echo "only $count langgraph test files matched; the glob has gone stale" >&2; exit 1; }
-          node --test 'arcjet-guard/src/langgraph/**/*.test.ts'
-        working-directory: ${{ github.workspace }}
-
-      # The genkit namespace imports genkit for types only. A static scan
-      # proves the imports are written `import type`; this proves the
-      # consequence, catching a build step that re-emits one as a value
-      # import.
-      #
-      # Only `src/genkit` is globbed. The suites that exercise the real
-      # `defineTool` and the real `ai.generate()` loop value-import the
-      # peer, so they live in `test/genkit` and run in the unit-test step
-      # above, where the peer is installed.
-      #
-      # Runs before the eve-absent step because that one deletes a different
-      # optional peer. Typecheck legitimately fails without the peer.
-      - name: Unit tests with genkit absent
-        run: |
-          rm -rf node_modules/genkit node_modules/@genkit-ai arcjet-guard/node_modules/genkit arcjet-guard/node_modules/@genkit-ai
-          node -e "try { require.resolve('genkit', { paths: ['arcjet-guard/src/genkit/v1'] }); console.error('genkit still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          count=$(find arcjet-guard/src/genkit -name '*.test.ts' | wc -l)
-          test "$count" -ge 5 || { echo "only $count genkit test files matched; the glob has gone stale" >&2; exit 1; }
-          node --test 'arcjet-guard/src/genkit/**/*.test.ts'
-        working-directory: ${{ github.workspace }}
-
-      # The openai-agents namespace imports @openai/agents for types only. A
-      # static scan proves the imports are written `import type`; this proves
+      # Each type-only vendor namespace is the same check: delete the optional
+      # peer, prove it no longer resolves, then run `src/<namespace>` tests.
+      # A static scan proves the imports are written `import type`; this proves
       # the consequence, catching a build step that re-emits one as a value
       # import.
       #
-      # Only `src/openai-agents` is globbed. The suites that exercise the real
-      # `tool()` and the real `run()` loop value-import the peer, so they live
-      # in `test/openai-agents` and run in the unit-test step above, where the
-      # peer is installed.
+      # Only `src/<namespace>` is globbed. Suites that exercise the real SDK
+      # live under `test/<namespace>` and run in the unit-test step above.
+      # `vercel-ai` is omitted: its `src/` tests value-import `ai`.
       #
-      # Runs before the eve-absent step because that one deletes a different
-      # optional peer. Typecheck legitimately fails without the peer.
-      - name: Unit tests with openai-agents absent
-        run: |
-          rm -rf node_modules/@openai/agents arcjet-guard/node_modules/@openai/agents
-          node -e "try { require.resolve('@openai/agents', { paths: ['arcjet-guard/src/openai-agents/v0'] }); console.error('openai-agents still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          count=$(find arcjet-guard/src/openai-agents -name '*.test.ts' | wc -l)
-          test "$count" -ge 5 || { echo "only $count openai-agents test files matched; the glob has gone stale" >&2; exit 1; }
-          node --test 'arcjet-guard/src/openai-agents/**/*.test.ts'
-        working-directory: ${{ github.workspace }}
-
-      # The mastra namespace imports @mastra/core for types only. A static scan
-      # proves the imports are written `import type`; this proves the
-      # consequence, catching a build step that re-emits one as a value import.
-      #
-      # Runs before the eve-absent step because that one deletes a different
-      # optional peer. Typecheck legitimately fails without @mastra/core.
-      - name: Unit tests with mastra absent
-        run: |
-          rm -rf node_modules/@mastra/core arcjet-guard/node_modules/@mastra/core
-          node -e "try { require.resolve('@mastra/core', { paths: ['arcjet-guard/src/mastra/v1'] }); console.error('mastra still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          count=$(find arcjet-guard/src/mastra -name '*.test.ts' | wc -l)
-          test "$count" -ge 5 || { echo "only $count mastra test files matched; the glob has gone stale" >&2; exit 1; }
-          node --test 'arcjet-guard/src/mastra/**/*.test.ts'
-        working-directory: ${{ github.workspace }}
-
-      # The vercel-eve namespace imports eve for types only, which is what lets
-      # guard support Node 22 at all — eve declares engines.node ">=24". A static
-      # scan proves the imports are written `import type`; this proves the
-      # consequence, catching a build step that re-emits one as a value import.
-      #
-      # Runs on every leg of the matrix rather than just Node 22, because the
-      # criterion is about all three. Runs last because it deletes a
-      # devDependency: the typecheck legitimately fails without eve, since types
-      # are a build-time dependency.
-      - name: Unit tests with eve absent
-        run: |
-          rm -rf node_modules/eve arcjet-guard/node_modules/eve
-          node -e "try { require.resolve('eve', { paths: ['arcjet-guard/src/vercel-eve/v0'] }); console.error('eve still resolves'); process.exit(1) } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error }"
-          count=$(find arcjet-guard/src/vercel-eve -name '*.test.ts' | wc -l)
-          test "$count" -ge 5 || { echo "only $count vercel-eve test files matched; the glob has gone stale" >&2; exit 1; }
-          node --test 'arcjet-guard/src/vercel-eve/**/*.test.ts'
-        working-directory: ${{ github.workspace }}
+      # Eve is last inside the script because it deletes a shared
+      # devDependency. The floor-pin step above also needs eve on disk.
+      # Runs on every matrix leg — eve's engines.node is ">=24", and the
+      # type-only import is what lets guard support Node 22 at all.
+      - name: Unit tests with optional peers absent
+        run: npm run test-peers-absent
 
   lint:
     name: Lint & Typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,12 @@ who never touch an AI SDK are unaffected.
 
 5. If the SDK is a new dependency, declare it in `peerDependencies` and mark it
    optional in `peerDependenciesMeta`.
+6. If the namespace imports its SDK for types only, add a check to
+   `arcjet-guard/scripts/test-peers-absent.mjs` (and a `type-only.test.ts`).
+   CI runs that script after unit tests and fails if a `type-only.test.ts`
+   exists with no matching check, or the other way around. Skip this when
+   `src/` tests value-import the SDK — `vercel-ai/v7` does, and has no
+   type-only scan.
 
 No changes to the shared layer, the build config, or the root export are
 required — `tsdown` runs with `unbundle: true`, so a new directory under `src/`

--- a/arcjet-guard/.oxlintrc.json
+++ b/arcjet-guard/.oxlintrc.json
@@ -62,5 +62,5 @@
       }
     }
   ],
-  "ignorePatterns": ["examples/**"]
+  "ignorePatterns": ["examples/**", "scripts/**"]
 }

--- a/arcjet-guard/CONTRIBUTING.md
+++ b/arcjet-guard/CONTRIBUTING.md
@@ -68,6 +68,13 @@ type stripping):
 npm run test-unit
 ```
 
+Optional-peer isolation (deletes those SDKs from `node_modules`, then runs
+each type-only namespace). Re-install afterwards:
+
+```sh
+npm run test-peers-absent
+```
+
 Runtime tests (build first — imports from `dist/` via package exports):
 
 ```sh

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -109,6 +109,7 @@
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
     "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts'",
+    "test-peers-absent": "node scripts/test-peers-absent.mjs",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
     "test-runtime-deno": "npm run build && deno test --no-check --allow-all test/runtime/deno.test.ts",

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -1,0 +1,250 @@
+/**
+ * Prove each type-only vendor namespace still runs when its optional peer is
+ * gone. A static scan (`type-only.test.ts`) proves the imports are written
+ * `import type`; this proves the consequence, catching a build step that
+ * re-emits one as a value import.
+ *
+ * Only `src/<namespace>` is globbed. Suites that exercise the real SDK
+ * value-import the peer, so they live under `test/<namespace>` and run in
+ * `npm run test-unit`, where the peer is installed.
+ *
+ * `vercel-ai` is omitted on purpose: its `src/` tests value-import `ai`,
+ * and it has no `type-only.test.ts`. Adding that file without adding a
+ * check here fails the discovery assertion below.
+ *
+ * Eve is last because it deletes a shared devDependency. The floor-pin
+ * step in CI also needs eve on disk, so it runs before this script.
+ *
+ * Usage: `node scripts/test-peers-absent.mjs [name...]`
+ * With no names, every check runs.
+ */
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(SCRIPT_DIR, "..");
+const WORKSPACE_ROOT = join(PACKAGE_ROOT, "..");
+const SRC_ROOT = join(PACKAGE_ROOT, "src");
+const MIN_TEST_FILES = 5;
+
+/**
+ * One check per namespace that imports its SDK for types only.
+ * `dir` is the folder under `src/`. `remove` may include a scope
+ * (`@genkit-ai`) so nested copies of the peer disappear too.
+ */
+const CHECKS = [
+  {
+    name: "claude-agent-sdk",
+    dir: "claude-agent-sdk",
+    version: "v0",
+    remove: ["@anthropic-ai/claude-agent-sdk"],
+    resolve: ["@anthropic-ai/claude-agent-sdk"],
+  },
+  {
+    name: "langgraph",
+    dir: "langgraph",
+    version: "v1",
+    remove: ["@langchain/langgraph", "@langchain/core"],
+    resolve: ["@langchain/langgraph", "@langchain/core"],
+  },
+  {
+    name: "genkit",
+    dir: "genkit",
+    version: "v1",
+    remove: ["genkit", "@genkit-ai"],
+    resolve: ["genkit"],
+  },
+  {
+    name: "openai-agents",
+    dir: "openai-agents",
+    version: "v0",
+    remove: ["@openai/agents"],
+    resolve: ["@openai/agents"],
+  },
+  {
+    name: "mastra",
+    dir: "mastra",
+    version: "v1",
+    remove: ["@mastra/core"],
+    resolve: ["@mastra/core"],
+  },
+  // Last: deletes a shared devDependency.
+  {
+    name: "eve",
+    dir: "vercel-eve",
+    version: "v0",
+    remove: ["eve"],
+    resolve: ["eve"],
+  },
+];
+
+function nodeModulesCopies(id) {
+  return [join(WORKSPACE_ROOT, "node_modules", id), join(PACKAGE_ROOT, "node_modules", id)];
+}
+
+function removeFromDisk(id) {
+  for (const target of nodeModulesCopies(id)) {
+    rmSync(target, { recursive: true, force: true });
+  }
+}
+
+function assertUnresolved(specifier, resolveFrom) {
+  const require = createRequire(join(resolveFrom, "dummy.js"));
+  try {
+    require.resolve(specifier);
+  } catch (error) {
+    if (error.code === "MODULE_NOT_FOUND") {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`${specifier} still resolves`);
+}
+
+function countTestFiles(dir) {
+  return readdirSync(dir, { recursive: true, encoding: "utf8" }).filter((name) =>
+    name.endsWith(".test.ts"),
+  ).length;
+}
+
+/**
+ * Namespaces that already have a type-only scan must have a check here, and
+ * every check must have that scan. Otherwise a new vendor can land a
+ * `type-only.test.ts` (or a YAML-era check) and CI will keep passing.
+ */
+function discoverTypeOnlyNamespaces() {
+  const found = [];
+  for (const entry of readdirSync(SRC_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const nsDir = join(SRC_ROOT, entry.name);
+    for (const version of readdirSync(nsDir, { withFileTypes: true })) {
+      if (!version.isDirectory()) {
+        continue;
+      }
+      if (existsSync(join(nsDir, version.name, "type-only.test.ts"))) {
+        found.push({ dir: entry.name, version: version.name });
+      }
+    }
+  }
+  return found;
+}
+
+function assertChecksMatchSource() {
+  if (CHECKS.at(-1)?.dir !== "vercel-eve") {
+    throw new Error("eve must run last: it deletes a shared devDependency");
+  }
+
+  const discovered = discoverTypeOnlyNamespaces();
+  const missing = discovered.filter(
+    (ns) => !CHECKS.some((check) => check.dir === ns.dir && check.version === ns.version),
+  );
+  const extra = CHECKS.filter(
+    (check) =>
+      !discovered.some((ns) => ns.dir === check.dir && ns.version === check.version),
+  );
+
+  const errors = [];
+  if (missing.length > 0) {
+    errors.push(
+      `type-only namespaces with no peer-absent check: ${missing
+        .map((ns) => `${ns.dir}/${ns.version}`)
+        .join(", ")}`,
+    );
+  }
+  if (extra.length > 0) {
+    errors.push(
+      `peer-absent checks with no type-only.test.ts: ${extra
+        .map((check) => `${check.dir}/${check.version}`)
+        .join(", ")}`,
+    );
+  }
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+}
+
+function beginGroup(title) {
+  if (process.env.GITHUB_ACTIONS === "true") {
+    console.log(`::group::${title}`);
+  } else {
+    console.log(`\n=== ${title} ===`);
+  }
+}
+
+function endGroup() {
+  if (process.env.GITHUB_ACTIONS === "true") {
+    console.log("::endgroup::");
+  }
+}
+
+function runCheck(check) {
+  const title = `Unit tests with ${check.name} absent`;
+  beginGroup(title);
+  try {
+    for (const id of check.remove) {
+      removeFromDisk(id);
+    }
+
+    const resolveFrom = join(PACKAGE_ROOT, "src", check.dir, check.version);
+    for (const specifier of check.resolve) {
+      assertUnresolved(specifier, resolveFrom);
+    }
+
+    const testDir = join(PACKAGE_ROOT, "src", check.dir);
+    const count = countTestFiles(testDir);
+    if (count < MIN_TEST_FILES) {
+      throw new Error(
+        `only ${count} ${check.name} test files matched; the glob has gone stale`,
+      );
+    }
+
+    const glob = `src/${check.dir}/**/*.test.ts`;
+    const result = spawnSync(process.execPath, ["--test", glob], {
+      cwd: PACKAGE_ROOT,
+      stdio: "inherit",
+    });
+    if (result.status !== 0) {
+      throw new Error(`${title} failed (exit ${result.status ?? "null"})`);
+    }
+    console.log(`${title}: ${count} files, peers gone`);
+  } finally {
+    endGroup();
+  }
+}
+
+const requested = process.argv.slice(2);
+const selected = requested.length === 0
+  ? CHECKS
+  : requested.map((name) => {
+      const check = CHECKS.find((entry) => entry.name === name);
+      if (!check) {
+        throw new Error(
+          `unknown peer-absent check "${name}"; known: ${CHECKS.map((entry) => entry.name).join(", ")}`,
+        );
+      }
+      return check;
+    });
+
+assertChecksMatchSource();
+
+const failures = [];
+for (const check of selected) {
+  try {
+    runCheck(check);
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} peer-absent check(s) failed:`);
+  for (const message of failures) {
+    console.error(`  ${message}`);
+  }
+  process.exit(1);
+}

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -19,8 +19,8 @@
  * With no names, every check runs.
  */
 import { spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
 import { existsSync, readdirSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -144,8 +144,7 @@ function assertChecksMatchSource() {
     (ns) => !CHECKS.some((check) => check.dir === ns.dir && check.version === ns.version),
   );
   const extra = CHECKS.filter(
-    (check) =>
-      !discovered.some((ns) => ns.dir === check.dir && ns.version === check.version),
+    (check) => !discovered.some((ns) => ns.dir === check.dir && ns.version === check.version),
   );
 
   const errors = [];
@@ -198,9 +197,7 @@ function runCheck(check) {
     const testDir = join(PACKAGE_ROOT, "src", check.dir);
     const count = countTestFiles(testDir);
     if (count < MIN_TEST_FILES) {
-      throw new Error(
-        `only ${count} ${check.name} test files matched; the glob has gone stale`,
-      );
+      throw new Error(`only ${count} ${check.name} test files matched; the glob has gone stale`);
     }
 
     const glob = `src/${check.dir}/**/*.test.ts`;
@@ -218,17 +215,18 @@ function runCheck(check) {
 }
 
 const requested = process.argv.slice(2);
-const selected = requested.length === 0
-  ? CHECKS
-  : requested.map((name) => {
-      const check = CHECKS.find((entry) => entry.name === name);
-      if (!check) {
-        throw new Error(
-          `unknown peer-absent check "${name}"; known: ${CHECKS.map((entry) => entry.name).join(", ")}`,
-        );
-      }
-      return check;
-    });
+const selected =
+  requested.length === 0
+    ? CHECKS
+    : requested.map((name) => {
+        const check = CHECKS.find((entry) => entry.name === name);
+        if (!check) {
+          throw new Error(
+            `unknown peer-absent check "${name}"; known: ${CHECKS.map((entry) => entry.name).join(", ")}`,
+          );
+        }
+        return check;
+      });
 
 assertChecksMatchSource();
 

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -15,6 +15,10 @@
  * Eve is last because it deletes a shared devDependency. The floor-pin
  * step in CI also needs eve on disk, so it runs before this script.
  *
+ * A failing check does not stop the run: each check only needs its own peer
+ * gone, so reporting all of them beats the one-at-a-time YAML steps this
+ * replaced, where the first failure hid the rest.
+ *
  * Usage: `node scripts/test-peers-absent.mjs [name...]`
  * With no names, every check runs.
  */
@@ -92,9 +96,9 @@ function removeFromDisk(id) {
 }
 
 function assertUnresolved(specifier, resolveFrom) {
-  const require = createRequire(join(resolveFrom, "dummy.js"));
+  const resolver = createRequire(join(resolveFrom, "dummy.js"));
   try {
-    require.resolve(specifier);
+    resolver.resolve(specifier);
   } catch (error) {
     if (error.code === "MODULE_NOT_FOUND") {
       return;
@@ -200,13 +204,19 @@ function runCheck(check) {
       throw new Error(`only ${count} ${check.name} test files matched; the glob has gone stale`);
     }
 
+    // Node expands the glob itself; `spawnSync` without a shell passes it through
+    // literally, which is what the quoting did in the YAML this replaced.
     const glob = `src/${check.dir}/**/*.test.ts`;
     const result = spawnSync(process.execPath, ["--test", glob], {
       cwd: PACKAGE_ROOT,
       stdio: "inherit",
     });
+    if (result.error) {
+      throw new Error(`${title} could not start: ${result.error.message}`);
+    }
     if (result.status !== 0) {
-      throw new Error(`${title} failed (exit ${result.status ?? "null"})`);
+      const how = result.signal === null ? `exit ${result.status}` : `signal ${result.signal}`;
+      throw new Error(`${title} failed (${how})`);
     }
     console.log(`${title}: ${count} files, peers gone`);
   } finally {
@@ -244,5 +254,7 @@ if (failures.length > 0) {
   for (const message of failures) {
     console.error(`  ${message}`);
   }
-  process.exit(1);
+  // Not `process.exit`: that can drop buffered stdout when it is a pipe, which
+  // is exactly where this summary is read from under Actions.
+  process.exitCode = 1;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`guard.yml` had six copy-pasted **Unit tests with &lt;peer&gt; absent** steps (claude-agent-sdk, langgraph, genkit, openai-agents, mastra, eve). Each one deleted the optional peer, asserted it no longer resolved, required ≥5 test files so a stale glob could not pass, and ran `node --test` on `src/<namespace>`.

A new type-only namespace meant pasting another YAML block. Forgetting that block would leave CI green.

## Approach

Keep the checks in the same build-matrix job (they mutate `node_modules` after unit tests; a matrix of jobs would redo install + build). Drive them from `arcjet-guard/scripts/test-peers-absent.mjs` and one workflow step:

```yaml
- name: Unit tests with optional peers absent
  run: npm run test-peers-absent
```

The script still deletes **one namespace’s peers at a time** (not every optional peer at once). `vercel-eve/v0/index.test.ts` value-imports the vercel-ai namespace, which needs `ai` on disk.

Eve stays last because it deletes a shared devDependency. The lowest-supported-eve floor pin is unchanged and still runs first.

Adding a type-only namespace is a config entry. The script also walks `src/*/v*/type-only.test.ts` and fails if a scan exists with no check, or the other way around. `vercel-ai` is omitted on purpose: its `src/` tests value-import `ai`.

Unlike the YAML steps, a failing check no longer hides the rest — each check only needs its own peer gone, so all failures are reported together.

Locally: `npm run test-peers-absent` (re-install afterwards; this is not part of `npm test`).

## Alternatives not taken

- **Job matrix per namespace** — 3 Node versions × 6 namespaces re-installs and rebuilds.
- **Composite action invoked six times** — shorter YAML, still six copies, no staleness check.
- **YAML anchors** — not reliably supported by GitHub Actions.

## Testing

`npm run test-peers-absent` on Node 22.22.2 after a workspace install. All six groups pass (657 tests, 0 failures):

| namespace | files | tests |
|---|---|---|
| claude-agent-sdk | 9 | 114 |
| langgraph | 7 | 78 |
| genkit | 7 | 102 |
| openai-agents | 6 | 69 |
| mastra | 9 | 119 |
| eve | 10 | 175 |

CI on this branch: **Build & Unit Test** passed on Node 22, 24, and 26, each running the consolidated step.

Because a consolidated runner is only worth having if it still fails, each fail-closed path was verified rather than assumed:

- A deliberately failing test in `src/genkit/v1` → exit 1, `Unit tests with genkit absent failed (exit 1)`.
- Two `openai-agents` test files moved aside (6 → 4) → exit 1, `only 4 openai-agents test files matched; the glob has gone stale`.
- A temporary `src/vercel-ai/v7/type-only.test.ts` → exit 1, `type-only namespaces with no peer-absent check: vercel-ai/v7`.
- Unknown check names fail closed.
- After a run, `genkit` no longer resolves from its namespace (`MODULE_NOT_FOUND`).

## Review follow-ups

Fixed in a second commit after reviewing the script:

- `process.exit(1)` can drop buffered stdout when it is a pipe — which is where Actions reads the failure summary from. Uses `process.exitCode` now.
- A spawn error and a killing signal both printed `exit null`; they are now reported distinctly.
- Renamed a shadowed `require` binding.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0d6032d-f6e3-4426-a190-f6dca4359970?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0d6032d-f6e3-4426-a190-f6dca4359970&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

