### PR TITLE
ci: enforce harden-runner egress allow-lists instead of audit

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -38,8 +38,18 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # `decide.arcjet.com` is reached by the unit tests, unlike the runtime
+          # job below, which serves a local mock instead.
+          allowed-endpoints: >
+            api.github.com:443
+            decide.arcjet.com:443
+            github.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
           disable-sudo-and-containers: true
-          egress-policy: audit
+          egress-policy: block
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -134,8 +144,17 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # Installs and builds, then runs oxlint and tsgo locally: no Arcjet
+          # endpoint, because nothing here runs a test.
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
           disable-sudo-and-containers: true
-          egress-policy: audit
+          egress-policy: block
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -213,8 +232,24 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # One list for every leg of the matrix: Deno's installer reaches
+          # `deno.com` / `deno.land` / `dl.deno.land`, Bun downloads its zip from
+          # GitHub releases, and miniflare's bundled workerd calls
+          # `workers.cloudflare.com` on startup. The runtime tests themselves
+          # talk to a local mock DecideService, so no Arcjet endpoint is needed.
+          allowed-endpoints: >
+            api.github.com:443
+            deno.com:443
+            deno.land:443
+            dl.deno.land:443
+            github.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            workers.cloudflare.com:443
           disable-sudo-and-containers: true
-          egress-policy: audit
+          egress-policy: block
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -38,8 +38,21 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          # `decide.arcjet.com` is reached by the unit tests, unlike the runtime
-          # job below, which serves a local mock instead.
+          # Every list in this file comes from harden-runner's own DNS logs for
+          # these jobs, with two deliberate exceptions noted below.
+          #
+          # Observed: `decide.arcjet.com` is reached by the unit tests, unlike
+          # the runtime job below, which serves a local mock instead.
+          # `release-assets.githubusercontent.com` is where setup-node fetches a
+          # Node version the runner image has not already cached — it shows up on
+          # the Node 26 leg and not on 22 or 24.
+          #
+          # Not observed, kept deliberately: `nodejs.org` and
+          # `objects.githubusercontent.com` are the documented fallbacks for
+          # those same downloads, and every other block-mode workflow here lists
+          # them. Whether they are reached depends on what the runner image
+          # happens to have cached, so omitting them would fail only
+          # occasionally — the worst way to find out.
           allowed-endpoints: >
             api.github.com:443
             decide.arcjet.com:443
@@ -145,7 +158,9 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           # Installs and builds, then runs oxlint and tsgo locally: no Arcjet
-          # endpoint, because nothing here runs a test.
+          # endpoint, because nothing here runs a test. Only `github.com` and
+          # `registry.npmjs.org` were observed; the rest are the same
+          # toolchain-download fallbacks described on the build job above.
           allowed-endpoints: >
             api.github.com:443
             github.com:443
@@ -232,22 +247,22 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          # One list for every leg of the matrix: Deno's installer reaches
-          # `deno.com` / `deno.land` / `dl.deno.land`, Bun downloads its zip from
-          # GitHub releases, and miniflare's bundled workerd calls
-          # `workers.cloudflare.com` on startup. The runtime tests themselves
-          # talk to a local mock DecideService, so no Arcjet endpoint is needed.
+          # The per-runtime endpoints are added only on the leg that needs them,
+          # so a Node leg cannot reach Deno's installer hosts and only the
+          # workerd leg can reach Cloudflare. Bun needs nothing extra: it
+          # downloads its zip from GitHub releases.
+          #
+          # The runtime tests talk to a local mock DecideService, so unlike the
+          # unit-test job above this needs no Arcjet endpoint.
           allowed-endpoints: >
             api.github.com:443
-            deno.com:443
-            deno.land:443
-            dl.deno.land:443
             github.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
-            workers.cloudflare.com:443
+            ${{ matrix.runtime == 'deno' && 'deno.com:443 deno.land:443 dl.deno.land:443' || '' }}
+            ${{ matrix.runtime == 'cloudflare' && 'workers.cloudflare.com:443' || '' }}
           disable-sudo-and-containers: true
           egress-policy: block
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -71,6 +71,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # This job only reads a needs result, so it needs no endpoint of its
+          # own. The list is still required: `block` with none at all also drops
+          # harden-runner's own API and the runner's orchestrator calls, which it
+          # then reports as unexpected network calls.
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
           disable-sudo-and-containers: true
           egress-policy: block
       - name: All Bun OS jobs passed
@@ -139,6 +146,11 @@ jobs:
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # Same as the Bun gate above: a non-empty list is what lets
+          # harden-runner keep its own API and the runner's own calls allowed.
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
           disable-sudo-and-containers: true
           egress-policy: block
       - name: All Deno OS jobs passed

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,6 +24,12 @@ jobs:
     if: (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]')
     steps:
       # Environment security
+      #
+      # This job runs in a container, which harden-runner cannot monitor from
+      # inside — it logs "This job is running in a container" and does nothing
+      # else. Neither policy has any effect here, so `audit` stays rather than
+      # implying an egress allow-list is being enforced. Monitoring container
+      # jobs needs harden-runner installed in a custom runner image.
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does and does not do

This hardens harden-runner in the Linux jobs it can actually protect. **It does not make the `StepSecurity Harden-Runner` check pass** — that check's alerts come from somewhere no workflow change can reach. Evidence for both halves below. That check is not in the `main` ruleset's required checks, so it does not block merges; [#6244](https://github.com/arcjet/arcjet-js/pull/6244) merged with it red.

## The two real misconfigurations, fixed

I read the harden-runner DNS logs each run prints in its post-step. Every lookup carries the policy it matched, and two sets matched nothing (`matchedPolicy=NONE`):

**1. `guard.yml` ran all three jobs on `egress-policy: audit`.** Audit installs no policy, so nothing was enforced — those jobs had monitoring only. Now `block`, with an allow-list per job.

**2. The `Bun` and `Deno` gate jobs in `reusable-test.yml` used `block` with no `allowed-endpoints`.** These are the small aggregation jobs that only read a `needs` result. An empty list also drops harden-runner's *own* API and the runner's orchestrator calls:

```
Run tests / Deno: prod.app-api.stepsecurity.io  policies=['NONE']
Run tests / Deno: hosted-compute-request-orchestrator-prod-eus-02.githubapp.com  policies=['NONE']
```

Those same domains match `EXACT_DOMAIN` / `WILDCARD_DOMAIN` in every job that has a non-empty list, without being listed — harden-runner adds its own required endpoints only once a policy exists. The jobs passed anyway, since their `test` command needs no network, which is why this went unnoticed.

### Where each endpoint came from

Taken from the DNS logs, not guessed:

| endpoint | status |
|---|---|
| `github.com`, `registry.npmjs.org` | observed in every job |
| `api.github.com` | observed |
| `release-assets.githubusercontent.com` | observed — `setup-node` fetches from it when the image has not cached the requested Node, so it appears on the Node 26 leg but not 22 or 24 |
| `decide.arcjet.com` | observed, **unit-test job only** — the runtime jobs serve a local mock DecideService |
| `deno.land`, `dl.deno.land` | observed, Deno legs only |
| `workers.cloudflare.com` | observed, workerd leg only |
| `nodejs.org`, `objects.githubusercontent.com` | **not** observed; kept as the documented fallbacks for those same toolchain downloads, as in every other block-mode workflow here |
| `deno.com` | **not** observed here, but observed by the equivalent job in `reusable-test.yml`; kept on the Deno legs only |

Whether the unobserved three are reached depends on what the runner image has cached, so omitting them would fail only on some runs.

The runtime job scopes its per-runtime endpoints to the leg that needs them, so a Node leg cannot reach Deno's installer hosts and only the workerd leg can reach Cloudflare:

| leg | endpoints |
|---|---|
| `node`, `fetch`, `bun` | 6 (shared base) |
| `cloudflare` | 7 |
| `deno` | 9 |

### Verified

| | unmatched (`NONE`) lookups |
|---|---|
| `guard.yml` before | every endpoint (audit = no policy) |
| `guard.yml` after | **0** — 451 `EXACT_DOMAIN`, 187 `WILDCARD_DOMAIN` |
| `pull-request.yml` before | 16, all in the `Deno` gate job |
| `pull-request.yml` after | **0** |

`actionlint` 1.7.12 and `zizmor` 1.24.1 (pinned in `dev/mise.toml`, matching the `Lint workflows` gate) both pass: `No findings to report. Good job! (4 ignored, 16 suppressed)`.

Note that `Run tests / Bun` and `Run tests / Deno` — two of the five required checks — are the gate jobs changed here, so a green run on this PR exercises them directly.

## Why the StepSecurity check still fails, and why that is not fixable here

Its report lists 57 alert rows. All 57 are from `pull-request.yml`, and all 26 distinct endpoints are operating-system and preinstalled-browser background traffic on the **macOS and Windows** legs of the test matrix:

- **Apple / macOS (16)** — `gateway.icloud.com`, `itunes.apple.com`, `xp.apple.com`, `token.safebrowsing.apple`, `apps.mzstatic.com`, …
- **Windows (4)** — `client.wns.windows.com`, `settings-win.data.microsoft.com`, `www.msftconnecttest.com`, `ipv6.msftncsi.com`
- **Firefox telemetry (1)** — `incoming.telemetry.mozilla.org`
- **CA revocation (3)** — `ocsp.sectigo.com`, `crl.sectigo.com`, `ocsp.digicert.com`
- **Other (2)** — `safebrowsing.googleapis.com`, `ohttp-relay1.fastly-edge.com`

None is reachable from this repository's code or dependencies; they are daemons on the runner image. `guard.yml` contributed **zero** alert rows both before and after this change, which is why fixing it did not move the check.

Two things make this un-fixable in a workflow file:

1. Harden-runner's [compatibility matrix](https://github.com/step-security/harden-runner) lists GitHub-hosted **Windows and macOS as audit mode only**. An `allowed-endpoints` entry cannot change behaviour there.
2. The check is baseline anomaly detection — it fails when a job's observed destinations differ from its learned baseline. StepSecurity's guidance for jobs with inherently unpredictable traffic is to *"create suppression rules for specific endpoints that consistently trigger alerts or disable detections from the job altogether"* — both dashboard actions.

Allow-listing Apple, Microsoft, and Mozilla telemetry to silence it would be strictly worse: it grants that egress on the one platform where blocking does work, and commits us to chasing hostnames as those services change.

**Required follow-up, outside this repo:** in the StepSecurity dashboard, suppress these endpoints or disable anomalous-call detection for the macOS/Windows legs of `reusable-test.yml`.

## Deliberately unchanged

- **`semgrep.yml`** runs in a container, where harden-runner logs `This job is running in a container` and does nothing. Left on `audit` with a comment, since `block` would imply an allow-list is enforced when none is.
- **`push.yml`** only runs on `main`, so no PR run produced endpoint data to derive a list from. Converting it blind risks breaking Release Please.
- **The `block` policy on the macOS/Windows test legs.** The matrix above says audit-only, but a comment in `reusable-test.yml` records Windows harden-runner's DNS proxy actively dropping lookups, so it does something in practice. Downgrading it could quietly reduce enforcement, so I left it and flagged it here instead.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0d6032d-f6e3-4426-a190-f6dca4359970?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0d6032d-f6e3-4426-a190-f6dca4359970&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

