### PR TITLE
feat(guard): record `degraded` when policy did not judge an action fully

### DIFF
--- a/arcjet-guard/src/agents/guard-action.test.ts
+++ b/arcjet-guard/src/agents/guard-action.test.ts
@@ -221,6 +221,15 @@ test("AC4.4: guard throws, onGuardError: 'allow' → fn runs, result passes thro
     );
     assert.equal(guardCalls.length, 1, "guard should be called");
     assert.equal(captureCalls.length, 1, "capture should still fire");
+    // The action ran only because onGuardError is "allow", and policy judged
+    // none of it, so the record must not claim a success.
+    assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "degraded");
+    // No decision exists to point at, which is what says policy judged nothing.
+    assert.equal(
+      recorded(captureCalls[0])["decisionId"],
+      undefined,
+      "a call guard never judged has no decision id",
+    );
   } finally {
     console.warn = originalWarn;
     restoreLogLevel();
@@ -261,6 +270,14 @@ test("AC4.4: guard resolves fail-open ALLOW, onGuardError: 'allow' → fn runs, 
       "warning should mention failed open",
     );
     assert.equal(captureCalls.length, 1, "capture should fire");
+    // A failed-open decision judged nothing, so this is not a success either.
+    assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "degraded");
+    // The synthesized fail-open decision carries id "", which is suppressed.
+    assert.equal(
+      recorded(captureCalls[0])["decisionId"],
+      undefined,
+      "an empty id is not a decision id",
+    );
   } finally {
     console.warn = originalWarn;
     restoreLogLevel();

--- a/arcjet-guard/src/agents/guarded.ts
+++ b/arcjet-guard/src/agents/guarded.ts
@@ -21,8 +21,9 @@ import type { ArcjetAgentClient } from "./capture.ts";
  *    `onUnavailable` without executing; with `"allow"`, both fail open and
  *    proceed to execute.
  * 2. On DENY, capture `outcome: "denied"` and return `onDeny(decision)`.
- * 3. Otherwise run `execute()`, capturing `outcome: "success"` — or, if it
- *    throws, `outcome: "error"` before rethrowing.
+ * 3. Otherwise run `execute()`, capturing `outcome: "success"` when policy
+ *    judged the action, or `outcome: "degraded"` when `"allow"` let it run
+ *    unjudged — or, if it throws, `outcome: "error"` before rethrowing.
  *
  * `onDeny` returns the value the caller hands back on denial. Model-facing
  * helpers wrap the shared `ArcjetDenialResult` in a framework-idiomatic
@@ -69,6 +70,11 @@ export async function runGuarded<T>(
 
   const failClosed = onGuardError === "deny";
 
+  // Cleared wherever `onGuardError: "allow"` lets the action run without a
+  // complete judgement, so the capture at the tail reports what happened
+  // rather than claiming a success policy never made.
+  let judgedFully = true;
+
   let decisionId: string | undefined;
   let decision: Decision | undefined;
   try {
@@ -98,7 +104,8 @@ export async function runGuarded<T>(
       return onUnavailable({ kind: "threw", error });
     }
     warnUnavailable(action, "threw", false, error);
-    decision = undefined; // fall through to execute, exactly as today
+    decision = undefined; // fall through to execute
+    judgedFully = false;
   }
   if (decision !== undefined) {
     // Suppress an empty id. Every decision the client synthesizes on a
@@ -129,7 +136,8 @@ export async function runGuarded<T>(
     }
     if (decision.conclusion === "ALLOW" && decision.hasFailedOpen()) {
       warnUnavailable(action, "failed-open", false);
-      // fall through to execute
+      // fall through to execute, with nothing judged
+      judgedFully = false;
     }
     if (decision.conclusion === "DENY") {
       captureEvent(client, {
@@ -159,7 +167,7 @@ export async function runGuarded<T>(
     action,
     ...correlation,
     ...(decisionId !== undefined && { decisionId }),
-    metadata: { ...metadata, outcome: "success" },
+    metadata: { ...metadata, outcome: judgedFully ? "success" : "degraded" },
   });
   return result;
 }


### PR DESCRIPTION
Every action that ran captured `outcome: "success"`, whether policy judged it or not. An operator reading the capture stream could not separate an approved action from one that ran because `onGuardError: "allow"` let it through during an outage — the calls a post-incident review most needs to find were the ones the record made invisible.

`success` claims policy judged the action, so it is now reserved for the case where policy judged all of it. The two conditions that fall through to execute capture `degraded` instead: the guard call threw, and the decision failed open.

Unchanged: the fail-closed halves of those conditions still capture `unavailable` without executing, and an action that runs and then throws still captures `error`, which takes precedence.

Neither condition carries a decision id — a synthesized fail-open decision has `id: ""`, which is suppressed, and a throwing guard call produces no decision at all. So every `degraded` event from this SDK reports that policy judged nothing. The partial case exists only in `arcjet-py`, which calls Guard with whatever resolved; closing that divergence is a separate decision.

The two fail-open tests asserted only that a capture fired, never which outcome it carried, so both now pin it.

Implements the decision in the `arcjet` monorepo ADR "Capture outcome for an action that ran without evaluated policy".