### PR TITLE
fix(transport): port HTTP/2 PING keep-alive and connection recycling (#6255)

### DIFF
--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -127,6 +127,7 @@
   "dependencies": {
     "@arcjet/analyze": "1.11.0",
     "@arcjet/logger": "1.11.0",
+    "@arcjet/transport": "1.11.0",
     "@bufbuild/protobuf": "2.14.0",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2",

--- a/arcjet-guard/src/transport-http2.ts
+++ b/arcjet-guard/src/transport-http2.ts
@@ -2,83 +2,18 @@
  * Direct HTTP/2 transport factory shared by the `@arcjet/guard` Node and Bun
  * entry points.
  *
- * Both Node and Bun talk to the Arcjet API over HTTP/2 via
- * `@connectrpc/connect-node` (Bun implements `node:http2`, but its `fetch` does
- * not support HTTP/2 — {@link https://github.com/oven-sh/bun/issues/7194}). The
- * proxy strategy differs between the two runtimes, so each entry point handles
- * proxying itself and reuses this for the direct, no-proxy case.
+ * Re-exports the shared factory from `@arcjet/transport/http2` so Guard and the
+ * main SDK stay on the same PING keep-alive and deadline-based recycling
+ * behavior. The unconditional `/http2` subpath is required on Bun: the
+ * `@arcjet/transport` package `"bun"` condition resolves to fetch/HTTP/1.1,
+ * while Guard's Bun entry still wants Node HTTP/2 for the direct (no-proxy)
+ * path — Bun implements `node:http2`, but its `fetch` does not support HTTP/2
+ * ({@link https://github.com/oven-sh/bun/issues/7194}).
  *
  * @packageDocumentation
  */
 
-import type { Transport } from "@connectrpc/connect";
-import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
-
-import { withConnectionRecycling } from "./transport-recycle.ts";
-
-/**
- * A direct HTTP/2 transport plus the session manager that owns its connection.
- *
- * The session manager is exposed so callers (and tests) can tear the
- * connection down deterministically.
- */
-export interface Http2TransportHandle {
-  transport: Transport;
-  sessionManager: Http2SessionManager;
-}
-
-/**
- * Create a direct HTTP/2 Connect transport, optimistically pre-connecting.
- *
- * The session is pre-connected so the first `.guard()` call doesn't pay the
- * full TCP + TLS setup cost. PING keep-alive and deadline-based connection
- * recycling detect a silently dropped connection (an intermediary expiring an
- * idle flow without notifying either end) and replace it, instead of letting a
- * dead session fail every call until the process restarts.
- *
- * @param baseUrl Base URL for the Arcjet API.
- * @returns The transport and its session manager.
- */
-export function createHttp2Transport(baseUrl: string): Http2TransportHandle {
-  const sessionManager = new Http2SessionManager(baseUrl, {
-    // Detect and survive silently dropped connections:
-    //
-    // - `pingIntervalMs` sends PING frames on connections with in-flight
-    //   streams and, crucially, verifies a connection with a PING before
-    //   reusing it after `pingIntervalMs` of inactivity — transparently
-    //   dialing a fresh connection when the old one is dead.
-    // - `pingIdleConnection` extends the pings to idle connections, keeping
-    //   NAT/conntrack entries on the path alive (AWS NAT gateways expire idle
-    //   flows at 350s, Global Accelerator at 340s). Global Accelerator's idle
-    //   timeout is not reset by dataless TCP keepalive packets, but HTTP/2
-    //   PING frames are stream data, which does reset it. Ref:
-    //   https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout
-    //   Idle connections and the ping timers are unref'd by connect-es, so
-    //   this does not keep a quiescent process from exiting.
-    // - `pingTimeoutMs` bounds how long a dead connection lingers once a PING
-    //   goes unanswered; the default of 15s is slow next to typical guard
-    //   call timeouts of 1-2s.
-    // - `idleConnectionTimeoutMs` still closes a connection nothing has used
-    //   for a while; the pre-request verification above makes the subsequent
-    //   re-dial transparent.
-    pingIntervalMs: 55 * 1000,
-    pingTimeoutMs: 5 * 1000,
-    pingIdleConnection: true,
-    idleConnectionTimeoutMs: 340 * 1000,
-  });
-
-  // Optimistic pre-connect — failures are silently ignored because the real RPC
-  // call will retry the connection anyway.
-  void sessionManager.connect().catch(() => {});
-
-  const transport = withConnectionRecycling(
-    createConnectTransport({
-      baseUrl,
-      httpVersion: "2",
-      sessionManager,
-    }),
-    sessionManager,
-  );
-
-  return { transport, sessionManager };
-}
+export {
+  createHttp2Transport,
+  type Http2TransportHandle,
+} from "@arcjet/transport/http2";

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,6 +178,7 @@
       "dependencies": {
         "@arcjet/analyze": "1.11.0",
         "@arcjet/logger": "1.11.0",
+        "@arcjet/transport": "1.11.0",
         "@bufbuild/protobuf": "2.14.0",
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-node": "2.1.2",

--- a/transport/README.md
+++ b/transport/README.md
@@ -68,6 +68,11 @@ This package exports the identifier
 [`createTransport`][api-create-transport].
 There is no default export.
 
+The unconditional subpath `@arcjet/transport/http2` exports
+[`createHttp2Transport`][api-create-http2-transport] for callers that need the
+Node HTTP/2 Connect path regardless of the package's runtime export conditions
+(used by `@arcjet/guard` on Bun).
+
 This package exports the [TypeScript][] types
 [`ProxyEnvironment`][api-proxy-environment],
 [`TransportLogger`][api-transport-logger], and
@@ -79,6 +84,17 @@ Creates a transport that talks to the Arcjet API. On Node.js it uses
 `@connectrpc/connect-node` over HTTP/2; separate entry points for Bun, Deno,
 Edge Light, and `workerd` use `@connectrpc/connect-web` instead. This is a thin
 wrapper around [`createConnectTransport`][connect-create-transport].
+
+Direct HTTP/2 sessions (and HTTP/2-over-`CONNECT` when `proxyHttpVersion` is
+`"2"`) enable PING keep-alive and recycle the connection after consecutive
+deadline failures, matching the recovery behavior introduced for Guard in
+[#6137](https://github.com/arcjet/arcjet-js/pull/6137).
+
+### `createHttp2Transport(baseUrl[, http2SessionOptions])`
+
+Creates a direct HTTP/2 Connect transport with PING keep-alive and
+deadline-based connection recycling. Returns `{ transport, sessionManager }` so
+callers can tear the session down. Import from `@arcjet/transport/http2`.
 
 ### Proxy support
 
@@ -186,6 +202,7 @@ Configuration for `createTransport` (TypeScript type).
 [Apache License, Version 2.0][apache-license] © [Arcjet Labs, Inc.][arcjet]
 
 [apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+[api-create-http2-transport]: #createhttp2transportbaseurl-http2sessionoptions
 [api-create-transport]: #createtransportbaseurl-options
 [api-proxy-environment]: #proxyenvironment
 [api-transport-logger]: #transportlogger

--- a/transport/package.json
+++ b/transport/package.json
@@ -53,6 +53,10 @@
         "default": "./dist/index.js"
       }
     },
+    "./http2": {
+      "types": "./dist/http2.d.ts",
+      "default": "./dist/http2.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/transport/src/connection-recycle.ts
+++ b/transport/src/connection-recycle.ts
@@ -1,5 +1,5 @@
 /**
- * Dead-connection recovery for the guard HTTP/2 transport.
+ * Dead-connection recovery for Arcjet HTTP/2 transports.
  *
  * A long-lived HTTP/2 session can die silently: an intermediary (NAT gateway,
  * L4 load balancer, connection-tracking table) can drop the connection state
@@ -8,12 +8,13 @@
  * RPC times out — and keeps timing out until TCP retransmission gives up many
  * minutes later, because nothing else tears the session down.
  *
- * The PING keep-alive configured in `transport-http2.ts` detects most of this,
- * but as a backstop this wrapper watches RPC outcomes: after a run of
- * consecutive deadline failures with no success in between, it aborts the
- * managed session so the next call dials a fresh connection.
+ * The PING keep-alive configured in `http2.ts` detects most of this, but as a
+ * backstop this wrapper watches RPC outcomes: after a run of consecutive
+ * deadline failures with no success in between, it aborts the managed session
+ * so the next call dials a fresh connection.
  *
- * @packageDocumentation
+ * Shared by `@arcjet/transport` (main SDK) and `@arcjet/guard` so both stay on
+ * the same recovery behavior.
  */
 
 import { Code, ConnectError } from "@connectrpc/connect";
@@ -109,7 +110,9 @@ export function withConnectionRecycling(
         throw error;
       }
     },
-    // Guard is unary-only; pass streaming calls through untouched.
+    // Streaming is passed through untouched; Arcjet's production paths are
+    // unary-only, and streaming outcomes are a weaker signal for a dead
+    // session (long-lived streams can fail for many non-connection reasons).
     stream(method, signal, timeoutMs, header, input, contextValues) {
       return transport.stream(method, signal, timeoutMs, header, input, contextValues);
     },
@@ -123,8 +126,10 @@ export function withConnectionRecycling(
  */
 function recycle(session: RecyclableSession): void {
   // Mirror the edge-safe, `ARCJET_LOG_LEVEL`-gated logging pattern of
-  // `detect-proxy.ts`: this event is the SDK healing a broken network path,
-  // which is worth surfacing during an incident, but stays quiet by default.
+  // `detect-proxy.ts` in `@arcjet/guard`: this event is the SDK healing a
+  // broken network path, which is worth surfacing during an incident, but
+  // stays quiet by default. Kept free of `@arcjet/logger` so the shared
+  // HTTP/2 path stays usable from packages that avoid that dependency.
   const level = globalThis.process?.env?.["ARCJET_LOG_LEVEL"];
   if (level === "debug" || level === "info" || level === "warn") {
     console.warn(

--- a/transport/src/http2.ts
+++ b/transport/src/http2.ts
@@ -1,0 +1,112 @@
+/**
+ * Direct HTTP/2 Connect transport factory shared by `@arcjet/transport` and
+ * `@arcjet/guard`.
+ *
+ * Exported as `@arcjet/transport/http2` so callers that need Node's
+ * `connect-node` HTTP/2 path unconditionally (notably `@arcjet/guard` on Bun,
+ * where the package's `"bun"` condition resolves to fetch/HTTP/1.1) can import
+ * it without hitting a runtime-conditioned entry point.
+ *
+ * Bun implements `node:http2` but its `fetch` does not support HTTP/2
+ * ({@link https://github.com/oven-sh/bun/issues/7194}), which is why Guard
+ * keeps a separate Bun entry for proxying while still using this factory for
+ * the direct path.
+ */
+
+import type { ClientSessionOptions, SecureClientSessionOptions } from "node:http2";
+
+import type { Transport } from "@connectrpc/connect";
+import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
+
+import { withConnectionRecycling } from "./connection-recycle.js";
+
+/**
+ * Optional `http2.connect` session options forwarded to `Http2SessionManager`.
+ *
+ * Used by the Node proxy path to tunnel HTTP/2 through `CONNECT` via
+ * `createConnection`.
+ */
+export type Http2ConnectOptions = ClientSessionOptions | SecureClientSessionOptions;
+
+/**
+ * A direct HTTP/2 transport plus the session manager that owns its connection.
+ *
+ * The session manager is exposed so callers (and tests) can tear the
+ * connection down deterministically.
+ */
+export interface Http2TransportHandle {
+  transport: Transport;
+  sessionManager: Http2SessionManager;
+}
+
+/**
+ * Create a direct HTTP/2 Connect transport, optimistically pre-connecting.
+ *
+ * The session is pre-connected so the first RPC doesn't pay the full TCP + TLS
+ * setup cost (skipped under Deno's Node HTTP/2 compatibility layer, which can
+ * surface background session failures as uncaught test errors). PING keep-alive
+ * and deadline-based connection recycling detect a silently dropped connection
+ * (an intermediary expiring an idle flow without notifying either end) and
+ * replace it, instead of letting a dead session fail every call until the
+ * process restarts — or, on serverless, leaving a GOAWAY from a peer-closed
+ * idle connection as an uncaught exception on a frozen instance.
+ *
+ * @param baseUrl Base URL for the Arcjet API.
+ * @param http2SessionOptions Optional options passed to `http2.connect`
+ *   (for example a `createConnection` tunnel).
+ * @returns The transport and its session manager.
+ */
+export function createHttp2Transport(
+  baseUrl: string,
+  http2SessionOptions?: Http2ConnectOptions,
+): Http2TransportHandle {
+  const sessionManager = new Http2SessionManager(
+    baseUrl,
+    {
+      // Detect and survive silently dropped connections:
+      //
+      // - `pingIntervalMs` sends PING frames on connections with in-flight
+      //   streams and, crucially, verifies a connection with a PING before
+      //   reusing it after `pingIntervalMs` of inactivity — transparently
+      //   dialing a fresh connection when the old one is dead.
+      // - `pingIdleConnection` extends the pings to idle connections, keeping
+      //   NAT/conntrack entries on the path alive (AWS NAT gateways expire idle
+      //   flows at 350s, Global Accelerator at 340s). Global Accelerator's idle
+      //   timeout is not reset by dataless TCP keepalive packets, but HTTP/2
+      //   PING frames are stream data, which does reset it. Ref:
+      //   https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout
+      //   Idle connections and the ping timers are unref'd by connect-es, so
+      //   this does not keep a quiescent process from exiting.
+      // - `pingTimeoutMs` bounds how long a dead connection lingers once a PING
+      //   goes unanswered; the default of 15s is slow next to typical Arcjet
+      //   call timeouts of 1-2s.
+      // - `idleConnectionTimeoutMs` still closes a connection nothing has used
+      //   for a while; the pre-request verification above makes the subsequent
+      //   re-dial transparent.
+      pingIntervalMs: 55 * 1000,
+      pingTimeoutMs: 5 * 1000,
+      pingIdleConnection: true,
+      idleConnectionTimeoutMs: 340 * 1000,
+    },
+    http2SessionOptions,
+  );
+
+  // Optimistic pre-connect. In Deno, the Node HTTP/2 compatibility layer can
+  // surface background session failures as uncaught test errors, so we only
+  // warm the connection outside Deno. Failures are ignored because the real
+  // RPC call will retry the connection anyway.
+  if (!("Deno" in globalThis)) {
+    void sessionManager.connect().catch(() => {});
+  }
+
+  const transport = withConnectionRecycling(
+    createConnectTransport({
+      baseUrl,
+      httpVersion: "2",
+      sessionManager,
+    }),
+    sessionManager,
+  );
+
+  return { transport, sessionManager };
+}

--- a/transport/src/index.ts
+++ b/transport/src/index.ts
@@ -2,9 +2,10 @@ import * as http from "node:http";
 import * as https from "node:https";
 
 import type { Transport } from "@connectrpc/connect";
-import { createConnectTransport, Http2SessionManager } from "@connectrpc/connect-node";
+import { createConnectTransport } from "@connectrpc/connect-node";
 
 import { detectProxy } from "./detect-proxy.js";
+import { createHttp2Transport } from "./http2.js";
 import { createTunnelingConnection } from "./proxy-tunnel.js";
 
 export type { ProxyEnvironment, TransportLogger, TransportOptions } from "./detect-proxy.js";
@@ -40,7 +41,9 @@ export function createTransport(baseUrl: string, options?: TransportOptions): Tr
       // HTTP/2 through the proxy: open a `CONNECT` tunnel and keep HTTP/2 to
       // the origin end-to-end. The proxy only blindly forwards the tunnel, so
       // ALPN is negotiated directly with the origin — see `./proxy-tunnel.ts`.
-      return createHttp2Transport(baseUrl, createTunnelingConnection(proxyUrl));
+      return createHttp2Transport(baseUrl, {
+        createConnection: createTunnelingConnection(proxyUrl),
+      }).transport;
     }
 
     // HTTP/1.1 through the proxy (default). Hand the agent only the single
@@ -77,44 +80,5 @@ export function createTransport(baseUrl: string, options?: TransportOptions): Tr
   }
 
   // No proxy: connect directly over HTTP/2.
-  return createHttp2Transport(baseUrl);
-}
-
-/**
- * Build a direct HTTP/2 transport with an optimistically pre-connecting session
- * manager.
- *
- * When `createConnection` is supplied the session is tunneled through it (used
- * to route HTTP/2 through a proxy via `CONNECT`); otherwise it connects directly
- * to `baseUrl`. Either way pings and the idle timeout behave identically — only
- * the underlying connection differs.
- *
- * @param baseUrl
- *   Base URI for all HTTP requests.
- * @param createConnection
- *   Optional connection factory passed through to `http2.connect` (optional).
- * @returns
- *   Connect transport that talks HTTP/2 to `baseUrl`.
- */
-function createHttp2Transport(
-  baseUrl: string,
-  createConnection?: ReturnType<typeof createTunnelingConnection>,
-): Transport {
-  const sessionManager = new Http2SessionManager(
-    baseUrl,
-    // AWS Global Accelerator doesn't support PING so we use a very high idle
-    // timeout. Ref:
-    // https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout
-    { idleConnectionTimeoutMs: 340 * 1000 },
-    createConnection ? { createConnection } : undefined,
-  );
-
-  // This is an optimistic pre-connect. In Deno, the Node HTTP/2 compatibility
-  // layer can surface background session failures as uncaught test errors, so
-  // we only warm the connection in Node.
-  if (!("Deno" in globalThis)) {
-    sessionManager.connect();
-  }
-
-  return createConnectTransport({ baseUrl, httpVersion: "2", sessionManager });
+  return createHttp2Transport(baseUrl).transport;
 }

--- a/transport/test/connection-recycle.test.ts
+++ b/transport/test/connection-recycle.test.ts
@@ -12,13 +12,13 @@ import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError, createClient, createRouterTransport } from "@connectrpc/connect";
 import type { Client } from "@connectrpc/connect";
 
-import { DecideService, GuardResponseSchema } from "./proto/proto/decide/v2/decide_pb.js";
-import type { GuardResponse } from "./proto/proto/decide/v2/decide_pb.js";
 import {
   withConnectionRecycling,
   RECYCLE_AFTER_CONSECUTIVE_DEADLINES,
-} from "./transport-recycle.ts";
-import type { RecyclableSession } from "./transport-recycle.ts";
+} from "../src/connection-recycle.ts";
+import type { RecyclableSession } from "../src/connection-recycle.ts";
+import { ElizaService, SayResponseSchema } from "./eliza_pb.ts";
+import type { SayResponse } from "./eliza_pb.ts";
 
 /** Per-call outcome for the scripted inner transport. */
 type Outcome = "ok" | "deadline" | "canceled" | "internal";
@@ -40,13 +40,13 @@ function fakeSession(): RecyclableSession & { aborts: number; connects: number }
 
 /** Build a client whose calls play back `outcomes` in order, then a session spy. */
 function scriptedClient(outcomes: Outcome[]): {
-  client: Client<typeof DecideService>;
+  client: Client<typeof ElizaService>;
   session: ReturnType<typeof fakeSession>;
 } {
   let call = 0;
   const inner = createRouterTransport(({ service }) => {
-    service(DecideService, {
-      guard() {
+    service(ElizaService, {
+      say() {
         const outcome = outcomes[call] ?? "ok";
         call += 1;
         switch (outcome) {
@@ -57,19 +57,19 @@ function scriptedClient(outcomes: Outcome[]): {
           case "internal":
             throw new ConnectError("internal", Code.Internal);
           case "ok":
-            return create(GuardResponseSchema, {});
+            return create(SayResponseSchema, { sentence: "ok" });
         }
       },
     });
   });
   const session = fakeSession();
-  const client = createClient(DecideService, withConnectionRecycling(inner, session));
+  const client = createClient(ElizaService, withConnectionRecycling(inner, session));
   return { client, session };
 }
 
-/** Call `guard` and swallow the expected rejection. */
-async function callIgnoringError(client: Client<typeof DecideService>): Promise<void> {
-  await client.guard({}).catch(() => {});
+/** Call `say` and swallow the expected rejection. */
+async function callIgnoringError(client: Client<typeof ElizaService>): Promise<void> {
+  await client.say({ sentence: "hi" }).catch(() => {});
 }
 
 describe("withConnectionRecycling", () => {
@@ -151,15 +151,15 @@ describe("withConnectionRecycling", () => {
       release = resolve;
     });
     const inner = createRouterTransport(({ service }) => {
-      service(DecideService, {
-        async guard(): Promise<never> {
+      service(ElizaService, {
+        async say(): Promise<never> {
           await gate;
           throw new ConnectError("deadline", Code.DeadlineExceeded);
         },
       });
     });
     const session = fakeSession();
-    const client = createClient(DecideService, withConnectionRecycling(inner, session));
+    const client = createClient(ElizaService, withConnectionRecycling(inner, session));
 
     const calls: Promise<void>[] = [];
     for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES * 2; index++) {
@@ -182,20 +182,20 @@ describe("withConnectionRecycling", () => {
     });
     let call = 0;
     const inner = createRouterTransport(({ service }) => {
-      service(DecideService, {
-        async guard(): Promise<GuardResponse> {
+      service(ElizaService, {
+        async say(): Promise<SayResponse> {
           if (call++ === 0) {
             await firstGate;
-            return create(GuardResponseSchema, {});
+            return create(SayResponseSchema, { sentence: "ok" });
           }
           throw new ConnectError("deadline", Code.DeadlineExceeded);
         },
       });
     });
     const session = fakeSession();
-    const client = createClient(DecideService, withConnectionRecycling(inner, session));
+    const client = createClient(ElizaService, withConnectionRecycling(inner, session));
 
-    const held = client.guard({});
+    const held = client.say({ sentence: "hi" });
     for (let index = 0; index < RECYCLE_AFTER_CONSECUTIVE_DEADLINES; index++) {
       await callIgnoringError(client);
     }
@@ -219,10 +219,10 @@ describe("withConnectionRecycling", () => {
   test("responses and errors pass through unchanged", async () => {
     const { client } = scriptedClient(["ok", "deadline"]);
 
-    await client.guard({});
+    await client.say({ sentence: "hi" });
 
     await assert.rejects(
-      () => client.guard({}),
+      () => client.say({ sentence: "hi" }),
       (error: unknown) => ConnectError.from(error).code === Code.DeadlineExceeded,
     );
   });

--- a/transport/test/index.test.ts
+++ b/transport/test/index.test.ts
@@ -87,6 +87,12 @@ test("@arcjet/transport", async function (t) {
     assert.deepEqual(Object.keys(await import("../dist/index.js")).sort(), ["createTransport"]);
   });
 
+  await t.test("should expose the shared HTTP/2 factory", async function () {
+    assert.deepEqual(Object.keys(await import("../dist/http2.js")).sort(), [
+      "createHttp2Transport",
+    ]);
+  });
+
   await t.test("should throw w/o `url`", async function () {
     assert.throws(function () {
       // @ts-expect-error: test runtime behavior.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the HTTP/2 connection recovery from `#6137` (`arcjet-guard`) into `@arcjet/transport`, and centralizes the factory so Guard and the main SDK share one implementation.

Fixes `#6255` (async `GOAWAY` / silently dead HTTP/2 sessions for `@arcjet/next` and other adapters that use `@arcjet/transport`).

## Changes

- Add PING keep-alive (`pingIntervalMs: 55s`, `pingTimeoutMs: 5s`, `pingIdleConnection: true`) and deadline-based connection recycling to the Node HTTP/2 path in `@arcjet/transport`.
- Correct the Global Accelerator comment (HTTP/2 PING frames *do* reset the idle timer; dataless TCP keepalives do not).
- Export `@arcjet/transport/http2` (unconditional — not subject to the package `bun`/`deno` conditions) so `@arcjet/guard` can reuse the same factory on Node and Bun.
- Point Guard’s Node/Bun direct path at that shared factory; remove the duplicated recycle module from `arcjet-guard`.

## Behavior note: HTTP/2-through-CONNECT also gets PINGs

`proxyHttpVersion: "2"` already shared the same `Http2SessionManager` factory as the direct path (and the pre-existing comment said pings/idle timeout behave identically for both). Previously that meant “no PINGs on either path.” After this PR both paths get the PING keep-alive + recycling — including periodic HTTP/2 PING frames on the tunneled session. That is intentional: a tunneled connection is end-to-end HTTP/2 with the origin (the proxy only forwards bytes), and RFC 7540 requires PING support. Default proxying remains HTTP/1.1.

## Why not fully unify `createTransport`?

- **Bun diverges on purpose:** `@arcjet/transport`’s `bun` entry uses fetch/HTTP/1.1; Guard’s Bun entry still wants Node HTTP/2 for the direct path (Bun’s `fetch` has no HTTP/2).
- **Proxy detection stays duplicated:** Guard’s `detect-proxy` copy is intentionally edge-safe with no `@arcjet/logger` / `@arcjet/env` imports (existing drift test).

## Test plan

- [x] `@arcjet/transport` unit tests — 54 pass (includes moved recycle suite)
- [x] `@arcjet/guard` unit tests — 1424 pass
- [x] `@arcjet/guard` Node runtime — 35 pass (includes production `createHttp2Transport` factory test)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0494c-bd53-7e6e-84b4-07d66fdc8b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0494c-bd53-7e6e-84b4-07d66fdc8b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

