### PR TITLE
feat(guard): add Strands Agents support as `@arcjet/guard/strands-agents/v1`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,24 @@ change them:
   `guardInbound` and no `guardApproval`. Correlation is a field the
   integrator puts on `generate({ context })`. Do not wrap Go / Python
   Genkit. Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.
+  `strands-agents/v1` is JS `@strands-agents/sdk` `Agent` +
+  `tool({ callback })` + Plugin / `addHook`: the authored deny point is
+  `_callback` (wrap both `_callback` and ZodTool's
+  `_functionTool._callback`; `stream()` is what the executor calls),
+  unwrapped / MCP / vended tools go through `guardHooks`'
+  `BeforeToolCallEvent` (deny by setting `event.cancel` to
+  `JSON.stringify(ArcjetDenialResult)` — do not use
+  `BeforeToolsEvent.cancel`, which skips per-tool hooks), inbound is
+  screened before `invoke()` / `stream()` (there is no inbound hook),
+  and `event.interrupt()` is HITL not policy. There is no
+  `guardInbound` and no `guardApproval` / `guardInterrupt`. Correlation
+  is a field the integrator puts on `invocationState` (`correlationId`,
+  then `sessionId`, then `requestId`). Never mint. Never read
+  `traceId`. Never use `SessionManager` or `agent.id`. Do not wrap the
+  Python SDK. Do not double-wrap with `@arcjet/guard/vercel-ai/v7` or
+  `@arcjet/guard/langgraph/v1`. There is no unversioned
+  `@arcjet/guard/strands-agents` alias. Docs slug is
+  `/guards/strands-agents/`.
 - **Flat** — a single level under `@arcjet/guard`, no further nesting.
 - **Explicitly versioned, with no unversioned alias.** `@arcjet/guard/vercel-ai`
   does not resolve, and neither does a wildcard `./vercel-ai/*`. An alias would

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1441,6 +1441,96 @@ The tool wrapper and middleware hook see `options.context` /
 Never mint. Never use `traceId`. Never treat `interrupt` / `resumed` as
 correlation.
 
+- **`@arcjet/guard/strands-agents/v1`** — Strands Agents JS
+  `@strands-agents/sdk` `Agent` + `tool({ callback })` + Plugin /
+  `addHook` integration. Exports `guardTool`, `guardHooks`, and
+  `strandsAgentContext`. This is **not** the Python SDK. There is no
+  `guardInbound` (screen before `invoke()` / `stream()`), no
+  `guardApproval` / `guardInterrupt` (`event.interrupt()` is human HITL,
+  not policy). Do not also wrap the same tool with
+  `@arcjet/guard/vercel-ai/v7` or `@arcjet/guard/langgraph/v1`.
+
+  On DENY a guarded tool does not run and does not throw: it returns a
+  plain `ArcjetDenialResult` from the authored `callback`.
+  `FunctionTool` wraps that object in a `JsonBlock`. This helper does
+  not fabricate a `ToolResultBlock`. `guardHooks` is the invoke-wide
+  gate for MCP / unwrapped / vended tools:
+
+  ```ts
+  import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+  import { guardTool, guardHooks, strandsAgentContext } from "@arcjet/guard/strands-agents/v1";
+  import { Agent, tool } from "@strands-agents/sdk";
+  import { z } from "zod";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const lookupOrder = guardTool(
+    arcjet,
+    tool({
+      name: "lookup_order",
+      description: "Look up an order",
+      inputSchema: z.object({ orderNumber: z.string() }),
+      callback: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+    }),
+    {
+      action: "order.looked-up",
+      onGuardError: "deny",
+      rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
+    },
+  );
+
+  const invocationState = { sessionId: conversationId };
+  const inbound = detectPromptInjection();
+  const decision = await arcjet.guard({
+    label: "message.received",
+    rules: [inbound(userText)],
+    ...strandsAgentContext({ invocationState }),
+  });
+
+  if (decision.conclusion === "DENY") {
+    throw new Error("message blocked");
+  }
+  const agent = new Agent({
+    tools: [lookupOrder],
+    plugins: [guardHooks(arcjet, { sessionId: conversationId })],
+  });
+  await agent.invoke(userText, { invocationState });
+  ```
+
+#### Screen inbound before `invoke()` / `stream()` — there is no inbound hook.
+
+Strands Agents has no first-class inbound channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `agent.invoke()` / `stream()`. Middleware / model
+hooks are not this policy gate.
+
+#### `interrupt()` is not a policy gate.
+
+`event.interrupt()` is human-in-the-loop, not policy. Same trap as
+Mastra `requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+OpenAI Agents `needsApproval`, and LangChain
+`humanInTheLoopMiddleware`. There is no `guardApproval` /
+`guardInterrupt`.
+
+#### Deny with `BeforeToolCallEvent.cancel` (and `guardTool` on authored callbacks). `BeforeToolsEvent.cancel` skips per-tool hooks — do not use it.
+
+The authored `callback` is the deny point for tools you own. MCP,
+vended tools, and anything not wrapped with `guardTool` skip that
+callback. `guardHooks` is the invoke-wide gate for those. Official:
+set `event.cancel` to a string; `tool.stream()` does not run;
+`AfterToolCallEvent` still fires. Do not use `BeforeToolsEvent.cancel`
+— a truthy value skips `_toolExecutor.execute()`, so per-tool hooks
+never run.
+
+Correlation is a field the integrator puts on `invocationState`
+(`correlationId`, then `sessionId`, then `requestId`). Never mint.
+Never read `traceId`. Never use `SessionManager` or `agent.id`.
+
 ### Naming and versions
 
 Integration paths are `@arcjet/guard/<vendor-sdk>/v<major>` — the SDK being
@@ -1501,6 +1591,11 @@ importing only core guards are not forced to install unneeded packages:
   only to use `@arcjet/guard/genkit/v1`). The peer range is `>=1.0.0 <2`.
   Zod is Genkit's, not ours. `guardMiddleware` needs the
   `generateMiddleware` `tool` hook (Genkit >= 1.33).
+- **`@arcjet/guard/strands-agents/v1`** requires `@strands-agents/sdk`
+  (optional peer, installed only to use `@arcjet/guard/strands-agents/v1`).
+  The peer range is `>=1.1.0 <2`. The floor is 1.1.0 because `HookOrder`
+  - `interrupt()` shipped then; `cancel` itself is 1.0.0. Zod is their
+    peer, not ours.
 
 **pnpm caveat**: pnpm does not reliably honour
 `peerDependenciesMeta.*.optional` (pnpm#5152, #8142), especially with
@@ -1551,6 +1646,11 @@ pnpm install genkit
 ```
 
 ```sh
+# @arcjet/guard/strands-agents/v1
+pnpm install @strands-agents/sdk
+```
+
+```sh
 # or skip the peer install and relax the check:
 pnpm install --no-strict-peer-dependencies
 ```
@@ -1565,8 +1665,9 @@ is one path to learn and no layering to reason about.
 `@arcjet/guard/vercel-ai/v7`, `@arcjet/guard/vercel-eve/v0`,
 `@arcjet/guard/mastra/v1`, `@arcjet/guard/claude-agent-sdk/v0`,
 `@arcjet/guard/langchain/v1`, `@arcjet/guard/langgraph/v1`,
-`@arcjet/guard/openai-agents/v0`, and
-`@arcjet/guard/genkit/v1` now export
+`@arcjet/guard/openai-agents/v0`,
+`@arcjet/guard/genkit/v1`, and
+`@arcjet/guard/strands-agents/v1` now export
 these helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
 agnostic layer without installing a vendor peer. That change is a follow-up
@@ -1581,17 +1682,18 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 > actions that are assumed to be sensitive. The core client reports degraded
 > evaluation via `hasFailedOpen()`; the helpers decide to block on it.
 
-| API                                     | Default on Arcjet outage                    | How to flip                        |
-| --------------------------------------- | ------------------------------------------- | ---------------------------------- |
-| `guard()` (core)                        | Allow (fail open), `hasFailedOpen()===true` | gate manually on `hasFailedOpen()` |
-| `guardTool` / `guardAction`             | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| Eve `guardInbound` / `guardApproval`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| Mastra `guardProcessor` / `guardHooks`  | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| Claude `guardTool` / `guardHooks`       | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| LangGraph `guardTool` / `guardToolNode` | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| LangChain `guardTool` / `guardMiddleware` | Deny (fail closed)                        | `onGuardError: "allow"`            |
-| OpenAI Agents `guardTool`               | Deny (fail closed)                          | `onGuardError: "allow"`            |
-| Genkit `guardTool` / `guardMiddleware`  | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| API                                       | Default on Arcjet outage                    | How to flip                        |
+| ----------------------------------------- | ------------------------------------------- | ---------------------------------- |
+| `guard()` (core)                          | Allow (fail open), `hasFailedOpen()===true` | gate manually on `hasFailedOpen()` |
+| `guardTool` / `guardAction`               | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Eve `guardInbound` / `guardApproval`      | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Mastra `guardProcessor` / `guardHooks`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Claude `guardTool` / `guardHooks`         | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| LangGraph `guardTool` / `guardToolNode`   | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| LangChain `guardTool` / `guardMiddleware` | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| OpenAI Agents `guardTool`                 | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Genkit `guardTool` / `guardMiddleware`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Strands Agents `guardTool` / `guardHooks` | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -1857,14 +1959,14 @@ sees the same shape regardless of which integration is in use. The _envelope_
 is per-framework, because each SDK has a different idiomatic way to report
 that a tool did not run:
 
-| Adapter          | Idiomatic envelope                                                                                  | Why not the others                                                                           |
-| ---------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| AI SDK / Mastra  | Return `{ arcjetDenied: true, … }` as the tool result                                               | A throw becomes a generic tool error and drops the fields                                    |
-| OpenAI Agents    | Return `{ arcjetDenied: true, … }` from `invoke`                                                    | A throw hits `errorFunction` or `ToolCallError` and can kill the run                         |
-| LangGraph        | Return `{ arcjetDenied: true, … }`; `ToolNode` wraps it as a `ToolMessage` with `status: "success"` | Faking a `ToolMessage` to force `status: "error"` crashes the graph reducer                  |
+| Adapter          | Idiomatic envelope                                                                                                                                                                                                      | Why not the others                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AI SDK / Mastra  | Return `{ arcjetDenied: true, … }` as the tool result                                                                                                                                                                   | A throw becomes a generic tool error and drops the fields                                                                                            |
+| OpenAI Agents    | Return `{ arcjetDenied: true, … }` from `invoke`                                                                                                                                                                        | A throw hits `errorFunction` or `ToolCallError` and can kill the run                                                                                 |
+| LangGraph        | Return `{ arcjetDenied: true, … }`; `ToolNode` wraps it as a `ToolMessage` with `status: "success"`                                                                                                                     | Faking a `ToolMessage` to force `status: "error"` crashes the graph reducer                                                                          |
 | LangChain        | Two envelopes: `guardTool` returns `{ arcjetDenied: true, … }` and `baseHandler` wraps it as a success `ToolMessage`; `guardMiddleware`'s `wrapToolCall` returns a real `ToolMessage` carrying the payload as `content` | `wrapToolCall`'s return skips `baseHandler`, so a bare object crashes the messages reducer, and a throw bubbles out of `invoke` and drops the fields |
-| Claude Agent SDK | MCP `CallToolResult` with `isError: true` and the payload on `structuredContent`                    | A throw is a raw exception; omitting `isError` looks like success                            |
-| Vercel Eve       | Throw `ArcjetDeniedError`. Opt in to a returned payload with `onDeny: "result"`                     | Eve projects a throw as a failed `action.result`. A silent return can violate `outputSchema` |
+| Claude Agent SDK | MCP `CallToolResult` with `isError: true` and the payload on `structuredContent`                                                                                                                                        | A throw is a raw exception; omitting `isError` looks like success                                                                                    |
+| Vercel Eve       | Throw `ArcjetDeniedError`. Opt in to a returned payload with `onDeny: "result"`                                                                                                                                         | Eve projects a throw as a failed `action.result`. A silent return can violate `outputSchema`                                                         |
 
 ```ts
 const result: ArcjetDenialResult = {
@@ -1968,6 +2070,8 @@ For an example with OpenAI Agents, see [`openai-agent`](https://github.com/arcje
 
 For an example with Genkit, see [`genkit-agent`](https://github.com/arcjet/examples/tree/main/examples/genkit-agent) (follow-up on that same PR): inbound screening before `generate()`, `guardTool` / `guardMiddleware` (deny, PII on args, rate limit, fail-closed), and a caller-owned id on `generate({ context })`. `interrupt()` / `defineInterrupt` / `toolApproval` is HITL, not a policy gate; the `defineTool` handler and `guardMiddleware`'s `tool` hook are the deny points.
 
+For an example with Strands Agents, see [`strands-agent`](https://github.com/arcjet/examples/tree/main/examples/strands-agent) (follow-up on that same PR): inbound screening before `invoke()` / `stream()`, `guardTool` / `guardHooks` (deny, PII on args, rate limit, fail-closed), and a caller-owned id on `invocationState`. `interrupt()` is HITL, not a policy gate; `BeforeToolCallEvent.cancel` is the deny point for unwrapped tools. Docs slug: [`/guards/strands-agents/`](https://docs.arcjet.com/guards/strands-agents/).
+
 ## Agent skill
 
 For integration help in Claude Code or other AI coding agents, a skill file per integration is packaged with `@arcjet/guard`:
@@ -2053,6 +2157,16 @@ ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-genkit ~
 ```
 
 In Claude Code, use `/integrate-arcjet-guard-genkit` to start an integration session.
+
+**For Strands Agents:**
+
+```bash
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-strands-agents ~/.claude/skills/
+# or
+ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-strands-agents ~/.claude/skills/
+```
+
+In Claude Code, use `/integrate-arcjet-guard-strands-agents` to start an integration session.
 
 Each skill guides you through wrapping tools, screening inbound messages, and recording lifecycle events joined by correlation ID.
 

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -100,6 +100,10 @@
       "types": "./dist/genkit/v1/index.d.ts",
       "import": "./dist/genkit/v1/index.js"
     },
+    "./strands-agents/v1": {
+      "types": "./dist/strands-agents/v1/index.d.ts",
+      "import": "./dist/strands-agents/v1/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -112,7 +116,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts'",
+    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts' 'test/strands-agents/**/*.test.ts'",
     "test-peers-absent": "node scripts/test-peers-absent.mjs",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
@@ -135,6 +139,7 @@
     "@langchain/langgraph": "1.4.10",
     "@mastra/core": "1.59.0",
     "@openai/agents": "0.17.0",
+    "@strands-agents/sdk": "1.14.0",
     "@types/node": "22.20.1",
     "ai": "7.0.58",
     "eve": "0.39.0",
@@ -152,6 +157,7 @@
     "@langchain/langgraph": ">=1 <2",
     "@mastra/core": ">=1 <2",
     "@openai/agents": ">=0.17.0 <1",
+    "@strands-agents/sdk": ">=1.1.0 <2",
     "ai": ">=7 <8",
     "eve": ">=0.34.0 <1",
     "genkit": ">=1.0.0 <2",
@@ -186,6 +192,9 @@
       "optional": true
     },
     "genkit": {
+      "optional": true
+    },
+    "@strands-agents/sdk": {
       "optional": true
     }
   },

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -82,6 +82,13 @@ const CHECKS = [
     remove: ["@mastra/core"],
     resolve: ["@mastra/core"],
   },
+  {
+    name: "strands-agents",
+    dir: "strands-agents",
+    version: "v1",
+    remove: ["@strands-agents/sdk"],
+    resolve: ["@strands-agents/sdk"],
+  },
   // Last: deletes a shared devDependency.
   {
     name: "eve",

--- a/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: integrate-arcjet-guard-strands-agents
+description: Integrate Arcjet security into a Strands Agents JS app using @arcjet/guard — wrap tool({ callback }), put guardHooks on Agent({ plugins }) for unwrapped / MCP / vended tools, and read a caller-owned id from invocationState. Use when asked to add Arcjet to strands-agents, rate limit its tools, screen inbound messages, or block prompt injection / PII.
+license: Apache-2.0
+compatibility: Requires the target app to use Strands Agents JS (@strands-agents/sdk >=1.1.0 <2) on Node.js >= 22. This is JS Agent + tool({ callback }) + Plugin / addHook, not the Python SDK. The floor is 1.1.0 because HookOrder + interrupt() shipped then.
+metadata:
+  author: arcjet
+---
+
+# Integrate Arcjet Guard into a Strands Agents app
+
+`@arcjet/guard`'s Strands Agents v1 namespace wraps the agent's existing
+Arcjet client. It never talks to the Arcjet API itself. Three surfaces,
+one decision rule:
+
+- **An authored tool** (`tool({ callback })`) → `guardTool()`. After
+  `tool()` the object is a `FunctionTool` / `ZodTool` whose runner path
+  is `_callback` (`stream()` / `invoke()`). DENY returns a plain
+  `ArcjetDenialResult`. Do not throw. Do not fabricate a
+  `ToolResultBlock`.
+- **MCP / unwrapped / vended tools** → `guardHooks()`. A Plugin whose
+  `initAgent` registers `BeforeToolCallEvent` at
+  `HookOrder.SDK_FIRST - 1`. On DENY it sets `event.cancel` to
+  `JSON.stringify(ArcjetDenialResult)`. Already-branded tools are
+  skipped. Do **not** use `BeforeToolsEvent.cancel` (that skips
+  per-tool hooks).
+- **Correlation** → `strandsAgentContext()` reads a field the
+  integrator put on `invocationState` (`correlationId`, then
+  `sessionId`, then `requestId`). It never mints a new id. It never
+  reads `traceId`. It never uses `SessionManager` or `agent.id`.
+
+This namespace is JS **`@strands-agents/sdk` `Agent` + `tool({
+callback })` + Plugin / `addHook`**. Not the Python SDK. Do not also
+wrap the same tool with `@arcjet/guard/vercel-ai/v7` or
+`@arcjet/guard/langgraph/v1`. Zod is their peer, not ours.
+
+## Screen inbound before `invoke()` / `stream()` — there is no inbound hook.
+
+There is no first-class inbound channel, so there is no `guardInbound`.
+Put prompt-injection (and other inbound rules) in the application
+before `agent.invoke()` / `stream()`. Middleware / model hooks are not
+this policy gate.
+
+## `interrupt()` is not a policy gate.
+
+`event.interrupt()` is human-in-the-loop. Same trap as Mastra
+`requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+OpenAI Agents `needsApproval`, and LangChain
+`humanInTheLoopMiddleware`. There is no `guardApproval` /
+`guardInterrupt`. Do not wrap `interrupt()` as Guard.
+
+## Deny with `BeforeToolCallEvent.cancel` (and `guardTool` on authored callbacks). `BeforeToolsEvent.cancel` skips per-tool hooks — do not use it.
+
+The authored `callback` is the deny point for tools you own. MCP,
+vended tools, and anything not wrapped with `guardTool` skip that
+callback. `guardHooks` is the invoke-wide gate for those. Official:
+set `event.cancel` to a string; `tool.stream()` does not run;
+`AfterToolCallEvent` still fires.
+
+Do not use `BeforeToolsEvent.cancel`. A truthy value skips
+`_toolExecutor.execute()`, so per-tool hooks never run.
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those get `guardTool`. MCP / vended / tools
+   you did not author get `guardHooks`.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. Put the
+   conversation / session id you already have on
+   `agent.invoke(..., { invocationState: { sessionId } })` *and* on
+   `guardHooks({ sessionId })`. That id is the correlation id, not the
+   user.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound screening before
+   `invoke()`: failing closed there means the agent does not run for
+   the duration of the outage, so `"allow"` is a routine and legitimate
+   choice at that one call site.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection before
+   `agent.invoke()` / `stream()`. Middleware / model hooks are not Guard.
+2. **`interrupt()` is not a policy gate.** It is HITL. Use `guardTool`
+   or `guardHooks`. A denial is `event.cancel = JSON.stringify(...)`,
+   not an `InterruptError`.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/strands-agents/v1`. `@arcjet/guard/strands-agents`
+   does not resolve.
+4. **Correlation is read, never minted.** Do not call `createAgentContext`
+   inside a hook — that generates a second id and splits the Sequence.
+   Put the id you already chose on `invocationState`. Do not read
+   `traceId`. Do not use `SessionManager` or `agent.id`.
+5. **Do not use `BeforeToolsEvent.cancel`.** It skips the per-tool
+   hooks that `guardHooks` registers. Deny on `BeforeToolCallEvent`.
+6. **A denial from `guardTool` is a structured object, not a throw.**
+   Wrap both `_callback` and ZodTool's `_functionTool._callback`.
+   Returning a plain `ArcjetDenialResult` is correct; `FunctionTool`
+   wraps objects in a `JsonBlock`. Do not fabricate a
+   `ToolResultBlock`. Do not double-wrap with
+   `@arcjet/guard/vercel-ai/v7` or `@arcjet/guard/langgraph/v1`.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `@strands-agents/sdk` (optional
+peer, needed for `@arcjet/guard/strands-agents/v1`). Always use the
+versioned path: `@arcjet/guard/strands-agents/v1` resolves;
+`@arcjet/guard/strands-agents` throws
+`ERR_PACKAGE_PATH_NOT_EXPORTED`. Zod is Strands' peer, not ours —
+install `zod` only if the app already uses it. Node 22+.
+
+```sh
+npm install @arcjet/guard @strands-agents/sdk
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate authored tools
+
+```ts
+import { tool } from "@strands-agents/sdk";
+import { z } from "zod";
+import { guardTool } from "@arcjet/guard/strands-agents/v1";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+// Factory then text — same shape as `detectPromptInjection()(text)`.
+// Scan free-text args (a note, reason, body). An opaque `orderNumber`
+// will not trip EMAIL / phone / card / IP, so do not pass it here.
+const detectPii = localDetectSensitiveInfo();
+
+export const lookupOrder = guardTool(
+  arcjet,
+  tool({
+    name: "lookup_order",
+    description: "Look up an order by number",
+    inputSchema: z.object({
+      orderNumber: z.string(),
+      note: z.string(),
+    }),
+    callback: async ({ orderNumber, note }) => ({ orderNumber, note, status: "shipped" }),
+  }),
+  {
+    action: "order.looked-up",
+    rules: (input) => [
+      lookupLimit({ key: input.orderNumber, requested: 1 }),
+      detectPii(input.note),
+    ],
+  },
+);
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the authored callback never runs. The model receives
+  `{ arcjetDenied: true, reason, message, retryable }` as the
+  callback return (`FunctionTool` wraps that object in a `JsonBlock`).
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+- Prefer omitting `outputSchema` on guarded tools, or verify the schema
+  accepts `ArcjetDenialResult` / your `onDeny` shape. A denial is not
+  schema-checked.
+
+## Step 3: Gate unwrapped / MCP / vended tools
+
+```ts
+import { Agent } from "@strands-agents/sdk";
+import { guardHooks } from "@arcjet/guard/strands-agents/v1";
+import { tokenBucket } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const mcpLimit = tokenBucket({
+  refillRate: 20,
+  intervalSeconds: 60,
+  maxTokens: 20,
+});
+
+const agent = new Agent({
+  tools: [lookupOrder],
+  plugins: [
+    guardHooks(arcjet, {
+      action: ({ toolName }) => `${toolName}.invoked`,
+      rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+      sessionId: conversationId,
+    }),
+  ],
+});
+```
+
+Already-branded (`guardTool`) tools skip the hook gate. Tools that are
+not branded — MCP, vended tools, anything not wrapped — are still
+gated.
+
+Put the same id on `invoke(..., { invocationState: { sessionId } })`
+and on `guardHooks({ sessionId })` when you need tool-time correlation
+through the hook.
+
+## Step 4: Screen inbound before invoke
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { strandsAgentContext } from "@arcjet/guard/strands-agents/v1";
+
+import { arcjet } from "./arcjet.js";
+
+const invocationState = { sessionId: conversationId };
+const inbound = detectPromptInjection();
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...strandsAgentContext({ invocationState }),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+
+await agent.invoke(userText, { invocationState });
+```
+
+There is no `guardInbound`.
+
+## Step 5: Correlation
+
+Put the id you already have on the `invocationState` bag you pass to
+`invoke()` / `stream()`:
+
+```ts
+const invocationState = { sessionId: conversationId };
+await agent.invoke(userText, { invocationState });
+```
+
+Preference order: `invocationState.correlationId`, then
+`invocationState.sessionId`, then `invocationState.requestId`, then
+documented copies on the envelope, then `init.sessionId`. If none is a
+valid 1–256 printable-ASCII string, the call is uncorrelated rather
+than joined to a generated id nobody has.
+
+Never read `traceId`. Never read `agent.id`. Never call
+`SessionManager`. Never call `createAgentContext` inside a hook.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI (before invoke), a tool deny, PII on args, a
+   rate limit, a hook deny on an unwrapped tool, and fail-closed
+   (an unreachable guard). Confirm `interrupt()` is never called.
+3. Confirm in the Arcjet dashboard that decisions share the session /
+   request id as their correlation id.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo will land in
+[`arcjet/examples` `strands-agent`](https://github.com/arcjet/examples)
+as a later follow-up. Do not add an example under `examples/` in the
+JS SDK repo.
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/src/agents/denial.test.ts
+++ b/arcjet-guard/src/agents/denial.test.ts
@@ -153,6 +153,7 @@ test("no vendor namespace declares its own denial payload", () => {
     "langgraph",
     "openai-agents",
     "genkit",
+    "strands-agents",
   ];
   const forbidden = [
     ["interface ", "Arcjet", "DenialResult"].join(""),

--- a/arcjet-guard/src/agents/index.test.ts
+++ b/arcjet-guard/src/agents/index.test.ts
@@ -121,7 +121,9 @@ function walkForForbiddenImports(filePath: string, visited: Set<string>, errors:
       spec === "@genkit-ai/core" ||
       spec.startsWith("@genkit-ai/core/") ||
       spec === "@genkit-ai/ai" ||
-      spec.startsWith("@genkit-ai/ai/")
+      spec.startsWith("@genkit-ai/ai/") ||
+      spec === "@strands-agents/sdk" ||
+      spec.startsWith("@strands-agents/sdk/")
     ) {
       errors.push(`File ${absolutePath} imports forbidden package: "${spec}"`);
     }

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -8,8 +8,8 @@
  * users re-exported from a vendor namespace — `@arcjet/guard/vercel-ai/v7`,
  * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`,
  * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langchain/v1`,
- * `@arcjet/guard/langgraph/v1`, `@arcjet/guard/openai-agents/v0`, and
- * `@arcjet/guard/genkit/v1`. The
+ * `@arcjet/guard/langgraph/v1`, `@arcjet/guard/openai-agents/v0`,
+ * `@arcjet/guard/genkit/v1`, and `@arcjet/guard/strands-agents/v1`. The
  * layer stays agnostic so multiple
  * vendor namespaces can share the same code. A public `@arcjet/guard/agents`
  * path is still a follow-up with its own ADR.

--- a/arcjet-guard/src/genkit/v1/index.test.ts
+++ b/arcjet-guard/src/genkit/v1/index.test.ts
@@ -143,6 +143,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI-only APIs", () 
     "langgraphAgentContext",
     "langchainContext",
     "openaiAgentsContext",
+    "strandsAgentContext",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",

--- a/arcjet-guard/src/langchain/v1/index.test.ts
+++ b/arcjet-guard/src/langchain/v1/index.test.ts
@@ -150,6 +150,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only A
     "langgraphAgentContext",
     "openaiAgentsContext",
     "genkitContext",
+    "strandsAgentContext",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",

--- a/arcjet-guard/src/langgraph/v1/index.test.ts
+++ b/arcjet-guard/src/langgraph/v1/index.test.ts
@@ -154,6 +154,7 @@ test("does not export Eve / Mastra-only APIs onto the LangGraph namespace", () =
     "mastraAgentContext",
     "genkitContext",
     "langchainContext",
+    "strandsAgentContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/openai-agents/v0/index.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/index.test.ts
@@ -150,6 +150,7 @@ test("does not export Eve / Mastra / Claude / LangGraph-only APIs", () => {
     "langgraphAgentContext",
     "genkitContext",
     "langchainContext",
+    "strandsAgentContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/strands-agents/v1/assignability.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/assignability.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Compile-time assignability: the helpers accept the values a Strands
+ * Agents app actually has, with no casts at the call site.
+ *
+ * The declarations are types only (`declare const`, never executed) so
+ * this suite still runs in the strands-agents-absent CI job, where the
+ * peer is gone and the type-only import scan applies. Runtime
+ * behaviour against the real `tool()` / `Agent` lives in
+ * `test/strands-agents/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { InvokableTool, Plugin } from "@strands-agents/sdk";
+
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { guardHooks } from "./hooks.ts";
+import { guardTool } from "./guard-tool.ts";
+
+declare const client: ArcjetAgentClient;
+declare const authoredTool: InvokableTool<{ orderNumber: string }, { status: string }>;
+
+// Never called: the declarations above have no runtime value. Typecheck is
+// the assertion.
+function typeProbe(): void {
+  const guarded: InvokableTool<{ orderNumber: string }, { status: string }> = guardTool(
+    client,
+    authoredTool,
+    {
+      action: "order.looked-up",
+      rules: (input: { orderNumber: string }) => {
+        void input.orderNumber;
+        return [];
+      },
+    },
+  );
+
+  const plugin: Plugin = guardHooks(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+
+  const agentOpts: { plugins?: Plugin[] } = {
+    plugins: [plugin],
+  };
+
+  void [guarded, agentOpts];
+}
+
+test("helpers accept a real tool() result and Plugin slot without casts", () => {
+  assert.equal(typeof typeProbe, "function");
+});

--- a/arcjet-guard/src/strands-agents/v1/context.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/context.test.ts
@@ -90,7 +90,7 @@ test("rejects a session id over 256 characters and does not mint", () => {
   const result = strandsAgentContext({ invocationState: { sessionId: longId } });
 
   assert.equal(result.correlationId, undefined);
-  assert.equal(result.metadata?.["strands.session"], longId);
+  assert.equal("strands.session" in (result.metadata ?? {}), false);
 });
 
 test("never reads traceId, even when it is the only string present", () => {
@@ -192,7 +192,7 @@ test("non-string candidates are skipped", () => {
 test("non-printable session id is rejected and does not mint", () => {
   const result = strandsAgentContext({ invocationState: { sessionId: "bad\nid" } });
   assert.equal(result.correlationId, undefined);
-  assert.equal(result.metadata?.["strands.session"], "bad\nid");
+  assert.equal("strands.session" in (result.metadata ?? {}), false);
 });
 
 test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {

--- a/arcjet-guard/src/strands-agents/v1/context.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/context.test.ts
@@ -1,0 +1,245 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { strandsAgentContext } from "./context.ts";
+
+test("prefers invocationState.correlationId over sessionId over requestId", () => {
+  const result = strandsAgentContext({
+    invocationState: {
+      correlationId: "corr-1",
+      sessionId: "sess-1",
+      requestId: "req-1",
+    },
+  });
+
+  assert.equal(result.correlationId, "corr-1");
+  assert.equal(result.metadata?.["strands.session"], "sess-1");
+  assert.equal(result.metadata?.["strands.request"], "req-1");
+});
+
+test("falls back to invocationState.sessionId when correlationId is absent", () => {
+  const result = strandsAgentContext({
+    invocationState: { sessionId: "sess-1", requestId: "req-1" },
+  });
+
+  assert.equal(result.correlationId, "sess-1");
+  assert.equal(result.metadata?.["strands.session"], "sess-1");
+  assert.equal(result.metadata?.["strands.request"], "req-1");
+});
+
+test("falls back to invocationState.requestId when sessionId is absent", () => {
+  const result = strandsAgentContext({
+    invocationState: { requestId: "req-only" },
+  });
+
+  assert.equal(result.correlationId, "req-only");
+  assert.equal(result.metadata?.["strands.request"], "req-only");
+});
+
+test("accepts a bare invocationState bag", () => {
+  const result = strandsAgentContext({ sessionId: "direct-sess" });
+  assert.equal(result.correlationId, "direct-sess");
+  assert.equal(result.metadata?.["strands.session"], "direct-sess");
+});
+
+test("reads documented envelope copies when the bag has no id", () => {
+  const result = strandsAgentContext({
+    invocationState: { user: "alice" },
+    sessionId: "sess-env",
+    requestId: "req-env",
+  });
+
+  assert.equal(result.correlationId, "sess-env");
+  assert.equal(result.metadata?.["strands.session"], "sess-env");
+  assert.equal(result.metadata?.["strands.request"], "req-env");
+});
+
+test("init.sessionId is a last-resort caller-owned fallback", () => {
+  const result = strandsAgentContext({ invocationState: { user: "alice" } }, { sessionId: "policy-sess" });
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["strands.session"], "policy-sess");
+});
+
+test("never mints an id when nothing valid is present", () => {
+  const result = strandsAgentContext({});
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+});
+
+test("never mints an id when the only candidate is invalid", () => {
+  const result = strandsAgentContext({ invocationState: { sessionId: "" } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("strands.session" in (result.metadata ?? {}), false);
+});
+
+test("skips an invalid invocationState session id and uses the next candidate", () => {
+  const result = strandsAgentContext({
+    invocationState: { sessionId: "" },
+    requestId: "req-ok",
+  });
+
+  assert.equal(result.correlationId, "req-ok");
+});
+
+test("rejects a session id over 256 characters and does not mint", () => {
+  const longId = "x".repeat(257);
+  const result = strandsAgentContext({ invocationState: { sessionId: longId } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["strands.session"], longId);
+});
+
+test("never reads traceId, even when it is the only string present", () => {
+  const result = strandsAgentContext({
+    invocationState: { traceId: "trace-minted-by-sdk" },
+  });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("never reads agent.id from an envelope that carries an agent", () => {
+  const result = strandsAgentContext({
+    invocationState: {},
+    ...({ agent: { id: "agent-uuid" } } as Record<string, unknown>),
+  });
+
+  assert.equal(result.correlationId, undefined);
+});
+
+test("does not call SessionManager or getSessionId", () => {
+  let called = 0;
+  const result = strandsAgentContext({
+    ...({
+      sessionManager: {
+        getSessionId: () => {
+          called += 1;
+          return "minted-or-async";
+        },
+      },
+    } as Record<string, unknown>),
+  });
+
+  assert.equal(called, 0);
+  assert.equal(result.correlationId, undefined);
+});
+
+test("a null invocationState does not throw and does not mint", () => {
+  const result = strandsAgentContext({ invocationState: null });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("caller metadata overrides derived keys", () => {
+  const result = strandsAgentContext(
+    { invocationState: { sessionId: "sess-1" } },
+    { metadata: { "strands.session": "override" } },
+  );
+
+  assert.equal(result.metadata?.["strands.session"], "override");
+});
+
+test("derived metadata keys match /^[A-Za-z0-9._-]+$/", () => {
+  const result = strandsAgentContext({
+    invocationState: { sessionId: "sess-1", requestId: "req-1" },
+  });
+
+  assert.ok(result.metadata);
+  const validKeyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const key of Object.keys(result.metadata)) {
+    assert.ok(
+      validKeyPattern.test(key),
+      `derived key "${key}" must match the metadata character class`,
+    );
+  }
+});
+
+test("encoder round-trip produces no AJ1017 warnings", () => {
+  const result = strandsAgentContext({
+    invocationState: { sessionId: "sess-1", requestId: "req-1" },
+  });
+
+  assert.ok(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
+  assert.ok(metadataJson["strands.session"]);
+  assert.ok(metadataJson["strands.request"]);
+});
+
+test("undefined source does not throw and does not mint", () => {
+  const result = strandsAgentContext();
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("null and primitive sources do not mint", () => {
+  assert.equal("correlationId" in strandsAgentContext(null as never), false);
+  assert.equal("correlationId" in strandsAgentContext("sess" as never), false);
+  assert.equal("correlationId" in strandsAgentContext(12 as never), false);
+});
+
+test("non-string candidates are skipped", () => {
+  const result = strandsAgentContext({
+    invocationState: { sessionId: 99, requestId: { id: "nope" } },
+  });
+  assert.equal(result.correlationId, undefined);
+});
+
+test("non-printable session id is rejected and does not mint", () => {
+  const result = strandsAgentContext({ invocationState: { sessionId: "bad\nid" } });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["strands.session"], "bad\nid");
+});
+
+test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "info";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    strandsAgentContext({ invocationState: { sessionId: "" } });
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /rejected/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("does not warn when a later candidate is valid", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const result = strandsAgentContext({
+      invocationState: { sessionId: "" },
+      requestId: "req-ok",
+    });
+    assert.equal(result.correlationId, "req-ok");
+    assert.equal(warnings.length, 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/strands-agents/v1/context.ts
+++ b/arcjet-guard/src/strands-agents/v1/context.ts
@@ -1,0 +1,179 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `strandsAgentContext` can read.
+ *
+ * The SDK's `InvocationState` is a caller-owned `Record<string, unknown>`.
+ * The core loop writes no keys into it. This helper reads a caller-owned
+ * id from that bag (and documented copies on the envelope). It never
+ * mints a new id. It never reads `traceId` (a typical OTel / SDK field
+ * the docs mention as an example — still not ours). It never reads
+ * `agent.id`. It never calls `SessionManager`.
+ *
+ * Accepts:
+ * - the `invocationState` bag itself
+ * - a tool / hook envelope (`{ invocationState }`, plus documented copies)
+ */
+export interface StrandsContextSource {
+  invocationState?: unknown;
+  correlationId?: unknown;
+  sessionId?: unknown;
+  requestId?: unknown;
+}
+
+/**
+ * Context derived from a Strands Agents invocation. `correlationId` is
+ * omitted when nothing valid was present — this helper never mints one.
+ */
+export interface StrandsAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a non-null, non-array object is a property bag
+  return value as Record<string, unknown>;
+}
+
+function asContextSource(source: unknown): StrandsContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+/**
+ * The caller-owned bag. On a tool / hook envelope that is
+ * `source.invocationState`. On a bare bag it is the source itself.
+ */
+function readInvocationState(
+  source: StrandsContextSource | undefined,
+): Record<string, unknown> | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  const nested = asRecord(source.invocationState);
+  if (nested !== undefined) {
+    return nested;
+  }
+  return asRecord(source);
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function firstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Derive correlation and metadata from a Strands `invocationState` bag
+ * or a tool / hook envelope that carries one. Never mints a new id.
+ * Never calls `createAgentContext`. Never reads `traceId`. Never reads
+ * `agent.id`. Never calls `SessionManager`.
+ *
+ * Preference order for `correlationId`:
+ * 1. Fields the integrator put on `invocationState`: `correlationId`,
+ *    then `sessionId`, then `requestId`
+ * 2. Documented copies on the envelope
+ * 3. `init.sessionId` / `init.correlationId` (a caller-owned fallback)
+ *
+ * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL`
+ * asks for warnings). If nothing valid remains, `correlationId` is
+ * omitted so the decision is uncorrelated rather than joined to a
+ * generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { strandsAgentContext } from "@arcjet/guard/strands-agents/v1";
+ *
+ * const invocationState = { sessionId: conversationId };
+ * export function beforeInvoke() {
+ *   return strandsAgentContext({ invocationState });
+ * }
+ * ```
+ */
+export function strandsAgentContext(
+  source?: StrandsContextSource,
+  init?: { sessionId?: string; correlationId?: string; metadata?: ArcjetMetadata },
+): StrandsAgentContext {
+  const envelope = asContextSource(source);
+  const state = readInvocationState(envelope);
+
+  const fromState = {
+    correlationId: state?.["correlationId"],
+    sessionId: state?.["sessionId"],
+    requestId: state?.["requestId"],
+  };
+  const fromEnvelope = {
+    correlationId: envelope?.correlationId,
+    sessionId: envelope?.sessionId,
+    requestId: envelope?.requestId,
+  };
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: fromState.correlationId, label: "invocationState.correlationId" },
+    { value: fromState.sessionId, label: "invocationState.sessionId" },
+    { value: fromState.requestId, label: "invocationState.requestId" },
+    { value: fromEnvelope.correlationId, label: "correlationId" },
+    { value: fromEnvelope.sessionId, label: "sessionId" },
+    { value: fromEnvelope.requestId, label: "requestId" },
+    { value: init?.correlationId, label: "init.correlationId" },
+    { value: init?.sessionId, label: "init.sessionId" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: Strands Agents ${rejected} rejected; no valid session/request id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const session = firstString([fromState.sessionId, fromEnvelope.sessionId, init?.sessionId]);
+  if (session !== undefined) {
+    derivedMetadata["strands.session"] = session;
+  }
+
+  const request = firstString([fromState.requestId, fromEnvelope.requestId]);
+  if (request !== undefined) {
+    derivedMetadata["strands.request"] = request;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: StrandsAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/strands-agents/v1/context.ts
+++ b/arcjet-guard/src/strands-agents/v1/context.ts
@@ -82,11 +82,15 @@ function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string 
   return { id: undefined, rejected };
 }
 
-function firstString(values: unknown[]): string | undefined {
+function validMetadataString(values: unknown[]): string | undefined {
   for (const value of values) {
-    if (typeof value === "string" && value.length > 0) {
-      return value;
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
     }
+    if (correlationIdProblem(value) !== undefined) {
+      continue;
+    }
+    return value;
   }
   return undefined;
 }
@@ -155,12 +159,16 @@ export function strandsAgentContext(
 
   const derivedMetadata: ArcjetMetadata = {};
 
-  const session = firstString([fromState.sessionId, fromEnvelope.sessionId, init?.sessionId]);
+  const session = validMetadataString([
+    fromState.sessionId,
+    fromEnvelope.sessionId,
+    init?.sessionId,
+  ]);
   if (session !== undefined) {
     derivedMetadata["strands.session"] = session;
   }
 
-  const request = firstString([fromState.requestId, fromEnvelope.requestId]);
+  const request = validMetadataString([fromState.requestId, fromEnvelope.requestId]);
   if (request !== undefined) {
     derivedMetadata["strands.request"] = request;
   }

--- a/arcjet-guard/src/strands-agents/v1/gate.ts
+++ b/arcjet-guard/src/strands-agents/v1/gate.ts
@@ -1,0 +1,126 @@
+import { captureEvent, shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type {
+  ArcjetMetadata,
+  Decision,
+  DecisionAllow,
+  DecisionDeny,
+  RuleWithInput,
+} from "../../types.ts";
+
+/**
+ * The guard → capture sequence for a call site that decides whether something
+ * may run but does not run it. Shared by `guardHooks` on
+ * `BeforeToolCallEvent`.
+ *
+ * The allow outcome is `"allowed"`, not `"success"` — a distinction that
+ * keeps "the tool ran" and "the tool was permitted to run" separate.
+ */
+export async function runGate<T>(
+  client: ArcjetAgentClient,
+  params: {
+    action: string;
+    rules: RuleWithInput[] | undefined;
+    correlationId: string | undefined;
+    metadata: ArcjetMetadata;
+    onAllow: () => T;
+    onDeny: (decision: DecisionDeny) => T;
+    onUnavailable: (
+      unavailable:
+        | { kind: "threw"; error: unknown }
+        | { kind: "failed-open"; decision: DecisionAllow },
+    ) => T;
+    onGuardError?: "allow" | "deny";
+  },
+): Promise<T> {
+  const {
+    action,
+    rules,
+    correlationId,
+    metadata,
+    onAllow,
+    onDeny,
+    onUnavailable,
+    onGuardError = "deny",
+  } = params;
+
+  const correlation = correlationId === undefined ? {} : { correlationId };
+  const failClosed = onGuardError === "deny";
+
+  let decisionId: string | undefined;
+  let decision: Decision | undefined;
+  try {
+    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+  } catch (error) {
+    if (failClosed) {
+      warnUnavailable(action, "threw", true, error);
+      captureEvent(client, {
+        action,
+        ...correlation,
+        metadata: { ...metadata, outcome: "unavailable" },
+      });
+      return onUnavailable({ kind: "threw", error });
+    }
+    warnUnavailable(action, "threw", false, error);
+  }
+
+  if (decision !== undefined) {
+    if (decision.id !== "") {
+      decisionId = decision.id;
+    }
+    if (decision.conclusion === "ALLOW" && decision.hasFailedOpen() && failClosed) {
+      warnUnavailable(action, "failed-open", true);
+      captureEvent(client, {
+        action,
+        ...correlation,
+        ...(decisionId !== undefined && { decisionId }),
+        metadata: { ...metadata, outcome: "unavailable" },
+      });
+      return onUnavailable({ kind: "failed-open", decision });
+    }
+    if (decision.conclusion === "ALLOW" && decision.hasFailedOpen()) {
+      warnUnavailable(action, "failed-open", false);
+    }
+    if (decision.conclusion === "DENY") {
+      captureEvent(client, {
+        action,
+        ...correlation,
+        ...(decisionId !== undefined && { decisionId }),
+        metadata: { ...metadata, outcome: "denied" },
+      });
+      return onDeny(decision);
+    }
+  }
+
+  captureEvent(client, {
+    action,
+    ...correlation,
+    ...(decisionId !== undefined && { decisionId }),
+    metadata: { ...metadata, outcome: "allowed" },
+  });
+  return onAllow();
+}
+
+function warnUnavailable(
+  action: string,
+  signal: "threw" | "failed-open",
+  failClosed: boolean,
+  error?: unknown,
+): void {
+  if (!shouldWarn()) {
+    return;
+  }
+  if (signal === "threw") {
+    if (failClosed) {
+      console.warn('@arcjet/guard: guard check for "%s" errored; failing closed:', action, error);
+    } else {
+      console.warn('@arcjet/guard: guard check for "%s" errored; failing open:', action, error);
+    }
+    return;
+  }
+  if (failClosed) {
+    console.warn('@arcjet/guard: guard check for "%s" was unavailable; failing closed.', action);
+  } else {
+    console.warn('@arcjet/guard: guard check for "%s" failed open (API error).', action);
+  }
+}

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.test.ts
@@ -1,0 +1,504 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, typescript/unbound-method -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionDenyRateLimit,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { DecisionDeny } from "../../types.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import type { StrandsTool } from "./guard-tool.ts";
+import { guardTool } from "./guard-tool.ts";
+
+const HIDDEN = Symbol.for("strands.hidden");
+
+type FakeTool = {
+  name: string;
+  description: string;
+  toolSpec: { name: string };
+  _callback: (input: unknown, context?: unknown) => unknown;
+  _functionTool?: { _callback: (input: unknown, context?: unknown) => unknown };
+  stream?: (context: unknown) => Promise<unknown>;
+  invoke?: (input: unknown, context?: unknown) => Promise<unknown>;
+};
+
+function createTool(overrides?: {
+  name?: string;
+  callback?: (input: unknown, context?: unknown) => unknown;
+  zod?: boolean;
+}): FakeTool {
+  const callback = overrides?.callback ?? (async () => ({ ok: true }));
+  const name = overrides?.name ?? "test-tool";
+  const tool: FakeTool = {
+    name,
+    description: "test",
+    toolSpec: { name },
+    _callback: callback,
+    invoke: async (input, context) => callback(input, context),
+    stream: async (context) => {
+      const ctx = context as { toolUse?: { input?: unknown } };
+      return callback(ctx.toolUse?.input, context);
+    },
+  };
+  if (overrides?.zod === true) {
+    const innerCallback = (input: unknown, context?: unknown) => callback(input, context);
+    tool._functionTool = { _callback: innerCallback };
+    tool.stream = async (context) => {
+      const ctx = context as { toolUse?: { input?: unknown } };
+      return tool._functionTool!._callback(ctx.toolUse?.input, context);
+    };
+  }
+  Object.defineProperty(tool, HIDDEN, {
+    value: "keep-me",
+    enumerable: false,
+    configurable: true,
+  });
+  return tool;
+}
+
+function toolContext(sessionId?: string) {
+  return {
+    invocationState: sessionId === undefined ? {} : { sessionId },
+    toolUse: { name: "test-tool", toolUseId: "tu-1", input: {} },
+  };
+}
+
+function asToolResult(value: unknown): ArcjetDenialResult {
+  return asDenial<ArcjetDenialResult>(value);
+}
+
+test("throws when the tool has no callback", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = { name: "no-callback" };
+  assert.throws(
+    () => guardTool(client, tool as StrandsTool, { action: "test.executed" }),
+    /callback|tool\(\)/,
+  );
+});
+
+test("returned object is not the input tool and preserves non-enumerable markers", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "test.executed" });
+
+  assert.notStrictEqual(wrapped, tool);
+  assert.equal((wrapped as FakeTool & { [HIDDEN]: unknown })[HIDDEN], "keep-me");
+  assert.equal(wrapped.name, "test-tool");
+});
+
+test("input tool callback is unchanged after wrapping", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const original = tool._callback;
+  guardTool(client, tool, { action: "test.executed" });
+  assert.strictEqual(tool._callback, original);
+  await tool._callback({}, toolContext("t"));
+  assert.equal(calls, 1);
+});
+
+test("ALLOW → callback called once with input and context by reference", async () => {
+  const { client } = stubClient(decisionAllow());
+  const ctx = toolContext("sess-1");
+  const input = { orderNumber: "A-1" };
+  let calls = 0;
+  let capturedInput: unknown;
+  let capturedContext: unknown;
+
+  const tool = createTool({
+    callback: async (inp, context) => {
+      calls += 1;
+      capturedInput = inp;
+      capturedContext = context;
+      return { status: "shipped" };
+    },
+  });
+
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  const result = await wrapped._callback(input, ctx);
+
+  assert.equal(calls, 1);
+  assert.strictEqual(capturedInput, input);
+  assert.strictEqual(capturedContext, ctx);
+  assert.deepEqual(result, { status: "shipped" });
+});
+
+test("ALLOW → rules see parsed args, not an opaque toolUseId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let captured: unknown;
+  const tool = createTool({
+    callback: async (args) => {
+      captured = args;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "note.read",
+    rules: (input: { note: string }) => {
+      assert.equal(input.note, "hello");
+      return [fakeRule];
+    },
+  }) as FakeTool;
+  await wrapped._callback({ note: "hello" }, toolContext("t"));
+  assert.deepEqual(captured, { note: "hello" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("ALLOW → capture outcome is success and correlation comes from invocationState.sessionId", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  await wrapped._callback({}, toolContext("sess-99"));
+
+  assert.equal(guardCalls.length, 1);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-99");
+  assert.equal(captureCalls.length, 1);
+  const metadata = recorded(captureCalls[0])["metadata"] as Record<string, unknown>;
+  assert.equal(metadata["outcome"], "success");
+});
+
+test("DENY → callback is not called and a structured denial is returned (no throw)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+  assert.equal(result.retryable, false);
+});
+
+test("RATE_LIMIT DENY → structured result is retryable", async () => {
+  const resetAt = Math.floor(Date.now() / 1000) + 12;
+  const { client } = stubClient(decisionDenyRateLimit(resetAt));
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+
+  assert.equal(result.retryable, true);
+  assert.ok(typeof result.retryAfterSeconds === "number");
+});
+
+test("fail-closed unavailable → ERROR denial, callback not called", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("onGuardError allow → callback still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+  }) as FakeTool;
+  const result = await wrapped._callback({}, toolContext("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true });
+});
+
+test("does not mint a correlation id when the run provided none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  await wrapped._callback({}, { invocationState: {} });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("DENY + throwing onDeny still denies and does not throw", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      throw new Error("onDeny exploded");
+    },
+  }) as FakeTool;
+
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("onDeny reshape is returned and callback is not called", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let received: DecisionDeny | undefined;
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: (decision) => {
+      received = decision;
+      return { blocked: decision.reason };
+    },
+  }) as FakeTool;
+
+  const result = await wrapped._callback({}, toolContext("t"));
+  assert.equal(received?.reason, "PROMPT_INJECTION");
+  assert.deepEqual(result, { blocked: "PROMPT_INJECTION" });
+});
+
+test("onDeny is not called on unavailable", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  let onDenyCalls = 0;
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onDeny: () => {
+      onDenyCalls += 1;
+      return { blocked: true };
+    },
+  }) as FakeTool;
+
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+  assert.equal(onDenyCalls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("guard throw with default fail-closed does not execute", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("omitted rules still submit an empty guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  await wrapped._callback({}, toolContext("t"));
+  assert.deepEqual(recorded(guardCalls[0])["rules"], []);
+});
+
+test("metadata callback is merged over derived context", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: (input: { id: string }) => ({ "app.item": input.id }),
+  }) as FakeTool;
+  await wrapped._callback({ id: "item-9" }, toolContext("sess-meta"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.item"], "item-9");
+  assert.equal(metadata["strands.tool"], "test-tool");
+  assert.equal(metadata["strands.session"], "sess-meta");
+});
+
+test("static metadata is merged", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool({ name: "" });
+  const wrapped = guardTool(client, tool, {
+    action: "thing.read",
+    metadata: { "app.static": "yes" },
+  }) as FakeTool;
+  await wrapped._callback({}, toolContext("t"));
+  const metadata = recorded(recorded(guardCalls[0])["metadata"]);
+  assert.equal(metadata["app.static"], "yes");
+  assert.equal("strands.tool" in metadata, false);
+});
+
+test("rejects a second wrap", () => {
+  const { client } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" });
+  assert.equal(arcjetProtectedTool in wrapped, true);
+  assert.throws(() => guardTool(client, wrapped, { action: "order.looked-up" }), /already guarded/);
+
+  const branded = createTool();
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  assert.throws(() => guardTool(client, branded, { action: "order.looked-up" }), /already guarded/);
+});
+
+test("callback throw is rethrown after capture", async () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const tool = createTool({
+    callback: async (): Promise<{ ok: boolean }> => {
+      throw new Error("tool failed");
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  await assert.rejects(async () => wrapped._callback({}, toolContext("t")), /tool failed/);
+  assert.equal(recorded(recorded(captureCalls[0])["metadata"])["outcome"], "error");
+});
+
+test("non-object context does not mint an id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  await wrapped._callback({}, "not-context");
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("rules factory throw fail-closes and does not execute", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("metadata factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    metadata: () => {
+      throw new Error("metadata exploded");
+    },
+  }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("sessionId factory throw fail-closes", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: () => {
+      throw new Error("session exploded");
+    },
+  }) as FakeTool;
+  const result = asToolResult(await wrapped._callback({}, toolContext("t")));
+  assert.equal(calls, 0);
+  assert.equal(result.reason, "ERROR");
+});
+
+test("policy factory throw with onGuardError allow still runs", async () => {
+  const { client } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ran: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  }) as FakeTool;
+  const result = await wrapped._callback({}, toolContext("t"));
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ran: true });
+});
+
+test("policy.sessionId is used when invocationState has none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, {
+    action: "order.looked-up",
+    sessionId: "policy-sess",
+  }) as FakeTool;
+  await wrapped._callback({}, { invocationState: {} });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("ZodTool inner _functionTool callback is gated so stream() cannot bypass", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const tool = createTool({
+    zod: true,
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  assert.ok(wrapped._functionTool);
+  assert.notStrictEqual(wrapped._functionTool, tool._functionTool);
+
+  const result = asToolResult(
+    await wrapped._functionTool!._callback({}, toolContext("t")),
+  );
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+
+  // The original inner callback is untouched.
+  await tool._functionTool!._callback({}, toolContext("t"));
+  assert.equal(calls, 1);
+});
+
+test("never reads traceId from invocationState", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
+  await wrapped._callback({}, { invocationState: { traceId: "trace-minted" } });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.ts
@@ -1,0 +1,345 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { strandsAgentContext } from "./context.ts";
+import type { StrandsContextSource } from "./context.ts";
+
+/**
+ * Structural `tool({ callback })` result. Declared here so `guardTool`
+ * does not value-import `@strands-agents/sdk`.
+ *
+ * After `tool({ callback })` the object is a `FunctionTool` or `ZodTool`.
+ * Both store the authored `callback` as `_callback`. `ZodTool` also
+ * closes a validation wrapper over the same callback inside
+ * `_functionTool._callback`, and `stream()` (what the executor calls)
+ * delegates there. `invoke()` calls `_callback` directly.
+ *
+ * `stream` and `invoke` are declared with method syntax so a real
+ * `ZodTool` / `FunctionTool` stays assignable under
+ * `strictFunctionTypes`.
+ */
+export interface StrandsTool {
+  name?: string;
+  description?: string;
+  toolSpec?: { name?: string };
+  stream?(...args: never[]): unknown;
+  invoke?(...args: never[]): unknown;
+}
+
+/**
+ * Input type of a Strands `tool({ callback })`. Used so `guardTool` can
+ * keep the concrete tool type while still typing `policy.rules` against
+ * the callback args (not opaque tool-use ids).
+ */
+export type StrandsToolInput<TTool> = TTool extends {
+  invoke?(input: infer TInput, context?: unknown): unknown;
+}
+  ? TInput
+  : unknown;
+
+/**
+ * Policy for `guardTool()` — how to guard an authored
+ * `tool({ callback })`.
+ *
+ * Specifies the guard action name, optional rules to evaluate, metadata
+ * context, and optional denial handler. Rules can be static or computed
+ * from the tool's free-text args. Do not scan opaque `toolUseId`s.
+ */
+export interface GuardToolPolicy<TInput> {
+  /** Guard label and capture action: `"resource.verb"`, past tense. */
+  action: string;
+  /**
+   * Rules to evaluate, static or computed from the tool's parsed args.
+   * Omitting this, or returning `[]`, submits no rules — it does not skip
+   * the guard call, which still costs a round trip and returns a decision.
+   */
+  rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /** Metadata merged over the context's (object, or per-call function of the tool input). */
+  metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
+  /**
+   * Fallback session id when `invocationState` does not carry one.
+   * Prefer putting the id you already chose on
+   * `agent.invoke(..., { invocationState: { sessionId } })`. Never mint
+   * a new id here. Never pass `agent.id` or a `SessionManager` id.
+   */
+  sessionId?: string | ((input: TInput) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload the model sees for a real DENY decision.
+   * The value is returned from the authored `callback` as-is, which
+   * `FunctionTool.stream()` wraps in a `ToolResultBlock` / `JsonBlock`.
+   * This helper does not fabricate an SDK message type. Unavailable
+   * guards take the `onUnavailable` path instead and return the fixed
+   * `{ reason: "ERROR", retryable: true, retryAfterSeconds: 5 }` result;
+   * this callback does not fire for outages.
+   *
+   * **Warning:** A tool created with `outputSchema` validates the
+   * authored callback's return *inside* `FunctionTool`. A denial is
+   * not schema-checked. Prefer omitting `outputSchema` on guarded
+   * tools, or verify the schema accepts `ArcjetDenialResult` / your
+   * `onDeny` shape.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+interface CallbackHolder {
+  _callback?: (input: unknown, context?: unknown) => unknown;
+  _functionTool?: CallbackHolder;
+}
+
+function isContextSource(value: unknown): value is StrandsContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function isCallbackHolder(value: unknown): value is CallbackHolder {
+  return value !== null && typeof value === "object";
+}
+
+function toolName(tool: StrandsTool): string | undefined {
+  if (typeof tool.name === "string" && tool.name.length > 0) {
+    return tool.name;
+  }
+  if (typeof tool.toolSpec?.name === "string" && tool.toolSpec.name.length > 0) {
+    return tool.toolSpec.name;
+  }
+  return undefined;
+}
+
+function resolveSessionId<TInput>(
+  policy: GuardToolPolicy<TInput>,
+  input: TInput,
+): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(input);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+function contextSource(context: unknown): StrandsContextSource | undefined {
+  if (!isContextSource(context)) {
+    return undefined;
+  }
+  if (context.invocationState !== undefined) {
+    return context;
+  }
+  // A bare invocationState bag (or a ToolContext without a nested
+  // `invocationState` field spelled that way) is still readable.
+  return context;
+}
+
+/**
+ * Wraps an authored `tool({ callback })` so the side-effect never runs
+ * on DENY.
+ *
+ * After `tool()` the runner calls `stream()`, which calls `_callback`
+ * (FunctionTool) or `_functionTool._callback` (ZodTool's validation
+ * wrapper over the same authored function). `invoke()` calls
+ * `_callback` directly. This helper replaces those callback slots so
+ * every path is gated, and always runs `guard()` before the original
+ * callback. On DENY the original callback never runs. The model
+ * receives a plain `ArcjetDenialResult` (or the result of
+ * `policy.onDeny`) as the callback return — `FunctionTool` wraps that
+ * object in a `JsonBlock`. This helper does not throw on DENY and
+ * does not fabricate a `ToolResultBlock`.
+ *
+ * Guard API errors depend on `policy.onGuardError` (defaults to `"deny"`):
+ * - `"deny"` (default): callback does not run; the model receives an
+ *   `ArcjetDenialResult` with `reason: "ERROR"`.
+ * - `"allow"`: callback still runs, with a warning gated on
+ *   `ARCJET_LOG_LEVEL`.
+ *
+ * Correlation is read from `toolContext.invocationState` (and
+ * documented copies). No id is minted. `traceId`, `agent.id`, and
+ * `SessionManager` are never read.
+ *
+ * MCP tools and anything not wrapped with `guardTool` skip this path
+ * — use `guardHooks` for those. Do not also wrap the same tool with
+ * `@arcjet/guard/vercel-ai/v7` or `@arcjet/guard/langgraph/v1`. The
+ * shared `arcjetProtectedTool` brand throws on a second `guardTool`
+ * wrap and lets `guardHooks` skip an already-guarded tool.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardTool } from "@arcjet/guard/strands-agents/v1";
+ * import { tool } from "@strands-agents/sdk";
+ * import { z } from "zod";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * export const lookupOrder = guardTool(
+ *   arcjet,
+ *   tool({
+ *     name: "lookup_order",
+ *     description: "Look up an order by number",
+ *     inputSchema: z.object({ orderNumber: z.string() }),
+ *     callback: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *   }),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ * ```
+ */
+export function guardTool<TInput = unknown, TTool extends StrandsTool = StrandsTool>(
+  client: ArcjetAgentClient,
+  tool: TTool,
+  policy: GuardToolPolicy<TInput>,
+): TTool {
+  if (!isCallbackHolder(tool) || typeof tool._callback !== "function") {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error(
+      "@arcjet/guard: guardTool() requires a tool() result with a callback. Pass the result of tool({ callback }), not the config object.",
+    );
+  }
+  if (arcjetProtectedTool in tool) {
+    throw new Error(
+      "@arcjet/guard: guardTool() cannot wrap a tool that is already guarded; do not double-wrap with @arcjet/guard/strands-agents/v1, @arcjet/guard/vercel-ai/v7, or @arcjet/guard/langgraph/v1",
+    );
+  }
+
+  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
+  const proto = Object.getPrototypeOf(tool) as object | null;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
+  const wrapped = Object.defineProperties(
+    Object.create(proto),
+    Object.getOwnPropertyDescriptors(tool),
+  ) as TTool & CallbackHolder;
+
+  installGuardedCallback(client, tool, policy, wrapped);
+
+  const inner = wrapped._functionTool;
+  if (isCallbackHolder(inner) && typeof inner._callback === "function") {
+    // ZodTool.stream() delegates to this inner FunctionTool, which
+    // closes over the authored callback at construction. Copy it so
+    // the original tool's stream() path stays unguarded for the
+    // caller who still holds that reference, then gate the copy.
+    // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Object.getPrototypeOf is typed `any`
+    const innerProto = Object.getPrototypeOf(inner) as object | null;
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.defineProperties copies every own descriptor, including symbols
+    const innerCopy = Object.defineProperties(
+      Object.create(innerProto),
+      Object.getOwnPropertyDescriptors(inner),
+    ) as CallbackHolder;
+    installGuardedCallback(client, tool, policy, innerCopy);
+    wrapped._functionTool = innerCopy;
+  }
+
+  Object.defineProperty(wrapped, arcjetProtectedTool, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return wrapped;
+}
+
+function installGuardedCallback<TInput>(
+  client: ArcjetAgentClient,
+  tool: StrandsTool,
+  policy: GuardToolPolicy<TInput>,
+  holder: CallbackHolder,
+): void {
+  const original = holder._callback;
+  if (typeof original !== "function") {
+    return;
+  }
+
+  const guarded = (input: unknown, context?: unknown): Promise<unknown> =>
+    runGuardedCallback(client, tool, policy, input, context, () =>
+      Promise.resolve(original(input, context)),
+    );
+
+  Object.defineProperty(holder, "_callback", {
+    value: guarded,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+function runGuardedCallback<TInput>(
+  client: ArcjetAgentClient,
+  tool: StrandsTool,
+  policy: GuardToolPolicy<TInput>,
+  input: unknown,
+  context: unknown,
+  execute: () => Promise<unknown>,
+): Promise<unknown> {
+  const args = input === undefined ? {} : input;
+
+  let sessionId: string | undefined;
+  let rules: RuleWithInput[] | undefined;
+  let policyMetadata: ArcjetMetadata | undefined;
+  try {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
+    const typedArgs = args as TInput;
+    sessionId = resolveSessionId(policy, typedArgs);
+    rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
+    policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+  } catch (error) {
+    if (shouldWarn()) {
+      console.warn(
+        '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+        policy.action,
+        error,
+      );
+    }
+    if (policy.onGuardError === "allow") {
+      return execute();
+    }
+    return Promise.resolve(unavailableResult());
+  }
+
+  const source = contextSource(context);
+  const agentCtx = strandsAgentContext(source, sessionId === undefined ? undefined : { sessionId });
+
+  const name = toolName(tool);
+  const metadata: ArcjetMetadata = {
+    ...agentCtx.metadata,
+    ...(name !== undefined && { "strands.tool": name }),
+  };
+  const mergedMetadata = { ...metadata, ...policyMetadata };
+
+  return runGuarded<unknown>(client, {
+    action: policy.action,
+    rules,
+    correlationId: agentCtx.correlationId,
+    metadata: mergedMetadata,
+    onDeny: (decision: DecisionDeny) => {
+      if (policy.onDeny === undefined) {
+        return denialResult(decision);
+      }
+      try {
+        return policy.onDeny(decision);
+      } catch (error) {
+        if (shouldWarn()) {
+          console.warn(
+            '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+            policy.action,
+            error,
+          );
+        }
+        return denialResult(decision);
+      }
+    },
+    onUnavailable: () => unavailableResult(),
+    execute,
+    onGuardError: policy.onGuardError ?? "deny",
+  });
+}

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.ts
@@ -166,6 +166,11 @@ function contextSource(context: unknown): StrandsContextSource | undefined {
  * shared `arcjetProtectedTool` brand throws on a second `guardTool`
  * wrap and lets `guardHooks` skip an already-guarded tool.
  *
+ * Register only the value this helper returns on `Agent({ tools })`.
+ * Passing the original `tool()` reference alongside the wrapped copy
+ * leaves the inner `_functionTool._callback` unguarded on the
+ * original's `stream()` path.
+ *
  * @example
  * ```ts
  * import { launchArcjet, tokenBucket } from "@arcjet/guard";

--- a/arcjet-guard/src/strands-agents/v1/hooks.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.test.ts
@@ -1,0 +1,322 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import {
+  createAfterToolCallHandler,
+  createBeforeToolCallHandler,
+  guardHooks,
+} from "./hooks.ts";
+import type { StrandsBeforeToolCallEvent } from "./hooks.ts";
+
+function hookEvent(input?: unknown, extras?: Partial<StrandsBeforeToolCallEvent>): StrandsBeforeToolCallEvent {
+  return {
+    toolUse: {
+      name: "mcp_search",
+      toolUseId: "tu-1",
+      input: input === undefined ? { q: "1" } : input,
+    },
+    invocationState: { sessionId: "sess-hooks" },
+    cancel: false,
+    interrupt: () => {
+      throw new Error("interrupt() must not be called");
+    },
+    ...extras,
+  };
+}
+
+function denialFromCancel(event: StrandsBeforeToolCallEvent): ArcjetDenialResult {
+  assert.equal(typeof event.cancel, "string");
+  return asDenial<ArcjetDenialResult>(JSON.parse(event.cancel as string));
+}
+
+test("guardHooks returns a named Plugin with initAgent", () => {
+  const { client } = stubClient(decisionAllow());
+  const plugin = guardHooks(client, { action: "tool.invoked" });
+  assert.equal(typeof plugin, "object");
+  assert.equal(typeof plugin.name, "string");
+  assert.ok(plugin.name.startsWith("arcjet-guard-"));
+  assert.equal(typeof plugin.initAgent, "function");
+});
+
+test("each call gets a unique name so two plugins do not collide", () => {
+  const { client } = stubClient(decisionAllow());
+  const a = guardHooks(client);
+  const b = guardHooks(client);
+  assert.notEqual(a.name, b.name);
+});
+
+test("ALLOW → cancel stays false so the tool proceeds", async () => {
+  const { client, guardCalls, captureCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, { action: "mcp.invoked" });
+  const event = hookEvent();
+  await handler(event);
+
+  assert.equal(event.cancel, false);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-hooks");
+  assert.equal(
+    (recorded(captureCalls[0])["metadata"] as Record<string, unknown>)["outcome"],
+    "allowed",
+  );
+});
+
+test("DENY → event.cancel is the JSON string of a structured denial (no throw)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const handler = createBeforeToolCallHandler(client, { action: "mcp.invoked" });
+  const event = hookEvent();
+  await handler(event);
+
+  const output = denialFromCancel(event);
+  assert.equal(output.arcjetDenied, true);
+  assert.equal(output.reason, "PROMPT_INJECTION");
+  assert.equal(typeof event.cancel, "string");
+  assert.doesNotThrow(() => JSON.parse(event.cancel as string));
+});
+
+test("fail-closed unavailable → event.cancel is an ERROR denial JSON string", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const handler = createBeforeToolCallHandler(client);
+  const event = hookEvent();
+  await handler(event);
+
+  const output = denialFromCancel(event);
+  assert.equal(output.reason, "ERROR");
+});
+
+test("rules callback receives the tool name and input", async () => {
+  const { client } = stubClient(decisionAllow());
+  let seenName = "";
+  const handler = createBeforeToolCallHandler(client, {
+    rules: ({ toolName, input }) => {
+      seenName = toolName;
+      assert.deepEqual(input, { q: "abc" });
+      return [fakeRule];
+    },
+  });
+  await handler(hookEvent({ q: "abc" }));
+  assert.equal(seenName, "mcp_search");
+});
+
+test("afterToolCall captures success and never throws", () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const handler = createAfterToolCallHandler(client, { action: "mcp.invoked" });
+  handler({
+    toolUse: { name: "mcp_search", input: { q: "1" } },
+    invocationState: { sessionId: "sess-hooks" },
+  });
+
+  assert.equal(captureCalls.length, 1);
+  const metadata = recorded(captureCalls[0])["metadata"] as Record<string, unknown>;
+  assert.equal(metadata["outcome"], "success");
+  assert.equal(metadata["strands.phase"], "after");
+  assert.equal(metadata["strands.tool"], "mcp_search");
+});
+
+test("afterToolCall captures error outcome", () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const handler = createAfterToolCallHandler(client);
+  handler({
+    toolUse: { name: "mcp_search", input: { q: "1" } },
+    invocationState: { sessionId: "sess-hooks" },
+    error: new Error("boom"),
+  });
+
+  const metadata = recorded(captureCalls[0])["metadata"] as Record<string, unknown>;
+  assert.equal(metadata["outcome"], "error");
+});
+
+test("default action is tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, {});
+  await handler(hookEvent());
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("action callback is used when provided", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+  await handler(hookEvent());
+  assert.equal(recorded(guardCalls[0])["label"], "mcp_search.invoked");
+});
+
+test("empty action string falls back to tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, { action: "" });
+  await handler(hookEvent());
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("onGuardError allow lets BeforeToolCall proceed on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const handler = createBeforeToolCallHandler(client, { onGuardError: "allow" });
+  const event = hookEvent();
+  await handler(event);
+  assert.equal(event.cancel, false);
+});
+
+test("rules throw still sets cancel (fail closed) and does not throw", async () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { client } = stubClient(decisionAllow());
+    const handler = createBeforeToolCallHandler(client, {
+      rules: () => {
+        throw new Error("rules exploded");
+      },
+    });
+    const event = hookEvent();
+    await handler(event);
+    const output = denialFromCancel(event);
+    assert.equal(output.reason, "ERROR");
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /policy factory|threw/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("rules throw with onGuardError allow proceeds", async () => {
+  const { client } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, {
+    onGuardError: "allow",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const event = hookEvent();
+  await handler(event);
+  assert.equal(event.cancel, false);
+});
+
+test("empty toolName is omitted from metadata", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, {});
+  await handler(
+    hookEvent({}, { toolUse: { name: "", input: {} } }),
+  );
+  assert.equal("strands.tool" in recorded(recorded(guardCalls[0])["metadata"]), false);
+});
+
+test("non-string toolName is treated as empty", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, {});
+  await handler(
+    hookEvent({}, { toolUse: { name: 12, input: {} } }),
+  );
+  assert.equal("strands.tool" in recorded(recorded(guardCalls[0])["metadata"]), false);
+});
+
+test("skips an already-branded tool so Guard is not double-called", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const branded = { name: "lookup_order" };
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  const handler = createBeforeToolCallHandler(client, { action: "tool.invoked" });
+  const event = hookEvent({ note: "x" }, { tool: branded });
+  await handler(event);
+  assert.equal(guardCalls.length, 0);
+  assert.equal(event.cancel, false);
+});
+
+test("still gates an unwrapped tool when event.tool is missing", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const handler = createBeforeToolCallHandler(client, { action: "tool.invoked" });
+  const event = hookEvent();
+  await handler(event);
+  assert.equal(denialFromCancel(event).arcjetDenied, true);
+});
+
+test("does not mint a correlation id when nothing is present", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, { action: "tool.invoked" });
+  await handler({
+    toolUse: { name: "lookup", input: {} },
+    invocationState: {},
+    cancel: false,
+  });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("policy.sessionId is used when invocationState has none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, {
+    action: "tool.invoked",
+    sessionId: "policy-sess",
+  });
+  await handler({
+    toolUse: { name: "lookup", input: {} },
+    invocationState: {},
+    cancel: false,
+  });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("never reads traceId from invocationState", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const handler = createBeforeToolCallHandler(client, { action: "tool.invoked" });
+  await handler({
+    toolUse: { name: "lookup", input: {} },
+    invocationState: { traceId: "trace-minted" },
+    cancel: false,
+  });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("interrupt() is never called on DENY", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let interruptCalls = 0;
+  const handler = createBeforeToolCallHandler(client, { action: "tool.invoked" });
+  const event = hookEvent(
+    {},
+    {
+      interrupt: () => {
+        interruptCalls += 1;
+        throw new Error("HITL");
+      },
+    },
+  );
+  await handler(event);
+  assert.equal(interruptCalls, 0);
+  assert.equal(typeof event.cancel, "string");
+});
+
+test("onDeny reshape is JSON.stringified onto event.cancel", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const handler = createBeforeToolCallHandler(client, {
+    action: "tool.invoked",
+    onDeny: (decision) => ({ blocked: decision.reason }),
+  });
+  const event = hookEvent();
+  await handler(event);
+  assert.deepEqual(JSON.parse(event.cancel as string), { blocked: "PROMPT_INJECTION" });
+});
+
+test("handler never throws even when the guard client throws", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  const handler = createBeforeToolCallHandler(client, { action: "tool.invoked" });
+  const event = hookEvent();
+  await handler(event);
+  assert.equal(denialFromCancel(event).reason, "ERROR");
+});

--- a/arcjet-guard/src/strands-agents/v1/hooks.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.test.ts
@@ -135,6 +135,21 @@ test("afterToolCall captures error outcome", () => {
   assert.equal(metadata["outcome"], "error");
 });
 
+test("afterToolCall outcome cannot be overridden by policy metadata", () => {
+  const { client, captureCalls } = stubClient(decisionAllow());
+  const handler = createAfterToolCallHandler(client, {
+    metadata: { outcome: "custom" },
+  });
+  handler({
+    toolUse: { name: "mcp_search", input: { q: "1" } },
+    invocationState: { sessionId: "sess-hooks" },
+    error: new Error("boom"),
+  });
+
+  const metadata = recorded(captureCalls[0])["metadata"] as Record<string, unknown>;
+  assert.equal(metadata["outcome"], "error");
+});
+
 test("default action is tool.invoked", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const handler = createBeforeToolCallHandler(client, {});

--- a/arcjet-guard/src/strands-agents/v1/hooks.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.ts
@@ -127,9 +127,7 @@ async function loadStrandsHooks(): Promise<StrandsHookSdk> {
     sdk = await import("@strands-agents/sdk");
   } catch (error) {
     const code =
-      error !== null && typeof error === "object" && "code" in error
-        ? (error as { code: unknown }).code
-        : undefined;
+      error !== null && typeof error === "object" && "code" in error ? error.code : undefined;
     if (code === "ERR_MODULE_NOT_FOUND") {
       // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
       throw new Error(

--- a/arcjet-guard/src/strands-agents/v1/hooks.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.ts
@@ -1,0 +1,411 @@
+import type { Plugin } from "@strands-agents/sdk";
+
+import { captureEvent, shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { strandsAgentContext } from "./context.ts";
+import type { StrandsContextSource } from "./context.ts";
+import { runGate } from "./gate.ts";
+
+/**
+ * Input passed to `rules` / `metadata` / `action` callbacks on `guardHooks`.
+ * `input` is the tool's free-text args, not the opaque `toolUseId`.
+ */
+export interface GuardHooksCall {
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Policy for `guardHooks()` — a Plugin whose `initAgent` registers
+ * `BeforeToolCallEvent` (deny unwrapped / MCP-like tools) and
+ * `AfterToolCallEvent` (capture only).
+ *
+ * ## Screen inbound before `invoke()` / `stream()` — there is no inbound hook.
+ *
+ * There is no first-class inbound channel, so there is no `guardInbound`.
+ * Middleware / model hooks are not this gate.
+ *
+ * ## `interrupt()` is not a policy gate.
+ *
+ * `event.interrupt()` is human-in-the-loop. Same trap as Mastra
+ * `requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+ * OpenAI Agents `needsApproval`, and LangChain
+ * `humanInTheLoopMiddleware`. This helper never calls it.
+ *
+ * ## Deny with `BeforeToolCallEvent.cancel`. `BeforeToolsEvent.cancel`
+ * skips per-tool hooks — do not use it.
+ *
+ * Official: set `event.cancel` to a string. `tool.stream()` does not
+ * run; `AfterToolCallEvent` still fires. A non-InterruptError throw
+ * aborts the invocation and drops the envelope, so this helper never
+ * throws.
+ */
+export interface GuardHooksPolicy {
+  /**
+   * Guard label and capture action. Defaults to `"tool.invoked"`. May be a
+   * function of the tool name and input.
+   */
+  action?: string | ((call: GuardHooksCall) => string);
+  /**
+   * Rules to evaluate before an unwrapped tool runs. Omitting this still
+   * performs the guard call.
+   */
+  rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
+  /** Metadata merged over the derived Strands context. */
+  metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
+  /**
+   * Fallback session id when `invocationState` does not carry one.
+   * Prefer putting the id you already chose on
+   * `agent.invoke(..., { invocationState: { sessionId } })`. Never mint
+   * a new id here.
+   */
+  sessionId?: string | ((call: GuardHooksCall) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * Reshape the denial payload JSON-stringified onto `event.cancel` for
+   * a real DENY decision. Unavailable guards take the `onUnavailable`
+   * path instead.
+   */
+  onDeny?: (decision: DecisionDeny) => unknown;
+}
+
+/**
+ * Structural `BeforeToolCallEvent` this helper mutates. Declared here
+ * so tests can drive the handler without constructing the SDK class.
+ */
+export interface StrandsBeforeToolCallEvent {
+  toolUse?: { name?: unknown; input?: unknown; toolUseId?: unknown };
+  tool?: object;
+  invocationState?: unknown;
+  cancel?: boolean | string;
+  interrupt?: (...args: never[]) => unknown;
+}
+
+/**
+ * Structural `AfterToolCallEvent` this helper reads for capture.
+ */
+export interface StrandsAfterToolCallEvent {
+  toolUse?: { name?: unknown; input?: unknown };
+  error?: unknown;
+  invocationState?: unknown;
+}
+
+/**
+ * The Plugin this helper returns. Matches the SDK `Plugin` interface
+ * (`name` + `initAgent`) via `import type` only.
+ */
+export type StrandsGuardPlugin = Plugin;
+
+interface StrandsHookSdk {
+  BeforeToolCallEvent: unknown;
+  AfterToolCallEvent: unknown;
+  HookOrder: { readonly SDK_FIRST: number };
+}
+
+let loadedSdk: StrandsHookSdk | undefined;
+
+/**
+ * `addHook` keys the registry by constructor identity, so the Plugin
+ * must pass the real `BeforeToolCallEvent` / `AfterToolCallEvent`
+ * classes. A static value import would make the namespace unloadable
+ * when the optional peer is absent. Loading only inside `initAgent`
+ * (which an app reaches only after constructing an Agent) keeps
+ * `import { guardTool } from "@arcjet/guard/strands-agents/v1"`
+ * peer-free. Same reason LangChain dynamically loads `ToolMessage`.
+ */
+async function loadStrandsHooks(): Promise<StrandsHookSdk> {
+  if (loadedSdk !== undefined) {
+    return loadedSdk;
+  }
+  const sdk = await import("@strands-agents/sdk");
+  const before = sdk.BeforeToolCallEvent;
+  const after = sdk.AfterToolCallEvent;
+  const hookOrder = sdk.HookOrder;
+  if (typeof before !== "function" || typeof after !== "function") {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error(
+      "@arcjet/guard: guardHooks() could not load BeforeToolCallEvent / AfterToolCallEvent from @strands-agents/sdk; the Plugin cannot register.",
+    );
+  }
+  if (hookOrder === null || typeof hookOrder !== "object" || typeof hookOrder.SDK_FIRST !== "number") {
+    // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+    throw new Error(
+      "@arcjet/guard: guardHooks() could not load HookOrder from @strands-agents/sdk; the Plugin cannot register.",
+    );
+  }
+  loadedSdk = {
+    BeforeToolCallEvent: before,
+    AfterToolCallEvent: after,
+    HookOrder: hookOrder,
+  };
+  return loadedSdk;
+}
+
+function isContextSource(value: unknown): value is StrandsContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function resolveAction(policy: GuardHooksPolicy, call: GuardHooksCall): string {
+  if (typeof policy.action === "function") {
+    return policy.action(call);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "tool.invoked";
+}
+
+function resolveSessionId(policy: GuardHooksPolicy, call: GuardHooksCall): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(call);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+function cancelString(payload: unknown): string {
+  try {
+    return JSON.stringify(payload);
+  } catch (error) {
+    if (shouldWarn()) {
+      console.warn(
+        "@arcjet/guard: guardHooks() could not JSON.stringify a denial payload; using the default denial:",
+        error,
+      );
+    }
+    return JSON.stringify(unavailableResult());
+  }
+}
+
+let pluginSeq = 0;
+
+/**
+ * A registry key, not a secret: PluginRegistry rejects a second plugin
+ * of the same name, so two distinct instances sharing one must not
+ * happen — the second would be refused. The counter alone is not
+ * enough because a second copy of this module starts counting at one
+ * again.
+ */
+function pluginName(): string {
+  pluginSeq += 1;
+  return `arcjet-guard-${pluginSeq}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * The `BeforeToolCallEvent` handler. Exported for src tests so the
+ * deny / allow / brand-skip path can run without loading the peer
+ * (the Plugin's `initAgent` is the only place that value-imports).
+ */
+export function createBeforeToolCallHandler(
+  client: ArcjetAgentClient,
+  policy: GuardHooksPolicy = {},
+): (event: StrandsBeforeToolCallEvent) => Promise<void> {
+  return async (event: StrandsBeforeToolCallEvent): Promise<void> => {
+    try {
+      if (event.tool !== undefined && arcjetProtectedTool in event.tool) {
+        return;
+      }
+
+      const call: GuardHooksCall = {
+        toolName: stringField(event.toolUse?.name),
+        input: event.toolUse?.input ?? {},
+      };
+
+      let action: string;
+      let sessionId: string | undefined;
+      let rules: RuleWithInput[] | undefined;
+      let policyMetadata: ArcjetMetadata | undefined;
+      try {
+        action = resolveAction(policy, call);
+        sessionId = resolveSessionId(policy, call);
+        rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
+        policyMetadata =
+          typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+      } catch (error) {
+        const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
+        if (shouldWarn()) {
+          console.warn(
+            '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+            actionLabel,
+            error,
+          );
+        }
+        if (policy.onGuardError === "allow") {
+          return;
+        }
+        event.cancel = cancelString(unavailableResult());
+        return;
+      }
+
+      const source = isContextSource(event) ? event : undefined;
+      const agentCtx = strandsAgentContext(
+        source,
+        sessionId === undefined ? undefined : { sessionId },
+      );
+
+      const metadata: ArcjetMetadata = {
+        ...agentCtx.metadata,
+        "strands.phase": "before",
+        ...(call.toolName.length > 0 && { "strands.tool": call.toolName }),
+      };
+      const mergedMetadata = { ...metadata, ...policyMetadata };
+
+      await runGate<void>(client, {
+        action,
+        rules,
+        correlationId: agentCtx.correlationId,
+        metadata: mergedMetadata,
+        onAllow: () => {
+          /* allow the tool to proceed — do not set event.cancel */
+        },
+        onDeny: (decision: DecisionDeny) => {
+          if (policy.onDeny === undefined) {
+            event.cancel = cancelString(denialResult(decision));
+            return;
+          }
+          try {
+            event.cancel = cancelString(policy.onDeny(decision));
+          } catch (error) {
+            if (shouldWarn()) {
+              console.warn(
+                '@arcjet/guard: onDeny for "%s" threw; returning the default denial:',
+                action,
+                error,
+              );
+            }
+            event.cancel = cancelString(denialResult(decision));
+          }
+        },
+        onUnavailable: () => {
+          event.cancel = cancelString(unavailableResult());
+        },
+        onGuardError: policy.onGuardError ?? "deny",
+      });
+    } catch (error) {
+      // A non-InterruptError throw from a hook aborts the invocation
+      // and drops the envelope. Fail closed by setting cancel instead.
+      if (shouldWarn()) {
+        console.warn("@arcjet/guard: guardHooks BeforeToolCallEvent threw; denying the tool:", error);
+      }
+      if (policy.onGuardError === "allow") {
+        return;
+      }
+      event.cancel = cancelString(unavailableResult());
+    }
+  };
+}
+
+/**
+ * The `AfterToolCallEvent` handler. Capture only; never sets cancel
+ * and never throws.
+ */
+export function createAfterToolCallHandler(
+  client: ArcjetAgentClient,
+  policy: GuardHooksPolicy = {},
+): (event: StrandsAfterToolCallEvent) => void {
+  return (event: StrandsAfterToolCallEvent): void => {
+    try {
+      const call: GuardHooksCall = {
+        toolName: stringField(event.toolUse?.name),
+        input: event.toolUse?.input ?? {},
+      };
+      const action = resolveAction(policy, call);
+      const source = isContextSource(event) ? event : undefined;
+      const agentCtx = strandsAgentContext(source);
+
+      const policyMetadata =
+        typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+      const metadata: ArcjetMetadata = {
+        ...agentCtx.metadata,
+        "strands.phase": "after",
+        outcome: event.error === undefined ? "success" : "error",
+        ...(call.toolName.length > 0 && { "strands.tool": call.toolName }),
+        ...policyMetadata,
+      };
+
+      const correlation =
+        agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
+
+      captureEvent(client, {
+        action,
+        ...correlation,
+        metadata,
+      });
+    } catch {
+      // Never throw from a hook
+    }
+  };
+}
+
+/**
+ * A Plugin registered on `new Agent({ plugins })`.
+ *
+ * `initAgent` calls `agent.addHook(BeforeToolCallEvent, …, { order:
+ * HookOrder.SDK_FIRST - 1 })` so this gate runs before the SDK's own
+ * earliest hooks. On DENY it sets `event.cancel` to
+ * `JSON.stringify(ArcjetDenialResult)`. `tool.stream()` does not run;
+ * `AfterToolCallEvent` still fires.
+ *
+ * Already-branded (`guardTool`) tools are skipped so Guard is not
+ * double-called. Tools that are not branded — MCP, vended tools,
+ * anything not wrapped — are still gated.
+ *
+ * Do **not** use `BeforeToolsEvent.cancel` (that skips per-tool hooks).
+ * Do **not** call `event.interrupt()` (that is HITL).
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardHooks } from "@arcjet/guard/strands-agents/v1";
+ * import { Agent } from "@strands-agents/sdk";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const mcpLimit = tokenBucket({
+ *   refillRate: 20,
+ *   intervalSeconds: 60,
+ *   maxTokens: 20,
+ * });
+ *
+ * const agent = new Agent({
+ *   tools: [lookupOrder],
+ *   plugins: [
+ *     guardHooks(arcjet, {
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+ *       sessionId: conversationId,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function guardHooks(
+  client: ArcjetAgentClient,
+  policy: GuardHooksPolicy = {},
+): StrandsGuardPlugin {
+  const onBefore = createBeforeToolCallHandler(client, policy);
+  const onAfter = createAfterToolCallHandler(client, policy);
+
+  return {
+    name: pluginName(),
+    initAgent: async (agent): Promise<void> => {
+      const sdk = await loadStrandsHooks();
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- addHook is generic over the event constructor; we pass the real class from the peer
+      agent.addHook(sdk.BeforeToolCallEvent as never, onBefore as never, {
+        order: sdk.HookOrder.SDK_FIRST - 1,
+      });
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- AfterToolCallEvent is capture only; same constructor-identity constraint
+      agent.addHook(sdk.AfterToolCallEvent as never, onAfter as never);
+    },
+  };
+}

--- a/arcjet-guard/src/strands-agents/v1/hooks.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.ts
@@ -122,7 +122,23 @@ async function loadStrandsHooks(): Promise<StrandsHookSdk> {
   if (loadedSdk !== undefined) {
     return loadedSdk;
   }
-  const sdk = await import("@strands-agents/sdk");
+  let sdk;
+  try {
+    sdk = await import("@strands-agents/sdk");
+  } catch (error) {
+    const code =
+      error !== null && typeof error === "object" && "code" in error
+        ? (error as { code: unknown }).code
+        : undefined;
+    if (code === "ERR_MODULE_NOT_FOUND") {
+      // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
+      throw new Error(
+        "@arcjet/guard: install @strands-agents/sdk (>=1.1.0 <2) to use guardHooks() from @arcjet/guard/strands-agents/v1",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
   const before = sdk.BeforeToolCallEvent;
   const after = sdk.AfterToolCallEvent;
   const hookOrder = sdk.HookOrder;
@@ -192,10 +208,9 @@ let pluginSeq = 0;
 
 /**
  * A registry key, not a secret: PluginRegistry rejects a second plugin
- * of the same name, so two distinct instances sharing one must not
- * happen — the second would be refused. The counter alone is not
- * enough because a second copy of this module starts counting at one
- * again.
+ * of the same name. The per-process counter helps debugging; cross-copy
+ * uniqueness comes from the random UUID suffix (a second bundle of this
+ * module resets the counter to 1).
  */
 function pluginName(): string {
   pluginSeq += 1;
@@ -328,10 +343,10 @@ export function createAfterToolCallHandler(
         typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
       const metadata: ArcjetMetadata = {
         ...agentCtx.metadata,
-        "strands.phase": "after",
-        outcome: event.error === undefined ? "success" : "error",
-        ...(call.toolName.length > 0 && { "strands.tool": call.toolName }),
         ...policyMetadata,
+        "strands.phase": "after",
+        ...(call.toolName.length > 0 && { "strands.tool": call.toolName }),
+        outcome: event.error === undefined ? "success" : "error",
       };
 
       const correlation =

--- a/arcjet-guard/src/strands-agents/v1/index.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/index.test.ts
@@ -10,19 +10,19 @@ import {
 } from "../../../test/_shared/source-scan.ts";
 import * as agentsBarrel from "../../agents/index.ts";
 import * as v7Namespace from "../../vercel-ai/v7/index.ts";
-import * as claudeNamespace from "./index.ts";
+import * as strandsNamespace from "./index.ts";
 import type {
   ArcjetDenialResult,
-  ClaudeAgentContext,
   GuardHooksPolicy,
   GuardToolPolicy,
+  StrandsAgentContext,
 } from "./index.ts";
 
 function verifyTypeExports(): void {
   const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
   const hooksPolicy: GuardHooksPolicy | undefined = undefined;
   const denialResult: ArcjetDenialResult | undefined = undefined;
-  const agentContext: ClaudeAgentContext | undefined = undefined;
+  const agentContext: StrandsAgentContext | undefined = undefined;
   void [toolPolicy, hooksPolicy, denialResult, agentContext];
 }
 
@@ -46,19 +46,19 @@ function objectField(
 }
 
 test("exports the three own helpers as functions", () => {
-  const ownExports = ["claudeAgentContext", "guardTool", "guardHooks"] as const;
+  const ownExports = ["strandsAgentContext", "guardTool", "guardHooks"] as const;
 
   for (const funcName of ownExports) {
-    const func = (claudeNamespace as Record<string, unknown>)[funcName];
+    const func = (strandsNamespace as Record<string, unknown>)[funcName];
     assert.equal(
       typeof func,
       "function",
-      `@arcjet/guard/claude-agent-sdk/v0 must export ${funcName} as a function`,
+      `@arcjet/guard/strands-agents/v1 must export ${funcName} as a function`,
     );
   }
 });
 
-test("claude namespace exports the agnostic helpers", () => {
+test("strands-agents namespace exports the agnostic helpers", () => {
   const requiredSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -68,12 +68,12 @@ test("claude namespace exports the agnostic helpers", () => {
   ] as const;
 
   for (const symbol of requiredSymbols) {
-    const value = (claudeNamespace as Record<string, unknown>)[symbol];
-    assert.ok(value !== undefined, `@arcjet/guard/claude-agent-sdk/v0 must export ${symbol}`);
+    const value = (strandsNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/strands-agents/v1 must export ${symbol}`);
   }
 });
 
-test("agnostic exports have same identity across Claude and v7 namespaces", () => {
+test("agnostic exports have same identity across Strands and v7 namespaces", () => {
   const agnosticSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -84,28 +84,28 @@ test("agnostic exports have same identity across Claude and v7 namespaces", () =
   ] as const;
 
   for (const symbol of agnosticSymbols) {
-    const claudeValue = (claudeNamespace as Record<string, unknown>)[symbol];
+    const strandsValue = (strandsNamespace as Record<string, unknown>)[symbol];
     const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
 
     assert.strictEqual(
-      claudeValue,
+      strandsValue,
       v7Value,
-      `${symbol} must be the same object identity from both @arcjet/guard/claude-agent-sdk/v0 and @arcjet/guard/vercel-ai/v7`,
+      `${symbol} must be the same object identity from both @arcjet/guard/strands-agents/v1 and @arcjet/guard/vercel-ai/v7`,
     );
   }
 });
 
-test("Claude namespace is a strict superset of the agents barrel with same identity", () => {
-  const claudeKeys = Object.keys(claudeNamespace);
+test("Strands namespace is a strict superset of the agents barrel with same identity", () => {
+  const strandsKeys = Object.keys(strandsNamespace);
   const agentKeys = Object.keys(agentsBarrel);
 
   for (const key of agentKeys) {
     assert.ok(
-      claudeKeys.includes(key),
-      `agents barrel key "${key}" must be present in claude namespace`,
+      strandsKeys.includes(key),
+      `agents barrel key "${key}" must be present in strands-agents namespace`,
     );
     assert.strictEqual(
-      (claudeNamespace as Record<string, unknown>)[key],
+      (strandsNamespace as Record<string, unknown>)[key],
       (agentsBarrel as Record<string, unknown>)[key],
       `${key} must be the same object identity from both imports`,
     );
@@ -113,65 +113,68 @@ test("Claude namespace is a strict superset of the agents barrel with same ident
 
   const expectedAdditions = 3;
   assert.equal(
-    claudeKeys.length,
+    strandsKeys.length,
     agentKeys.length + expectedAdditions,
-    `claude namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+    `strands-agents namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
   );
 
-  const claudeOnlyKeys = claudeKeys.filter((key) => !agentKeys.includes(key));
-  const ownExportsArray = ["claudeAgentContext", "guardHooks", "guardTool"];
+  const strandsOnlyKeys = strandsKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["guardTool", "guardHooks", "strandsAgentContext"];
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
   const expectedOwnExports: readonly string[] = ownExportsArray.sort();
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-  const sorted: readonly string[] = claudeOnlyKeys.sort();
+  const sorted: readonly string[] = strandsOnlyKeys.sort();
   assert.deepEqual(sorted, expectedOwnExports);
 });
 
-test("export map has no unversioned ./claude-agent-sdk and no wildcard subpaths", () => {
+test("export map has no unversioned ./strands-agents and no wildcard subpaths", () => {
   const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
   const exportsMap = objectField(packageJson, "exports");
   assert.ok(exportsMap, "package.json must have an exports field");
 
   const exportKeys = Object.keys(exportsMap);
 
+  assert.ok(!exportKeys.includes("./strands-agents"), 'export map must not have "./strands-agents"');
   assert.ok(
-    !exportKeys.includes("./claude-agent-sdk"),
-    'export map must not have "./claude-agent-sdk"',
-  );
-  assert.ok(
-    exportKeys.includes("./claude-agent-sdk/v0"),
-    'export map must have "./claude-agent-sdk/v0"',
+    exportKeys.includes("./strands-agents/v1"),
+    'export map must have "./strands-agents/v1"',
   );
 
   for (const key of exportKeys) {
-    if (key.startsWith("./claude-agent-sdk/")) {
+    if (key.startsWith("./strands-agents/")) {
       assert.equal(
         key,
-        "./claude-agent-sdk/v0",
-        `export map must not have wildcard claude-agent-sdk subpaths; found "${key}"`,
+        "./strands-agents/v1",
+        `export map must not have wildcard strands-agents subpaths; found "${key}"`,
       );
     }
   }
 });
 
-test("does not export Eve-only or Mastra-only APIs onto the Claude namespace", () => {
+test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only APIs", () => {
   const forbidden = [
     "eveAgentContext",
+    "mastraAgentContext",
+    "claudeAgentContext",
+    "langgraphAgentContext",
+    "langchainContext",
+    "openaiAgentsContext",
+    "genkitContext",
     "guardInbound",
     "guardApproval",
+    "guardInterrupt",
+    "guardToolNode",
+    "guardMiddleware",
+    "guardProcessor",
     "arcjetHooks",
     "guardConnection",
-    "mastraAgentContext",
-    "strandsAgentContext",
-    "guardProcessor",
-    "canUseTool",
     "guardCanUseTool",
   ];
   for (const key of forbidden) {
     assert.equal(
-      (claudeNamespace as Record<string, unknown>)[key],
+      (strandsNamespace as Record<string, unknown>)[key],
       undefined,
-      `claude namespace must not export "${key}"`,
+      `strands-agents namespace must not export "${key}"`,
     );
   }
 });

--- a/arcjet-guard/src/strands-agents/v1/index.ts
+++ b/arcjet-guard/src/strands-agents/v1/index.ts
@@ -1,0 +1,128 @@
+/**
+ * @packageDocumentation
+ *
+ * Strands Agents namespace for Arcjet Guards.
+ *
+ * This module provides Strands Agents helpers plus the
+ * framework-agnostic layer they build on, so a Strands agent needs one
+ * import path and no notion of layering.
+ *
+ * **Requires the optional peer dependency `@strands-agents/sdk`
+ * (`>=1.1.0 <2`)**. Nothing in this module imports that package at
+ * module load: every Strands type arrives through `import type`, and
+ * the Plugin's `initAgent` loads `BeforeToolCallEvent` / `HookOrder`
+ * dynamically so installing `@arcjet/guard` never pulls the SDK in.
+ * Zod is their peer, not ours. The floor is 1.1.0 because `HookOrder`
+ * + `interrupt()` shipped then; `cancel` itself is 1.0.0.
+ *
+ * **Note:** the version segment is `v1` because it names Strands
+ * Agents' major. There is deliberately no unversioned
+ * `@arcjet/guard/strands-agents` alias.
+ *
+ * v1 is JS `@strands-agents/sdk` `Agent` + `tool({ callback })` +
+ * Plugin / `addHook`. Not the Python SDK.
+ *
+ * Three surfaces, and the things this namespace does not build:
+ *
+ * - **An authored tool** (`tool({ callback })`) → `guardTool()`. After
+ *   `tool()` the object is a `FunctionTool` / `ZodTool` whose runner
+ *   path is `_callback` (`stream()` / `invoke()`). DENY returns a
+ *   plain `ArcjetDenialResult`. It does not throw. It does not
+ *   fabricate an SDK message type.
+ * - **MCP / unwrapped / vended tools** → `guardHooks()`. A Plugin
+ *   whose `initAgent` registers `BeforeToolCallEvent` at
+ *   `HookOrder.SDK_FIRST - 1`. On DENY it sets `event.cancel` to
+ *   `JSON.stringify(ArcjetDenialResult)`. Already-branded tools are
+ *   skipped. Do **not** use `BeforeToolsEvent.cancel` (that skips
+ *   per-tool hooks).
+ * - **Correlation** → `strandsAgentContext()` reads a field the
+ *   integrator put on `invocationState` (`correlationId`, then
+ *   `sessionId`, then `requestId`). It never mints a new id. It never
+ *   reads `traceId`. It never uses `SessionManager` or `agent.id`.
+ *
+ * ## Screen inbound before `invoke()` / `stream()` — there is no inbound hook.
+ *
+ * There is no first-class inbound channel, so there is no `guardInbound`.
+ * Put prompt-injection (and other inbound rules) in the application
+ * before `agent.invoke()` / `stream()`. Middleware / model hooks are
+ * not this policy gate.
+ *
+ * ## `interrupt()` is not a policy gate.
+ *
+ * `event.interrupt()` is human-in-the-loop. Same trap as Mastra
+ * `requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+ * OpenAI Agents `needsApproval`, and LangChain
+ * `humanInTheLoopMiddleware`. There is no `guardApproval` /
+ * `guardInterrupt`.
+ *
+ * ## Deny with `BeforeToolCallEvent.cancel` (and `guardTool` on authored callbacks). `BeforeToolsEvent.cancel` skips per-tool hooks — do not use it.
+ *
+ * The authored `callback` is the deny point for tools you own. MCP,
+ * vended tools, and anything not wrapped with `guardTool` skip that
+ * callback. `guardHooks` is the invoke-wide gate for those. Official:
+ * set `event.cancel` to a string; `tool.stream()` does not run;
+ * `AfterToolCallEvent` still fires.
+ *
+ * Do not also wrap the same tool with `@arcjet/guard/vercel-ai/v7` or
+ * `@arcjet/guard/langgraph/v1`.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardTool, guardHooks, strandsAgentContext } from "@arcjet/guard/strands-agents/v1";
+ * import { Agent, tool } from "@strands-agents/sdk";
+ * import { z } from "zod";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const lookupOrder = guardTool(
+ *   client,
+ *   tool({
+ *     name: "lookup_order",
+ *     description: "Look up an order",
+ *     inputSchema: z.object({ orderNumber: z.string() }),
+ *     callback: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
+ *   }),
+ *   {
+ *     action: "order.looked-up",
+ *     rules: (input) => [lookupLimit({ key: input.orderNumber, requested: 1 })],
+ *   },
+ * );
+ *
+ * const invocationState = { sessionId: conversationId };
+ * const inbound = detectPromptInjection();
+ * const decision = await client.guard({
+ *   label: "message.received",
+ *   rules: [inbound(userText)],
+ *   ...strandsAgentContext({ invocationState }),
+ * });
+ * if (decision.conclusion === "DENY") {
+ *   throw new Error("message blocked");
+ * }
+ *
+ * const agent = new Agent({
+ *   tools: [lookupOrder],
+ *   plugins: [guardHooks(client, { sessionId: conversationId })],
+ * });
+ * await agent.invoke(userText, { invocationState });
+ * ```
+ */
+
+export { strandsAgentContext } from "./context.ts";
+export type { StrandsAgentContext, StrandsContextSource } from "./context.ts";
+export { guardTool } from "./guard-tool.ts";
+export type { GuardToolPolicy, StrandsTool, StrandsToolInput } from "./guard-tool.ts";
+export { guardHooks } from "./hooks.ts";
+export type {
+  GuardHooksCall,
+  GuardHooksPolicy,
+  StrandsAfterToolCallEvent,
+  StrandsBeforeToolCallEvent,
+  StrandsGuardPlugin,
+} from "./hooks.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/strands-agents/v1/peer.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/peer.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("@strands-agents/sdk is an optional peer and not a dependency", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+
+  const peerDependencies = objectField(packageJson, "peerDependencies");
+  assert.ok(peerDependencies);
+  assert.equal(peerDependencies["@strands-agents/sdk"], ">=1.1.0 <2");
+
+  const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
+  assert.ok(peerDependenciesMeta);
+  const strandsMeta = objectField(peerDependenciesMeta, "@strands-agents/sdk");
+  assert.ok(strandsMeta);
+  assert.equal(strandsMeta["optional"], true);
+
+  const dependencies = objectField(packageJson, "dependencies");
+  assert.ok(!(dependencies && "@strands-agents/sdk" in dependencies));
+
+  // Zod is Strands' peer, not ours: nothing in this namespace types against
+  // it, and adding it would force it on every `@arcjet/guard` user.
+  assert.ok(!("zod" in peerDependencies));
+  assert.ok(!(dependencies && "zod" in dependencies));
+});

--- a/arcjet-guard/src/strands-agents/v1/type-only.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/type-only.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+const PEER = "@strands-agents/sdk";
+
+function isStrandsPeer(specifier: string): boolean {
+  return specifier === PEER || specifier.startsWith(`${PEER}/`);
+}
+
+/**
+ * `addHook` keys the registry by constructor identity, so hooks.ts
+ * dynamically loads `BeforeToolCallEvent` / `HookOrder` inside
+ * `initAgent` only. Every other peer import in this namespace must
+ * stay type-only.
+ */
+const ALLOWED_DYNAMIC_INIT_IMPORT = PEER;
+
+test("type-only import scanner works on @strands-agents/sdk fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of @strands-agents/sdk",
+      content: `import { Agent, tool } from "${PEER}";\nvoid Agent;\nvoid tool;`,
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of @strands-agents/sdk",
+      content: `import type { Plugin } from "${PEER}";\nvoid 0;`,
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content: `import { type Plugin, Agent } from "${PEER}";\nvoid Agent;`,
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of @strands-agents/sdk",
+      content: `export type { Plugin } from "${PEER}";`,
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { Agent } from "@strands-agents/tools";\nvoid Agent;',
+      shouldHaveImport: false,
+    },
+    {
+      name: "detects dynamic import of @strands-agents/sdk",
+      content: `const sdk = await import("${PEER}");\nvoid sdk;`,
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const peerImports = imports.filter((imp) => isStrandsPeer(imp.specifier));
+
+    if (fixture.shouldHaveImport === false) {
+      assert.equal(peerImports.length, 0, `${fixture.name}: should not have strands imports`);
+    } else {
+      assert.equal(peerImports.length, 1, `${fixture.name}: should have exactly one strands import`);
+      assert.equal(
+        peerImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all @strands-agents/sdk imports in the namespace are type-only except the initAgent load", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+  let allowedDynamic = 0;
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (!isStrandsPeer(imp.specifier) || imp.typeOnly) {
+        continue;
+      }
+      if (imp.specifier === ALLOWED_DYNAMIC_INIT_IMPORT && basename(filePath) === "hooks.ts") {
+        allowedDynamic += 1;
+        continue;
+      }
+      errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in strands-agents namespace:\n${errors.join("\n")}`,
+  );
+  assert.equal(
+    allowedDynamic,
+    1,
+    "expected exactly one dynamic @strands-agents/sdk load in hooks.ts",
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-strands-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, `import { Agent } from "${PEER}";\nvoid Agent;`);
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const peerImports = imports.filter((imp) => isStrandsPeer(imp.specifier));
+    assert.equal(peerImports.length, 1);
+    assert.equal(peerImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/src/vendor-isolation.test.ts
+++ b/arcjet-guard/src/vendor-isolation.test.ts
@@ -30,6 +30,7 @@ const NAMESPACES = [
   { dir: "langgraph", packages: ["@langchain/langgraph", "@langchain/core"] },
   { dir: "openai-agents", packages: ["@openai/agents"] },
   { dir: "genkit", packages: ["genkit", "@genkit-ai"] },
+  { dir: "strands-agents", packages: ["@strands-agents/sdk"] },
 ] as const;
 
 /**
@@ -109,6 +110,8 @@ test("the scanner detects a cross-vendor import when one is introduced", () => {
     { from: "openai-agents", content: 'export type { X } from "@mastra/core/tools";' },
     { from: "vercel-ai", content: 'const m = await import("@openai/agents");\nvoid m;' },
     { from: "genkit", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
+    { from: "strands-agents", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
+    { from: "genkit", content: 'import type { Plugin } from "@strands-agents/sdk";\nvoid 0;' },
     {
       from: "mastra",
       content: 'import { denialResult } from "../../langgraph/v1/denial.ts";\nvoid denialResult;',

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -299,6 +299,7 @@ export const EXPECTED_ROOT_KEYS = [
   "./node",
   "./openai-agents/v0",
   "./package.json",
+  "./strands-agents/v1",
   // The in-memory client for application tests. Deliberately a single entry
   // rather than a runtime-conditional one: it has no transport, so there is
   // nothing for a condition to select.

--- a/arcjet-guard/test/strands-agents/real-hooks.test.ts
+++ b/arcjet-guard/test/strands-agents/real-hooks.test.ts
@@ -1,0 +1,122 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/no-unsafe-type-assertion -- test fixtures built from the real SDK types
+/**
+ * Behaviour against the real `@strands-agents/sdk` Plugin / addHook
+ * surface, rather than hand-written fakes.
+ *
+ * `addHook` keys the registry by constructor identity. A fake that
+ * stored the callback under a string name would report success while
+ * the real Agent never fired it. This file proves `initAgent` passes
+ * the real `BeforeToolCallEvent` class and `HookOrder.SDK_FIRST - 1`.
+ *
+ * This file value-imports the optional peer, so it lives outside
+ * `src/strands-agents/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  AfterToolCallEvent,
+  BeforeToolCallEvent,
+  HookOrder,
+} from "@strands-agents/sdk";
+
+import { guardHooks } from "../../src/strands-agents/v1/hooks.ts";
+import { guardTool } from "../../src/strands-agents/v1/guard-tool.ts";
+import { asDenial } from "../_shared/source-scan.ts";
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+import { tool } from "@strands-agents/sdk";
+import { z } from "zod";
+
+test("initAgent registers BeforeToolCallEvent at HookOrder.SDK_FIRST - 1", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const plugin = guardHooks(client, { action: "tool.invoked" });
+
+  const registered: Array<{ eventType: unknown; options?: { order?: number } }> = [];
+  await plugin.initAgent({
+    addHook(eventType: unknown, _callback: unknown, options?: { order?: number }) {
+      registered.push(options === undefined ? { eventType } : { eventType, options });
+      return () => {
+        /* cleanup */
+      };
+    },
+  } as never);
+
+  const before = registered.find((entry) => entry.eventType === BeforeToolCallEvent);
+  assert.ok(before, "initAgent must register BeforeToolCallEvent by constructor identity");
+  assert.equal(before.options?.order, HookOrder.SDK_FIRST - 1);
+
+  const after = registered.find((entry) => entry.eventType === AfterToolCallEvent);
+  assert.ok(after, "initAgent must register AfterToolCallEvent by constructor identity");
+});
+
+test("initAgent's BeforeToolCallEvent handler sets cancel to a JSON denial string", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const plugin = guardHooks(client, { action: "tool.invoked" });
+
+  let beforeCb: ((event: InstanceType<typeof BeforeToolCallEvent>) => Promise<void>) | undefined;
+  await plugin.initAgent({
+    addHook(eventType: unknown, callback: unknown) {
+      if (eventType === BeforeToolCallEvent) {
+        beforeCb = callback as (event: InstanceType<typeof BeforeToolCallEvent>) => Promise<void>;
+      }
+      return () => {
+        /* cleanup */
+      };
+    },
+  } as never);
+
+  assert.ok(beforeCb);
+  const event = new BeforeToolCallEvent({
+    agent: {} as never,
+    toolUse: { name: "mcp_search", toolUseId: "tu-1", input: { q: "1" } },
+    tool: undefined,
+    invocationState: { sessionId: "sess-real" },
+  });
+  await beforeCb(event);
+
+  assert.equal(typeof event.cancel, "string");
+  const denial = asDenial<ArcjetDenialResult>(JSON.parse(event.cancel as string));
+  assert.equal(denial.arcjetDenied, true);
+  assert.equal(denial.reason, "PROMPT_INJECTION");
+});
+
+test("initAgent's handler skips a tool() already wrapped with guardTool", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const branded = guardTool(
+    client,
+    tool({
+      name: "lookup_order",
+      description: "already guarded",
+      inputSchema: z.object({ note: z.string() }),
+      callback: () => "ran",
+    }),
+    { action: "order.looked-up" },
+  );
+
+  const plugin = guardHooks(client, { action: "tool.invoked" });
+  let beforeCb: ((event: InstanceType<typeof BeforeToolCallEvent>) => Promise<void>) | undefined;
+  await plugin.initAgent({
+    addHook(eventType: unknown, callback: unknown) {
+      if (eventType === BeforeToolCallEvent) {
+        beforeCb = callback as (event: InstanceType<typeof BeforeToolCallEvent>) => Promise<void>;
+      }
+      return () => {
+        /* cleanup */
+      };
+    },
+  } as never);
+
+  assert.ok(beforeCb);
+  const callsBefore = guardCalls.length;
+  const event = new BeforeToolCallEvent({
+    agent: {} as never,
+    toolUse: { name: "lookup_order", toolUseId: "tu-1", input: { note: "x" } },
+    tool: branded as never,
+    invocationState: { sessionId: "sess-real" },
+  });
+  await beforeCb(event);
+
+  assert.equal(event.cancel, false);
+  assert.equal(guardCalls.length, callsBefore);
+});

--- a/arcjet-guard/test/strands-agents/real-tool.test.ts
+++ b/arcjet-guard/test/strands-agents/real-tool.test.ts
@@ -1,0 +1,153 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-assignment, typescript/no-unnecessary-type-assertion, typescript/no-unsafe-type-assertion, typescript/unbound-method, typescript/require-await, eslint/require-await -- test fixtures built from the real SDK types
+/**
+ * Behaviour against the real `@strands-agents/sdk` `tool()`, rather
+ * than hand-written fakes.
+ *
+ * Every assertion here corresponds to a bypass the fakes in
+ * `src/strands-agents/v1/*.test.ts` could not see:
+ *
+ * - `tool({ callback })` with a Zod schema returns `ZodTool`. `stream()`
+ *   (what the executor calls) delegates to `_functionTool._callback`,
+ *   which closes over the authored callback at construction. Wrapping
+ *   only `_callback` would report success in a fake that invoked
+ *   `_callback` directly, while the real class ran the unguarded body.
+ * - `tool({ callback })` with a JSON schema returns `FunctionTool`.
+ *   `stream()` and `invoke()` both call `_callback`.
+ *
+ * This file value-imports the optional peer, so it lives outside
+ * `src/strands-agents/` — that directory is globbed by the
+ * strands-agents-absent CI job and scanned for type-only imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { tool } from "@strands-agents/sdk";
+import { z } from "zod";
+
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { guardTool } from "../../src/strands-agents/v1/guard-tool.ts";
+import { asDenial, recorded } from "../_shared/source-scan.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+function toolContext(sessionId: string, input: unknown) {
+  return {
+    toolUse: { name: "lookup_order", toolUseId: "tu-1", input },
+    invocationState: { sessionId },
+    agent: {},
+    cancelSignal: new AbortController().signal,
+    interrupt: () => {
+      throw new Error("interrupt() must not be called");
+    },
+  };
+}
+
+async function streamResult(toolObj: {
+  stream: (context: never) => AsyncGenerator<unknown, unknown, unknown>;
+}, context: unknown): Promise<unknown> {
+  const generator = toolObj.stream(context as never);
+  let next = await generator.next();
+  while (next.done !== true) {
+    next = await generator.next();
+  }
+  return next.value;
+}
+
+test("real Zod tool() stream() is gated so the authored callback never runs on DENY", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    inputSchema: z.object({ note: z.string() }),
+    callback: (input) => {
+      calls += 1;
+      return `ran:${input.note}`;
+    },
+  });
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const result = await streamResult(wrapped, toolContext("sess-1", { note: "hello" }));
+
+  assert.equal(calls, 0);
+  // FunctionTool wraps a callback object in a ToolResultBlock / JsonBlock.
+  // The denial itself is the callback return; stream() envelopes it.
+  // Either the raw denial (if a test path unwraps) or a result whose
+  // JSON content carries it is acceptable — the authored body must not run.
+  void result;
+  assert.equal(calls, 0);
+});
+
+test("real Zod tool() invoke() returns the plain denial payload (no throw)", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    inputSchema: z.object({ note: z.string() }),
+    callback: (input) => {
+      calls += 1;
+      return `ran:${input.note}`;
+    },
+  });
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const result = asDenial<ArcjetDenialResult>(
+    await wrapped.invoke({ note: "hello" }, toolContext("sess-1", { note: "hello" }) as never),
+  );
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+  assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+test("real Zod tool() ALLOW still reaches the callback through stream() and invoke()", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "real dependency test tool",
+    inputSchema: z.object({ note: z.string() }),
+    callback: (input) => {
+      calls += 1;
+      return { note: input.note, status: "shipped" };
+    },
+  });
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const invoked = await wrapped.invoke(
+    { note: "n1" },
+    toolContext("sess-real", { note: "n1" }) as never,
+  );
+  assert.deepEqual(invoked, { note: "n1", status: "shipped" });
+  assert.equal(calls, 1);
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-real");
+
+  await streamResult(wrapped, toolContext("sess-real", { note: "n2" }));
+  assert.equal(calls, 2);
+});
+
+test("real FunctionTool (JSON schema) callback is gated on DENY", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  let calls = 0;
+  const authored = tool({
+    name: "lookup_order",
+    description: "json-schema tool",
+    inputSchema: {
+      type: "object",
+      properties: { note: { type: "string" } },
+      required: ["note"],
+    },
+    callback: (input) => {
+      calls += 1;
+      return `ran:${(input as { note: string }).note}`;
+    },
+  });
+
+  const wrapped = guardTool(client, authored, { action: "order.looked-up" });
+  const result = asDenial<ArcjetDenialResult>(
+    await wrapped.invoke({ note: "hello" }, toolContext("sess-1", { note: "hello" }) as never),
+  );
+
+  assert.equal(calls, 0);
+  assert.equal(result.arcjetDenied, true);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,7 @@
         "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.59.0",
         "@openai/agents": "0.17.0",
+        "@strands-agents/sdk": "1.14.0",
         "@types/node": "22.20.1",
         "ai": "7.0.58",
         "eve": "0.39.0",
@@ -210,6 +211,7 @@
         "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
         "@openai/agents": ">=0.17.0 <1",
+        "@strands-agents/sdk": ">=1.1.0 <2",
         "ai": ">=7 <8",
         "eve": ">=0.34.0 <1",
         "genkit": ">=1.0.0 <2",
@@ -234,6 +236,9 @@
         "@openai/agents": {
           "optional": true
         },
+        "@strands-agents/sdk": {
+          "optional": true
+        },
         "ai": {
           "optional": true
         },
@@ -244,6 +249,106 @@
           "optional": true
         },
         "langchain": {
+          "optional": true
+        }
+      }
+    },
+    "arcjet-guard/node_modules/@strands-agents/sdk": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-1.14.0.tgz",
+      "integrity": "sha512-tBRRklCs6KRQ1dd1JgOe6L402YwDVkZuIM1JdDWXrfpzqA+V2EO2IE0nVjPSZfPwmnPZ7+gTll94pDRyPqa+uQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1107.0",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@types/json-schema": "^7.0.15",
+        "uuid": "^14.0.1",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@ai-sdk/provider": "^3.0.0",
+        "@anthropic-ai/sdk": "^0.109.1",
+        "@aws-sdk/client-bedrock-agent": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-s3": "^3.1078.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.0.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
+        "@google/genai": "^2.6.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-metrics": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.15.1",
+        "express": "^5.1.0",
+        "openai": "^6.45.0",
+        "zod": "^4.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@a2a-js/sdk": {
+          "optional": true
+        },
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@aws/bedrock-token-generator": {
+          "optional": true
+        },
+        "@cedar-policy/cedar-wasm": {
+          "optional": true
+        },
+        "@cedar-policy/mcp-schema-generator-wasm": {
+          "optional": true
+        },
+        "@google/genai": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-metrics-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-metrics": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "@smithy/types": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "openai": {
           "optional": true
         }
       }
@@ -1281,9 +1386,9 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.117.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
-      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+      "version": "0.109.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.1.tgz",
+      "integrity": "sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1706,6 +1811,367 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1117.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1117.0.tgz",
+      "integrity": "sha512-rUc58ZS5GgsvzfM265XsrNno35dsRIwQb0aDfJIZbJyn1VGP+6XVL5Pwm8Rg9uABQSdKpdTayu5R3ZuDlFfIHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/eventstream-handler-node": "^3.972.34",
+        "@aws-sdk/middleware-eventstream": "^3.972.29",
+        "@aws-sdk/middleware-websocket": "^3.972.52",
+        "@aws-sdk/token-providers": "3.1117.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1117.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1117.0.tgz",
+      "integrity": "sha512-I7QIf9aR0+J4Q1qlLQw006d8hs3Pb/J6mOVSCQ/fnQ4AXHTQ6Y/M45O2dWDRKoYqsQJ2kN8sg6b5709/qCzp9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -8763,6 +9229,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -10600,6 +11153,13 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {

--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,13 @@
       "allowedVersions": "<2"
     },
     {
+      "description": "Never automerge @strands-agents/sdk majors. `@arcjet/guard/strands-agents/v1` types against tool({ callback }), FunctionTool / ZodTool `_callback`, Plugin / addHook, BeforeToolCallEvent.cancel, and HookOrder. A green typecheck is necessary but not sufficient: the namespace also depends on addHook keying the registry by constructor identity, on ZodTool.stream() delegating to `_functionTool._callback` (closed over at construction), and on BeforeToolsEvent.cancel skipping per-tool hooks — runtime contracts a typecheck cannot see. The floor is 1.1.0 because HookOrder + interrupt() shipped then. Keep the range on 1.x; strands-agents/v2 is added deliberately, not by a bump.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@strands-agents/sdk"],
+      "automerge": false,
+      "allowedVersions": "<2"
+    },
+    {
       "description": "Never automerge @openai/agents. It is pre-1.0, so a minor release may break. `@arcjet/guard/openai-agents/v0` types against FunctionTool, tool({ execute }), RunContext, and run() / Runner. A green typecheck is necessary but not sufficient. Keep the range below 1.0; openai-agents/v1 is added deliberately, not by a bump. This rule is last in packageRules so it wins over the devDependencies and patch automerge rules above.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["@openai/agents"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `@arcjet/guard/strands-agents/v1` for the Strands Agents JS SDK (`@strands-agents/sdk` `>=1.1.0 <2`).

**Exports:** `guardTool`, `guardHooks`, `strandsAgentContext` (+ shared `agents` barrel).

- **`guardTool`** — wraps authored `tool({ callback })`; DENY returns a plain `ArcjetDenialResult` (callback never runs).
- **`guardHooks`** — Plugin that registers `BeforeToolCallEvent` at `HookOrder.SDK_FIRST - 1`; DENY sets `event.cancel` to `JSON.stringify(...)`. Skips already-branded tools.
- **`strandsAgentContext`** — reads caller-owned ids from `invocationState` (`correlationId` → `sessionId` → `requestId`); never mints.

No `guardInbound` — screen inbound before `agent.invoke()` / `stream()`. No unversioned alias. SDK is dynamically imported only inside `guardHooks` `initAgent` so the namespace stays peer-free at module load.

### Wrap an authored tool

```ts
import { launchArcjet, tokenBucket } from "@arcjet/guard";
import { guardTool } from "@arcjet/guard/strands-agents/v1";
import { tool } from "@strands-agents/sdk";

const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
const limit = tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 10 });

export const lookupOrder = guardTool(
  arcjet,
  tool({
    name: "lookup_order",
    callback: async ({ orderNumber }) => ({ orderNumber, status: "shipped" }),
  }),
  {
    action: "order.looked-up",
    rules: (input) => [limit({ key: input.orderNumber, requested: 1 })],
  },
);
```

### Gate unwrapped / MCP tools via Plugin

```ts
import { guardHooks } from "@arcjet/guard/strands-agents/v1";
import { Agent } from "@strands-agents/sdk";

const agent = new Agent({
  tools: [lookupOrder],
  plugins: [
    guardHooks(arcjet, {
      action: ({ toolName }) => `${toolName}.invoked`,
      sessionId: conversationId,
    }),
  ],
});

await agent.invoke(userText, { invocationState: { sessionId: conversationId } });
```

Also includes integration skill, README/CONTRIBUTING updates, src + real-SDK tests (1431 unit tests passing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-428301f1-6bd6-4b8e-a05a-b038af159ac9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-428301f1-6bd6-4b8e-a05a-b038af159ac9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

