### PR TITLE
feat(guard): add LangChain createAgent support as @arcjet/guard/langchain/v1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,25 @@ change them:
   `langgraph/v1` is Graph API (`StateGraph` + `ToolNode`): authored tools
   are `guardTool`, unwrapped / MCP tools go through `guardToolNode`, and
   `interrupt()` is HITL not policy. `createReactAgent` is deprecated; do not
-  build on it or on LangChain `createAgent`.
+  build on it. LangChain `createAgent` / `wrapToolCall` is
+  `langchain/v1`.
+  `langchain/v1` is JS `createAgent` + `createMiddleware({ wrapToolCall })`:
+  the authored deny point is `guardTool` (plain `ArcjetDenialResult`;
+  `baseHandler` wraps it in a success `ToolMessage`), MCP / unwrapped /
+  runtime-discovered tools go through `guardMiddleware`'s `wrapToolCall`
+  (it MUST return a real `ToolMessage` — a bare object is the
+  reducer-crash case; do not set `status: "error"`; do not throw),
+  inbound is screened before `agent.invoke` (SDK middleware that is not
+  `wrapToolCall` is not Guard), and `humanInTheLoopMiddleware` /
+  `interrupt()` is HITL not policy. Policy sits on `wrapToolCall` only —
+  do not deny in `afterModel`. There is no `guardInbound` and no
+  `guardApproval`. Correlation is `configurable.thread_id` (what
+  wrapToolCall sees as of langchain 1.2.34), then caller-owned
+  `sessionId` / `conversationId`. Server-side provider tools and
+  headless `.implement()` tools are out of scope. Do not add
+  `@langchain/langgraph` as a new peer. There is no unversioned
+  `@arcjet/guard/langchain` alias. Docs slug is `/guards/langchain-js/`,
+  not `/guards/langchain/` (the live Python page).
   `openai-agents/v0` is text `Agent` + `run()` / `Runner` + authored
   `tool({ execute })`: the runner-facing deny point is `FunctionTool.invoke`
   (the SDK closes over `execute`), inbound is screened before `run()`

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1064,10 +1064,11 @@ helper. Currently available:
 - **`@arcjet/guard/langgraph/v1`** — LangGraph Graph API (`StateGraph` +
   `ToolNode`) integration. Exports `guardTool`, `guardToolNode`, and
   `langgraphAgentContext`. This is **not** LangChain `createAgent` /
-  `wrapToolCall`, and `createReactAgent` is deprecated in LangGraph JS v1
-  — do not build on it. There is no `guardInbound` (screen before
-  `invoke` or at the first graph node) and no `guardInterrupt` /
-  `guardApproval` (`interrupt()` is human HITL, not policy).
+  `wrapToolCall` — that is `@arcjet/guard/langchain/v1` — and
+  `createReactAgent` is deprecated in LangGraph JS v1 — do not build on
+  it. There is no `guardInbound` (screen before `invoke` or at the first
+  graph node) and no `guardInterrupt` / `guardApproval` (`interrupt()`
+  is human HITL, not policy).
 
   On DENY a guarded tool does not run and does not throw: it returns a
   structured `ArcjetDenialResult`, which `ToolNode` turns into a real
@@ -1141,6 +1142,111 @@ If you invoke a guarded tool yourself rather than through `ToolNode`, read
 the denial and build your own `ToolMessage`; do not push the denial object
 straight into `messages`, because the graph's message reducer only accepts
 real messages.
+
+- **`@arcjet/guard/langchain/v1`** — LangChain JS `createAgent` +
+  `createMiddleware({ wrapToolCall })` integration. Exports `guardTool`,
+  `guardMiddleware`, and `langchainContext`. This is **not** LangGraph
+  Graph API (`StateGraph` + `ToolNode`) — that is
+  `@arcjet/guard/langgraph/v1` — and not `vercel-ai/v7`. There is no
+  `guardInbound` (screen before `agent.invoke`; SDK middleware that is
+  not `wrapToolCall` is not Guard) and no `guardApproval`
+  (`humanInTheLoopMiddleware` / `interrupt()` is human HITL, not
+  policy). Policy sits on `wrapToolCall` only — do not deny in
+  `afterModel`. Server-side provider tools and headless `.implement()`
+  tools are out of scope. Docs live at
+  [`/guards/langchain-js/`](https://docs.arcjet.com/guards/langchain-js/);
+  do not overwrite [`/guards/langchain/`](https://docs.arcjet.com/guards/langchain/)
+  (the live Python page).
+
+  Two denial envelopes — do not collapse them. `guardTool` returns a
+  plain `ArcjetDenialResult`; it does not throw and does not fabricate
+  a `ToolMessage`. `createAgent`'s `baseHandler` wraps a non-ToolMessage
+  in a success `ToolMessage`. `guardMiddleware` `wrapToolCall` MUST
+  return a real `ToolMessage` (`content` = JSON of the payload,
+  `tool_call_id` = `request.toolCall.id`, `name` =
+  `request.toolCall.name`). wrapToolCall's return is **not** passed
+  through `baseHandler`; a bare object is the messages-reducer crash.
+  Do not set `status: "error"`. Do not throw (throws bubble and drop
+  `arcjetDenied`). Already-branded tools are skipped so Guard is not
+  double-called:
+
+  ```ts
+  import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+  import { guardTool, guardMiddleware, langchainContext } from "@arcjet/guard/langchain/v1";
+  import { createAgent } from "langchain";
+  import { tool } from "@langchain/core/tools";
+  import { z } from "zod";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const lookupOrder = guardTool(
+    arcjet,
+    tool(async ({ orderNumber }) => ({ orderNumber, status: "shipped" }), {
+      name: "lookup_order",
+      description: "Look up an order",
+      schema: z.object({ orderNumber: z.string() }),
+    }),
+    {
+      action: "order.looked-up",
+      onGuardError: "deny",
+      rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
+    },
+  );
+
+  const inbound = detectPromptInjection();
+  const decision = await arcjet.guard({
+    label: "message.received",
+    rules: [inbound(userText)],
+    ...langchainContext({ configurable: { thread_id: conversationId } }),
+  });
+
+  if (decision.conclusion === "DENY") {
+    throw new Error("message blocked");
+  }
+  if (decision.hasFailedOpen()) {
+    throw new Error("inbound screening failed open");
+  }
+
+  const agent = createAgent({
+    model,
+    tools: [lookupOrder],
+    middleware: [guardMiddleware(arcjet, { sessionId: conversationId })],
+  });
+  await agent.invoke(
+    { messages: [{ role: "user", content: userText }] },
+    { configurable: { thread_id: conversationId } },
+  );
+  ```
+
+#### Screen inbound before `agent.invoke` — there is no inbound hook. SDK middleware that is not `wrapToolCall` is not Guard.
+
+LangChain `createAgent` has no first-class inbound channel, so there
+is no `guardInbound`. Put prompt-injection (and other inbound rules)
+in the application before `agent.invoke`. `wrapModelCall` /
+`beforeModel` / `afterModel` intercept the model call, not user text.
+They are not this policy gate.
+
+#### `humanInTheLoopMiddleware` / `interrupt` is HITL, not a policy gate.
+
+`humanInTheLoopMiddleware` / `interrupt()` / approve-edit-reject-respond
+is human-in-the-loop, not policy. Same trap as Mastra `requireApproval`,
+Claude `canUseTool`, LangGraph `interrupt()`, Genkit `toolApproval`,
+and OpenAI Agents `needsApproval`. There is no `guardApproval`. Policy
+sits on `wrapToolCall` only — do not deny in `afterModel`.
+
+#### Deny inside `tool()` (and `guardMiddleware`'s `wrapToolCall`). MCP and unwrapped tools skip an unwrapped handler.
+
+The authored `tool()` handler is the deny point for tools you own.
+MCP tools, runtime-discovered tools, and anything not wrapped with
+`guardTool` skip that handler. `guardMiddleware` is the invoke()-wide
+gate for those — its `wrapToolCall` denies by returning a real
+`ToolMessage` without calling `handler`. wrapToolCall only sees
+`runtime.configurable.thread_id` as of langchain 1.2.34.
 
 - **`@arcjet/guard/openai-agents/v0`** — OpenAI Agents text `Agent` +
   `run()` / `Runner` integration. Exports `guardTool` and
@@ -1375,7 +1481,14 @@ importing only core guards are not forced to install unneeded packages:
   `@arcjet/guard/claude-agent-sdk/v0`). The peer range is `>=0.1.0 <1`.
 - **`@arcjet/guard/langgraph/v1`** requires `@langchain/langgraph` and
   `@langchain/core` (optional peers, installed only to use
-  `@arcjet/guard/langgraph/v1`). The peer range is `>=1 <2` for both.
+  `@arcjet/guard/langgraph/v1`). The peer range is `>=1 <2` for
+  `@langchain/langgraph` and `>=1.2.0 <2` for `@langchain/core`.
+- **`@arcjet/guard/langchain/v1`** requires `langchain` and
+  `@langchain/core` (optional peers, installed only to use
+  `@arcjet/guard/langchain/v1`). The peer range is `>=1.2.0 <2` for
+  both. `wrapToolCall` only sees `runtime.configurable.thread_id` as of
+  langchain 1.2.34. This namespace does not add `@langchain/langgraph`
+  as a new peer.
 - **`@arcjet/guard/openai-agents/v0`** requires `@openai/agents` (optional
   peer, installed only to use `@arcjet/guard/openai-agents/v0`). The peer
   range is `>=0.17.0 <1`. Zod is their peer, not ours.
@@ -1418,6 +1531,11 @@ pnpm install @langchain/langgraph @langchain/core
 ```
 
 ```sh
+# @arcjet/guard/langchain/v1
+pnpm install langchain @langchain/core
+```
+
+```sh
 # @arcjet/guard/openai-agents/v0
 pnpm install @openai/agents
 ```
@@ -1441,7 +1559,8 @@ is one path to learn and no layering to reason about.
 
 `@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`,
 `@arcjet/guard/mastra/v1`, `@arcjet/guard/claude-agent-sdk/v0`,
-`@arcjet/guard/langgraph/v1`, `@arcjet/guard/openai-agents/v0`, and
+`@arcjet/guard/langchain/v1`, `@arcjet/guard/langgraph/v1`,
+`@arcjet/guard/openai-agents/v0`, and
 `@arcjet/guard/genkit/v1` now export
 these helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
@@ -1836,6 +1955,8 @@ For an example with Mastra, see [`mastra-agent`](https://github.com/arcjet/examp
 
 For an example with LangGraph, see [`langgraph-agent`](https://github.com/arcjet/examples/tree/main/examples/langgraph-agent) (follow-up on that same PR): inbound screening before `invoke`, `guardTool` / `guardToolNode` (deny, PII on args, rate limit, fail-closed), and `thread_id` correlation. `interrupt()` is HITL, not a policy gate; `ToolNode` is the deny point for tools.
 
+For an example with LangChain JS `createAgent`, see [`langchain-agent`](https://github.com/arcjet/examples/tree/main/examples/langchain-agent) (follow-up on that same PR): inbound screening before `agent.invoke`, `guardTool` / `guardMiddleware` (deny, PII on args, rate limit, fail-closed), and `thread_id` correlation. `humanInTheLoopMiddleware` / `interrupt()` is HITL, not a policy gate; `wrapToolCall` is the deny point for tools. Docs: [`/guards/langchain-js/`](https://docs.arcjet.com/guards/langchain-js/).
+
 For an example with OpenAI Agents, see [`openai-agent`](https://github.com/arcjet/examples/tree/main/examples/openai-agent) (follow-up on that same PR): inbound screening before `run()`, `guardTool` (deny, PII on args, rate limit, fail-closed), and a caller-owned id on `run(..., { context })`. `needsApproval` is HITL, not a policy gate; authored `tool()` `invoke` is the deny point.
 
 For an example with Genkit, see [`genkit-agent`](https://github.com/arcjet/examples/tree/main/examples/genkit-agent) (follow-up on that same PR): inbound screening before `generate()`, `guardTool` / `guardMiddleware` (deny, PII on args, rate limit, fail-closed), and a caller-owned id on `generate({ context })`. `interrupt()` / `defineInterrupt` / `toolApproval` is HITL, not a policy gate; the `defineTool` handler and `guardMiddleware`'s `tool` hook are the deny points.
@@ -1895,6 +2016,16 @@ ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-langgrap
 ```
 
 In Claude Code, use `/integrate-arcjet-guard-langgraph` to start an integration session.
+
+**For LangChain JS (`createAgent`):**
+
+```bash
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-langchain ~/.claude/skills/
+# or
+ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-langchain ~/.claude/skills/
+```
+
+In Claude Code, use `/integrate-arcjet-guard-langchain` to start an integration session.
 
 **For OpenAI Agents:**
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1481,14 +1481,19 @@ importing only core guards are not forced to install unneeded packages:
   `@arcjet/guard/claude-agent-sdk/v0`). The peer range is `>=0.1.0 <1`.
 - **`@arcjet/guard/langgraph/v1`** requires `@langchain/langgraph` and
   `@langchain/core` (optional peers, installed only to use
-  `@arcjet/guard/langgraph/v1`). The peer range is `>=1 <2` for
-  `@langchain/langgraph` and `>=1.2.0 <2` for `@langchain/core`.
+  `@arcjet/guard/langgraph/v1`). The peer range is `>=1 <2` for both
+  `@langchain/langgraph` and `@langchain/core`.
 - **`@arcjet/guard/langchain/v1`** requires `langchain` and
   `@langchain/core` (optional peers, installed only to use
   `@arcjet/guard/langchain/v1`). The peer range is `>=1.2.0 <2` for
-  both. `wrapToolCall` only sees `runtime.configurable.thread_id` as of
-  langchain 1.2.34. This namespace does not add `@langchain/langgraph`
-  as a new peer.
+  `langchain` and `>=1 <2` for `@langchain/core`. `wrapToolCall` only
+  sees `runtime.configurable.thread_id` as of langchain 1.2.34, which is
+  why `langchain` carries the higher floor. `@langchain/core` keeps the
+  range `langgraph/v1` already shipped: tightening the shared peer would
+  constrain langgraph-only consumers for no reason, since
+  `@langchain/langgraph` itself asks only for core `^1.1.48`, and anyone
+  installing `langchain` is already held to its own `^1.2.9` peer on
+  core. This namespace does not add `@langchain/langgraph` as a new peer.
 - **`@arcjet/guard/openai-agents/v0`** requires `@openai/agents` (optional
   peer, installed only to use `@arcjet/guard/openai-agents/v0`). The peer
   range is `>=0.17.0 <1`. Zod is their peer, not ours.

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1584,6 +1584,7 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 | Mastra `guardProcessor` / `guardHooks`  | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Claude `guardTool` / `guardHooks`       | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | LangGraph `guardTool` / `guardToolNode` | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| LangChain `guardTool` / `guardMiddleware` | Deny (fail closed)                        | `onGuardError: "allow"`            |
 | OpenAI Agents `guardTool`               | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Genkit `guardTool` / `guardMiddleware`  | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
@@ -1856,6 +1857,7 @@ that a tool did not run:
 | AI SDK / Mastra  | Return `{ arcjetDenied: true, … }` as the tool result                                               | A throw becomes a generic tool error and drops the fields                                    |
 | OpenAI Agents    | Return `{ arcjetDenied: true, … }` from `invoke`                                                    | A throw hits `errorFunction` or `ToolCallError` and can kill the run                         |
 | LangGraph        | Return `{ arcjetDenied: true, … }`; `ToolNode` wraps it as a `ToolMessage` with `status: "success"` | Faking a `ToolMessage` to force `status: "error"` crashes the graph reducer                  |
+| LangChain        | Two envelopes: `guardTool` returns `{ arcjetDenied: true, … }` and `baseHandler` wraps it as a success `ToolMessage`; `guardMiddleware`'s `wrapToolCall` returns a real `ToolMessage` carrying the payload as `content` | `wrapToolCall`'s return skips `baseHandler`, so a bare object crashes the messages reducer, and a throw bubbles out of `invoke` and drops the fields |
 | Claude Agent SDK | MCP `CallToolResult` with `isError: true` and the payload on `structuredContent`                    | A throw is a raw exception; omitting `isError` looks like success                            |
 | Vercel Eve       | Throw `ArcjetDeniedError`. Opt in to a returned payload with `onDeny: "result"`                     | Eve projects a throw as a failed `action.result`. A silent return can violate `outputSchema` |
 

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -148,7 +148,7 @@
   "peerDependencies": {
     "@ai-sdk/provider-utils": ">=5 <6",
     "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
-    "@langchain/core": ">=1.2.0 <2",
+    "@langchain/core": ">=1 <2",
     "@langchain/langgraph": ">=1 <2",
     "@mastra/core": ">=1 <2",
     "@openai/agents": ">=0.17.0 <1",

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -84,6 +84,10 @@
       "types": "./dist/claude-agent-sdk/v0/index.d.ts",
       "import": "./dist/claude-agent-sdk/v0/index.js"
     },
+    "./langchain/v1": {
+      "types": "./dist/langchain/v1/index.d.ts",
+      "import": "./dist/langchain/v1/index.js"
+    },
     "./langgraph/v1": {
       "types": "./dist/langgraph/v1/index.d.ts",
       "import": "./dist/langgraph/v1/index.js"
@@ -108,7 +112,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts'",
+    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts'",
     "test-peers-absent": "node scripts/test-peers-absent.mjs",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
@@ -127,8 +131,9 @@
   "devDependencies": {
     "@ai-sdk/provider-utils": "5.0.25",
     "@anthropic-ai/claude-agent-sdk": "0.3.221",
-    "@langchain/core": "1.2.8",
+    "@langchain/core": "1.2.9",
     "@langchain/langgraph": "1.4.10",
+    "langchain": "1.5.10",
     "@mastra/core": "1.58.0",
     "@openai/agents": "0.17.0",
     "@types/node": "22.20.1",
@@ -143,8 +148,9 @@
   "peerDependencies": {
     "@ai-sdk/provider-utils": ">=5 <6",
     "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
-    "@langchain/core": ">=1 <2",
+    "@langchain/core": ">=1.2.0 <2",
     "@langchain/langgraph": ">=1 <2",
+    "langchain": ">=1.2.0 <2",
     "@mastra/core": ">=1 <2",
     "@openai/agents": ">=0.17.0 <1",
     "ai": ">=7 <8",
@@ -171,6 +177,9 @@
       "optional": true
     },
     "@langchain/langgraph": {
+      "optional": true
+    },
+    "langchain": {
       "optional": true
     },
     "@openai/agents": {

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -55,6 +55,13 @@ const CHECKS = [
     resolve: ["@langchain/langgraph", "@langchain/core"],
   },
   {
+    name: "langchain",
+    dir: "langchain",
+    version: "v1",
+    remove: ["langchain", "@langchain/core"],
+    resolve: ["langchain", "@langchain/core"],
+  },
+  {
     name: "genkit",
     dir: "genkit",
     version: "v1",

--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: integrate-arcjet-guard-langchain
+description: Integrate Arcjet security into a LangChain JS createAgent using @arcjet/guard — wrap tool() / StructuredTool, put guardMiddleware on createAgent({ middleware }) for MCP / unwrapped tools, and read configurable.thread_id for correlation. Use when asked to add Arcjet to langchain createAgent, rate limit its tools, screen inbound messages, or block prompt injection / PII. This is LangChain JS, not the Python page.
+license: Apache-2.0
+compatibility: Requires the target app to use LangChain JS (langchain >=1.2.0 <2 and @langchain/core >=1.2.0 <2) on Node.js >= 22. This is createAgent + createMiddleware({ wrapToolCall }), not LangGraph StateGraph / ToolNode. wrapToolCall only sees runtime.configurable.thread_id as of langchain 1.2.34.
+metadata:
+  author: arcjet
+---
+
+# Integrate Arcjet Guard into a LangChain JS createAgent
+
+`@arcjet/guard`'s LangChain v1 namespace wraps the agent's existing Arcjet
+client. It never talks to the Arcjet API itself. Three surfaces, one
+decision rule:
+
+- **An authored tool** (`tool()` / `StructuredTool`) → `guardTool()`.
+  DENY returns a plain `ArcjetDenialResult`. Do not throw. Do not
+  fabricate a `ToolMessage`. `createAgent`'s `baseHandler` wraps a
+  non-ToolMessage in a success `ToolMessage`.
+- **MCP / unwrapped / runtime-discovered tools** → `guardMiddleware()`.
+  A `createAgent({ middleware })` middleware whose `wrapToolCall` is
+  the invoke()-wide gate. It denies by returning a **real**
+  `ToolMessage` (`content` = JSON of the payload, `tool_call_id` =
+  `request.toolCall.id`, `name` = `request.toolCall.name`) without
+  calling `handler`. Already-branded tools are skipped when
+  `request.tool` can be looked up. Do not set `status: "error"`. Do
+  not throw (throws bubble and drop `arcjetDenied`).
+- **Correlation** → `langchainContext()` reads
+  `configurable.thread_id` (what wrapToolCall sees on
+  `runtime.configurable` as of langchain 1.2.34), then caller-owned
+  `sessionId` / `conversationId`. It never mints a new id. It never
+  reads `traceId`. It never treats `interrupt` / resume as
+  correlation.
+
+This namespace is LangChain JS **`createAgent` + `wrapToolCall`**. Not
+LangGraph Graph API (`StateGraph` + `ToolNode`) — that is
+`@arcjet/guard/langgraph/v1`. Not `vercel-ai/v7`. Server-side provider
+tools and headless `.implement()` tools are out of scope. Do not also
+wrap the same tool with `@arcjet/guard/langgraph/v1` or
+`@arcjet/guard/vercel-ai/v7`.
+
+Docs live at
+[docs.arcjet.com/guards/langchain-js/](https://docs.arcjet.com/guards/langchain-js/).
+Do **not** use `/guards/langchain/` — that is the live Python page.
+
+## Screen inbound before `agent.invoke` — there is no inbound hook. SDK middleware that is not `wrapToolCall` is not Guard.
+
+There is no first-class inbound channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `agent.invoke`. `wrapModelCall` / `beforeModel` /
+`afterModel` intercept the model call, not user text. They are not
+this policy gate.
+
+## `humanInTheLoopMiddleware` / `interrupt` is HITL, not a policy gate.
+
+`humanInTheLoopMiddleware` / `interrupt()` / approve-edit-reject-respond
+is human-in-the-loop. Same trap as Mastra `requireApproval`, Claude
+`canUseTool`, LangGraph `interrupt()`, Genkit `toolApproval`, and
+OpenAI Agents `needsApproval`. There is no `guardApproval`. Policy
+sits on `wrapToolCall` only — do not deny in `afterModel`. HITL
+already lives there.
+
+## Deny inside `tool()` (and `guardMiddleware`'s `wrapToolCall`). MCP and unwrapped tools skip an unwrapped handler.
+
+The authored `tool()` handler is the deny point for tools you own.
+MCP tools, runtime-discovered tools, and anything not wrapped with
+`guardTool` skip that handler. `guardMiddleware` is the invoke()-wide
+gate for those.
+
+`guardMiddleware` **can deny**. LangChain's official auth example
+returns a `ToolMessage` without calling `handler`. wrapToolCall's
+return is **not** passed through `baseHandler`. A duck-typed object
+without the real class fails `ToolMessage.isInstance` and crashes the
+messages reducer. Do not throw. Do not set `status: "error"`.
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those get `guardTool`. MCP / runtime-discovered
+   / tools you did not author get `guardMiddleware`.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. Put the
+   conversation / session id you already have on
+   `agent.invoke(..., { configurable: { thread_id } })`. That id is the
+   correlation id, not the user. wrapToolCall only sees
+   `runtime.configurable.thread_id` as of langchain 1.2.34.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound screening before
+   `agent.invoke`: failing closed there means the agent does not run for
+   the duration of the outage, so `"allow"` is a routine and legitimate
+   choice at that one call site.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection before
+   `agent.invoke`. `wrapModelCall` / `beforeModel` / `afterModel` are
+   not Guard.
+2. **`humanInTheLoopMiddleware` / `interrupt()` is not a policy gate.**
+   It is HITL. Policy sits on `wrapToolCall` only. Do not deny in
+   `afterModel`.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/langchain/v1`. `@arcjet/guard/langchain` does not
+   resolve. Docs are `/guards/langchain-js/`, not `/guards/langchain/`.
+4. **Correlation is read, never minted.** Do not call `createAgentContext`
+   inside a middleware / tool callback — that generates a second id and
+   splits the Sequence. Put the id you already chose on
+   `configurable.thread_id`. Do not read `traceId`. Do not treat
+   `interrupt` / resume as correlation.
+5. **Do not double-wrap with `@arcjet/guard/langgraph/v1` or
+   `@arcjet/guard/vercel-ai/v7`.** `guardTool` throws if the tool
+   already carries the Arcjet protection brand. `guardMiddleware`
+   skips branded tools so Guard is not double-called.
+6. **Two denial envelopes. Do not collapse them.** `guardTool` returns
+   a plain `ArcjetDenialResult`. `guardMiddleware` `wrapToolCall` MUST
+   return a real `ToolMessage`. A bare object from wrapToolCall is the
+   reducer-crash case.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `langchain` and
+`@langchain/core` (optional peers, needed for
+`@arcjet/guard/langchain/v1`). Always use the versioned path:
+`@arcjet/guard/langchain/v1` resolves; `@arcjet/guard/langchain` throws
+`ERR_PACKAGE_PATH_NOT_EXPORTED`. The peer range is `>=1.2.0 <2` for
+both. wrapToolCall only sees `runtime.configurable.thread_id` as of
+langchain 1.2.34. Node 22+.
+
+```sh
+npm install @arcjet/guard langchain @langchain/core
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate authored tools
+
+```ts
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+import { guardTool } from "@arcjet/guard/langchain/v1";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+// Factory then text — same shape as `detectPromptInjection()(text)`.
+// Scan free-text args (a note, reason, body). An opaque `orderNumber`
+// will not trip EMAIL / phone / card / IP, so do not pass it here.
+const detectPii = localDetectSensitiveInfo();
+
+export const lookupOrder = guardTool(
+  arcjet,
+  tool(
+    async ({ orderNumber, note }) => ({ orderNumber, note, status: "shipped" }),
+    {
+      name: "lookup_order",
+      description: "Look up an order by number",
+      schema: z.object({
+        orderNumber: z.string(),
+        note: z.string(),
+      }),
+    },
+  ),
+  {
+    action: "order.looked-up",
+    rules: (input) => [
+      lookupLimit({ key: input.orderNumber, requested: 1 }),
+      detectPii(input.note),
+    ],
+  },
+);
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the original `func` / `invoke` never runs. The caller
+  receives `{ arcjetDenied: true, reason, message, retryable }`.
+  Through `createAgent`, `baseHandler` wraps that object in a success
+  `ToolMessage`.
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+
+## Step 3: Gate unwrapped / MCP / runtime-discovered tools
+
+```ts
+import { createAgent } from "langchain";
+import { guardMiddleware } from "@arcjet/guard/langchain/v1";
+import { tokenBucket } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const mcpLimit = tokenBucket({
+  refillRate: 20,
+  intervalSeconds: 60,
+  maxTokens: 20,
+});
+
+const agent = createAgent({
+  model,
+  tools: [lookupOrder, ...mcpTools],
+  middleware: [
+    guardMiddleware(arcjet, {
+      action: ({ toolName }) => `${toolName}.invoked`,
+      rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+      sessionId: conversationId,
+    }),
+  ],
+});
+```
+
+Already-branded (`guardTool`) tools skip the middleware guard when
+they are present on `request.tool`. Tools that cannot be looked up
+(`request.tool` undefined — MCP / unwrapped / runtime-discovered)
+are still gated.
+
+## Step 4: Screen inbound before invoke
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { langchainContext } from "@arcjet/guard/langchain/v1";
+
+import { arcjet } from "./arcjet.js";
+
+const inbound = detectPromptInjection();
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...langchainContext({ configurable: { thread_id: conversationId } }),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+if (decision.hasFailedOpen()) {
+  throw new Error("inbound screening failed open");
+}
+
+await agent.invoke(
+  { messages: [{ role: "user", content: userText }] },
+  { configurable: { thread_id: conversationId } },
+);
+```
+
+There is no `guardInbound`.
+
+## Step 5: Correlation
+
+Put the id you already have on `configurable.thread_id`:
+
+```ts
+await agent.invoke(
+  { messages: [{ role: "user", content: userText }] },
+  { configurable: { thread_id: conversationId } },
+);
+```
+
+Preference order: `configurable.thread_id`, then caller-owned
+`sessionId`, then `conversationId`, then `init.sessionId` /
+`init.correlationId`. If none is a valid 1–256 printable-ASCII
+string, the call is uncorrelated rather than joined to a generated
+id nobody has.
+
+Never mint a new id. Never read `traceId`. Never treat `interrupt` /
+resume as correlation. wrapToolCall only sees
+`runtime.configurable.thread_id` as of langchain 1.2.34.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI (before invoke), a tool deny, PII on args, a
+   rate limit, a middleware deny on an unwrapped tool, and fail-closed
+   (an unreachable guard). Confirm the denial is a completed
+   `ToolMessage` (`status` is not `"error"`) and the run is not an
+   `interrupt()`.
+3. Confirm in the Arcjet dashboard that decisions share the
+   `thread_id` as their correlation id.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo will land in
+[`arcjet/examples` `langchain-agent`](https://github.com/arcjet/examples/tree/main/examples/langchain-agent)
+as a later follow-up. Do not add an example under `examples/` in the
+JS SDK repo.
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -2,7 +2,7 @@
 name: integrate-arcjet-guard-langchain
 description: Integrate Arcjet security into a LangChain JS createAgent using @arcjet/guard — wrap tool() / StructuredTool, put guardMiddleware on createAgent({ middleware }) for MCP / unwrapped tools, and read configurable.thread_id for correlation. Use when asked to add Arcjet to langchain createAgent, rate limit its tools, screen inbound messages, or block prompt injection / PII. This is LangChain JS, not the Python page.
 license: Apache-2.0
-compatibility: Requires the target app to use LangChain JS (langchain >=1.2.0 <2 and @langchain/core >=1.2.0 <2) on Node.js >= 22. This is createAgent + createMiddleware({ wrapToolCall }), not LangGraph StateGraph / ToolNode. wrapToolCall only sees runtime.configurable.thread_id as of langchain 1.2.34.
+compatibility: Requires the target app to use LangChain JS (langchain >=1.2.0 <2 and @langchain/core >=1 <2) on Node.js >= 22. This is createAgent + createMiddleware({ wrapToolCall }), not LangGraph StateGraph / ToolNode. wrapToolCall only sees runtime.configurable.thread_id as of langchain 1.2.34.
 metadata:
   author: arcjet
 ---
@@ -125,8 +125,10 @@ Install `@arcjet/guard` (required), plus `langchain` and
 `@arcjet/guard/langchain/v1`). Always use the versioned path:
 `@arcjet/guard/langchain/v1` resolves; `@arcjet/guard/langchain` throws
 `ERR_PACKAGE_PATH_NOT_EXPORTED`. The peer range is `>=1.2.0 <2` for
-both. wrapToolCall only sees `runtime.configurable.thread_id` as of
-langchain 1.2.34. Node 22+.
+`langchain` and `>=1 <2` for `@langchain/core` (the range
+`langgraph/v1` already shipped — `langchain`'s own `^1.2.9` peer on core
+is what actually binds here). wrapToolCall only sees
+`runtime.configurable.thread_id` as of langchain 1.2.34. Node 22+.
 
 ```sh
 npm install @arcjet/guard langchain @langchain/core

--- a/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
@@ -26,7 +26,8 @@ decision rule:
 This namespace is LangGraph **Graph API** (`StateGraph` + `ToolNode`).
 `createReactAgent` is deprecated in LangGraph JS v1 in favor of LangChain
 `createAgent` / `wrapToolCall`. Do not build on `createReactAgent`. Do not
-use this path for a LangChain `createAgent` app — that is a later adapter.
+use this path for a LangChain `createAgent` app — that is
+`@arcjet/guard/langchain/v1`.
 
 ## Screen inbound before `invoke` (or at the first graph node)
 

--- a/arcjet-guard/src/agents/denial.test.ts
+++ b/arcjet-guard/src/agents/denial.test.ts
@@ -149,6 +149,7 @@ test("no vendor namespace declares its own denial payload", () => {
     "vercel-eve",
     "mastra",
     "claude-agent-sdk",
+    "langchain",
     "langgraph",
     "openai-agents",
     "genkit",

--- a/arcjet-guard/src/agents/index.test.ts
+++ b/arcjet-guard/src/agents/index.test.ts
@@ -108,6 +108,8 @@ function walkForForbiddenImports(filePath: string, visited: Set<string>, errors:
       spec.startsWith("@mastra/core/") ||
       spec === "@anthropic-ai/claude-agent-sdk" ||
       spec.startsWith("@anthropic-ai/claude-agent-sdk/") ||
+      spec === "langchain" ||
+      spec.startsWith("langchain/") ||
       spec === "@langchain/langgraph" ||
       spec.startsWith("@langchain/langgraph/") ||
       spec === "@langchain/core" ||

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -7,8 +7,9 @@
  * @internal This barrel has no export map entry. Every symbol below reaches
  * users re-exported from a vendor namespace — `@arcjet/guard/vercel-ai/v7`,
  * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`,
- * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langgraph/v1`,
- * `@arcjet/guard/openai-agents/v0`, and `@arcjet/guard/genkit/v1`. The
+ * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langchain/v1`,
+ * `@arcjet/guard/langgraph/v1`, `@arcjet/guard/openai-agents/v0`, and
+ * `@arcjet/guard/genkit/v1`. The
  * layer stays agnostic so multiple
  * vendor namespaces can share the same code. A public `@arcjet/guard/agents`
  * path is still a follow-up with its own ADR.

--- a/arcjet-guard/src/genkit/v1/index.test.ts
+++ b/arcjet-guard/src/genkit/v1/index.test.ts
@@ -141,6 +141,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI-only APIs", () 
     "mastraAgentContext",
     "claudeAgentContext",
     "langgraphAgentContext",
+    "langchainContext",
     "openaiAgentsContext",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/langchain/v1/assignability.test.ts
+++ b/arcjet-guard/src/langchain/v1/assignability.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Compile-time assignability: the helpers accept the values a LangChain
+ * `createAgent` app actually has, with no casts at the call site.
+ *
+ * The declarations are types only (`declare const`, never executed) so
+ * this suite still runs in the langchain-absent CI job, where the peers
+ * are gone and the type-only import scan applies. Runtime behaviour
+ * against the real `tool()` / `createAgent` lives in `test/langchain/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { AgentMiddleware } from "langchain";
+import type { DynamicStructuredTool, StructuredToolInterface } from "@langchain/core/tools";
+
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { guardMiddleware } from "./guard-middleware.ts";
+import { guardTool } from "./guard-tool.ts";
+
+declare const client: ArcjetAgentClient;
+declare const authoredTool: DynamicStructuredTool;
+
+// Never called: the declarations above have no runtime value. Typecheck is
+// the assertion.
+function typeProbe(): void {
+  const guarded: DynamicStructuredTool = guardTool(client, authoredTool, {
+    action: "order.looked-up",
+    rules: (input: { orderNumber: string }) => {
+      void input.orderNumber;
+      return [];
+    },
+  });
+
+  const asStructured: StructuredToolInterface = guarded;
+
+  const middleware = guardMiddleware(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+
+  const createAgentOpts: { middleware?: AgentMiddleware[] } = {
+    middleware: [middleware],
+  };
+
+  void [guarded, asStructured, createAgentOpts];
+}
+
+test("helpers accept a real tool() and createMiddleware-shaped result without casts", () => {
+  assert.equal(typeof typeProbe, "function");
+});

--- a/arcjet-guard/src/langchain/v1/context.test.ts
+++ b/arcjet-guard/src/langchain/v1/context.test.ts
@@ -110,8 +110,9 @@ test("init metadata overrides derived keys", () => {
 
 test("never reads traceId or interrupt / resume", () => {
   const result = langchainContext({
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- asserting we do not read these
-    ...( { traceId: "trace-minted", interrupt: "hitl", resumed: true } as Record<string, unknown>),
+    traceId: "trace-minted",
+    interrupt: "hitl",
+    resumed: true,
     sessionId: "sess-real",
   } as never);
   assert.equal(result.correlationId, "sess-real");
@@ -136,7 +137,8 @@ test("derived metadata is encodeMetadata-safe", () => {
     conversationId: "conv-1",
   });
   assert.ok(result.metadata);
-  const metadataJson = encodeMetadata(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
   assert.ok(metadataJson["langchain.thread"]);
   assert.ok(metadataJson["langchain.session"]);
   assert.ok(metadataJson["langchain.conversation"]);

--- a/arcjet-guard/src/langchain/v1/context.test.ts
+++ b/arcjet-guard/src/langchain/v1/context.test.ts
@@ -45,6 +45,42 @@ test("accepts a bare thread_id field", () => {
   assert.equal(result.correlationId, "direct-thread");
 });
 
+// A caller threading a partially-built config can carry an empty
+// `configurable` alongside the real id. Reading the empty one and stopping
+// would send the decision out uncorrelated with no way to notice.
+test("an empty configurable does not shadow a thread_id living elsewhere", () => {
+  assert.equal(
+    langchainContext({ configurable: {}, config: { configurable: { thread_id: "t-config" } } })
+      .correlationId,
+    "t-config",
+  );
+  assert.equal(
+    langchainContext({ configurable: {}, runtime: { configurable: { thread_id: "t-runtime" } } })
+      .correlationId,
+    "t-runtime",
+  );
+  assert.equal(langchainContext({ configurable: {}, thread_id: "t-bare" }).correlationId, "t-bare");
+});
+
+test("the first configurable carrying a thread_id wins", () => {
+  const result = langchainContext({
+    configurable: { thread_id: "outer" },
+    config: { configurable: { thread_id: "inner" } },
+  });
+  assert.equal(result.correlationId, "outer");
+  assert.equal(result.metadata?.["langchain.thread"], "outer");
+});
+
+// An invalid id is an answer, not a miss: falling through to the next
+// candidate would silently swap the id the caller believes they set.
+test("an invalid thread_id is reported rather than skipped for the next candidate", () => {
+  const result = langchainContext({
+    configurable: { thread_id: "bad\nid" },
+    config: { configurable: { thread_id: "good-id" } },
+  });
+  assert.equal("correlationId" in result, false);
+});
+
 test("falls back to caller-owned sessionId when thread_id is absent", () => {
   const result = langchainContext({ sessionId: "sess-1", conversationId: "conv-1" });
   assert.equal(result.correlationId, "sess-1");

--- a/arcjet-guard/src/langchain/v1/context.test.ts
+++ b/arcjet-guard/src/langchain/v1/context.test.ts
@@ -1,0 +1,148 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { langchainContext } from "./context.ts";
+
+test("prefers configurable.thread_id", () => {
+  const result = langchainContext({
+    configurable: { thread_id: "thread-abc" },
+    sessionId: "sess-fallback",
+    conversationId: "conv-fallback",
+  });
+
+  assert.equal(result.correlationId, "thread-abc");
+  assert.equal(result.metadata?.["langchain.thread"], "thread-abc");
+  assert.equal(result.metadata?.["langchain.session"], "sess-fallback");
+  assert.equal(result.metadata?.["langchain.conversation"], "conv-fallback");
+});
+
+test("reads thread_id from wrapToolCall runtime.configurable", () => {
+  const result = langchainContext({
+    configurable: { thread_id: "from-runtime" },
+  });
+  assert.equal(result.correlationId, "from-runtime");
+  assert.equal(result.metadata?.["langchain.thread"], "from-runtime");
+});
+
+test("reads thread_id from a nested runtime.configurable", () => {
+  const result = langchainContext({
+    runtime: { configurable: { thread_id: "nested-runtime" } },
+  });
+  assert.equal(result.correlationId, "nested-runtime");
+});
+
+test("reads thread_id from config.configurable", () => {
+  const result = langchainContext({
+    config: { configurable: { thread_id: "from-config" } },
+  });
+  assert.equal(result.correlationId, "from-config");
+});
+
+test("accepts a bare thread_id field", () => {
+  const result = langchainContext({ thread_id: "direct-thread" });
+  assert.equal(result.correlationId, "direct-thread");
+});
+
+test("falls back to caller-owned sessionId when thread_id is absent", () => {
+  const result = langchainContext({ sessionId: "sess-1", conversationId: "conv-1" });
+  assert.equal(result.correlationId, "sess-1");
+  assert.equal(result.metadata?.["langchain.session"], "sess-1");
+  assert.equal(result.metadata?.["langchain.conversation"], "conv-1");
+});
+
+test("falls back to conversationId when sessionId is absent", () => {
+  const result = langchainContext({ conversationId: "conv-only" });
+  assert.equal(result.correlationId, "conv-only");
+  assert.equal(result.metadata?.["langchain.conversation"], "conv-only");
+});
+
+test("reads sessionId from nested context / runtime.context", () => {
+  const result = langchainContext({
+    context: { sessionId: "sess-app" },
+  });
+  assert.equal(result.correlationId, "sess-app");
+
+  const fromRuntime = langchainContext({
+    runtime: { context: { conversationId: "conv-rt" } },
+  });
+  assert.equal(fromRuntime.correlationId, "conv-rt");
+});
+
+test("init.sessionId is a last-resort fallback", () => {
+  const result = langchainContext({}, { sessionId: "init-sess" });
+  assert.equal(result.correlationId, "init-sess");
+  assert.equal(result.metadata?.["langchain.session"], "init-sess");
+});
+
+test("does not mint a correlation id when nothing is present", () => {
+  const result = langchainContext({});
+  assert.equal("correlationId" in result, false);
+});
+
+test("skips an empty thread_id", () => {
+  const result = langchainContext({ configurable: { thread_id: "" } });
+  assert.equal("correlationId" in result, false);
+  assert.equal("langchain.thread" in (result.metadata ?? {}), false);
+});
+
+test("skips a thread_id with a newline and warns", () => {
+  const result = langchainContext({ configurable: { thread_id: "bad\nid" } });
+  assert.equal("correlationId" in result, false);
+  assert.equal(result.metadata?.["langchain.thread"], "bad\nid");
+});
+
+test("accepts a 256-character thread_id", () => {
+  const longId = "t".repeat(256);
+  const result = langchainContext({ configurable: { thread_id: longId } });
+  assert.equal(result.correlationId, longId);
+  assert.equal(result.metadata?.["langchain.thread"], longId);
+});
+
+test("init metadata overrides derived keys", () => {
+  const result = langchainContext(
+    { configurable: { thread_id: "thread-1" } },
+    { metadata: { "langchain.thread": "override" } },
+  );
+  assert.equal(result.metadata?.["langchain.thread"], "override");
+});
+
+test("never reads traceId or interrupt / resume", () => {
+  const result = langchainContext({
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- asserting we do not read these
+    ...( { traceId: "trace-minted", interrupt: "hitl", resumed: true } as Record<string, unknown>),
+    sessionId: "sess-real",
+  } as never);
+  assert.equal(result.correlationId, "sess-real");
+  assert.equal("langchain.trace" in (result.metadata ?? {}), false);
+});
+
+test("null / non-object sources leave the call uncorrelated", () => {
+  assert.equal("correlationId" in langchainContext(null as never), false);
+  assert.equal("correlationId" in langchainContext("thread" as never), false);
+  assert.equal("correlationId" in langchainContext(12 as never), false);
+});
+
+test("undefined source is uncorrelated", () => {
+  const result = langchainContext();
+  assert.equal("correlationId" in result, false);
+});
+
+test("derived metadata is encodeMetadata-safe", () => {
+  const result = langchainContext({
+    configurable: { thread_id: "thread-abc" },
+    sessionId: "sess-1",
+    conversationId: "conv-1",
+  });
+  assert.ok(result.metadata);
+  const metadataJson = encodeMetadata(result.metadata);
+  assert.ok(metadataJson["langchain.thread"]);
+  assert.ok(metadataJson["langchain.session"]);
+  assert.ok(metadataJson["langchain.conversation"]);
+});
+
+test("configurable null does not throw", () => {
+  const result = langchainContext({ configurable: null as never });
+  assert.equal("correlationId" in result, false);
+});

--- a/arcjet-guard/src/langchain/v1/context.ts
+++ b/arcjet-guard/src/langchain/v1/context.ts
@@ -47,7 +47,7 @@ function asContextSource(source: unknown): LangChainContextSource | undefined {
   return source;
 }
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
+function asAppContext(value: unknown): LangChainContextSource | undefined {
   if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
@@ -102,15 +102,17 @@ function readConfigurable(
   return undefined;
 }
 
-function readAppContext(source: LangChainContextSource | undefined): LangChainContextSource | undefined {
+function readAppContext(
+  source: LangChainContextSource | undefined,
+): LangChainContextSource | undefined {
   if (source === undefined) {
     return undefined;
   }
-  const fromRuntime = asRecord(source.runtime?.context);
+  const fromRuntime = asAppContext(source.runtime?.context);
   if (fromRuntime !== undefined) {
     return fromRuntime;
   }
-  const nested = asRecord(source.context);
+  const nested = asAppContext(source.context);
   if (nested !== undefined) {
     return nested;
   }

--- a/arcjet-guard/src/langchain/v1/context.ts
+++ b/arcjet-guard/src/langchain/v1/context.ts
@@ -81,23 +81,43 @@ function firstString(values: unknown[]): string | undefined {
   return undefined;
 }
 
-function readConfigurable(
+/**
+ * Every place a thread id may live, in preference order.
+ *
+ * A list rather than the first match: a caller threading a
+ * partially-built config can carry an empty `configurable` alongside the
+ * real id on `config.configurable`, and returning the empty one would
+ * leave the decision uncorrelated. A candidate that carries no
+ * `thread_id` at all is not an answer, so the search continues. One that
+ * carries an invalid id still is, so it is reported rather than skipped.
+ */
+function readConfigurables(
   source: LangChainContextSource | undefined,
-): Record<string, unknown> | undefined {
+): Array<Record<string, unknown>> {
   if (source === undefined) {
-    return undefined;
+    return [];
   }
-  if (source.configurable !== null && typeof source.configurable === "object") {
-    return source.configurable;
-  }
-  if (source.runtime?.configurable !== null && typeof source.runtime?.configurable === "object") {
-    return source.runtime.configurable;
-  }
-  if (source.config?.configurable !== null && typeof source.config?.configurable === "object") {
-    return source.config.configurable;
+  const candidates: Array<Record<string, unknown>> = [];
+  for (const value of [
+    source.configurable,
+    source.runtime?.configurable,
+    source.config?.configurable,
+  ]) {
+    if (value !== null && typeof value === "object") {
+      candidates.push(value);
+    }
   }
   if (source.thread_id !== undefined) {
-    return { thread_id: source.thread_id };
+    candidates.push({ thread_id: source.thread_id });
+  }
+  return candidates;
+}
+
+function readThreadId(candidates: ReadonlyArray<Record<string, unknown>>): unknown {
+  for (const candidate of candidates) {
+    if (candidate["thread_id"] !== undefined) {
+      return candidate["thread_id"];
+    }
   }
   return undefined;
 }
@@ -150,10 +170,9 @@ export function langchainContext(
   init?: { sessionId?: string; correlationId?: string; metadata?: ArcjetMetadata },
 ): LangChainAgentContext {
   const envelope = asContextSource(source);
-  const configurable = readConfigurable(envelope);
   const app = readAppContext(envelope);
 
-  const threadId = configurable?.["thread_id"];
+  const threadId = readThreadId(readConfigurables(envelope));
   const fromApp = {
     correlationId: app?.correlationId,
     sessionId: app?.sessionId,

--- a/arcjet-guard/src/langchain/v1/context.ts
+++ b/arcjet-guard/src/langchain/v1/context.ts
@@ -1,0 +1,212 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `langchainContext` can read.
+ *
+ * Accepts a LangChain `createAgent` invoke config (`configurable.thread_id`),
+ * a `wrapToolCall` `request.runtime` (which carries `configurable` as of
+ * langchain 1.2.34), a `tool()` invoke config / `ToolRuntime`, or the
+ * `configurable` object itself. Caller-owned `sessionId` / `conversationId`
+ * are fallbacks when no thread id is present.
+ *
+ * Never mints a new id. Never reads `traceId`. Never treats `interrupt` /
+ * resume as correlation. Declared here so this module never value-imports
+ * `langchain` or `@langchain/core`.
+ */
+export interface LangChainContextSource {
+  configurable?: Record<string, unknown>;
+  config?: {
+    configurable?: Record<string, unknown>;
+  };
+  runtime?: {
+    configurable?: Record<string, unknown>;
+    context?: unknown;
+  };
+  context?: unknown;
+  sessionId?: unknown;
+  conversationId?: unknown;
+  correlationId?: unknown;
+  thread_id?: unknown;
+}
+
+/**
+ * Context derived from a LangChain `createAgent` run. `correlationId` is
+ * omitted when nothing valid was present — this helper never mints one.
+ */
+export interface LangChainAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asContextSource(source: unknown): LangChainContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function firstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readConfigurable(
+  source: LangChainContextSource | undefined,
+): Record<string, unknown> | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  if (source.configurable !== null && typeof source.configurable === "object") {
+    return source.configurable;
+  }
+  if (source.runtime?.configurable !== null && typeof source.runtime?.configurable === "object") {
+    return source.runtime.configurable;
+  }
+  if (source.config?.configurable !== null && typeof source.config?.configurable === "object") {
+    return source.config.configurable;
+  }
+  if (source.thread_id !== undefined) {
+    return { thread_id: source.thread_id };
+  }
+  return undefined;
+}
+
+function readAppContext(source: LangChainContextSource | undefined): LangChainContextSource | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  const fromRuntime = asRecord(source.runtime?.context);
+  if (fromRuntime !== undefined) {
+    return fromRuntime;
+  }
+  const nested = asRecord(source.context);
+  if (nested !== undefined) {
+    return nested;
+  }
+  return source;
+}
+
+/**
+ * Derive correlation and metadata from a LangChain `createAgent` invoke
+ * config or a `wrapToolCall` `request.runtime`. Never mints a new id.
+ * Never calls `createAgentContext`. Never reads `traceId`. Never treats
+ * `interrupt` / resume as correlation.
+ *
+ * Preference order for `correlationId`:
+ * 1. `configurable.thread_id` — what `wrapToolCall` sees on
+ *    `runtime.configurable` as of langchain 1.2.34
+ * 2. Caller-owned `sessionId`, then `conversationId`
+ * 3. `init.sessionId` / `init.correlationId`
+ *
+ * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL`
+ * asks for warnings). If nothing valid remains, `correlationId` is
+ * omitted so the decision is uncorrelated rather than joined to a
+ * generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { langchainContext } from "@arcjet/guard/langchain/v1";
+ *
+ * export function fromInvoke(config: { configurable?: { thread_id?: string } }) {
+ *   return langchainContext(config);
+ * }
+ * ```
+ */
+export function langchainContext(
+  source?: LangChainContextSource,
+  init?: { sessionId?: string; correlationId?: string; metadata?: ArcjetMetadata },
+): LangChainAgentContext {
+  const envelope = asContextSource(source);
+  const configurable = readConfigurable(envelope);
+  const app = readAppContext(envelope);
+
+  const threadId = configurable?.["thread_id"];
+  const fromApp = {
+    correlationId: app?.correlationId,
+    sessionId: app?.sessionId,
+    conversationId: app?.conversationId,
+  };
+  const fromEnvelope = {
+    correlationId: envelope?.correlationId,
+    sessionId: envelope?.sessionId,
+    conversationId: envelope?.conversationId,
+  };
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: threadId, label: "thread_id" },
+    { value: fromApp.correlationId, label: "context.correlationId" },
+    { value: fromApp.sessionId, label: "context.sessionId" },
+    { value: fromApp.conversationId, label: "context.conversationId" },
+    { value: fromEnvelope.correlationId, label: "correlationId" },
+    { value: fromEnvelope.sessionId, label: "sessionId" },
+    { value: fromEnvelope.conversationId, label: "conversationId" },
+    { value: init?.correlationId, label: "init.correlationId" },
+    { value: init?.sessionId, label: "init.sessionId" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: LangChain ${rejected} rejected; no valid thread/session/conversation id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const thread = firstString([threadId]);
+  if (thread !== undefined) {
+    derivedMetadata["langchain.thread"] = thread;
+  }
+
+  const session = firstString([fromApp.sessionId, fromEnvelope.sessionId, init?.sessionId]);
+  if (session !== undefined) {
+    derivedMetadata["langchain.session"] = session;
+  }
+
+  const conversation = firstString([fromApp.conversationId, fromEnvelope.conversationId]);
+  if (conversation !== undefined) {
+    derivedMetadata["langchain.conversation"] = conversation;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: LangChainAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
@@ -1,0 +1,218 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/explicit-function-return-type, eslint/require-await, eslint/strict-boolean-expressions, typescript/strict-boolean-expressions, unicorn/no-useless-undefined, unicorn/no-object-as-default-parameter -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { recorded } from "../../../test/_shared/source-scan.ts";
+import { decisionAllow, decisionDenyPromptInjection, fakeRule, stubClient } from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { guardMiddleware } from "./guard-middleware.ts";
+import { guardTool } from "./guard-tool.ts";
+import type { LangChainTool } from "./guard-tool.ts";
+
+const MIDDLEWARE_BRAND = Symbol.for("AgentMiddleware");
+
+function toolRequest(name: string, args: unknown = {}, id = "call-1") {
+  return {
+    toolCall: { name, args, id, type: "tool_call" as const },
+    tool: { name },
+    runtime: { configurable: { thread_id: "thread-1" } },
+    state: { messages: [] },
+  };
+}
+
+async function runHook(
+  mw: ReturnType<typeof guardMiddleware>,
+  request: unknown,
+  handler: (request: unknown) => Promise<unknown>,
+): Promise<unknown> {
+  return mw.wrapToolCall(request, handler);
+}
+
+test("returns a named object with wrapToolCall (not a raw function)", () => {
+  const { client } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  assert.equal(typeof mw, "object");
+  assert.equal(typeof mw.name, "string");
+  assert.ok(mw.name.startsWith("arcjet-guard-"));
+  assert.equal(typeof mw.wrapToolCall, "function");
+  assert.equal((mw as unknown as Record<symbol, unknown>)[MIDDLEWARE_BRAND], true);
+  assert.equal("afterModel" in mw, false);
+  assert.equal("wrapModelCall" in mw, false);
+});
+
+test("each call gets a unique name so two instances do not collide", () => {
+  const { client } = stubClient(decisionAllow());
+  const a = guardMiddleware(client);
+  const b = guardMiddleware(client);
+  assert.notEqual(a.name, b.name);
+});
+
+test("ALLOW → handler is called and its result is returned", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolRequest("lookup"), async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+  assert.equal(guardCalls.length, 1);
+});
+
+test("rules see toolCall.args, not the opaque id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let scanned: unknown;
+  const mw = guardMiddleware(client, {
+    action: "note.read",
+    rules: ({ input, toolName }) => {
+      scanned = { input, toolName };
+      return [fakeRule];
+    },
+  });
+  await runHook(mw, toolRequest("lookup", { note: "hello" }, "ref-opaque"), async () => ({
+    ok: true,
+  }));
+  assert.deepEqual(scanned, { input: { note: "hello" }, toolName: "lookup" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("correlation comes from runtime.configurable.thread_id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  await runHook(mw, toolRequest("lookup"), async () => ({ ok: true }));
+  assert.equal(recorded(guardCalls[0])["correlationId"], "thread-1");
+});
+
+test("policy.sessionId is used when runtime has no thread_id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    sessionId: "policy-sess",
+  });
+  await runHook(
+    mw,
+    {
+      toolCall: { name: "lookup", args: {}, id: "c1" },
+      tool: { name: "lookup" },
+      runtime: { configurable: {} },
+    },
+    async () => ({ ok: true }),
+  );
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("does not mint a correlation id when nothing is present", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  await runHook(
+    mw,
+    {
+      toolCall: { name: "lookup", args: {}, id: "c1" },
+      tool: { name: "lookup" },
+      runtime: {},
+    },
+    async () => ({ ok: true }),
+  );
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("skips an already-branded tool on request.tool", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const branded = { name: "lookup_order" };
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  let calls = 0;
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(
+    mw,
+    {
+      toolCall: { name: "lookup_order", args: {}, id: "c1" },
+      tool: branded,
+      runtime: { configurable: { thread_id: "t" } },
+    },
+    async () => {
+      calls += 1;
+      return { ran: true };
+    },
+  );
+  assert.equal(calls, 1);
+  assert.equal(guardCalls.length, 0);
+  assert.deepEqual(result, { ran: true });
+});
+
+test("guardTool-wrapped fake is skipped when present on request.tool", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const raw: LangChainTool = {
+    name: "authored",
+    func: async () => ({ ok: true }),
+    invoke: async () => ({ ok: true }),
+  };
+  const wrapped = guardTool(client, raw, { action: "order.looked-up" });
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  let nextCalls = 0;
+  await runHook(
+    mw,
+    {
+      toolCall: { name: "authored", args: {}, id: "c1" },
+      tool: wrapped,
+      runtime: { configurable: { thread_id: "s" } },
+    },
+    async () => {
+      nextCalls += 1;
+      return { ok: true };
+    },
+  );
+  assert.equal(nextCalls, 1);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("a non-tool-call request is passed through without a guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  let calls = 0;
+  const result = await runHook(mw, { text: "not a tool" }, async (req) => {
+    calls += 1;
+    return req;
+  });
+  assert.equal(calls, 1);
+  assert.equal(guardCalls.length, 0);
+  assert.deepEqual(result, { text: "not a tool" });
+});
+
+test("action callback names the guard call from the tool name", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+  await runHook(mw, toolRequest("mcp_search"), async () => ({ ok: true }));
+  assert.equal(recorded(guardCalls[0])["label"], "mcp_search.invoked");
+});
+
+test("defaults the guard label to tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client);
+  await runHook(mw, toolRequest("mcp_search"), async () => ({ ok: true }));
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("sessionId callback receives the tool name and input", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let seen: unknown;
+  const mw = guardMiddleware(client, {
+    sessionId: (call) => {
+      seen = call;
+      return "sess-from-callback";
+    },
+  });
+  await runHook(
+    mw,
+    {
+      toolCall: { name: "mcp_search", args: { q: "hello" }, id: "c1" },
+      tool: { name: "mcp_search" },
+      runtime: {},
+    },
+    async () => ({ ok: true }),
+  );
+  assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
+});

--- a/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
@@ -3,7 +3,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { recorded } from "../../../test/_shared/source-scan.ts";
-import { decisionAllow, decisionDenyPromptInjection, fakeRule, stubClient } from "../../../test/_shared/stub-client.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
 import { guardTool } from "./guard-tool.ts";
@@ -25,7 +30,10 @@ async function runHook(
   request: unknown,
   handler: (request: unknown) => Promise<unknown>,
 ): Promise<unknown> {
-  return mw.wrapToolCall(request, handler);
+  const wrap = mw.wrapToolCall;
+  assert.ok(wrap, "guardMiddleware must install wrapToolCall");
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- src tests use structural fakes so the peer-absent job never constructs a real ToolCallRequest
+  return wrap(request as never, handler as never);
 }
 
 test("returns a named object with wrapToolCall (not a raw function)", () => {

--- a/arcjet-guard/src/langchain/v1/guard-middleware.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.ts
@@ -119,6 +119,28 @@ async function loadToolMessage(): Promise<ToolMessageCtor> {
   return toolMessageCtor;
 }
 
+/**
+ * `createAgent` always supplies a string id, so this is a degenerate
+ * input rather than a live path. There is also no id to correlate to
+ * when it is missing, and neither escape hatch is available: throwing
+ * bubbles out of `invoke` and drops `arcjetDenied`, and returning a
+ * bare object crashes the messages reducer. So the denial is still
+ * emitted — the tool must not run — and the anomaly is warned about
+ * instead of being passed off as a correlated message.
+ */
+function denialToolCallId(toolCall: { id?: string; name: string }): string {
+  if (typeof toolCall.id === "string" && toolCall.id.length > 0) {
+    return toolCall.id;
+  }
+  if (shouldWarn()) {
+    console.warn(
+      '@arcjet/guard: LangChain tool call "%s" carried no tool_call_id; denying with a blank id, which the model cannot pair with its request.',
+      toolCall.name,
+    );
+  }
+  return "";
+}
+
 async function denialToolMessage(
   request: { toolCall: { id?: string; name: string } },
   payload: unknown,
@@ -126,7 +148,7 @@ async function denialToolMessage(
   const ToolMessage = await loadToolMessage();
   const fields: DenialToolMessageFields = {
     content: JSON.stringify(payload),
-    tool_call_id: typeof request.toolCall.id === "string" ? request.toolCall.id : "",
+    tool_call_id: denialToolCallId(request.toolCall),
   };
   if (request.toolCall.name.length > 0) {
     fields.name = request.toolCall.name;
@@ -305,6 +327,11 @@ export function guardMiddleware(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
+      // Unlike guard-tool.ts, these handlers return a promise: building the
+      // denial has to await the dynamic `@langchain/core/messages` import.
+      // `runGuarded` is `async` and returns the handler's value directly, so
+      // the async return adopts the thenable and the hook resolves to the
+      // ToolMessage rather than to a promise wrapping one.
       onDeny: (decision: DecisionDeny) => {
         if (policy.onDeny === undefined) {
           return denialToolMessage(request, denialResult(decision));

--- a/arcjet-guard/src/langchain/v1/guard-middleware.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.ts
@@ -1,0 +1,341 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { langchainContext } from "./context.ts";
+import type { LangChainContextSource } from "./context.ts";
+
+/**
+ * Input passed to `rules` / `metadata` / `action` callbacks on
+ * `guardMiddleware`. `input` is the tool's free-text args, not the
+ * opaque `toolCall.id`.
+ */
+export interface GuardMiddlewareCall {
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Policy for `guardMiddleware()` — how to guard tools that execute
+ * through `createAgent({ middleware })`, including MCP tools,
+ * runtime-discovered tools, and anything not wrapped with `guardTool`.
+ *
+ * `humanInTheLoopMiddleware` / `interrupt()` is HITL, not a policy
+ * gate — this helper never calls `interrupt()` and never installs an
+ * `afterModel` hook.
+ */
+export interface GuardMiddlewarePolicy {
+  /**
+   * Guard label and capture action. Defaults to `"tool.invoked"`. May be a
+   * function of the tool name and args.
+   */
+  action?: string | ((call: GuardMiddlewareCall) => string);
+  /**
+   * Rules to evaluate before an unwrapped tool runs. Omitting this still
+   * performs the guard call.
+   */
+  rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
+  /** Metadata merged over the derived LangChain context. */
+  metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
+  /**
+   * Fallback session id when `runtime.configurable.thread_id` is absent.
+   * Prefer putting the id you already chose on
+   * `agent.invoke(..., { configurable: { thread_id } })`. Never mint a
+   * new id here.
+   */
+  sessionId?: string | ((call: GuardMiddlewareCall) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload JSON-stringified onto the completed
+   * `ToolMessage.content` for a real DENY decision. Unavailable guards
+   * take the `onUnavailable` path instead.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+/**
+ * Structural `createMiddleware` result this helper returns.
+ *
+ * Matches LangChain's `createMiddleware` object (`name` + `wrapToolCall`,
+ * branded with `Symbol.for("AgentMiddleware")`) so `createAgent({
+ * middleware })` accepts it. Declared here so this module never
+ * value-imports `createMiddleware`.
+ */
+export interface LangChainGuardMiddleware {
+  name: string;
+  wrapToolCall: (
+    request: unknown,
+    handler: (request: unknown) => Promise<unknown>,
+  ) => Promise<unknown>;
+}
+
+/**
+ * Well-known brand `createMiddleware` stamps on every instance. A raw
+ * function is not middleware; this symbol is what keeps a `{ name }`
+ * object from being mistaken for one.
+ */
+const MIDDLEWARE_BRAND: symbol = Symbol.for("AgentMiddleware");
+
+/**
+ * Fields wrapToolCall's official auth example puts on a deny
+ * `ToolMessage`. `status` is omitted so it stays success — the denial
+ * lives in `content`.
+ */
+interface DenialToolMessageFields {
+  content: string;
+  tool_call_id: string;
+  name?: string;
+}
+
+type ToolMessageCtor = new (fields: DenialToolMessageFields) => unknown;
+
+let toolMessageCtor: ToolMessageCtor | undefined;
+
+/**
+ * wrapToolCall's return is NOT passed through `baseHandler`. A bare
+ * object is the reducer-crash case. Construct a real `ToolMessage`
+ * from `@langchain/core/messages`.
+ *
+ * This is a dynamic import on purpose: a static value import would
+ * make the namespace unloadable when the optional peer is absent.
+ * Construction only runs on a deny / fail-closed path, which is
+ * only reachable in an app that already installed `langchain`.
+ */
+async function loadToolMessage(): Promise<ToolMessageCtor> {
+  if (toolMessageCtor !== undefined) {
+    return toolMessageCtor;
+  }
+  const messages = await import("@langchain/core/messages");
+  const ctor: unknown = messages.ToolMessage;
+  if (typeof ctor !== "function") {
+    throw new Error(
+      "@arcjet/guard: guardMiddleware() could not load ToolMessage from @langchain/core/messages; wrapToolCall cannot return a completed denial.",
+    );
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolMessage is the class createAgent's wrapToolCall validator accepts
+  toolMessageCtor = ctor as ToolMessageCtor;
+  return toolMessageCtor;
+}
+
+async function denialToolMessage(
+  request: { toolCall: { id?: string; name: string } },
+  payload: unknown,
+): Promise<unknown> {
+  const ToolMessage = await loadToolMessage();
+  const fields: DenialToolMessageFields = {
+    content: JSON.stringify(payload),
+    tool_call_id: typeof request.toolCall.id === "string" ? request.toolCall.id : "",
+  };
+  if (request.toolCall.name.length > 0) {
+    fields.name = request.toolCall.name;
+  }
+  return new ToolMessage(fields);
+}
+
+function isContextSource(value: unknown): value is LangChainContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isToolCallRequest(
+  value: unknown,
+): value is {
+  toolCall: { name: string; args?: unknown; id?: string };
+  tool?: object;
+  runtime?: unknown;
+} {
+  if (!isRecord(value) || !isRecord(value["toolCall"])) {
+    return false;
+  }
+  return typeof value["toolCall"]["name"] === "string";
+}
+
+function resolveAction(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall): string {
+  if (typeof policy.action === "function") {
+    return policy.action(call);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "tool.invoked";
+}
+
+function resolveSessionId(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(call);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+function isBrandedTool(tool: unknown): boolean {
+  return tool !== null && typeof tool === "object" && arcjetProtectedTool in tool;
+}
+
+let middlewareSeq = 0;
+
+/**
+ * A registry key, not a secret: `createAgent` composes middleware by
+ * name in error messages, and two distinct instances sharing one
+ * would be indistinguishable in those logs. The counter alone is not
+ * enough because a second copy of this module starts counting at one
+ * again.
+ */
+function middlewareName(): string {
+  middlewareSeq += 1;
+  return `arcjet-guard-${middlewareSeq}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * A `createAgent({ middleware })` middleware whose `wrapToolCall` is
+ * the invoke()-wide gate.
+ *
+ * MCP tools, runtime-discovered tools, and anything not wrapped with
+ * `guardTool` skip the authored handler. This is the Genkit
+ * `guardMiddleware` / LangGraph `guardToolNode` equivalent. Put it on
+ * `createAgent({ middleware: [guardMiddleware(...)] })`.
+ *
+ * `wrapToolCall` *can* deny: LangChain's official auth example returns
+ * a `ToolMessage` without calling `handler`. This helper does that.
+ * The return is validated with `ToolMessage.isInstance` and is **not**
+ * passed through `baseHandler`, so a bare object is the
+ * messages-reducer crash. This helper does **not** throw (throws
+ * bubble and drop `arcjetDenied`) and does **not** set
+ * `status: "error"` (the denial lives in `content`). Policy sits on
+ * `wrapToolCall` only — `afterModel` is where HITL already lives.
+ *
+ * Already-branded tools (`guardTool`) are skipped when
+ * `request.tool` can be looked up, so Guard is not double-called.
+ * Tools that cannot be looked up (`request.tool` undefined — MCP /
+ * unwrapped / runtime-discovered) are still gated.
+ *
+ * Correlation is read from `request.runtime.configurable.thread_id`
+ * (langchain >= 1.2.34). No id is minted.
+ *
+ * Server-side provider tools and headless `.implement()` tools are
+ * out of scope.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardMiddleware } from "@arcjet/guard/langchain/v1";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const mcpLimit = tokenBucket({
+ *   refillRate: 20,
+ *   intervalSeconds: 60,
+ *   maxTokens: 20,
+ * });
+ *
+ * const agent = createAgent({
+ *   model,
+ *   tools: [lookupOrder, ...mcpTools],
+ *   middleware: [
+ *     guardMiddleware(arcjet, {
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+ *       sessionId: conversationId,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function guardMiddleware(
+  client: ArcjetAgentClient,
+  policy: GuardMiddlewarePolicy = {},
+): LangChainGuardMiddleware {
+  const middleware: LangChainGuardMiddleware = {
+    name: middlewareName(),
+    wrapToolCall: async (request: unknown, handler: (request: unknown) => Promise<unknown>) => {
+      if (!isToolCallRequest(request)) {
+        return handler(request);
+      }
+
+      if (isBrandedTool(request.tool)) {
+        return handler(request);
+      }
+
+      const toolName = request.toolCall.name;
+      const input = request.toolCall.args ?? {};
+      const call: GuardMiddlewareCall = { toolName, input };
+
+      let action: string;
+      let sessionId: string | undefined;
+      let rules: RuleWithInput[] | undefined;
+      let policyMetadata: ArcjetMetadata | undefined;
+      try {
+        action = resolveAction(policy, call);
+        sessionId = resolveSessionId(policy, call);
+        rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
+        policyMetadata =
+          typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+      } catch (error) {
+        const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
+        if (shouldWarn()) {
+          console.warn(
+            '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+            actionLabel,
+            error,
+          );
+        }
+        if (policy.onGuardError === "allow") {
+          return handler(request);
+        }
+        return denialToolMessage(request, unavailableResult());
+      }
+
+      const source = isContextSource(request.runtime) ? request.runtime : undefined;
+      const agentCtx = langchainContext(source, sessionId === undefined ? undefined : { sessionId });
+
+      const metadata: ArcjetMetadata = {
+        ...agentCtx.metadata,
+        ...(toolName.length > 0 && { "langchain.tool": toolName }),
+      };
+      const mergedMetadata = { ...metadata, ...policyMetadata };
+
+      return runGuarded<unknown>(client, {
+        action,
+        rules,
+        correlationId: agentCtx.correlationId,
+        metadata: mergedMetadata,
+        onDeny: (decision: DecisionDeny) => {
+          if (policy.onDeny === undefined) {
+            return denialToolMessage(request, denialResult(decision));
+          }
+          try {
+            return denialToolMessage(request, policy.onDeny(decision));
+          } catch (error) {
+            if (shouldWarn()) {
+              console.warn(
+                '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+                action,
+                error,
+              );
+            }
+            return denialToolMessage(request, denialResult(decision));
+          }
+        },
+        onUnavailable: () => denialToolMessage(request, unavailableResult()),
+        execute: () => handler(request),
+        onGuardError: policy.onGuardError ?? "deny",
+      });
+    },
+  };
+
+  Object.defineProperty(middleware, MIDDLEWARE_BRAND, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return middleware;
+}

--- a/arcjet-guard/src/langchain/v1/guard-middleware.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.ts
@@ -1,3 +1,5 @@
+import type { AgentMiddleware, WrapToolCallHook } from "langchain";
+
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -58,20 +60,15 @@ export interface GuardMiddlewarePolicy {
 }
 
 /**
- * Structural `createMiddleware` result this helper returns.
+ * The `createMiddleware`-shaped result this helper returns.
  *
- * Matches LangChain's `createMiddleware` object (`name` + `wrapToolCall`,
- * branded with `Symbol.for("AgentMiddleware")`) so `createAgent({
- * middleware })` accepts it. Declared here so this module never
- * value-imports `createMiddleware`.
+ * This is LangChain's `AgentMiddleware` (via `import type` only — this
+ * module never value-imports `createMiddleware`). `createAgent({
+ * middleware })` accepts it with no cast.
  */
-export interface LangChainGuardMiddleware {
-  name: string;
-  wrapToolCall: (
-    request: unknown,
-    handler: (request: unknown) => Promise<unknown>,
-  ) => Promise<unknown>;
-}
+export type LangChainGuardMiddleware = AgentMiddleware & {
+  wrapToolCall: NonNullable<AgentMiddleware["wrapToolCall"]>;
+};
 
 /**
  * Well-known brand `createMiddleware` stamps on every instance. A raw
@@ -112,6 +109,7 @@ async function loadToolMessage(): Promise<ToolMessageCtor> {
   const messages = await import("@langchain/core/messages");
   const ctor: unknown = messages.ToolMessage;
   if (typeof ctor !== "function") {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
     throw new Error(
       "@arcjet/guard: guardMiddleware() could not load ToolMessage from @langchain/core/messages; wrapToolCall cannot return a completed denial.",
     );
@@ -144,9 +142,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
 
-function isToolCallRequest(
-  value: unknown,
-): value is {
+function isToolCallRequest(value: unknown): value is {
   toolCall: { name: string; args?: unknown; id?: string };
   tool?: object;
   runtime?: unknown;
@@ -167,7 +163,10 @@ function resolveAction(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall)
   return "tool.invoked";
 }
 
-function resolveSessionId(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall): string | undefined {
+function resolveSessionId(
+  policy: GuardMiddlewarePolicy,
+  call: GuardMiddlewareCall,
+): string | undefined {
   if (typeof policy.sessionId === "function") {
     return policy.sessionId(call);
   }
@@ -253,82 +252,85 @@ export function guardMiddleware(
   client: ArcjetAgentClient,
   policy: GuardMiddlewarePolicy = {},
 ): LangChainGuardMiddleware {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- body is structural; the hook type is what createAgent assigns without a cast
+  const wrapToolCall = ((request: unknown, handler: (request: unknown) => Promise<unknown>) => {
+    if (!isToolCallRequest(request)) {
+      return handler(request);
+    }
+
+    if (isBrandedTool(request.tool)) {
+      return handler(request);
+    }
+
+    const toolName = request.toolCall.name;
+    const input = request.toolCall.args ?? {};
+    const call: GuardMiddlewareCall = { toolName, input };
+
+    let action: string;
+    let sessionId: string | undefined;
+    let rules: RuleWithInput[] | undefined;
+    let policyMetadata: ArcjetMetadata | undefined;
+    try {
+      action = resolveAction(policy, call);
+      sessionId = resolveSessionId(policy, call);
+      rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
+      policyMetadata =
+        typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+    } catch (error) {
+      const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
+      if (shouldWarn()) {
+        console.warn(
+          '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+          actionLabel,
+          error,
+        );
+      }
+      if (policy.onGuardError === "allow") {
+        return handler(request);
+      }
+      return denialToolMessage(request, unavailableResult());
+    }
+
+    const source = isContextSource(request.runtime) ? request.runtime : undefined;
+    const agentCtx = langchainContext(source, sessionId === undefined ? undefined : { sessionId });
+
+    const metadata: ArcjetMetadata = {
+      ...agentCtx.metadata,
+      ...(toolName.length > 0 && { "langchain.tool": toolName }),
+    };
+    const mergedMetadata = { ...metadata, ...policyMetadata };
+
+    return runGuarded<unknown>(client, {
+      action,
+      rules,
+      correlationId: agentCtx.correlationId,
+      metadata: mergedMetadata,
+      onDeny: (decision: DecisionDeny) => {
+        if (policy.onDeny === undefined) {
+          return denialToolMessage(request, denialResult(decision));
+        }
+        try {
+          return denialToolMessage(request, policy.onDeny(decision));
+        } catch (error) {
+          if (shouldWarn()) {
+            console.warn(
+              '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+              action,
+              error,
+            );
+          }
+          return denialToolMessage(request, denialResult(decision));
+        }
+      },
+      onUnavailable: () => denialToolMessage(request, unavailableResult()),
+      execute: () => handler(request),
+      onGuardError: policy.onGuardError ?? "deny",
+    });
+  }) as WrapToolCallHook;
+
   const middleware: LangChainGuardMiddleware = {
     name: middlewareName(),
-    wrapToolCall: async (request: unknown, handler: (request: unknown) => Promise<unknown>) => {
-      if (!isToolCallRequest(request)) {
-        return handler(request);
-      }
-
-      if (isBrandedTool(request.tool)) {
-        return handler(request);
-      }
-
-      const toolName = request.toolCall.name;
-      const input = request.toolCall.args ?? {};
-      const call: GuardMiddlewareCall = { toolName, input };
-
-      let action: string;
-      let sessionId: string | undefined;
-      let rules: RuleWithInput[] | undefined;
-      let policyMetadata: ArcjetMetadata | undefined;
-      try {
-        action = resolveAction(policy, call);
-        sessionId = resolveSessionId(policy, call);
-        rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
-        policyMetadata =
-          typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-      } catch (error) {
-        const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
-        if (shouldWarn()) {
-          console.warn(
-            '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
-            actionLabel,
-            error,
-          );
-        }
-        if (policy.onGuardError === "allow") {
-          return handler(request);
-        }
-        return denialToolMessage(request, unavailableResult());
-      }
-
-      const source = isContextSource(request.runtime) ? request.runtime : undefined;
-      const agentCtx = langchainContext(source, sessionId === undefined ? undefined : { sessionId });
-
-      const metadata: ArcjetMetadata = {
-        ...agentCtx.metadata,
-        ...(toolName.length > 0 && { "langchain.tool": toolName }),
-      };
-      const mergedMetadata = { ...metadata, ...policyMetadata };
-
-      return runGuarded<unknown>(client, {
-        action,
-        rules,
-        correlationId: agentCtx.correlationId,
-        metadata: mergedMetadata,
-        onDeny: (decision: DecisionDeny) => {
-          if (policy.onDeny === undefined) {
-            return denialToolMessage(request, denialResult(decision));
-          }
-          try {
-            return denialToolMessage(request, policy.onDeny(decision));
-          } catch (error) {
-            if (shouldWarn()) {
-              console.warn(
-                '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
-                action,
-                error,
-              );
-            }
-            return denialToolMessage(request, denialResult(decision));
-          }
-        },
-        onUnavailable: () => denialToolMessage(request, unavailableResult()),
-        execute: () => handler(request),
-        onGuardError: policy.onGuardError ?? "deny",
-      });
-    },
+    wrapToolCall,
   };
 
   Object.defineProperty(middleware, MIDDLEWARE_BRAND, {

--- a/arcjet-guard/src/langchain/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.test.ts
@@ -1,0 +1,529 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions, typescript/unbound-method -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionDenyRateLimit,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { DecisionDeny } from "../../types.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import type { LangChainTool } from "./guard-tool.ts";
+import { guardTool } from "./guard-tool.ts";
+
+const HIDDEN = Symbol.for("langchain.hidden");
+
+function createLangChainTool<TInput = Record<string, unknown>>(overrides?: {
+  name?: string;
+  func?: (input: TInput, runtime?: unknown) => Promise<unknown>;
+  invoke?: (input: unknown, config?: unknown) => Promise<unknown>;
+}): LangChainTool<TInput> {
+  const func = overrides?.func ?? overrides?.invoke ?? (async () => ({ ok: true }));
+  const tool: LangChainTool<TInput> = {
+    name: overrides?.name ?? "test-tool",
+    description: "test tool",
+    func,
+    invoke:
+      overrides?.invoke ??
+      (async (input: unknown, config?: unknown) => {
+        const args =
+          input !== null &&
+          typeof input === "object" &&
+          "type" in input &&
+          (input as { type?: unknown }).type === "tool_call"
+            ? (input as unknown as { args: TInput }).args
+            : (input as TInput);
+        return func(args, config);
+      }),
+  };
+  Object.defineProperty(tool, HIDDEN, {
+    value: "keep-me",
+    enumerable: false,
+    configurable: true,
+  });
+  return tool;
+}
+
+function threadConfig(threadId: string) {
+  return { configurable: { thread_id: threadId } };
+}
+
+function asToolResult(value: unknown): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(value);
+}
+
+test("throws when the tool has no func or invoke", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = { name: "no-exec", description: "x" };
+  assert.throws(
+    () => guardTool(client, tool as LangChainTool, { action: "test.executed" }),
+    /func or invoke/,
+  );
+});
+
+test("returned object is not the input tool and preserves non-enumerable markers", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createLangChainTool();
+  const wrapped = guardTool(client, tool, { action: "test.executed" });
+
+  assert.notStrictEqual(wrapped, tool);
+  assert.equal((wrapped as any)[HIDDEN], "keep-me");
+});
+
+test("input tool.func and invoke are unchanged after wrapping", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createLangChainTool();
+  const originalFunc = tool.func;
+  const originalInvoke = tool.invoke;
+  guardTool(client, tool, { action: "test.executed" });
+  assert.strictEqual(tool.func, originalFunc);
+  assert.strictEqual(tool.invoke, originalInvoke);
+});
+
+test("ALLOW → func called once with input and config by reference", async () => {
+  const { client } = stubClient(decisionAllow());
+  const input = { orderNumber: "A-1" };
+  const ctx = threadConfig("thread-1");
+  let calls = 0;
+  let capturedInput: unknown;
+  let capturedCtx: unknown;
+
+  const tool = createLangChainTool({
+    func: async (inp, context) => {
+      calls += 1;
+      capturedInput = inp;
+      capturedCtx = context;
+      return { status: "shipped" };
+    },
+  });
+
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = await wrapped.func!(input, ctx);
+
+  assert.equal(calls, 1);
+  assert.strictEqual(capturedInput, input);
+  assert.strictEqual(capturedCtx, ctx);
+  assert.deepEqual(result, { status: "shipped" });
+});
+
+test("ALLOW → invoke with a tool_call uses args, not the opaque id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let captured: unknown;
+  const tool = createLangChainTool<{ note: string }>({
+    func: async (input) => {
+      captured = input;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "note.read",
+    rules: (input) => {
+      assert.equal(input.note, "hello");
+      return [fakeRule];
+    },
+  });
+  await wrapped.invoke!(
+    { name: "test-tool", args: { note: "hello" }, id: "call-opaque", type: "tool_call" },
+    threadConfig("t"),
+  );
+  assert.deepEqual(captured, { note: "hello" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("ALLOW → capture outcome is success and correlation comes from thread_id", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({
+    func: async () => ({ ok: true }),
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, threadConfig("thread-99"));
+
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "thread-99");
+  assert.equal(captureCalls.length, 1);
+  assert.equal(
+    recorded(captureCalls[0])["metadata"] &&
+      (recorded(captureCalls[0])["metadata"] as Record<string, unknown>)["outcome"],
+    "success",
+  );
+});
+
+test("DENY → func is not called and a plain ArcjetDenialResult is returned (no throw, no ToolMessage)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+  assert.equal(result.retryable, false);
+  assert.equal("type" in result, false);
+  assert.equal("tool_call_id" in result, false);
+});
+
+test("RATE_LIMIT DENY → structured result is retryable", async () => {
+  const resetAt = Math.floor(Date.now() / 1000) + 12;
+  const { client } = stubClient(decisionDenyRateLimit(resetAt));
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+
+  assert.equal(result.retryable, true);
+  assert.ok(typeof result.retryAfterSeconds === "number");
+});
+
+test("rules callback receives the tool input", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool<{ id: string }>({
+    func: async () => ({ ok: true }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    rules: (input) => {
+      assert.equal(input.id, "xyz");
+      return [fakeRule];
+    },
+  });
+  await wrapped.func!({ id: "xyz" }, threadConfig("t"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("fail-closed unavailable → ERROR denial, func not called", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("onGuardError allow → func still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+  });
+  const result = await wrapped.func!({}, threadConfig("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("does not mint a correlation id when LangChain provided none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, {});
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("policy.sessionId is used when the invoke config has no thread_id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: "policy-sess",
+  });
+  await wrapped.func!({}, {});
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("DENY + throwing onDeny still denies and does not throw", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      throw new Error("onDeny exploded");
+    },
+  });
+
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("onDeny reshape is returned and func is not called", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let received: DecisionDeny | undefined;
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: (decision) => {
+      received = decision;
+      return { blocked: decision.reason };
+    },
+  });
+
+  const result = await wrapped.func!({}, threadConfig("t"));
+  assert.equal(received?.reason, "PROMPT_INJECTION");
+  assert.deepEqual(result, { blocked: "PROMPT_INJECTION" });
+});
+
+test("onDeny is not called on unavailable", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let onDenyCalls = 0;
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      onDenyCalls += 1;
+      return { blocked: true };
+    },
+  });
+
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(onDenyCalls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("guard throw with default fail-closed does not execute", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("omitted rules still submit an empty guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, threadConfig("t"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], []);
+});
+
+test("metadata callback is merged over derived context", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool<{ id: string }>({
+    func: async () => ({ ok: true }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: (input) => ({ "app.item": input.id }),
+  });
+  await wrapped.func!({ id: "item-9" }, threadConfig("thread-meta"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.item"], "item-9");
+  assert.equal(metadata["langchain.tool"], "test-tool");
+});
+
+test("static metadata is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({ name: "", func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: { "app.static": "yes" },
+  });
+  await wrapped.func!({}, threadConfig("t"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.static"], "yes");
+  assert.equal("langchain.tool" in metadata, false);
+});
+
+test("rejects a second wrap (langchain, langgraph, or vercel-ai brand)", async () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createLangChainTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  assert.equal(arcjetProtectedTool in wrapped, true);
+  assert.throws(() => guardTool(client, wrapped, { action: "order.looked-up" }), /already guarded/);
+
+  const branded = createLangChainTool();
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  assert.throws(() => guardTool(client, branded, { action: "order.looked-up" }), /already guarded/);
+});
+
+test("func throw is rethrown after capture", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({
+    func: async (): Promise<{ ok: boolean }> => {
+      throw new Error("tool failed");
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await assert.rejects(async () => wrapped.func!({}, threadConfig("t")), /tool failed/);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "error");
+});
+
+test("non-object config does not mint an id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.func!({}, "not-context");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("rules factory throw fail-closes and does not execute", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("metadata factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    metadata: () => {
+      throw new Error("metadata exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("action factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: () => {
+      throw new Error("action exploded");
+    },
+  });
+  const result = asToolResult(await wrapped.func!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("rules factory throw with onGuardError allow still executes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await wrapped.func!({}, threadConfig("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("invoke and func share one guard call (no double-call)", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let funcCalls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      funcCalls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  await wrapped.invoke!({ orderNumber: "A-1" }, threadConfig("t"));
+  assert.equal(funcCalls, 1);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("invoke-only tool (no func) is still gated", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool: LangChainTool = {
+    name: "invoke-only",
+    invoke: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  };
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  const result = asToolResult(await wrapped.invoke!({}, threadConfig("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+});
+
+test("DENY through a tool_call envelope returns the denial and scans only args", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const tool = createLangChainTool({ func: async () => ({ ok: true }) });
+  let scanned: unknown;
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: (input) => {
+      scanned = input;
+      return [];
+    },
+  });
+  const result = asToolResult(
+    await wrapped.invoke!(
+      { name: "test-tool", args: { note: "x" }, id: "call-9", type: "tool_call" },
+      threadConfig("t"),
+    ),
+  );
+  assert.deepEqual(scanned, { note: "x" });
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});

--- a/arcjet-guard/src/langchain/v1/guard-tool.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.ts
@@ -214,6 +214,15 @@ export function guardTool<TTool extends LangChainTool<any>>(
   const originalInvoke = invoke?.bind(tool);
 
   // Preserve class prototype and non-enumerable markers.
+  //
+  // This copies own descriptors onto a fresh object sharing the prototype,
+  // which is what a real `DynamicStructuredTool` needs to stay usable. It
+  // only holds while LangChain resolves a tool's behaviour from the object
+  // it was handed. If a future version binds behaviour to the *instance*
+  // out of band — a `WeakMap` keyed on the original, say — the registered
+  // clone would resolve back to the unguarded original and this wrapper
+  // would stop gating. `test/langchain/real-agent.test.ts` pins today's
+  // shape end to end, so re-check it when bumping the `langchain` peer.
   // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
   const proto = Object.getPrototypeOf(tool) as object | null;
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols

--- a/arcjet-guard/src/langchain/v1/guard-tool.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.ts
@@ -1,32 +1,33 @@
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
-import { langgraphAgentContext } from "./context.ts";
-import type { LangGraphContextSource } from "./context.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import { langchainContext } from "./context.ts";
+import type { LangChainContextSource } from "./context.ts";
 
 /**
  * Structural LangChain `tool()` / `StructuredTool` / `RunnableToolLike`.
- * Declared here so `guardTool` does not value-import `@langchain/core`.
+ * Declared here so `guardTool` does not value-import `langchain` or
+ * `@langchain/core`.
  *
- * LangGraph Graph API tools are invoked through `invoke` (that is what
- * `ToolNode.runTool` calls) and authored `tool()` wrappers also expose `func`.
- * There is no `execute`.
+ * LangChain `createAgent` tools are invoked through `invoke` (that is
+ * what `createAgent`'s ToolNode `baseHandler` calls) and authored
+ * `tool()` wrappers also expose `func`. There is no `execute`.
  *
- * `invoke` and `func` are declared with method syntax, not as property types.
- * Method parameters are bivariant, which is what lets a real
+ * `invoke` and `func` are declared with method syntax, not as property
+ * types. Method parameters are bivariant, which is what lets a real
  * `DynamicStructuredTool` — whose `invoke` is generic over
- * `StructuredToolCallInput` — satisfy this interface. Written as property
- * types they are contravariant under `strictFunctionTypes`, and every real
- * LangChain tool is rejected at the call site.
+ * `StructuredToolCallInput` — satisfy this interface. Written as
+ * property types they are contravariant under `strictFunctionTypes`,
+ * and every real LangChain tool is rejected at the call site.
  *
- * `createReactAgent` is deprecated in LangGraph JS v1 in favor of LangChain
- * `createAgent`. This helper targets Graph API tools, not that middleware.
+ * This helper targets `createAgent` authored tools, not LangGraph
+ * Graph API `ToolNode` (`@arcjet/guard/langgraph/v1`).
  */
-export interface LangGraphTool<TInput = unknown> {
+export interface LangChainTool<TInput = unknown> {
   name: string;
   description?: string;
   invoke?(input: unknown, config?: unknown): unknown;
@@ -34,54 +35,60 @@ export interface LangGraphTool<TInput = unknown> {
 }
 
 /**
- * Input type of a LangGraph / LangChain structured tool. Used so `guardTool`
- * can keep the concrete tool type while still typing `policy.rules` against
- * the tool args (not opaque call ids).
+ * Input type of a LangChain structured tool. Used so `guardTool` can
+ * keep the concrete tool type while still typing `policy.rules`
+ * against the tool args (not opaque call ids).
  */
-export type LangGraphToolInput<TTool> = TTool extends {
+export type LangChainToolInput<TTool> = TTool extends {
   func?(input: infer TInput, runtime?: unknown): unknown;
 }
   ? TInput
   : unknown;
 
 /**
- * Policy for `guardTool()` — how to guard an authored LangChain `tool()` /
- * `StructuredTool`.
+ * Policy for `guardTool()` — how to guard an authored LangChain
+ * `tool()` / `StructuredTool`.
  *
- * Specifies the guard action name, optional rules to evaluate, metadata
- * context, and optional denial handler. Rules can be static or computed
- * from the tool's free-text args. Do not scan opaque ids.
+ * Specifies the guard action name, optional rules to evaluate,
+ * metadata context, and optional denial handler. Rules can be static
+ * or computed from the tool's free-text args. Do not scan opaque ids.
  */
 export interface GuardToolPolicy<TInput> {
   /**
    * Guard label and capture action: `"resource.verb"`, past tense. A
-   * function is resolved per call from the tool args (used by
-   * `guardToolNode` so one policy can name many tools).
+   * function is resolved per call from the tool args.
    */
   action: string | ((input: TInput) => string);
   /**
-   * Rules to evaluate, static or computed from the tool's input. Omitting
-   * this, or returning `[]`, submits no rules — it does not skip the guard
-   * call, which still costs a round trip and returns a decision.
+   * Rules to evaluate, static or computed from the tool's input.
+   * Omitting this, or returning `[]`, submits no rules — it does not
+   * skip the guard call, which still costs a round trip and returns a
+   * decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
+  /**
+   * Fallback session id when the invoke config / `ToolRuntime` does
+   * not carry `configurable.thread_id`. Prefer putting the id you
+   * already chose on `agent.invoke(..., { configurable: { thread_id } })`.
+   * Never mint a new id here.
+   */
+  sessionId?: string | ((input: TInput) => string | undefined);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
   onGuardError?: OnGuardError;
   /**
-   * Reshape the denial payload the model sees for a real DENY decision. The
-   * value is returned to the caller as-is, so `ToolNode` treats it exactly
-   * as it treats the default denial: a non-message object becomes the
-   * content of the `ToolMessage` it builds. Unavailable guards take the
-   * `onUnavailable` path instead and return the fixed
-   * `{ reason: "ERROR", retryable: true, retryAfterSeconds: 5 }` result;
-   * this callback does not fire for outages.
+   * Reshape the denial payload the model sees for a real DENY
+   * decision. The value is returned to the caller as-is, so
+   * `createAgent`'s `baseHandler` treats it exactly as it treats the
+   * default denial: a non-message object becomes the content of the
+   * `ToolMessage` it builds (`status` stays success). Unavailable
+   * guards take the `onUnavailable` path instead.
    */
   onDeny?: (decision: DecisionDeny) => unknown;
 }
 
-function isContextSource(value: unknown): value is LangGraphContextSource {
+function isContextSource(value: unknown): value is LangChainContextSource {
   return value !== null && typeof value === "object";
 }
 
@@ -96,45 +103,62 @@ function isToolCall(input: unknown): input is { args: unknown; type: "tool_call"
 }
 
 /**
- * The model-produced arguments. `ToolNode` invokes a tool with the whole
- * `ToolCall`, so rules must see `args` rather than the envelope — scanning
- * the envelope would feed an opaque `tool_call_id` to the detectors.
+ * The model-produced arguments. `createAgent` invokes a tool with the
+ * whole `ToolCall`, so rules must see `args` rather than the envelope
+ * — scanning the envelope would feed an opaque `tool_call_id` to the
+ * detectors.
  */
 function toolArgs(input: unknown): unknown {
   return isToolCall(input) ? input.args : input;
 }
 
+function resolveSessionId<TInput>(
+  policy: GuardToolPolicy<TInput>,
+  input: TInput,
+): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(input);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
 /**
- * Wraps a LangChain `tool()` / `StructuredTool` so `func` / `invoke` never
- * runs on DENY.
+ * Wraps a LangChain `tool()` / `StructuredTool` so `func` / `invoke`
+ * never runs on DENY.
  *
- * Always runs `guard()` before the tool, submitting `policy.rules` or none;
- * on DENY the original function never executes and the model receives an
- * `ArcjetDenialResult` (or the result of `policy.onDeny`). This helper does
- * not throw on DENY. Through `ToolNode` the denial arrives as the content of
- * a real `ToolMessage`; see {@link ArcjetDenialResult} for why the denial is
- * in the payload rather than the message status.
+ * Always runs `guard()` before the tool. On DENY the original
+ * function never executes and the caller receives a plain
+ * `ArcjetDenialResult` (or the result of `policy.onDeny`). This
+ * helper does not throw on DENY and does not fabricate a
+ * `ToolMessage`. Through `createAgent`, the ToolNode `baseHandler`
+ * wraps a non-ToolMessage result in a real `ToolMessage` whose
+ * `status` is success — the denial lives in the payload. Same
+ * envelope as `@arcjet/guard/langgraph/v1`.
  *
  * Guard API errors depend on `policy.onGuardError` (defaults to `"deny"`):
  * - `"deny"` (default): Tool does not execute; the model receives an
  *   `ArcjetDenialResult` with `reason: "ERROR"`.
- * - `"allow"`: Tool still runs, with a warning gated on `ARCJET_LOG_LEVEL`.
+ * - `"allow"`: Tool still runs, with a warning gated on
+ *   `ARCJET_LOG_LEVEL`.
  *
  * Correlation is read from the invoke `config` / `ToolRuntime`
- * (`configurable.thread_id`). No id is minted.
+ * (`configurable.thread_id` as of langchain 1.2.34). No id is minted.
  *
- * Do not also wrap the same tool with `@arcjet/guard/vercel-ai/v7`. The
- * shared `arcjetProtectedTool` brand throws on a second `guardTool` wrap, and
- * `guardToolNode` skips already-branded tools so Guard is not double-called.
+ * Do not also wrap the same tool with `@arcjet/guard/langgraph/v1` or
+ * `@arcjet/guard/vercel-ai/v7`. The shared `arcjetProtectedTool` brand
+ * throws on a second `guardTool` wrap, and `guardMiddleware` skips
+ * already-branded tools so Guard is not double-called.
  *
- * This is Graph API (`StateGraph` + `ToolNode`). `createReactAgent` is
- * deprecated in LangGraph JS v1; do not build on it. LangChain
- * `createAgent` / `wrapToolCall` is `@arcjet/guard/langchain/v1`.
+ * This is LangChain `createAgent`, not Graph API `StateGraph` +
+ * `ToolNode`.
  *
  * @example
  * ```ts
  * import { launchArcjet, tokenBucket } from "@arcjet/guard";
- * import { guardTool } from "@arcjet/guard/langgraph/v1";
+ * import { guardTool } from "@arcjet/guard/langchain/v1";
  * import { tool } from "@langchain/core/tools";
  * import { z } from "zod";
  *
@@ -162,10 +186,10 @@ function toolArgs(input: unknown): unknown {
  * );
  * ```
  */
-export function guardTool<TTool extends LangGraphTool<any>>(
+export function guardTool<TTool extends LangChainTool<any>>(
   client: ArcjetAgentClient,
   tool: TTool,
-  policy: GuardToolPolicy<LangGraphToolInput<TTool>>,
+  policy: GuardToolPolicy<LangChainToolInput<TTool>>,
 ): TTool {
   // oxlint-disable-next-line typescript/unbound-method -- read to be bound to `tool` immediately below, which is the point
   const func = typeof tool.func === "function" ? tool.func : undefined;
@@ -177,14 +201,14 @@ export function guardTool<TTool extends LangGraphTool<any>>(
   }
   if (arcjetProtectedTool in tool) {
     throw new Error(
-      "@arcjet/guard: guardTool() cannot wrap a tool that is already guarded; do not double-wrap with @arcjet/guard/langgraph/v1 or @arcjet/guard/vercel-ai/v7",
+      "@arcjet/guard: guardTool() cannot wrap a tool that is already guarded; do not double-wrap with @arcjet/guard/langchain/v1, @arcjet/guard/langgraph/v1, or @arcjet/guard/vercel-ai/v7",
     );
   }
 
   // Bound to the original tool, so the guarded `invoke` below reaches the
   // original `func` rather than the guarded one. That is what keeps a single
   // call from evaluating the guard twice, without any shared re-entry state:
-  // `ToolNode` fans parallel tool calls out through `Promise.all`, and a
+  // `createAgent` fans parallel tool calls out through `Promise.all`, and a
   // shared flag would let one of those calls skip the guard entirely.
   const originalFunc = func?.bind(tool);
   const originalInvoke = invoke?.bind(tool);
@@ -233,10 +257,10 @@ export function guardTool<TTool extends LangGraphTool<any>>(
   return wrapped;
 }
 
-function runGuardedTool<TTool extends LangGraphTool<any>>(
+function runGuardedTool<TTool extends LangChainTool<any>>(
   client: ArcjetAgentClient,
   tool: TTool,
-  policy: GuardToolPolicy<LangGraphToolInput<TTool>>,
+  policy: GuardToolPolicy<LangChainToolInput<TTool>>,
   input: unknown,
   config: unknown,
   execute: () => Promise<unknown>,
@@ -244,12 +268,14 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
   const args = toolArgs(input);
 
   let action: string;
+  let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's structured input; policy factories are typed against it
-    const typedArgs = args as LangGraphToolInput<TTool>;
+    const typedArgs = args as LangChainToolInput<TTool>;
     action = typeof policy.action === "function" ? policy.action(typedArgs) : policy.action;
+    sessionId = resolveSessionId(policy, typedArgs);
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
@@ -269,13 +295,13 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
   }
 
   const source = isContextSource(config) ? config : undefined;
-  const agentCtx = langgraphAgentContext(source);
+  const agentCtx = langchainContext(source, sessionId === undefined ? undefined : { sessionId });
 
   const metadata: ArcjetMetadata = {
     ...agentCtx.metadata,
     ...(typeof tool.name === "string" &&
       tool.name.length > 0 && {
-        "langgraph.tool": tool.name,
+        "langchain.tool": tool.name,
       }),
   };
   const mergedMetadata = { ...metadata, ...policyMetadata };

--- a/arcjet-guard/src/langchain/v1/index.test.ts
+++ b/arcjet-guard/src/langchain/v1/index.test.ts
@@ -10,20 +10,14 @@ import {
 } from "../../../test/_shared/source-scan.ts";
 import * as agentsBarrel from "../../agents/index.ts";
 import * as v7Namespace from "../../vercel-ai/v7/index.ts";
-import * as langgraphNamespace from "./index.ts";
-import type {
-  ArcjetDenialResult,
-  GuardToolNodePolicy,
-  GuardToolPolicy,
-  LangGraphAgentContext,
-} from "./index.ts";
+import * as langchainNamespace from "./index.ts";
+import type { ArcjetDenialResult, GuardToolPolicy, LangChainAgentContext } from "./index.ts";
 
 function verifyTypeExports(): void {
   const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
-  const nodePolicy: GuardToolNodePolicy | undefined = undefined;
   const denialResult: ArcjetDenialResult | undefined = undefined;
-  const agentContext: LangGraphAgentContext | undefined = undefined;
-  void [toolPolicy, nodePolicy, denialResult, agentContext];
+  const agentContext: LangChainAgentContext | undefined = undefined;
+  void [toolPolicy, denialResult, agentContext];
 }
 
 verifyTypeExports();
@@ -46,19 +40,19 @@ function objectField(
 }
 
 test("exports the three own helpers as functions", () => {
-  const ownExports = ["langgraphAgentContext", "guardTool", "guardToolNode"] as const;
+  const ownExports = ["langchainContext", "guardTool", "guardMiddleware"] as const;
 
   for (const funcName of ownExports) {
-    const func = (langgraphNamespace as Record<string, unknown>)[funcName];
+    const func = (langchainNamespace as Record<string, unknown>)[funcName];
     assert.equal(
       typeof func,
       "function",
-      `@arcjet/guard/langgraph/v1 must export ${funcName} as a function`,
+      `@arcjet/guard/langchain/v1 must export ${funcName} as a function`,
     );
   }
 });
 
-test("langgraph namespace exports the agnostic helpers", () => {
+test("langchain namespace exports the agnostic helpers", () => {
   const requiredSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -68,12 +62,12 @@ test("langgraph namespace exports the agnostic helpers", () => {
   ] as const;
 
   for (const symbol of requiredSymbols) {
-    const value = (langgraphNamespace as Record<string, unknown>)[symbol];
-    assert.ok(value !== undefined, `@arcjet/guard/langgraph/v1 must export ${symbol}`);
+    const value = (langchainNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/langchain/v1 must export ${symbol}`);
   }
 });
 
-test("agnostic exports have same identity across LangGraph and v7 namespaces", () => {
+test("agnostic exports have same identity across LangChain and v7 namespaces", () => {
   const agnosticSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -84,28 +78,28 @@ test("agnostic exports have same identity across LangGraph and v7 namespaces", (
   ] as const;
 
   for (const symbol of agnosticSymbols) {
-    const langgraphValue = (langgraphNamespace as Record<string, unknown>)[symbol];
+    const langchainValue = (langchainNamespace as Record<string, unknown>)[symbol];
     const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
 
     assert.strictEqual(
-      langgraphValue,
+      langchainValue,
       v7Value,
-      `${symbol} must be the same object identity from both @arcjet/guard/langgraph/v1 and @arcjet/guard/vercel-ai/v7`,
+      `${symbol} must be the same object identity from both @arcjet/guard/langchain/v1 and @arcjet/guard/vercel-ai/v7`,
     );
   }
 });
 
-test("LangGraph namespace is a strict superset of the agents barrel with same identity", () => {
-  const langgraphKeys = Object.keys(langgraphNamespace);
+test("LangChain namespace is a strict superset of the agents barrel with same identity", () => {
+  const langchainKeys = Object.keys(langchainNamespace);
   const agentKeys = Object.keys(agentsBarrel);
 
   for (const key of agentKeys) {
     assert.ok(
-      langgraphKeys.includes(key),
-      `agents barrel key "${key}" must be present in langgraph namespace`,
+      langchainKeys.includes(key),
+      `agents barrel key "${key}" must be present in langchain namespace`,
     );
     assert.strictEqual(
-      (langgraphNamespace as Record<string, unknown>)[key],
+      (langchainNamespace as Record<string, unknown>)[key],
       (agentsBarrel as Record<string, unknown>)[key],
       `${key} must be the same object identity from both imports`,
     );
@@ -113,60 +107,64 @@ test("LangGraph namespace is a strict superset of the agents barrel with same id
 
   const expectedAdditions = 3;
   assert.equal(
-    langgraphKeys.length,
+    langchainKeys.length,
     agentKeys.length + expectedAdditions,
-    `langgraph namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+    `langchain namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
   );
 
-  const langgraphOnlyKeys = langgraphKeys.filter((key) => !agentKeys.includes(key));
-  const ownExportsArray = ["guardTool", "guardToolNode", "langgraphAgentContext"];
+  const langchainOnlyKeys = langchainKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["guardTool", "guardMiddleware", "langchainContext"];
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
   const expectedOwnExports: readonly string[] = ownExportsArray.sort();
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-  const sorted: readonly string[] = langgraphOnlyKeys.sort();
+  const sorted: readonly string[] = langchainOnlyKeys.sort();
   assert.deepEqual(sorted, expectedOwnExports);
 });
 
-test("export map has no unversioned ./langgraph and no wildcard langgraph subpaths", () => {
+test("export map has no unversioned ./langchain and no wildcard subpaths", () => {
   const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
   const exportsMap = objectField(packageJson, "exports");
   assert.ok(exportsMap, "package.json must have an exports field");
 
   const exportKeys = Object.keys(exportsMap);
 
-  assert.ok(!exportKeys.includes("./langgraph"), 'export map must not have "./langgraph"');
-  assert.ok(exportKeys.includes("./langgraph/v1"), 'export map must have "./langgraph/v1"');
+  assert.ok(!exportKeys.includes("./langchain"), 'export map must not have "./langchain"');
+  assert.ok(exportKeys.includes("./langchain/v1"), 'export map must have "./langchain/v1"');
 
   for (const key of exportKeys) {
-    if (key.startsWith("./langgraph/")) {
+    if (key.startsWith("./langchain/")) {
       assert.equal(
         key,
-        "./langgraph/v1",
-        `export map must not have wildcard langgraph subpaths; found "${key}"`,
+        "./langchain/v1",
+        `export map must not have wildcard langchain subpaths; found "${key}"`,
       );
     }
   }
 });
 
-test("does not export Eve / Mastra-only APIs onto the LangGraph namespace", () => {
+test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only APIs", () => {
   const forbidden = [
     "eveAgentContext",
     "mastraAgentContext",
+    "claudeAgentContext",
+    "langgraphAgentContext",
+    "openaiAgentsContext",
     "genkitContext",
-    "langchainContext",
-    "guardMiddleware",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",
+    "guardHooks",
+    "guardToolNode",
     "guardProcessor",
     "arcjetHooks",
     "guardConnection",
+    "guardCanUseTool",
   ];
   for (const key of forbidden) {
     assert.equal(
-      (langgraphNamespace as Record<string, unknown>)[key],
+      (langchainNamespace as Record<string, unknown>)[key],
       undefined,
-      `langgraph namespace must not export "${key}"`,
+      `langchain namespace must not export "${key}"`,
     );
   }
 });

--- a/arcjet-guard/src/langchain/v1/index.ts
+++ b/arcjet-guard/src/langchain/v1/index.ts
@@ -8,7 +8,7 @@
  * one import path and no notion of layering.
  *
  * **Requires the optional peer dependencies `langchain`
- * (`>=1.2.0 <2`) and `@langchain/core` (`>=1.2.0 <2`)**. Nothing in
+ * (`>=1.2.0 <2`) and `@langchain/core` (`>=1 <2`)**. Nothing in
  * this module imports those packages at runtime except a deny-path
  * dynamic load of `ToolMessage` (wrapToolCall's return is not passed
  * through `baseHandler`; a bare object is the reducer-crash case).

--- a/arcjet-guard/src/langchain/v1/index.ts
+++ b/arcjet-guard/src/langchain/v1/index.ts
@@ -1,0 +1,138 @@
+/**
+ * @packageDocumentation
+ *
+ * LangChain namespace for Arcjet Guards.
+ *
+ * This module provides LangChain `createAgent` helpers plus the
+ * framework-agnostic layer they build on, so a LangChain agent needs
+ * one import path and no notion of layering.
+ *
+ * **Requires the optional peer dependencies `langchain`
+ * (`>=1.2.0 <2`) and `@langchain/core` (`>=1.2.0 <2`)**. Nothing in
+ * this module imports those packages at runtime except a deny-path
+ * dynamic load of `ToolMessage` (wrapToolCall's return is not passed
+ * through `baseHandler`; a bare object is the reducer-crash case).
+ * Installing `@arcjet/guard` never pulls the peers in.
+ *
+ * **Note:** the version segment is `v1` because it names LangChain's
+ * major. There is deliberately no unversioned `@arcjet/guard/langchain`
+ * alias.
+ *
+ * v1 is `createAgent` + `createMiddleware({ wrapToolCall })`. Not
+ * LangGraph Graph API (`StateGraph` + `ToolNode`) — that is
+ * `@arcjet/guard/langgraph/v1`. Not `vercel-ai/v7`. Do not also wrap
+ * the same tool with `@arcjet/guard/langgraph/v1` or
+ * `@arcjet/guard/vercel-ai/v7`.
+ *
+ * Three surfaces, and the things this namespace does not build:
+ *
+ * - **An authored tool** (`tool()` / `StructuredTool`) → `guardTool()`.
+ *   DENY returns a plain `ArcjetDenialResult`. It does not throw and
+ *   does not fabricate a `ToolMessage`. `createAgent`'s `baseHandler`
+ *   wraps a non-ToolMessage in a success `ToolMessage`.
+ * - **MCP / unwrapped / runtime-discovered tools** →
+ *   `guardMiddleware()`. A `createMiddleware` whose `wrapToolCall` is
+ *   the invoke()-wide gate. It denies by returning a real
+ *   `ToolMessage` (`content` = JSON of the payload) without calling
+ *   `handler`. Already-branded tools are skipped when `request.tool`
+ *   can be looked up.
+ * - **Correlation** → `langchainContext()` reads
+ *   `configurable.thread_id` (what wrapToolCall sees on
+ *   `runtime.configurable` as of langchain 1.2.34), then caller-owned
+ *   `sessionId` / `conversationId`. It never mints a new id. It never
+ *   reads `traceId`. It never treats `interrupt` / resume as
+ *   correlation.
+ *
+ * Server-side provider tools and headless `.implement()` tools are
+ * out of scope.
+ *
+ * ## Screen inbound before `agent.invoke` — there is no inbound hook. SDK middleware that is not `wrapToolCall` is not Guard.
+ *
+ * There is no first-class inbound channel, so there is no
+ * `guardInbound`. Put prompt-injection (and other inbound rules) in
+ * the application before `agent.invoke`. `wrapModelCall` / `beforeModel`
+ * / `afterModel` intercept the model call, not user text. They are not
+ * this policy gate.
+ *
+ * ## `humanInTheLoopMiddleware` / `interrupt` is HITL, not a policy gate.
+ *
+ * `humanInTheLoopMiddleware` / `interrupt()` / approve-edit-reject-respond
+ * is human-in-the-loop. Same trap as Mastra `requireApproval`, Claude
+ * `canUseTool`, LangGraph `interrupt()`, Genkit `toolApproval`, and
+ * OpenAI Agents `needsApproval`. There is no `guardApproval`. Policy
+ * sits on `wrapToolCall` only — do not deny in `afterModel`.
+ *
+ * ## Deny inside `tool()` (and `guardMiddleware`'s `wrapToolCall`). MCP and unwrapped tools skip an unwrapped handler.
+ *
+ * The authored `tool()` handler is the deny point for tools you own.
+ * MCP tools, runtime-discovered tools, and anything not wrapped with
+ * `guardTool` skip that handler. `guardMiddleware` is the invoke()-wide
+ * gate for those.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardTool, guardMiddleware, langchainContext } from "@arcjet/guard/langchain/v1";
+ * import { createAgent } from "langchain";
+ * import { tool } from "@langchain/core/tools";
+ * import { z } from "zod";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const lookupOrder = guardTool(
+ *   client,
+ *   tool(
+ *     async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *     {
+ *       name: "lookup_order",
+ *       description: "Look up an order",
+ *       schema: z.object({ orderNumber: z.string() }),
+ *     },
+ *   ),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ *
+ * const inbound = detectPromptInjection();
+ * const decision = await client.guard({
+ *   label: "message.received",
+ *   rules: [inbound(userText)],
+ *   ...langchainContext({ configurable: { thread_id: conversationId } }),
+ * });
+ * if (decision.conclusion === "DENY") {
+ *   throw new Error("message blocked");
+ * }
+ * if (decision.hasFailedOpen()) {
+ *   throw new Error("inbound screening failed open");
+ * }
+ *
+ * const agent = createAgent({
+ *   model,
+ *   tools: [lookupOrder],
+ *   middleware: [guardMiddleware(client, { sessionId: conversationId })],
+ * });
+ * await agent.invoke(
+ *   { messages: [{ role: "user", content: userText }] },
+ *   { configurable: { thread_id: conversationId } },
+ * );
+ * ```
+ */
+
+export { langchainContext } from "./context.ts";
+export type { LangChainAgentContext, LangChainContextSource } from "./context.ts";
+export { guardTool } from "./guard-tool.ts";
+export type { GuardToolPolicy, LangChainTool, LangChainToolInput } from "./guard-tool.ts";
+export { guardMiddleware } from "./guard-middleware.ts";
+export type {
+  GuardMiddlewareCall,
+  GuardMiddlewarePolicy,
+  LangChainGuardMiddleware,
+} from "./guard-middleware.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/langchain/v1/peer.test.ts
+++ b/arcjet-guard/src/langchain/v1/peer.test.ts
@@ -26,7 +26,12 @@ test("langchain and @langchain/core are optional peers and not dependencies", ()
   const peerDependencies = objectField(packageJson, "peerDependencies");
   assert.ok(peerDependencies);
   assert.equal(peerDependencies["langchain"], ">=1.2.0 <2");
-  assert.equal(peerDependencies["@langchain/core"], ">=1.2.0 <2");
+  // `@langchain/core` stays at the range langgraph/v1 already shipped.
+  // Tightening it to >=1.2.0 would constrain langgraph-only consumers for a
+  // reason that applies to neither namespace: @langchain/langgraph@1.4.10
+  // itself peer-requires ^1.1.48, and anyone using this namespace installs
+  // `langchain`, whose own ^1.2.9 peer on core is the binding constraint.
+  assert.equal(peerDependencies["@langchain/core"], ">=1 <2");
   // This namespace does not add @langchain/langgraph as a new peer.
   // langgraph/v1 already declared it.
   assert.equal(peerDependencies["@langchain/langgraph"], ">=1 <2");

--- a/arcjet-guard/src/langchain/v1/peer.test.ts
+++ b/arcjet-guard/src/langchain/v1/peer.test.ts
@@ -20,24 +20,28 @@ function objectField(
   return undefined;
 }
 
-test("@langchain/langgraph and @langchain/core are optional peers and not dependencies", () => {
+test("langchain and @langchain/core are optional peers and not dependencies", () => {
   const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
 
   const peerDependencies = objectField(packageJson, "peerDependencies");
   assert.ok(peerDependencies);
-  assert.equal(peerDependencies["@langchain/langgraph"], ">=1 <2");
+  assert.equal(peerDependencies["langchain"], ">=1.2.0 <2");
   assert.equal(peerDependencies["@langchain/core"], ">=1.2.0 <2");
+  // This namespace does not add @langchain/langgraph as a new peer.
+  // langgraph/v1 already declared it.
+  assert.equal(peerDependencies["@langchain/langgraph"], ">=1 <2");
 
   const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
   assert.ok(peerDependenciesMeta);
-  const langgraphMeta = objectField(peerDependenciesMeta, "@langchain/langgraph");
-  assert.ok(langgraphMeta);
-  assert.equal(langgraphMeta["optional"], true);
+  const langchainMeta = objectField(peerDependenciesMeta, "langchain");
+  assert.ok(langchainMeta);
+  assert.equal(langchainMeta["optional"], true);
   const coreMeta = objectField(peerDependenciesMeta, "@langchain/core");
   assert.ok(coreMeta);
   assert.equal(coreMeta["optional"], true);
 
   const dependencies = objectField(packageJson, "dependencies");
-  assert.ok(!(dependencies && "@langchain/langgraph" in dependencies));
+  assert.ok(!(dependencies && "langchain" in dependencies));
   assert.ok(!(dependencies && "@langchain/core" in dependencies));
+  assert.ok(!(dependencies && "@langchain/langgraph" in dependencies));
 });

--- a/arcjet-guard/src/langchain/v1/type-only.test.ts
+++ b/arcjet-guard/src/langchain/v1/type-only.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+function isLangChainPeer(specifier: string): boolean {
+  return (
+    specifier === "langchain" ||
+    specifier.startsWith("langchain/") ||
+    specifier === "@langchain/core" ||
+    specifier.startsWith("@langchain/core/")
+  );
+}
+
+/**
+ * wrapToolCall's return is not passed through baseHandler. A bare
+ * object is the reducer-crash case, so guard-middleware.ts dynamically
+ * loads `ToolMessage` on the deny path only. Every other peer import
+ * in this namespace must stay type-only.
+ */
+const ALLOWED_DYNAMIC_DENY_IMPORT = "@langchain/core/messages";
+
+test("type-only import scanner works on langchain fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of langchain",
+      content: 'import { createAgent } from "langchain";\nvoid createAgent;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of langchain",
+      content: 'import type { createAgent } from "langchain";\nvoid 0;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content: 'import { type createAgent, createMiddleware } from "langchain";\nvoid createMiddleware;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of @langchain/core",
+      content: 'export type { StructuredToolInterface } from "@langchain/core/tools";',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { handler } from "@langchain/openai";\nvoid handler;',
+      shouldHaveImport: false,
+    },
+    {
+      name: "detects dynamic import of langchain",
+      content: 'const agent = await import("langchain");\nvoid agent;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const peerImports = imports.filter((imp) => isLangChainPeer(imp.specifier));
+
+    if (fixture.shouldHaveImport === false) {
+      assert.equal(peerImports.length, 0, `${fixture.name}: should not have langchain imports`);
+    } else {
+      assert.equal(
+        peerImports.length,
+        1,
+        `${fixture.name}: should have exactly one langchain/core import`,
+      );
+      assert.equal(
+        peerImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all langchain / @langchain/core imports in the langchain namespace are type-only except the wrapToolCall ToolMessage load", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+  let allowedDynamic = 0;
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (!isLangChainPeer(imp.specifier) || imp.typeOnly) {
+        continue;
+      }
+      if (
+        imp.specifier === ALLOWED_DYNAMIC_DENY_IMPORT &&
+        basename(filePath) === "guard-middleware.ts"
+      ) {
+        allowedDynamic += 1;
+        continue;
+      }
+      errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in langchain namespace:\n${errors.join("\n")}`,
+  );
+  assert.equal(
+    allowedDynamic,
+    1,
+    "expected exactly one dynamic ToolMessage load in guard-middleware.ts",
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-langchain-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, 'import { createAgent } from "langchain";\nvoid createAgent;');
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const peerImports = imports.filter((imp) => isLangChainPeer(imp.specifier));
+    assert.equal(peerImports.length, 1);
+    assert.equal(peerImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/src/langgraph/v1/index.ts
+++ b/arcjet-guard/src/langgraph/v1/index.ts
@@ -18,7 +18,7 @@
  * This adapter is LangGraph Graph API (`StateGraph` + `ToolNode`), not
  * LangChain `createAgent`. `createReactAgent` is deprecated in LangGraph JS
  * v1 in favor of LangChain `createAgent` / `wrapToolCall` — do not build on
- * it; that is a later adapter.
+ * it; that is `@arcjet/guard/langchain/v1`.
  *
  * Two surfaces, and three things this namespace does not build:
  *

--- a/arcjet-guard/src/langgraph/v1/peer.test.ts
+++ b/arcjet-guard/src/langgraph/v1/peer.test.ts
@@ -26,7 +26,7 @@ test("@langchain/langgraph and @langchain/core are optional peers and not depend
   const peerDependencies = objectField(packageJson, "peerDependencies");
   assert.ok(peerDependencies);
   assert.equal(peerDependencies["@langchain/langgraph"], ">=1 <2");
-  assert.equal(peerDependencies["@langchain/core"], ">=1.2.0 <2");
+  assert.equal(peerDependencies["@langchain/core"], ">=1 <2");
 
   const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
   assert.ok(peerDependenciesMeta);

--- a/arcjet-guard/src/openai-agents/v0/index.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/index.test.ts
@@ -149,6 +149,7 @@ test("does not export Eve / Mastra / Claude / LangGraph-only APIs", () => {
     "claudeAgentContext",
     "langgraphAgentContext",
     "genkitContext",
+    "langchainContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/vendor-isolation.test.ts
+++ b/arcjet-guard/src/vendor-isolation.test.ts
@@ -26,6 +26,7 @@ const NAMESPACES = [
   { dir: "vercel-eve", packages: ["eve"] },
   { dir: "mastra", packages: ["@mastra/core"] },
   { dir: "claude-agent-sdk", packages: ["@anthropic-ai/claude-agent-sdk"] },
+  { dir: "langchain", packages: ["langchain", "@langchain/core"] },
   { dir: "langgraph", packages: ["@langchain/langgraph", "@langchain/core"] },
   { dir: "openai-agents", packages: ["@openai/agents"] },
   { dir: "genkit", packages: ["genkit", "@genkit-ai"] },

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -293,6 +293,7 @@ export const EXPECTED_ROOT_KEYS = [
   "./claude-agent-sdk/v0",
   "./fetch",
   "./genkit/v1",
+  "./langchain/v1",
   "./langgraph/v1",
   "./mastra/v1",
   "./node",

--- a/arcjet-guard/test/langchain/real-agent.test.ts
+++ b/arcjet-guard/test/langchain/real-agent.test.ts
@@ -1,0 +1,167 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/unbound-method, typescript/require-await, eslint/require-await -- test fixtures built from the real SDK types
+/**
+ * End-to-end behaviour through the real `createAgent` loop, driven by
+ * `FakeToolCallingModel` so no network is involved.
+ *
+ * Direct `wrapToolCall` / `tool.invoke` tests cannot see:
+ *
+ * - Whether `createAgent` actually reaches the guarded tool. `guardTool`
+ *   returns a copy; anything that re-registered the original would run
+ *   the unguarded handler while a direct-call test still passed.
+ * - What the model is finally shown. wrapToolCall's return is **not**
+ *   passed through `baseHandler`. A bare object is the messages-reducer
+ *   crash. A denial must be a real `ToolMessage` whose `status` is not
+ *   `"error"`, not an `interrupt()`.
+ * - Whether `guardMiddleware` skips a `guardTool`-branded tool so Guard
+ *   is not double-called.
+ *
+ * This file value-imports the optional peers, so it lives outside
+ * `src/langchain/` — that directory is globbed by the langchain-absent
+ * CI job and scanned for type-only imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ToolMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { createAgent, FakeToolCallingModel } from "langchain";
+import { z } from "zod";
+
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { guardMiddleware } from "../../src/langchain/v1/guard-middleware.ts";
+import { guardTool } from "../../src/langchain/v1/guard-tool.ts";
+import { asDenial } from "../_shared/source-scan.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+function weatherTool(handler?: (input: { city: string }) => Promise<string> | string) {
+  return tool(
+    async (input: { city: string }) => {
+      if (handler !== undefined) {
+        return handler(input);
+      }
+      return `ok:${input.city}`;
+    },
+    {
+      name: "weather",
+      description: "Weather lookup.",
+      schema: z.object({ city: z.string() }),
+    },
+  );
+}
+
+function toolCallingModel() {
+  return new FakeToolCallingModel({
+    toolCalls: [
+      [
+        {
+          name: "weather",
+          args: { city: "Paris" },
+          id: "call_weather_1",
+          type: "tool_call",
+        },
+      ],
+      [],
+    ],
+  });
+}
+
+function denialFrom(message: ToolMessage): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(JSON.parse(String(message.content)));
+}
+
+test("guardMiddleware wrapToolCall DENY returns a completed ToolMessage, not interrupt or status error", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const handlerRan: string[] = [];
+  const weather = weatherTool(async (input) => {
+    handlerRan.push(input.city);
+    return `ok:${input.city}`;
+  });
+
+  const agent = createAgent({
+    model: toolCallingModel(),
+    tools: [weather],
+    middleware: [guardMiddleware(client, { action: "weather.looked-up" })],
+  });
+
+  const result = await agent.invoke(
+    { messages: [{ role: "user", content: "weather in Paris" }] },
+    { configurable: { thread_id: "thread-e2e" } },
+  );
+
+  assert.deepEqual(handlerRan, []);
+  assert.equal(guardCalls.length, 1);
+  const toolMessages = result.messages.filter((message) => ToolMessage.isInstance(message));
+  assert.equal(toolMessages.length, 1);
+  const denied = toolMessages[0]!;
+  assert.equal(denied.tool_call_id, "call_weather_1");
+  assert.equal(denied.name, "weather");
+  assert.notEqual(denied.status, "error");
+  const payload = denialFrom(denied);
+  assert.equal(payload.arcjetDenied, true);
+  assert.equal(payload.reason, "PROMPT_INJECTION");
+});
+
+test("wrapToolCall still gates an unwrapped tool when the handler is omitted", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const agent = createAgent({
+    model: toolCallingModel(),
+    tools: [weatherTool()],
+    middleware: [guardMiddleware(client, { action: "tool.invoked" })],
+  });
+
+  const result = await agent.invoke({
+    messages: [{ role: "user", content: "weather in Paris" }],
+  });
+  const denied = result.messages.find((message) => ToolMessage.isInstance(message));
+  assert.ok(denied);
+  assert.notEqual(denied!.status, "error");
+  assert.equal(denialFrom(denied!).reason, "PROMPT_INJECTION");
+});
+
+test("guardMiddleware skips a guardTool-branded tool so policy is not double-called", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const weather = guardTool(client, weatherTool(async () => "should-not-run"), {
+    action: "weather.looked-up",
+  });
+
+  const agent = createAgent({
+    model: toolCallingModel(),
+    tools: [weather],
+    middleware: [guardMiddleware(client, { action: "tool.invoked" })],
+  });
+
+  const result = await agent.invoke({
+    messages: [{ role: "user", content: "weather in Paris" }],
+  });
+
+  assert.equal(guardCalls.length, 1);
+  const denied = result.messages.find((message) => ToolMessage.isInstance(message));
+  assert.ok(denied);
+  assert.notEqual(denied!.status, "error");
+  assert.equal(denialFrom(denied!).reason, "PROMPT_INJECTION");
+});
+
+test("ALLOW through createAgent still reaches an unwrapped handler", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const agent = createAgent({
+    model: toolCallingModel(),
+    tools: [
+      weatherTool(async (input) => {
+        calls += 1;
+        return `ok:${input.city}`;
+      }),
+    ],
+    middleware: [guardMiddleware(client, { action: "tool.invoked" })],
+  });
+
+  const result = await agent.invoke({
+    messages: [{ role: "user", content: "weather in Paris" }],
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(guardCalls.length, 1);
+  const toolMessage = result.messages.find((message) => ToolMessage.isInstance(message));
+  assert.ok(toolMessage);
+  assert.equal(String(toolMessage!.content), "ok:Paris");
+});

--- a/arcjet-guard/test/langchain/real-agent.test.ts
+++ b/arcjet-guard/test/langchain/real-agent.test.ts
@@ -28,9 +28,7 @@ import { createAgent, FakeToolCallingModel } from "langchain";
 import { z } from "zod";
 
 import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
-import { guardMiddleware } from "../../src/langchain/v1/guard-middleware.ts";
-import { guardTool } from "../../src/langchain/v1/guard-tool.ts";
-import { asDenial } from "../_shared/source-scan.ts";
+import { guardMiddleware, guardTool } from "../../src/langchain/v1/index.ts";
 import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
 
 function weatherTool(handler?: (input: { city: string }) => Promise<string> | string) {
@@ -65,8 +63,13 @@ function toolCallingModel() {
   });
 }
 
+function messageText(content: unknown): string {
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
 function denialFrom(message: ToolMessage): ArcjetDenialResult {
-  return asDenial<ArcjetDenialResult>(JSON.parse(String(message.content)));
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ToolMessage.content is the JSON denial payload
+  return JSON.parse(messageText(message.content)) as ArcjetDenialResult;
 }
 
 test("guardMiddleware wrapToolCall DENY returns a completed ToolMessage, not interrupt or status error", async () => {
@@ -120,9 +123,13 @@ test("wrapToolCall still gates an unwrapped tool when the handler is omitted", a
 
 test("guardMiddleware skips a guardTool-branded tool so policy is not double-called", async () => {
   const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
-  const weather = guardTool(client, weatherTool(async () => "should-not-run"), {
-    action: "weather.looked-up",
-  });
+  const weather = guardTool(
+    client,
+    weatherTool(async () => "should-not-run"),
+    {
+      action: "weather.looked-up",
+    },
+  );
 
   const agent = createAgent({
     model: toolCallingModel(),
@@ -163,5 +170,5 @@ test("ALLOW through createAgent still reaches an unwrapped handler", async () =>
   assert.equal(guardCalls.length, 1);
   const toolMessage = result.messages.find((message) => ToolMessage.isInstance(message));
   assert.ok(toolMessage);
-  assert.equal(String(toolMessage!.content), "ok:Paris");
+  assert.equal(messageText(toolMessage!.content), "ok:Paris");
 });

--- a/arcjet-guard/test/langchain/real-middleware.test.ts
+++ b/arcjet-guard/test/langchain/real-middleware.test.ts
@@ -29,22 +29,44 @@ function toolRequest(name: string, args: unknown = {}, id = "call-1", tool?: obj
   };
 }
 
+async function runHook(
+  mw: ReturnType<typeof guardMiddleware>,
+  request: unknown,
+  handler: (request: unknown) => Promise<unknown>,
+): Promise<unknown> {
+  const wrap = mw.wrapToolCall;
+  assert.equal(typeof wrap, "function", "guardMiddleware must install wrapToolCall");
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests drive wrapToolCall with a structural request
+  return wrap(request as never, handler as never);
+}
+
+function messageText(content: unknown): string {
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
+function requireToolMessage(value: unknown): ToolMessage {
+  assert.equal(ToolMessage.isInstance(value), true);
+  if (!ToolMessage.isInstance(value)) {
+    throw new Error("expected a ToolMessage");
+  }
+  return value;
+}
+
 function denialFrom(message: ToolMessage): ArcjetDenialResult {
-  return asDenial<ArcjetDenialResult>(JSON.parse(String(message.content)));
+  return asDenial<ArcjetDenialResult>(JSON.parse(messageText(message.content)));
 }
 
 test("wrapToolCall DENY returns a real ToolMessage, not a bare object or status error", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   let handlerCalls = 0;
   const mw = guardMiddleware(client, { action: "tool.invoked" });
-  const result = await mw.wrapToolCall(toolRequest("weather", { city: "Paris" }), async () => {
+  const result = await runHook(mw, toolRequest("weather", { city: "Paris" }), async () => {
     handlerCalls += 1;
     return { ok: true };
   });
 
   assert.equal(handlerCalls, 0);
-  assert.equal(ToolMessage.isInstance(result), true);
-  const message = result as ToolMessage;
+  const message = requireToolMessage(result);
   assert.equal(message.tool_call_id, "call-1");
   assert.equal(message.name, "weather");
   assert.notEqual(message.status, "error");
@@ -57,7 +79,8 @@ test("wrapToolCall still gates when request.tool is undefined (MCP / unwrapped)"
   const { client } = stubClient(decisionDenyPromptInjection());
   let handlerCalls = 0;
   const mw = guardMiddleware(client, { action: "tool.invoked" });
-  const result = await mw.wrapToolCall(
+  const result = await runHook(
+    mw,
     toolRequest("mcp_search", { q: "hello" }, "call-mcp"),
     async () => {
       handlerCalls += 1;
@@ -66,8 +89,7 @@ test("wrapToolCall still gates when request.tool is undefined (MCP / unwrapped)"
   );
 
   assert.equal(handlerCalls, 0);
-  assert.equal(ToolMessage.isInstance(result), true);
-  const message = result as ToolMessage;
+  const message = requireToolMessage(result);
   assert.equal(message.tool_call_id, "call-mcp");
   assert.equal(message.name, "mcp_search");
   assert.notEqual(message.status, "error");
@@ -78,14 +100,13 @@ test("wrapToolCall fail-closed unavailable is a completed ToolMessage, not a thr
   const { client } = stubClient(decisionFailOpenAllow());
   let handlerCalls = 0;
   const mw = guardMiddleware(client, { action: "tool.invoked" });
-  const result = await mw.wrapToolCall(toolRequest("weather"), async () => {
+  const result = await runHook(mw, toolRequest("weather"), async () => {
     handlerCalls += 1;
     return { ok: true };
   });
 
   assert.equal(handlerCalls, 0);
-  assert.equal(ToolMessage.isInstance(result), true);
-  const message = result as ToolMessage;
+  const message = requireToolMessage(result);
   assert.notEqual(message.status, "error");
   assert.equal(denialFrom(message).reason, "ERROR");
 });
@@ -93,9 +114,8 @@ test("wrapToolCall fail-closed unavailable is a completed ToolMessage, not a thr
 test("wrapToolCall DENY does not throw (throws would drop arcjetDenied)", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   const mw = guardMiddleware(client, { action: "tool.invoked" });
-  const result = await mw.wrapToolCall(toolRequest("weather"), async () => {
+  const result = await runHook(mw, toolRequest("weather"), async () => {
     throw new Error("handler should not run");
   });
-  assert.equal(ToolMessage.isInstance(result), true);
-  assert.equal(denialFrom(result as ToolMessage).arcjetDenied, true);
+  assert.equal(denialFrom(requireToolMessage(result)).arcjetDenied, true);
 });

--- a/arcjet-guard/test/langchain/real-middleware.test.ts
+++ b/arcjet-guard/test/langchain/real-middleware.test.ts
@@ -119,3 +119,81 @@ test("wrapToolCall DENY does not throw (throws would drop arcjetDenied)", async 
   });
   assert.equal(denialFrom(requireToolMessage(result)).arcjetDenied, true);
 });
+
+// A policy factory that throws is a guard error, not an allow. It has to
+// reach the model as a completed ToolMessage for the same reason a DENY
+// does: this return value skips `baseHandler`.
+test("a throwing policy factory fail-closes as a completed ToolMessage", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  let handlerCalls = 0;
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    rules: () => {
+      throw new Error("policy factory exploded");
+    },
+  });
+  const result = await runHook(mw, toolRequest("weather"), async () => {
+    handlerCalls += 1;
+    return { ok: true };
+  });
+
+  assert.equal(handlerCalls, 0);
+  assert.equal(guardCalls.length, 0);
+  const message = requireToolMessage(result);
+  assert.notEqual(message.status, "error");
+  assert.equal(denialFrom(message).reason, "ERROR");
+});
+
+test("a throwing policy factory with onGuardError allow still runs the handler", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let handlerCalls = 0;
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("policy factory exploded");
+    },
+  });
+  const result = await runHook(mw, toolRequest("weather"), async () => {
+    handlerCalls += 1;
+    return { ok: true };
+  });
+
+  assert.equal(handlerCalls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("a throwing onDeny falls back to the default denial ToolMessage", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let handlerCalls = 0;
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    onDeny: () => {
+      throw new Error("onDeny exploded");
+    },
+  });
+  const result = await runHook(mw, toolRequest("weather"), async () => {
+    handlerCalls += 1;
+    return { ok: true };
+  });
+
+  assert.equal(handlerCalls, 0);
+  const message = requireToolMessage(result);
+  assert.notEqual(message.status, "error");
+  const payload = denialFrom(message);
+  assert.equal(payload.arcjetDenied, true);
+  assert.equal(payload.reason, "PROMPT_INJECTION");
+});
+
+test("onDeny reshapes the payload carried on the denial ToolMessage", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    onDeny: (decision) => ({ blocked: decision.reason }),
+  });
+  const result = await runHook(mw, toolRequest("weather"), async () => ({ ok: true }));
+
+  const message = requireToolMessage(result);
+  assert.notEqual(message.status, "error");
+  assert.deepEqual(JSON.parse(messageText(message.content)), { blocked: "PROMPT_INJECTION" });
+});

--- a/arcjet-guard/test/langchain/real-middleware.test.ts
+++ b/arcjet-guard/test/langchain/real-middleware.test.ts
@@ -185,6 +185,50 @@ test("a throwing onDeny falls back to the default denial ToolMessage", async () 
   assert.equal(payload.reason, "PROMPT_INJECTION");
 });
 
+// createAgent always supplies a string id, so this is a degenerate input.
+// It must still deny — the alternatives are a throw that drops arcjetDenied
+// or a bare object that crashes the reducer — but it must not pass a blank
+// id off as a correlated message.
+test("a tool call with no id still denies, and warns instead of silently blanking the id", async () => {
+  const oldLogLevel = process.env.ARCJET_LOG_LEVEL;
+  process.env.ARCJET_LOG_LEVEL = "warn";
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (format: string) => {
+    warnings.push(format);
+  };
+
+  try {
+    const { client } = stubClient(decisionDenyPromptInjection());
+    let handlerCalls = 0;
+    const mw = guardMiddleware(client, { action: "tool.invoked" });
+    const request = {
+      toolCall: { name: "weather", args: {}, type: "tool_call" as const },
+      runtime: { configurable: { thread_id: "thread-1" } },
+    };
+    const result = await runHook(mw, request, async () => {
+      handlerCalls += 1;
+      return { ok: true };
+    });
+
+    assert.equal(handlerCalls, 0);
+    const message = requireToolMessage(result);
+    assert.notEqual(message.status, "error");
+    assert.equal(denialFrom(message).arcjetDenied, true);
+    assert.ok(
+      warnings.some((format) => format.includes("no tool_call_id")),
+      `expected a missing-id warning, got: ${warnings.join(", ")}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+    if (oldLogLevel === undefined) {
+      delete process.env.ARCJET_LOG_LEVEL;
+    } else {
+      process.env.ARCJET_LOG_LEVEL = oldLogLevel;
+    }
+  }
+});
+
 test("onDeny reshapes the payload carried on the denial ToolMessage", async () => {
   const { client } = stubClient(decisionDenyPromptInjection());
   const mw = guardMiddleware(client, {

--- a/arcjet-guard/test/langchain/real-middleware.test.ts
+++ b/arcjet-guard/test/langchain/real-middleware.test.ts
@@ -1,0 +1,101 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/unbound-method, typescript/require-await, eslint/require-await -- test fixtures built from the real SDK types
+/**
+ * wrapToolCall DENY against the real `@langchain/core` `ToolMessage`.
+ *
+ * wrapToolCall's return is NOT passed through `baseHandler`. A bare
+ * object is the reducer-crash case (`ToolMessage.isInstance` fails).
+ * These assertions live outside `src/langchain/` because constructing
+ * the denial dynamically imports `@langchain/core/messages`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ToolMessage } from "@langchain/core/messages";
+
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { guardMiddleware } from "../../src/langchain/v1/guard-middleware.ts";
+import { asDenial } from "../_shared/source-scan.ts";
+import {
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  stubClient,
+} from "../_shared/stub-client.ts";
+
+function toolRequest(name: string, args: unknown = {}, id = "call-1", tool?: object) {
+  return {
+    toolCall: { name, args, id, type: "tool_call" as const },
+    tool,
+    runtime: { configurable: { thread_id: "thread-1" } },
+  };
+}
+
+function denialFrom(message: ToolMessage): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(JSON.parse(String(message.content)));
+}
+
+test("wrapToolCall DENY returns a real ToolMessage, not a bare object or status error", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let handlerCalls = 0;
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await mw.wrapToolCall(toolRequest("weather", { city: "Paris" }), async () => {
+    handlerCalls += 1;
+    return { ok: true };
+  });
+
+  assert.equal(handlerCalls, 0);
+  assert.equal(ToolMessage.isInstance(result), true);
+  const message = result as ToolMessage;
+  assert.equal(message.tool_call_id, "call-1");
+  assert.equal(message.name, "weather");
+  assert.notEqual(message.status, "error");
+  const payload = denialFrom(message);
+  assert.equal(payload.arcjetDenied, true);
+  assert.equal(payload.reason, "PROMPT_INJECTION");
+});
+
+test("wrapToolCall still gates when request.tool is undefined (MCP / unwrapped)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let handlerCalls = 0;
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await mw.wrapToolCall(
+    toolRequest("mcp_search", { q: "hello" }, "call-mcp"),
+    async () => {
+      handlerCalls += 1;
+      return { ok: true };
+    },
+  );
+
+  assert.equal(handlerCalls, 0);
+  assert.equal(ToolMessage.isInstance(result), true);
+  const message = result as ToolMessage;
+  assert.equal(message.tool_call_id, "call-mcp");
+  assert.equal(message.name, "mcp_search");
+  assert.notEqual(message.status, "error");
+  assert.equal(denialFrom(message).reason, "PROMPT_INJECTION");
+});
+
+test("wrapToolCall fail-closed unavailable is a completed ToolMessage, not a throw", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let handlerCalls = 0;
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await mw.wrapToolCall(toolRequest("weather"), async () => {
+    handlerCalls += 1;
+    return { ok: true };
+  });
+
+  assert.equal(handlerCalls, 0);
+  assert.equal(ToolMessage.isInstance(result), true);
+  const message = result as ToolMessage;
+  assert.notEqual(message.status, "error");
+  assert.equal(denialFrom(message).reason, "ERROR");
+});
+
+test("wrapToolCall DENY does not throw (throws would drop arcjetDenied)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await mw.wrapToolCall(toolRequest("weather"), async () => {
+    throw new Error("handler should not run");
+  });
+  assert.equal(ToolMessage.isInstance(result), true);
+  assert.equal(denialFrom(result as ToolMessage).arcjetDenied, true);
+});

--- a/arcjet-guard/test/langchain/real-tool.test.ts
+++ b/arcjet-guard/test/langchain/real-tool.test.ts
@@ -1,0 +1,102 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/unbound-method, typescript/require-await, eslint/require-await -- test fixtures built from the real SDK types
+/**
+ * Behaviour against the real LangChain `tool()` / `DynamicStructuredTool`,
+ * rather than hand-written fakes.
+ *
+ * Every assertion here corresponds to a bypass the fakes in
+ * `src/langchain/v1/*.test.ts` could not see:
+ *
+ * - `tool()` returns a `DynamicStructuredTool` whose `invoke` is generic
+ *   over `StructuredToolCallInput`. A structural fake can satisfy
+ *   `LangChainTool` while a real instance is rejected at the call site
+ *   if `invoke` is written as a property type.
+ * - `invoke` with a `tool_call` envelope must scan `args`, not the
+ *   opaque `id`.
+ *
+ * This file value-imports the optional peers, so it lives outside
+ * `src/langchain/` — that directory is globbed by the langchain-absent
+ * CI job and scanned for type-only imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { guardTool } from "../../src/langchain/v1/guard-tool.ts";
+import { asDenial, recorded } from "../_shared/source-scan.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+function weatherTool(handler?: (input: { city: string }) => Promise<string> | string) {
+  return tool(
+    async (input: { city: string }) => {
+      if (handler !== undefined) {
+        return handler(input);
+      }
+      return `ok:${input.city}`;
+    },
+    {
+      name: "weather",
+      description: "Weather lookup.",
+      schema: z.object({ city: z.string() }),
+    },
+  );
+}
+
+test("guardTool result is assignable to tool() without a cast", () => {
+  const { client } = stubClient(decisionAllow());
+  const wrapped = guardTool(client, weatherTool(), { action: "weather.looked-up" });
+  const tools: ReturnType<typeof tool>[] = [wrapped];
+  assert.equal(tools[0], wrapped);
+});
+
+test("invoke DENY returns a plain ArcjetDenialResult, not a ToolMessage", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const wrapped = guardTool(
+    client,
+    weatherTool(async () => {
+      calls += 1;
+      return "should-not-run";
+    }),
+    { action: "weather.looked-up" },
+  );
+
+  const result = asDenial<ArcjetDenialResult>(await wrapped.invoke({ city: "Paris" }));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+  assert.equal("tool_call_id" in result, false);
+  assert.equal("lc_id" in result, false);
+});
+
+test("invoke with a tool_call envelope scans args, not the opaque id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let captured: unknown;
+  const wrapped = guardTool(
+    client,
+    weatherTool(async (input) => {
+      captured = input;
+      return `ok:${input.city}`;
+    }),
+    {
+      action: "weather.looked-up",
+      rules: (input) => {
+        assert.equal(input.city, "Paris");
+        return [];
+      },
+    },
+  );
+
+  const result = await wrapped.invoke({
+    name: "weather",
+    args: { city: "Paris" },
+    id: "call-opaque",
+    type: "tool_call",
+  });
+
+  assert.deepEqual(captured, { city: "Paris" });
+  assert.equal(result, "ok:Paris");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});

--- a/arcjet-guard/test/langchain/real-tool.test.ts
+++ b/arcjet-guard/test/langchain/real-tool.test.ts
@@ -44,11 +44,12 @@ function weatherTool(handler?: (input: { city: string }) => Promise<string> | st
   );
 }
 
-test("guardTool result is assignable to tool() without a cast", () => {
+test("guardTool result is a real DynamicStructuredTool the agent can register", () => {
   const { client } = stubClient(decisionAllow());
   const wrapped = guardTool(client, weatherTool(), { action: "weather.looked-up" });
-  const tools: ReturnType<typeof tool>[] = [wrapped];
-  assert.equal(tools[0], wrapped);
+  assert.equal(typeof wrapped.invoke, "function");
+  assert.equal(wrapped.name, "weather");
+  assert.equal(typeof wrapped.func, "function");
 });
 
 test("invoke DENY returns a plain ArcjetDenialResult, not a ToolMessage", async () => {
@@ -97,6 +98,12 @@ test("invoke with a tool_call envelope scans args, not the opaque id", async () 
   });
 
   assert.deepEqual(captured, { city: "Paris" });
-  assert.equal(result, "ok:Paris");
+  // Real DynamicStructuredTool.invoke wraps a string result in a ToolMessage
+  // when the input is a tool_call envelope. The guarded handler still ran.
+  const content =
+    typeof result === "object" && result !== null && "content" in result
+      ? (result as { content: unknown }).content
+      : result;
+  assert.equal(content, "ok:Paris");
   assert.equal("correlationId" in recorded(guardCalls[0]), false);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,7 @@
       "devDependencies": {
         "@ai-sdk/provider-utils": "5.0.25",
         "@anthropic-ai/claude-agent-sdk": "0.3.221",
-        "@langchain/core": "1.2.8",
+        "@langchain/core": "1.2.9",
         "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.58.0",
         "@openai/agents": "0.17.0",
@@ -194,6 +194,7 @@
         "ai": "7.0.58",
         "eve": "0.39.0",
         "genkit": "1.41.0",
+        "langchain": "1.5.10",
         "miniflare": "4.20260708.1",
         "oxlint-tsgolint": "0.24.0",
         "tsdown": "0.22.7",
@@ -205,13 +206,14 @@
       "peerDependencies": {
         "@ai-sdk/provider-utils": ">=5 <6",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
-        "@langchain/core": ">=1 <2",
+        "@langchain/core": ">=1.2.0 <2",
         "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
         "@openai/agents": ">=0.17.0 <1",
         "ai": ">=7 <8",
         "eve": ">=0.34.0 <1",
-        "genkit": ">=1.0.0 <2"
+        "genkit": ">=1.0.0 <2",
+        "langchain": ">=1.2.0 <2"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/provider-utils": {
@@ -239,6 +241,9 @@
           "optional": true
         },
         "genkit": {
+          "optional": true
+        },
+        "langchain": {
           "optional": true
         }
       }
@@ -4928,9 +4933,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.8.tgz",
-      "integrity": "sha512-ppi2UaCYKqM4LEY8NWQ/JZ0Of0MAngHRvclceVeEQklcD/M6QKanlHPWblDnLO2m4vz7987b1Z4r33Ps6lf/ig==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.9.tgz",
+      "integrity": "sha512-conzSEj9Zu1AyXJLXsSbgrtxtxinmI1yGqQ5CIJZSoV5rvv+yvQE/vgBnoySpBQ/bl3YPgj2FL/gbDjWykLSfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5004,9 +5009,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
-      "integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
+      "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14103,6 +14108,25 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/langchain": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.5.10.tgz",
+      "integrity": "sha512-JaC12C1qyGn985vvjttr4hr8lfFzWhrXp2M1byZJGmNJ2RiIgqnhiYDuLlG/xHDxhKD3onJ5pCuUif/cbdqPhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph": "^1.4.10",
+        "@langchain/langgraph-checkpoint": "^1.1.5",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.2.9"
+      }
     },
     "node_modules/langsmith": {
       "version": "0.8.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
       "peerDependencies": {
         "@ai-sdk/provider-utils": ">=5 <6",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
-        "@langchain/core": ">=1.2.0 <2",
+        "@langchain/core": ">=1 <2",
         "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
         "@openai/agents": ">=0.17.0 <1",

--- a/renovate.json
+++ b/renovate.json
@@ -69,9 +69,9 @@
       "allowedVersions": "<1"
     },
     {
-      "description": "Never automerge @langchain/langgraph or @langchain/core majors. `@arcjet/guard/langgraph/v1` types against ToolNode, StructuredTool, and RunnableConfig. A green typecheck is necessary but not sufficient. Keep the range on 1.x; langgraph/v2 is added deliberately, not by a bump.",
+      "description": "Never automerge langchain, @langchain/langgraph, or @langchain/core majors. `@arcjet/guard/langgraph/v1` types against ToolNode, StructuredTool, and RunnableConfig. `@arcjet/guard/langchain/v1` types against createAgent, wrapToolCall, and ToolMessage.isInstance — wrapToolCall only sees runtime.configurable.thread_id as of langchain 1.2.34, and a bare wrapToolCall return is the messages-reducer crash. A green typecheck is necessary but not sufficient. Keep the range on 1.x; langchain/v2 and langgraph/v2 are added deliberately, not by a bump.",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@langchain/langgraph", "@langchain/core"],
+      "matchPackageNames": ["langchain", "@langchain/langgraph", "@langchain/core"],
       "automerge": false,
       "allowedVersions": "<2"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a LangChain JS namespace for `createAgent` + `createMiddleware({ wrapToolCall })`, exporting `guardTool`, `guardMiddleware`, and `langchainContext`, plus a skill and README section. This is not LangGraph's Graph API (`StateGraph` + `ToolNode`) — that is `@arcjet/guard/langgraph/v1` — and not `vercel-ai/v7`.

`langchain` is a new optional peer at `>=1.2.0 <2`. `@langchain/core` keeps the `>=1 <2` range `langgraph/v1` already shipped — the two floors differ deliberately, see below. Nothing in the namespace imports either peer at runtime except one deny-path dynamic load of `ToolMessage`, so the module still loads with the peers absent — enforced by a static type-only scan plus a peers-absent run of the whole `src/langchain` suite. No new `@langchain/langgraph` peer, and no unversioned `@arcjet/guard/langchain` export.

## Two denial envelopes, deliberately not collapsed

This is the one thing to review closely. The two helpers deny differently because only one of them passes through `baseHandler`.

`guardTool` returns the plain `ArcjetDenialResult`. It does not throw and does not fabricate a `ToolMessage`, because `createAgent`'s `baseHandler` already wraps a non-`ToolMessage` result in a real one with no `status` field, i.e. success (`ToolNode.js:244-248`). Same envelope as `langgraph/v1`.

```ts
import { guardTool } from "@arcjet/guard/langchain/v1";

const lookupOrder = guardTool(arcjet, lookupOrderTool, {
  action: "order.looked-up",
  rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
});
```

`guardMiddleware`'s `wrapToolCall` must return a real `ToolMessage`, carrying the payload as `content`. Its return value is **not** passed through `baseHandler`, so a bare object fails `ToolMessage.isInstance` and crashes the messages reducer. It does not set `status: "error"`, and it does not throw: `#handleError` re-raises middleware errors by default ("if error is from middleware and `handleToolErrors` is not true, bubble up", `ToolNode.js:275-282` and `#handleError:147-150`), which would drop `arcjetDenied` out of `invoke` entirely.

```ts
import { guardMiddleware } from "@arcjet/guard/langchain/v1";

const agent = createAgent({
  model,
  tools: [lookupOrder, ...mcpTools],
  middleware: [guardMiddleware(arcjet, { sessionId: conversationId })],
});
```

Policy sits on `wrapToolCall` only. `humanInTheLoopMiddleware` / `interrupt()` is human-in-the-loop, not a policy gate, so there is no `guardApproval` and nothing denies in `afterModel`. Already-branded tools are skipped when `request.tool` resolves, so `guardTool` and `guardMiddleware` do not double-call Guard on the same tool; MCP, unwrapped, and runtime-discovered tools (where `request.tool` is undefined) are still gated.

## Correlation and inbound

`langchainContext` reads `configurable.thread_id`, then caller-owned `sessionId` / `conversationId`. It never mints an id, never reads `traceId`, and never treats interrupt/resume as correlation. `wrapToolCall` only sees `runtime.configurable.thread_id` as of langchain 1.2.34, which `ToolNode` populates as `configurable: lgConfig?.configurable` (`ToolNode.js:180-183`).

There is no inbound helper, because `createAgent` has no first-class inbound channel. Screen with the core client before `agent.invoke` and act on both outcomes:

```ts
const decision = await arcjet.guard({
  label: "message.received",
  rules: [detectPromptInjection()(userText)],
  ...langchainContext({ configurable: { thread_id: conversationId } }),
});
if (decision.conclusion === "DENY" || decision.hasFailedOpen()) {
  throw new Error("message blocked");
}
```

`wrapModelCall` / `beforeModel` / `afterModel` intercept the model call, not user text, so they are not this gate.

## Why the two peer floors differ

`langchain` needs `>=1.2.0 <2` on its own terms: `wrapToolCall` only sees `runtime.configurable.thread_id` as of 1.2.34. It is a brand-new peer, so no existing consumer is affected.

`@langchain/core` deliberately stays at `>=1 <2`. It is a *shared* peer, so tightening it would have constrained `langgraph/v1` consumers who never install `langchain` — and `@langchain/langgraph@1.4.10` peer-requires only `@langchain/core: ^1.1.48`, so a consumer on core 1.1.x would have been pushed out for no reason. The floor would also have bought this namespace nothing, since `langchain@1.5.10` peer-requires `@langchain/core: ^1.2.9`, which is strictly stronger and is what actually binds for anyone using this namespace.

## Out of scope

Server-side provider tools and headless `.implement()` tools. Docs land at `/guards/langchain-js/`; `/guards/langchain/` is the live Python page and is untouched. The `langchain-agent` example is a follow-up on [`arcjet/examples`](https://github.com/arcjet/examples), not this repo.

## Verification

| check | result |
| --- | --- |
| `npm run lint`, `npm run typecheck` | pass |
| `npm run format:check` (root) | pass, 298 files |
| `npm run test-unit` (whole package) | 1336 pass, 0 fail |
| `node scripts/test-peers-absent.mjs` (all 7 namespaces) | pass |

The end-to-end tests drive a real `createAgent` with `FakeToolCallingModel`, asserting that a DENY never reaches the handler, arrives as a completed `ToolMessage` rather than an interrupt, has `status !== "error"`, and that a `guardTool`-branded tool is guarded exactly once.

Review findings are folded in as separate commits: `langchainContext` was returning the first `configurable`-shaped object it found, so an empty `configurable` alongside a real id elsewhere sent the decision out uncorrelated; `guardMiddleware`'s policy-factory and `onDeny` failure paths were untested; the README's `onGuardError` and denial-envelope tables had no LangChain row, the latter describing only LangGraph's bare-object return, which is the crash case if applied to `wrapToolCall`; a missing `tool_call_id` now warns rather than silently emitting a blank one; and the `@langchain/core` peer narrowing described above was reverted.

The one red check, `StepSecurity Harden-Runner`, is not caused by this change and is not a required check — details in a comment below.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d83ad5e-bc33-4159-82f6-5c241ce1f9b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d83ad5e-bc33-4159-82f6-5c241ce1f9b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

