### PR TITLE
docs(guard): show that a resumed LangChain run keeps its correlation

### DIFF
--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -29,8 +29,10 @@ decision rule:
   `configurable.thread_id` (what wrapToolCall sees on
   `runtime.configurable` as of langchain 1.2.34), then caller-owned
   `sessionId` / `conversationId`. It never mints a new id. It never
-  reads `traceId`. It never treats `interrupt` / resume as
-  correlation.
+  reads `traceId`. A run that pauses on `interrupt()` resumes through
+  the same config, so it keeps its `thread_id` and its later decisions
+  stay on the Sequence that started it — the interrupt and its resume
+  value are simply not correlation sources of their own.
 
 This namespace is LangChain JS **`createAgent` + `wrapToolCall`**. Not
 LangGraph Graph API (`StateGraph` + `ToolNode`) — that is
@@ -107,8 +109,11 @@ Ask only what you cannot infer from the code; suggest defaults.
 4. **Correlation is read, never minted.** Do not call `createAgentContext`
    inside a middleware / tool callback — that generates a second id and
    splits the Sequence. Put the id you already chose on
-   `configurable.thread_id`. Do not read `traceId`. Do not treat
-   `interrupt` / resume as correlation.
+   `configurable.thread_id`. Do not read `traceId`. Resuming after an
+   `interrupt()` reuses the same config and therefore the same
+   `thread_id`, so decisions after the pause already correlate to the
+   originating Sequence — do not derive an id from the interrupt or its
+   resume value.
 5. **Do not double-wrap with `@arcjet/guard/langgraph/v1` or
    `@arcjet/guard/vercel-ai/v7`.** `guardTool` throws if the tool
    already carries the Arcjet protection brand. `guardMiddleware`
@@ -272,8 +277,11 @@ Preference order: `configurable.thread_id`, then caller-owned
 string, the call is uncorrelated rather than joined to a generated
 id nobody has.
 
-Never mint a new id. Never read `traceId`. Never treat `interrupt` /
-resume as correlation. wrapToolCall only sees
+Never mint a new id. Never read `traceId`. `humanInTheLoopMiddleware`
+resumes with `agent.invoke(new Command({ resume }), config)` — the same
+config, so the same `thread_id`, so the decisions after the pause land
+on the Sequence that started it. Do not substitute the interrupt or its
+resume value for that id. wrapToolCall only sees
 `runtime.configurable.thread_id` as of langchain 1.2.34.
 
 ## Verify the integration

--- a/arcjet-guard/src/langchain/v1/context.ts
+++ b/arcjet-guard/src/langchain/v1/context.ts
@@ -11,9 +11,10 @@ import type { ArcjetMetadata } from "../../types.ts";
  * `configurable` object itself. Caller-owned `sessionId` / `conversationId`
  * are fallbacks when no thread id is present.
  *
- * Never mints a new id. Never reads `traceId`. Never treats `interrupt` /
- * resume as correlation. Declared here so this module never value-imports
- * `langchain` or `@langchain/core`.
+ * Never mints a new id. Never reads `traceId`. A resumed run passes the
+ * same config, so it keeps its `thread_id`; the interrupt and its resume
+ * value are never read as correlation sources. Declared here so this
+ * module never value-imports `langchain` or `@langchain/core`.
  */
 export interface LangChainContextSource {
   configurable?: Record<string, unknown>;
@@ -142,8 +143,9 @@ function readAppContext(
 /**
  * Derive correlation and metadata from a LangChain `createAgent` invoke
  * config or a `wrapToolCall` `request.runtime`. Never mints a new id.
- * Never calls `createAgentContext`. Never reads `traceId`. Never treats
- * `interrupt` / resume as correlation.
+ * Never calls `createAgentContext`. Never reads `traceId`. A resumed run
+ * keeps its `thread_id`, so the interrupt and its resume value are never
+ * read as correlation sources.
  *
  * Preference order for `correlationId`:
  * 1. `configurable.thread_id` — what `wrapToolCall` sees on


### PR DESCRIPTION
The LangChain v1 correlation docs said the helper "never treats interrupt / resume as correlation". That is a statement about which values are read as a correlation source, but it parses as a statement about the run — that a resumed run will not be correlated to the Sequence that started it.

The opposite is true. `humanInTheLoopMiddleware` resumes with `agent.invoke(new Command({ resume }), config)`, passing the same config, and requires a checkpointer whose state is keyed by `thread_id`. So a resumed run keeps its `thread_id` and its later decisions land on the originating Sequence with nothing extra needed.

State that mechanism first, then scope the prohibition to what it was always about: the interrupt and its resume value are not themselves correlation sources.

This is an emergent property of the way we've implemented correlation within the context of the existing framework helpers. (Unfortunately) it is not captured in any existing ADRs, but I found it sufficiently confusing when reviewing the skill accompanying the new LangChain helpers that I felt it was worth ironing out, so agents don't implement based on the wrong reading.