### PR TITLE
docs: move client IP warning under installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,6 @@
 
 This is the monorepo containing various [Arcjet][arcjet] open source packages for JS.
 
-> [!WARNING]
-> When a platform-provided client IP is unavailable, Arcjet may use forwarding
-> headers such as `X-Forwarded-For`. Clients can spoof these headers if they can
-> reach your application directly or your proxy preserves client-supplied
-> values. Plain IP or CIDR entries in `proxies` tell Arcjet which hops to skip;
-> they do not verify that the connection came through those proxies.
->
-> In production, make the application reachable only through a proxy that
-> overwrites or safely appends forwarding headers, and list every trusted hop
-> in `proxies`. Use a proxy-service helper such as `cloudflare()` where
-> available. If your application determines the client IP itself, pass a
-> validated `ipSrc` to `protect()`.
-
 ## Why Arcjet?
 
 Your app's AI features and agents take real actions, calling tools, reading data, hitting APIs. Arcjet runs inside that code and lets you enforce security on each action in real time, then audit what happened
@@ -79,6 +66,19 @@ npx skills add arcjet/skills
 > and coding rules.
 
 ### Step 3: Install the package
+
+> [!WARNING]
+> When a platform-provided client IP is unavailable, Arcjet may use forwarding
+> headers such as `X-Forwarded-For`. Clients can spoof these headers if they can
+> reach your application directly or your proxy preserves client-supplied
+> values. Plain IP or CIDR entries in `proxies` tell Arcjet which hops to skip;
+> they do not verify that the connection came through those proxies.
+>
+> In production, make the application reachable only through a proxy that
+> overwrites or safely appends forwarding headers, and list every trusted hop
+> in `proxies`. Use a proxy-service helper such as `cloudflare()` where
+> available. If your application determines the client IP itself, pass a
+> validated `ipSrc` to `protect()`.
 
 **For request protection** — pick the SDK for your framework:
 


### PR DESCRIPTION
## Summary

- move the client IP trust warning from the README introduction to the package installation step
- preserve the warning text added in #6257

## Validation

- npm run format:check
- git diff --check