### PR TITLE
fix(guard): import Eve Approval types from eve/tools/approval

### DIFF
--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -142,7 +142,7 @@
     "@strands-agents/sdk": "1.14.0",
     "@types/node": "22.20.1",
     "ai": "7.0.58",
-    "eve": "0.39.0",
+    "eve": "0.46.0",
     "genkit": "1.41.0",
     "langchain": "1.5.10",
     "miniflare": "4.20260730.0",

--- a/arcjet-guard/src/vercel-eve/v0/approval-types.ts
+++ b/arcjet-guard/src/vercel-eve/v0/approval-types.ts
@@ -1,0 +1,29 @@
+import type { Approval, ApprovalContext, ApprovalStatus } from "eve/tools/approval";
+
+export type { Approval, ApprovalContext, ApprovalStatus };
+
+/**
+ * Eve 0.34 already exports `eve/tools/approval`, but only `Approval`,
+ * `ApprovalContext`, and `ApprovalStatus`. The rest of the public names
+ * (`ApprovalPolicy`, `ApprovalConfiguration`, response-time types) moved
+ * onto that path in 0.45 when `eve/tools` stopped re-exporting them.
+ * Derive them from `Approval` so the peer range `>=0.34.0 <1` stays honest.
+ *
+ * `Approval` has been `ApprovalPolicy | ApprovalConfiguration` since 0.34,
+ * and the `{ request, response? }` shape is unchanged through 0.46.
+ */
+export type ApprovalPolicy<TInput = Record<string, unknown>> = Extract<
+  Approval<TInput>,
+  (ctx: ApprovalContext<TInput>) => unknown
+>;
+export type ApprovalConfiguration<TInput = Record<string, unknown>> = Exclude<
+  Approval<TInput>,
+  ApprovalPolicy<TInput>
+>;
+export type ApprovalResponsePolicy<TInput = Record<string, unknown>> = NonNullable<
+  ApprovalConfiguration<TInput>["response"]
+>;
+export type ApprovalResponseContext<TInput = Record<string, unknown>> = Parameters<
+  ApprovalResponsePolicy<TInput>
+>[0];
+export type ApprovalResponseDecision = Awaited<ReturnType<ApprovalResponsePolicy>>;

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -2,7 +2,24 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { ApprovalContext, ApprovalResponseContext, ApprovalResponsePolicy } from "eve/tools";
+import type { Approval, ApprovalContext } from "eve/tools/approval";
+
+// Eve 0.34's `eve/tools/approval` only exports Approval, ApprovalContext, and
+// ApprovalStatus. Derive the response-time names the same way production does.
+type ApprovalPolicy<TInput = Record<string, unknown>> = Extract<
+  Approval<TInput>,
+  (ctx: ApprovalContext<TInput>) => unknown
+>;
+type ApprovalConfiguration<TInput = Record<string, unknown>> = Exclude<
+  Approval<TInput>,
+  ApprovalPolicy<TInput>
+>;
+type ApprovalResponsePolicy<TInput = Record<string, unknown>> = NonNullable<
+  ApprovalConfiguration<TInput>["response"]
+>;
+type ApprovalResponseContext<TInput = Record<string, unknown>> = Parameters<
+  ApprovalResponsePolicy<TInput>
+>[0];
 
 import { recorded } from "../../../test/_shared/source-scan.ts";
 import {

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -2,25 +2,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { Approval, ApprovalContext } from "eve/tools/approval";
-
-// Eve 0.34's `eve/tools/approval` only exports Approval, ApprovalContext, and
-// ApprovalStatus. Derive the response-time names the same way production does.
-type ApprovalPolicy<TInput = Record<string, unknown>> = Extract<
-  Approval<TInput>,
-  (ctx: ApprovalContext<TInput>) => unknown
->;
-type ApprovalConfiguration<TInput = Record<string, unknown>> = Exclude<
-  Approval<TInput>,
-  ApprovalPolicy<TInput>
->;
-type ApprovalResponsePolicy<TInput = Record<string, unknown>> = NonNullable<
-  ApprovalConfiguration<TInput>["response"]
->;
-type ApprovalResponseContext<TInput = Record<string, unknown>> = Parameters<
-  ApprovalResponsePolicy<TInput>
->[0];
-
 import { recorded } from "../../../test/_shared/source-scan.ts";
 import {
   decisionAllow,
@@ -32,6 +13,11 @@ import {
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
 import type { DecisionDeny } from "../../types.ts";
+import type {
+  ApprovalContext,
+  ApprovalResponseContext,
+  ApprovalResponsePolicy,
+} from "./approval-types.ts";
 import { eveAgentContext } from "./context.ts";
 import { guardApproval } from "./guard-approval.ts";
 

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -1,22 +1,39 @@
 import type { SessionContext } from "eve/context";
-import type {
-  Approval,
-  ApprovalConfiguration,
-  ApprovalContext,
-  ApprovalPolicy,
-  ApprovalResponseContext,
-  ApprovalResponseDecision,
-  ApprovalResponsePolicy,
-  ApprovalStatus,
-} from "eve/tools";
+import type { Approval, ApprovalContext, ApprovalStatus } from "eve/tools/approval";
 
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
 import { eveAgentContext } from "./context.ts";
-import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import { runGate } from "./gate.ts";
+
+/**
+ * Eve 0.34 already exports `eve/tools/approval`, but only `Approval`,
+ * `ApprovalContext`, and `ApprovalStatus`. The rest of the public names
+ * (`ApprovalPolicy`, `ApprovalConfiguration`, response-time types) moved
+ * onto that path in 0.45 when `eve/tools` stopped re-exporting them.
+ * Derive them from `Approval` so the peer range `>=0.34.0 <1` stays honest.
+ *
+ * `Approval` has been `ApprovalPolicy | ApprovalConfiguration` since 0.34,
+ * and the `{ request, response? }` shape is unchanged through 0.46.
+ */
+type ApprovalPolicy<TInput = Record<string, unknown>> = Extract<
+  Approval<TInput>,
+  (ctx: ApprovalContext<TInput>) => unknown
+>;
+type ApprovalConfiguration<TInput = Record<string, unknown>> = Exclude<
+  Approval<TInput>,
+  ApprovalPolicy<TInput>
+>;
+type ApprovalResponsePolicy<TInput = Record<string, unknown>> = NonNullable<
+  ApprovalConfiguration<TInput>["response"]
+>;
+type ApprovalResponseContext<TInput = Record<string, unknown>> = Parameters<
+  ApprovalResponsePolicy<TInput>
+>[0];
+type ApprovalResponseDecision = Awaited<ReturnType<ApprovalResponsePolicy>>;
 
 /**
  * Policy for `guardApproval()` — how to gate a tool call or connection invocation via Eve.

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -1,39 +1,22 @@
 import type { SessionContext } from "eve/context";
-import type { Approval, ApprovalContext, ApprovalStatus } from "eve/tools/approval";
 
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import type {
+  Approval,
+  ApprovalConfiguration,
+  ApprovalContext,
+  ApprovalPolicy,
+  ApprovalResponseContext,
+  ApprovalResponseDecision,
+  ApprovalResponsePolicy,
+  ApprovalStatus,
+} from "./approval-types.ts";
 import { eveAgentContext } from "./context.ts";
 import { runGate } from "./gate.ts";
-
-/**
- * Eve 0.34 already exports `eve/tools/approval`, but only `Approval`,
- * `ApprovalContext`, and `ApprovalStatus`. The rest of the public names
- * (`ApprovalPolicy`, `ApprovalConfiguration`, response-time types) moved
- * onto that path in 0.45 when `eve/tools` stopped re-exporting them.
- * Derive them from `Approval` so the peer range `>=0.34.0 <1` stays honest.
- *
- * `Approval` has been `ApprovalPolicy | ApprovalConfiguration` since 0.34,
- * and the `{ request, response? }` shape is unchanged through 0.46.
- */
-type ApprovalPolicy<TInput = Record<string, unknown>> = Extract<
-  Approval<TInput>,
-  (ctx: ApprovalContext<TInput>) => unknown
->;
-type ApprovalConfiguration<TInput = Record<string, unknown>> = Exclude<
-  Approval<TInput>,
-  ApprovalPolicy<TInput>
->;
-type ApprovalResponsePolicy<TInput = Record<string, unknown>> = NonNullable<
-  ApprovalConfiguration<TInput>["response"]
->;
-type ApprovalResponseContext<TInput = Record<string, unknown>> = Parameters<
-  ApprovalResponsePolicy<TInput>
->[0];
-type ApprovalResponseDecision = Awaited<ReturnType<ApprovalResponsePolicy>>;
 
 /**
  * Policy for `guardApproval()` — how to gate a tool call or connection invocation via Eve.

--- a/arcjet-guard/src/vercel-eve/v0/peer.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/peer.test.ts
@@ -39,11 +39,11 @@ test("AC1.5: eve is an optional peer and not a dependency", () => {
   const eveVersion = peerDependencies["eve"];
   assert.equal(eveVersion, ">=0.34.0 <1", 'peerDependencies.eve must be exactly ">=0.34.0 <1"');
 
-  // The assignability tests compile against this pin; keep it on a 0.34+ release
-  // that exports Approval as ApprovalPolicy | ApprovalConfiguration.
+  // The assignability tests compile against this pin. Eve 0.45 moved the
+  // Approval* types off the `eve/tools` barrel onto `eve/tools/approval`.
   const devDependencies = objectField(packageJson, "devDependencies");
   assert.ok(devDependencies, "package.json must have devDependencies");
-  assert.equal(devDependencies["eve"], "0.39.0", 'devDependencies.eve must be pinned to "0.39.0"');
+  assert.equal(devDependencies["eve"], "0.46.0", 'devDependencies.eve must be pinned to "0.46.0"');
 
   // Static assertion 2: peerDependenciesMeta.eve.optional is true
   const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
@@ -60,5 +60,26 @@ test("AC1.5: eve is an optional peer and not a dependency", () => {
   assert.ok(
     !(dependencies && "eve" in dependencies),
     "eve must not be in dependencies (it is a peer only)",
+  );
+});
+
+test("production Approval imports stay on names eve/tools/approval has exported since 0.34", () => {
+  const source = readFileSync(resolve(import.meta.dirname, "./guard-approval.ts"), "utf-8");
+  const importMatch = source.match(/import type \{([^}]+)\} from "eve\/tools\/approval"/);
+  assert.ok(importMatch, "guard-approval.ts must import types from eve/tools/approval");
+  const names = importMatch[1]
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0)
+    .toSorted();
+  assert.deepEqual(
+    names,
+    ["Approval", "ApprovalContext", "ApprovalStatus"],
+    "only import Approval names that eve/tools/approval exported in 0.34; derive the rest",
+  );
+  assert.equal(
+    source.includes('from "eve/tools"'),
+    false,
+    "guard-approval.ts must not import Approval types from the eve/tools barrel",
   );
 });

--- a/arcjet-guard/src/vercel-eve/v0/peer.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/peer.test.ts
@@ -64,22 +64,32 @@ test("AC1.5: eve is an optional peer and not a dependency", () => {
 });
 
 test("production Approval imports stay on names eve/tools/approval has exported since 0.34", () => {
-  const source = readFileSync(resolve(import.meta.dirname, "./guard-approval.ts"), "utf-8");
-  const importMatch = source.match(/import type \{([^}]+)\} from "eve\/tools\/approval"/);
-  assert.ok(importMatch, "guard-approval.ts must import types from eve/tools/approval");
-  const names = importMatch[1]
+  const source = readFileSync(resolve(import.meta.dirname, "./approval-types.ts"), "utf-8");
+  const specifier = 'from "eve/tools/approval"';
+  const fromIndex = source.indexOf(specifier);
+  assert.ok(fromIndex !== -1, "approval-types.ts must import types from eve/tools/approval");
+  const before = source.slice(0, fromIndex);
+  const open = before.lastIndexOf("{");
+  const close = before.lastIndexOf("}");
+  assert.ok(
+    open !== -1 && close > open,
+    "import from eve/tools/approval must be a named type import",
+  );
+  const names = before
+    .slice(open + 1, close)
     .split(",")
     .map((name) => name.trim())
-    .filter((name) => name.length > 0)
-    .toSorted();
+    .filter((name) => name.length > 0);
+  // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-call -- oxlint's type-aware checker has no signature for Array#toSorted, which unicorn/no-array-sort requires
+  const sortedNames = names.toSorted();
   assert.deepEqual(
-    names,
+    sortedNames,
     ["Approval", "ApprovalContext", "ApprovalStatus"],
     "only import Approval names that eve/tools/approval exported in 0.34; derive the rest",
   );
   assert.equal(
-    source.includes('from "eve/tools"'),
+    /from ["']eve\/tools["']/.test(source),
     false,
-    "guard-approval.ts must not import Approval types from the eve/tools barrel",
+    "approval-types.ts must not import Approval types from the eve/tools barrel",
   );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,7 +193,7 @@
         "@strands-agents/sdk": "1.14.0",
         "@types/node": "22.20.1",
         "ai": "7.0.58",
-        "eve": "0.39.0",
+        "eve": "0.46.0",
         "genkit": "1.41.0",
         "langchain": "1.5.10",
         "miniflare": "4.20260730.0",
@@ -12619,9 +12619,9 @@
       }
     },
     "node_modules/eve": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/eve/-/eve-0.39.0.tgz",
-      "integrity": "sha512-AbpCNmAHEJn2/BhFxu0FNlhQ3MsN0Sl//VgoPg+c8NMambPDs0jncfE9zOvIquW5AAMPOTj6a/erLdKIINm56A==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/eve/-/eve-0.46.0.tgz",
+      "integrity": "sha512-o8eW5ioYsOdWKCqvYw0U+YPPFCHNynm2cJt63dyDBndh4w1g42BfFeM5gt2WSv1qEn7+yKvVHlhkVxpxzhbAYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12638,7 +12638,7 @@
         "@opentelemetry/api": "^1.0.0",
         "ai": "^7.0.58",
         "braintrust": "^3.0.0",
-        "just-bash": "^3.0.0",
+        "just-bash": "^3.1.0",
         "microsandbox": "^0.5.0"
       },
       "peerDependenciesMeta": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Eve 0.45 stopped re-exporting `Approval*` types from the `eve/tools` barrel. They still exist, with the same public names, on `eve/tools/approval`. That broke compile-time compat for `@arcjet/guard/vercel-eve/v0` against latest Eve (0.46.0).

This stays on `vercel-eve/v0`. Eve has not published 1.0, so this is a compatible 0.x export-path fix, not a new major.

## What changed

- `approval-types.ts` type-imports `Approval`, `ApprovalContext`, and `ApprovalStatus` from `eve/tools/approval` and derives the rest from `Approval`. Those three names are the only Approval types that path exported in Eve 0.34 (our peer floor).
- `guardApproval` and its tests share those aliases so the derivations cannot drift.
- Compared Eve 0.34 vs 0.46 `Approval*` shapes: no API change. `ApprovalStatus` still accepts `{ type: "denied"; reason?: string }`. `{ request, response }` is unchanged. `ToolDefinition` / `ToolContext` still come from `eve/tools`. `SessionContext` is still on `eve/context`. Hook types are still on `eve/hooks`.
- Dev pin moved from `eve@0.39.0` to `eve@0.46.0`. Peer stays `>=0.34.0 <1`.
- Request-time denials still return `{ type: "denied" }`. HITL deny→cancel is untouched.

## Why not `vercel-eve/v1`

The break is an export-map move, not a type-shape break. Adding `/v1` would imply Eve 1.0.

## Verification

Against Eve 0.46.0:

- `npm run lint` and `npm run typecheck` (both tsconfigs)
- 176 `src/vercel-eve/**/*.test.ts` tests, including function-form and `{ request, response }` assignability

Against Eve 0.34.0 (peer floor, `--no-save`):

- Both typecheck projects
- The same 176 tests

`guardTool`, `guardInbound`, and hooks did not need changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62b1db74-2ec1-4b14-b018-e86de032a1b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62b1db74-2ec1-4b14-b018-e86de032a1b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

