### PR TITLE
feat: expose client IP provenance and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ npx skills add arcjet/skills
 > When a platform-provided client IP is unavailable, Arcjet may use forwarding
 > headers such as `X-Forwarded-For`. Clients can spoof these headers if they can
 > reach your application directly or your proxy preserves client-supplied
-> values. Arcjet continues protecting the request, but logs a warning once per
-> client and marks the source as `unverified-header` in the
+> values. Arcjet continues protecting the request, but logs one warning for the
+> lifetime of each Arcjet client instance and marks the source as
+> `unverified-header` in the
 > `client_ip_provenance` debug facet.
 >
 > In production, make the application reachable only through a proxy that
 > overwrites or safely appends forwarding headers, and list every trusted hop
 > in `proxies`. Use a proxy-service helper such as `cloudflare()` where
-> available. Invalid proxy entries and manual `ipSrc` values are rejected;
+> available. Invalid proxy entries and non-empty malformed `ipSrc` values are
+> rejected (`ipSrc: ""` remains equivalent to omitting the option);
 > trusting `0.0.0.0/0` or `::/0` emits a configuration warning. Inspect the
 > selection with `client.clientIpDetails(request)` in `@arcjet/node`, or
 > `findIpDetails()` / `resolveClientIp()` from `@arcjet/ip` in other adapters.

--- a/README.md
+++ b/README.md
@@ -71,14 +71,19 @@ npx skills add arcjet/skills
 > When a platform-provided client IP is unavailable, Arcjet may use forwarding
 > headers such as `X-Forwarded-For`. Clients can spoof these headers if they can
 > reach your application directly or your proxy preserves client-supplied
-> values. Plain IP or CIDR entries in `proxies` tell Arcjet which hops to skip;
-> they do not verify that the connection came through those proxies.
+> values. Arcjet continues protecting the request, but logs a warning once per
+> client and marks the source as `unverified-header` in the
+> `client_ip_provenance` debug facet.
 >
 > In production, make the application reachable only through a proxy that
 > overwrites or safely appends forwarding headers, and list every trusted hop
 > in `proxies`. Use a proxy-service helper such as `cloudflare()` where
-> available. If your application determines the client IP itself, pass a
-> validated `ipSrc` to `protect()`.
+> available. Invalid proxy entries and manual `ipSrc` values are rejected;
+> trusting `0.0.0.0/0` or `::/0` emits a configuration warning. Inspect the
+> selection with `client.clientIpDetails(request)` in `@arcjet/node`, or
+> `findIpDetails()` / `resolveClientIp()` from `@arcjet/ip` in other adapters.
+> If your application determines the address itself, pass that validated value
+> as `ipSrc` to both the debugging API and `protect()`.
 
 **For request protection** — pick the SDK for your framework:
 

--- a/arcjet-astro/src/internal.ts
+++ b/arcjet-astro/src/internal.ts
@@ -1,7 +1,13 @@
 import { readBodyWeb } from "@arcjet/body";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
 import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
@@ -250,6 +256,13 @@ export function createArcjetClient<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -271,11 +284,12 @@ export function createArcjetClient<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp({ ip: clientAddress, headers }, { platform: platform(env), proxies });
+    const ipDetails = resolveClientIp(
+      { ip: clientAddress, headers },
+      { development: isDevelopment(env), ipSrc, platform: platform(env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-bun/src/index.ts
+++ b/arcjet-bun/src/index.ts
@@ -1,4 +1,10 @@
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 /// <reference types="bun-types" />
 import core from "arcjet";
 import type {
@@ -254,6 +260,13 @@ export default function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -270,20 +283,18 @@ export default function arcjet<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          // This attempts to lookup the IP in the `ipCache`. This is primarily a
-          // workaround to the API design in Bun that requires access to the
-          // `Server` to lookup an IP.
-          ip: ipCache.get(request),
-          headers,
-        },
-        { platform: platform(env), proxies },
-      );
+    const ipDetails = resolveClientIp(
+      {
+        // This attempts to lookup the IP in the `ipCache`. This is primarily a
+        // workaround to the API design in Bun that requires access to the
+        // `Server` to lookup an IP.
+        ip: ipCache.get(request),
+        headers,
+      },
+      { development: isDevelopment(env), ipSrc, platform: platform(env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-bun/test/ip-src.test.ts
+++ b/arcjet-bun/test/ip-src.test.ts
@@ -44,12 +44,12 @@ test("explicit ipSrc takes precedence over the cached Bun address and is strippe
     },
   };
   const handler = client.handler(async (received) => {
-    await client.protect(received, { ipSrc: " application-owned:not-an-ip " });
+    await client.protect(received, { ipSrc: "8.8.8.8" });
     return new Response();
   });
 
   await handler.call(server as any, request, server as any);
 
-  assert.equal(details.ip, " application-owned:not-an-ip ");
+  assert.equal(details.ip, "8.8.8.8");
   assert.deepEqual(details.extra, {});
 });

--- a/arcjet-deno/src/index.ts
+++ b/arcjet-deno/src/index.ts
@@ -1,5 +1,11 @@
 import { readBodyWeb } from "@arcjet/body";
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 /// <reference types="@types/deno" />
 import core from "arcjet";
 import type {
@@ -254,6 +260,13 @@ export default function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -270,20 +283,18 @@ export default function arcjet<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          // This attempts to lookup the IP in the `ipCache`. This is primarily a
-          // workaround to the API design in Deno that requires access to the
-          // `ServeHandlerInfo` to lookup an IP.
-          ip: ipCache.get(request),
-          headers,
-        },
-        { platform: platform(env), proxies },
-      );
+    const ipDetails = resolveClientIp(
+      {
+        // This attempts to lookup the IP in the `ipCache`. This is primarily a
+        // workaround to the API design in Deno that requires access to the
+        // `ServeHandlerInfo` to lookup an IP.
+        ip: ipCache.get(request),
+        headers,
+      },
+      { development: isDevelopment(env), ipSrc, platform: platform(env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-deno/test/ip-src.test.ts
+++ b/arcjet-deno/test/ip-src.test.ts
@@ -38,7 +38,7 @@ test("explicit ipSrc takes precedence over the cached Deno address and is stripp
   });
   const request = new Request("https://example.com/");
   const handler = client.handler(async (received) => {
-    await client.protect(received, { ipSrc: " application-owned:not-an-ip " });
+    await client.protect(received, { ipSrc: "8.8.8.8" });
     return new Response();
   });
 
@@ -47,6 +47,6 @@ test("explicit ipSrc takes precedence over the cached Deno address and is stripp
     remoteAddr: { hostname: "192.0.2.1", port: 1234, transport: "tcp" },
   });
 
-  assert.equal(details.ip, " application-owned:not-an-ip ");
+  assert.equal(details.ip, "8.8.8.8");
   assert.deepEqual(details.extra, {});
 });

--- a/arcjet-fastify/src/index.ts
+++ b/arcjet-fastify/src/index.ts
@@ -2,7 +2,15 @@ import process from "node:process";
 
 import { baseUrl as baseUrlFromEnvironment, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
-import { type Cidr, findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  type Cidr,
+  type ClientIpDetails,
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
 // TODO(@wooorm-arcjet): use export maps to hide file extensions and lock down API.
 import { createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
@@ -242,6 +250,13 @@ export default function arcjet<
   const client = options.client ?? createRemoteClient();
   const log = options.log ? options.log : new Logger({ level: logLevel(process.env) });
   const proxies = options.proxies ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -260,6 +275,7 @@ export default function arcjet<
           fastifyRequest,
           log,
           proxies,
+          reportClientIp,
           // Cast of `{}` because here we switch from `undefined` to `Properties`.
           ruleProps as Properties,
           ipSrc,
@@ -310,6 +326,7 @@ function toArcjetRequest<Properties extends PlainObject>(
   request: ArcjetFastifyRequest,
   log: ArcjetLogger,
   proxies: ReadonlyArray<Cidr | string | ProxyService> | undefined,
+  reportClientIp: (details: ClientIpDetails) => void,
   properties: Properties,
   ipSrc?: string,
 ): ArcjetRequest<Properties> {
@@ -322,11 +339,12 @@ function toArcjetRequest<Properties extends PlainObject>(
   const cookies = typeof requestHeaders.cookie === "string" ? requestHeaders.cookie : "";
   const headers = new ArcjetHeaders(requestHeaders);
 
-  const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
-  let ip =
-    ipSrc ||
-    xArcjetIp ||
-    findIp({ headers, socket: request.socket }, { platform: platform(process.env), proxies });
+  const ipDetails = resolveClientIp(
+    { headers, socket: request.socket },
+    { development: isDevelopment(process.env), ipSrc, platform: platform(process.env), proxies },
+  );
+  reportClientIp(ipDetails);
+  let ip = ipDetails.ip;
 
   if (ip === "") {
     if (isDevelopment(process.env)) {

--- a/arcjet-fastify/test/ip-src.test.ts
+++ b/arcjet-fastify/test/ip-src.test.ts
@@ -50,8 +50,8 @@ test("explicit ipSrc bypasses the Fastify socket address and is stripped", async
       },
       url: "/",
     },
-    { ipSrc: " application-owned:not-an-ip " },
+    { ipSrc: "8.8.8.8" },
   );
-  assert.equal(details.ip, " application-owned:not-an-ip ");
+  assert.equal(details.ip, "8.8.8.8");
   assert.deepEqual(details.extra, {});
 });

--- a/arcjet-nest/src/index.ts
+++ b/arcjet-nest/src/index.ts
@@ -1,4 +1,10 @@
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 // NestJS requires this. Usually it is imported via their runtime but we
 // import it to be sure.
 // oxlint-disable-next-line import/no-unassigned-import
@@ -326,6 +332,13 @@ function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -342,18 +355,16 @@ function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          ip: request.ip,
-          socket: request.socket,
-          headers,
-        },
-        { platform: platform(process.env), proxies },
-      );
+    const ipDetails = resolveClientIp(
+      {
+        ip: request.ip,
+        socket: request.socket,
+        headers,
+      },
+      { development: isDevelopment(process.env), ipSrc, platform: platform(process.env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-next/src/index.ts
+++ b/arcjet-next/src/index.ts
@@ -1,5 +1,11 @@
 import { readBodyWeb } from "@arcjet/body";
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import core from "arcjet";
 import type {
   ArcjetDecision,
@@ -535,6 +541,13 @@ export default function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -548,20 +561,18 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          ip: request.ip,
-          socket: request.socket,
-          info: request.info,
-          requestContext: request.requestContext,
-          headers,
-        },
-        { platform: platform(process.env), proxies },
-      );
+    const ipDetails = resolveClientIp(
+      {
+        ip: request.ip,
+        socket: request.socket,
+        info: request.info,
+        requestContext: request.requestContext,
+        headers,
+      },
+      { development: isDevelopment(process.env), ipSrc, platform: platform(process.env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-node/src/index.ts
+++ b/arcjet-node/src/index.ts
@@ -1,4 +1,11 @@
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ClientIpDetails,
+  type ProxyService,
+} from "@arcjet/ip";
 import core from "arcjet";
 import type {
   ArcjetDecision,
@@ -14,7 +21,7 @@ import type {
 } from "arcjet";
 
 export { cloudflare } from "@arcjet/ip";
-export type { ProxyService } from "@arcjet/ip";
+export type { ClientIpDetails, ClientIpProvenance, ProxyService } from "@arcjet/ip";
 import { readBody } from "@arcjet/body";
 import type { Env } from "@arcjet/env";
 import { baseUrl, isDevelopment, logLevel, platform } from "@arcjet/env";
@@ -271,6 +278,12 @@ export type ArcjetOptions<
  *   Configuration.
  */
 export interface ArcjetNode<Props extends PlainObject> {
+  /** Explain how this client would resolve an IP without protecting. */
+  clientIpDetails(
+    request: ArcjetNodeRequest,
+    options?: { ipSrc?: string | undefined } | undefined,
+  ): ClientIpDetails;
+
   /**
    * Make a decision about how to handle a request.
    *
@@ -350,9 +363,25 @@ export default function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
+  }
+
+  function resolveIp(request: ArcjetNodeRequest, ipSrc?: string): ClientIpDetails {
+    const headers = new ArcjetHeaders(request.headers);
+    return resolveClientIp(
+      { socket: request.socket, headers },
+      { development: isDevelopment(env), ipSrc, platform: platform(env), proxies },
+    );
   }
 
   function toArcjetRequest<Props extends PlainObject>(
@@ -366,17 +395,9 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(request.headers);
 
-    const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          socket: request.socket,
-          headers,
-        },
-        { platform: platform(env), proxies },
-      );
+    const ipDetails = resolveIp(request, ipSrc);
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.
@@ -434,6 +455,9 @@ export default function arcjet<
     aj: Arcjet<Properties>,
   ): ArcjetNode<Properties> {
     const client: ArcjetNode<Properties> = {
+      clientIpDetails(request, options) {
+        return resolveIp(request, options?.ipSrc);
+      },
       withRule(rule) {
         const client = aj.withRule(rule);
         return withClient(client);

--- a/arcjet-node/src/index.ts
+++ b/arcjet-node/src/index.ts
@@ -278,7 +278,23 @@ export type ArcjetOptions<
  *   Configuration.
  */
 export interface ArcjetNode<Props extends PlainObject> {
-  /** Explain how this client would resolve an IP without protecting. */
+  /**
+   * Explain how this client would resolve an IP without protecting.
+   *
+   * This diagnostic is side-effect-free: it does not emit logs, consume the
+   * once-per-client-instance `unverified-header` warning, or send a decision.
+   * Pass the same independently trusted `ipSrc` here that you will pass to
+   * {@linkcode protect} when using a manual override.
+   *
+   * @example
+   * ```ts
+   * const details = aj.clientIpDetails(request);
+   * console.log(details.ip, details.provenance, details.verified, details.header);
+   * ```
+   *
+   * @throws {Error}
+   *   If a non-empty `ipSrc` is not a valid IPv4 or IPv6 address.
+   */
   clientIpDetails(
     request: ArcjetNodeRequest,
     options?: { ipSrc?: string | undefined } | undefined,
@@ -305,7 +321,12 @@ export interface ArcjetNode<Props extends PlainObject> {
     ...props: MaybeProperties<
       Props & {
         correlationId?: string;
-        /** Application-provided client IP address, used instead of automatic detection. */
+        /**
+         * Independently trusted client IP used instead of automatic detection.
+         * A non-empty malformed value throws. An empty string is treated as
+         * omitted for compatibility. Never copy a client-controlled forwarding
+         * header into this field.
+         */
         ipSrc?: string;
         metadata?: ArcjetMetadata;
       }

--- a/arcjet-node/test/index.test.ts
+++ b/arcjet-node/test/index.test.ts
@@ -456,7 +456,7 @@ test("`arcjetNode`", async function (t) {
     ]);
   });
 
-  await t.test("should prefer and strip an explicit `ipSrc`", async function () {
+  await t.test("should prefer and validate an explicit `ipSrc`", async function () {
     const restore = capture();
     let request: ArcjetRequestDetails | undefined;
     const arcjet = arcjetNode({
@@ -489,17 +489,25 @@ test("`arcjetNode`", async function (t) {
       decide(request) {
         return arcjet.protect(request, {
           correlationId: "wf_ip_src",
-          ipSrc: " application-owned:not-an-ip ",
+          ipSrc: "8.8.8.8",
           metadata: { integration: "custom-ip" },
         });
       },
     });
 
     await fetch(url, { headers: { "x-forwarded-for": "185.199.108.1" } });
-    assert.equal(request?.ip, " application-owned:not-an-ip ");
+    assert.equal(request?.ip, "8.8.8.8");
     assert.equal(request?.correlationId, "wf_ip_src");
     assert.deepEqual(request?.extra, {});
     assert.deepEqual(request?.metadata, { integration: "custom-ip" });
+
+    await assert.rejects(
+      arcjet.protect(
+        { headers: { "x-forwarded-for": "185.199.108.1" } },
+        { ipSrc: "application-owned:not-an-ip" },
+      ),
+      /Invalid ipSrc/,
+    );
 
     await arcjet.protect({ headers: { "x-forwarded-for": "185.199.108.1" } }, { ipSrc: "" });
     await server.close();
@@ -507,6 +515,51 @@ test("`arcjetNode`", async function (t) {
 
     assert.equal(request?.ip, "185.199.108.1");
     assert.deepEqual(request?.extra, {});
+  });
+
+  await t.test("should expose provenance and warn once for unverified headers", async () => {
+    const debug: Array<Array<unknown>> = [];
+    const warnings: Array<Array<unknown>> = [];
+    const arcjet = arcjetNode({
+      client: createLocalClient(),
+      key: exampleKey,
+      log: {
+        debug(...args: Array<unknown>) {
+          debug.push(args);
+        },
+        error() {},
+        info() {},
+        warn(...args: Array<unknown>) {
+          warnings.push(args);
+        },
+      },
+      rules: [],
+    });
+    const request = { headers: { "x-forwarded-for": "185.199.108.1" } };
+
+    assert.deepEqual(arcjet.clientIpDetails(request), {
+      ip: "185.199.108.1",
+      provenance: "unverified-header",
+      verified: false,
+      header: "x-forwarded-for",
+    });
+    await arcjet.protect(request);
+    await arcjet.protect(request);
+
+    assert.equal(
+      debug.some(
+        ([facets]) =>
+          typeof facets === "object" &&
+          facets !== null &&
+          "client_ip_provenance" in facets &&
+          facets.client_ip_provenance === "unverified-header",
+      ),
+      true,
+    );
+    assert.equal(
+      warnings.filter((args) => String(args[1]).includes("unverified forwarding header")).length,
+      1,
+    );
   });
 
   await t.test("should prefer `x-arcjet-ip` in development", async function () {

--- a/arcjet-node/test/index.test.ts
+++ b/arcjet-node/test/index.test.ts
@@ -456,7 +456,7 @@ test("`arcjetNode`", async function (t) {
     ]);
   });
 
-  await t.test("should prefer and validate an explicit `ipSrc`", async function () {
+  await t.test("should prefer an explicit `ipSrc` and treat empty as omitted", async function () {
     const restore = capture();
     let request: ArcjetRequestDetails | undefined;
     const arcjet = arcjetNode({
@@ -501,6 +501,20 @@ test("`arcjetNode`", async function (t) {
     assert.deepEqual(request?.extra, {});
     assert.deepEqual(request?.metadata, { integration: "custom-ip" });
 
+    await arcjet.protect({ headers: { "x-forwarded-for": "185.199.108.1" } }, { ipSrc: "" });
+    await server.close();
+    restore();
+
+    assert.equal(request?.ip, "185.199.108.1");
+    assert.deepEqual(request?.extra, {});
+  });
+
+  await t.test("should reject a malformed explicit `ipSrc`", async function () {
+    const arcjet = arcjetNode({
+      client: createLocalClient(),
+      key: exampleKey,
+      rules: [],
+    });
     await assert.rejects(
       arcjet.protect(
         { headers: { "x-forwarded-for": "185.199.108.1" } },
@@ -508,13 +522,6 @@ test("`arcjetNode`", async function (t) {
       ),
       /Invalid ipSrc/,
     );
-
-    await arcjet.protect({ headers: { "x-forwarded-for": "185.199.108.1" } }, { ipSrc: "" });
-    await server.close();
-    restore();
-
-    assert.equal(request?.ip, "185.199.108.1");
-    assert.deepEqual(request?.extra, {});
   });
 
   await t.test("should expose provenance and warn once for unverified headers", async () => {

--- a/arcjet-nuxt/src/internal.ts
+++ b/arcjet-nuxt/src/internal.ts
@@ -1,7 +1,15 @@
 import { readBody } from "@arcjet/body";
 import { baseUrl as baseUrlFromEnvironment, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
-import { type Cidr, findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  type Cidr,
+  type ClientIpDetails,
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
 import { type Client, createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
@@ -247,6 +255,8 @@ interface State {
    * Configured proxies.
    */
   proxies: ReadonlyArray<Cidr | string | ProxyService>;
+
+  reportClientIp: (details: ClientIpDetails) => void;
 }
 
 /**
@@ -279,11 +289,20 @@ export default function arcjet<
     key = config.__ARCJET_KEY;
   }
 
+  const log = options.log ?? new Logger({ level: logLevel(process.env) });
+  const proxies = options.proxies ? parseProxies(options.proxies) : [];
   const state: State = {
     client: options.client ?? createRemoteClient(),
-    log: options.log ?? new Logger({ level: logLevel(process.env) }),
-    proxies: options.proxies ? parseProxies(options.proxies) : [],
+    log,
+    proxies,
+    reportClientIp: createClientIpDiagnostics(log),
   };
+  if (hasTrustAllProxy(state.proxies)) {
+    state.log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     state.log.warn(
@@ -405,14 +424,14 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
   ipSrc?: string,
 ): ArcjetRequest<Properties> {
   const headers = new ArcjetHeaders(event.node.req.headers);
-  const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
-  let ip =
-    ipSrc ||
-    xArcjetIp ||
-    findIp(event.node.req, {
-      platform: platform(process.env),
-      proxies: state.proxies,
-    });
+  const ipDetails = resolveClientIp(event.node.req, {
+    development: isDevelopment(process.env),
+    ipSrc,
+    platform: platform(process.env),
+    proxies: state.proxies,
+  });
+  state.reportClientIp(ipDetails);
+  let ip = ipDetails.ip;
 
   if (!ip) {
     if (isDevelopment(process.env)) {

--- a/arcjet-react-router/src/index.ts
+++ b/arcjet-react-router/src/index.ts
@@ -349,25 +349,16 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
   ipSrc?: string,
 ): ArcjetRequest<Properties> {
   const headers = new ArcjetHeaders(details.request.headers);
-  let applicationIp: string | undefined = ipSrc || undefined;
 
   // Get the IP from non-middleware context (no `future.v8_middleware` flag).
   // Users *themselves* must provide this `ip` field if they use a particular
   // adapter.
-  if (
-    !applicationIp &&
-    details.context &&
-    typeof details.context === "object" &&
-    "ip" in details.context &&
-    typeof details.context.ip === "string"
-  ) {
-    applicationIp = details.context.ip;
-  }
+  const contextIp = (details.context as { ip?: unknown } | null | undefined)?.ip;
   const ipDetails = resolveClientIp(
-    { headers },
+    { headers, ip: typeof contextIp === "string" ? contextIp : undefined },
     {
       development: isDevelopment(process.env),
-      ipSrc: applicationIp,
+      ipSrc,
       platform: platform(process.env),
       proxies: state.proxies,
     },

--- a/arcjet-react-router/src/index.ts
+++ b/arcjet-react-router/src/index.ts
@@ -1,7 +1,15 @@
 import { readBodyWeb } from "@arcjet/body";
 import { baseUrl as baseUrlFromEnvironment, isDevelopment, logLevel, platform } from "@arcjet/env";
 import { ArcjetHeaders } from "@arcjet/headers";
-import { type Cidr, findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  type Cidr,
+  type ClientIpDetails,
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import { Logger } from "@arcjet/logger";
 import { type Client, createClient, resolveClientTimeout } from "@arcjet/protocol/client.js";
 import { createTransport } from "@arcjet/transport";
@@ -178,6 +186,8 @@ interface State {
    * Configured proxies.
    */
   proxies: ReadonlyArray<Cidr | string | ProxyService>;
+
+  reportClientIp: (details: ClientIpDetails) => void;
 }
 
 /**
@@ -204,11 +214,20 @@ export default function arcjet<
 >(
   options: ArcjetOptions<Rules, Characteristics>,
 ): ArcjetReactRouter<ExtraProps<Rules> & CharacteristicProps<Characteristics>> {
+  const log = options.log ?? new Logger({ level: logLevel(process.env) });
+  const proxies = options.proxies ? parseProxies(options.proxies) : [];
   const state: State = {
     client: options.client ?? createRemoteClient(),
-    log: options.log ?? new Logger({ level: logLevel(process.env) }),
-    proxies: options.proxies ? parseProxies(options.proxies) : [],
+    log,
+    proxies,
+    reportClientIp: createClientIpDiagnostics(log),
   };
+  if (hasTrustAllProxy(state.proxies)) {
+    state.log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     state.log.warn(
@@ -330,45 +349,36 @@ function toArcjetRequest<Properties extends Record<PropertyKey, unknown>>(
   ipSrc?: string,
 ): ArcjetRequest<Properties> {
   const headers = new ArcjetHeaders(details.request.headers);
-  let ip: string | undefined = ipSrc || undefined;
+  let applicationIp: string | undefined = ipSrc || undefined;
 
   // Get the IP from non-middleware context (no `future.v8_middleware` flag).
   // Users *themselves* must provide this `ip` field if they use a particular
   // adapter.
   if (
-    !ip &&
+    !applicationIp &&
     details.context &&
     typeof details.context === "object" &&
     "ip" in details.context &&
     typeof details.context.ip === "string"
   ) {
-    ip = details.context.ip;
+    applicationIp = details.context.ip;
   }
-
-  const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
-
-  if (!ip && xArcjetIp) {
-    ip = xArcjetIp;
-  }
-
-  if (!ip) {
-    ip = findIp(details.request, {
+  const ipDetails = resolveClientIp(
+    { headers },
+    {
+      development: isDevelopment(process.env),
+      ipSrc: applicationIp,
       platform: platform(process.env),
       proxies: state.proxies,
-    });
-  }
+    },
+  );
+  state.reportClientIp(ipDetails);
+  const ip = ipDetails.ip;
 
   if (!ip) {
-    if (isDevelopment(process.env)) {
-      // In development, there is a warning for this when the client is
-      // constructed.
-      ip = "127.0.0.1";
-    } else {
-      // In production, warn for every request.
-      state.log.warn(
-        "Cannot find client IP address; if this is a development environment, set the `ARCJET_ENV` environment variable to `development`; in production, provide `context.ip` or an `x-client-ip` (or similar) header",
-      );
-    }
+    state.log.warn(
+      "Cannot find client IP address; if this is a development environment, set the `ARCJET_ENV` environment variable to `development`; in production, provide `context.ip` or an `x-client-ip` (or similar) header",
+    );
   }
 
   const url = new URL(details.request.url);

--- a/arcjet-react-router/test/index.test.ts
+++ b/arcjet-react-router/test/index.test.ts
@@ -164,6 +164,25 @@ test("`default`", async function (t) {
         assert.equal(called, false);
       },
     );
+
+    await t.test("should warn when proxy configuration trusts every peer", () => {
+      let parameters: unknown;
+      arcjet({
+        key: "",
+        log: {
+          ...createArcjetLogger(),
+          warn(...rest) {
+            parameters = rest;
+          },
+        },
+        proxies: ["0.0.0.0/0"],
+        rules: [],
+      });
+      assert.deepEqual(parameters, [
+        { trustAll: true },
+        "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+      ]);
+    });
   });
 
   await t.test("`protect()`", async function (t) {
@@ -194,6 +213,7 @@ test("`default`", async function (t) {
       assert.deepEqual(parameters, undefined);
 
       await integration.protect({
+        context: { ip: 123 } as any,
         request: new Request("https://example.com/"),
       });
 

--- a/arcjet-react-router/test/index.test.ts
+++ b/arcjet-react-router/test/index.test.ts
@@ -550,9 +550,13 @@ test("`default`", async function (t) {
         rules: [sensitiveInfo({ deny: ["EMAIL"], mode: "LIVE" })],
       });
 
+      const body = "email test@example.com phone 011234567 ip 10.12.234.2";
       const request = new Request("https://example.com/", {
-        body: "email test@example.com phone 011234567 ip 10.12.234.2",
-        headers: { "x-client-ip": "185.199.108.153" },
+        body,
+        headers: {
+          "content-length": String(new TextEncoder().encode(body).byteLength),
+          "x-client-ip": "185.199.108.153",
+        },
         method: "POST",
       });
       const result = await integration.protect({ request });

--- a/arcjet-react-router/test/ip-src.test.ts
+++ b/arcjet-react-router/test/ip-src.test.ts
@@ -51,4 +51,22 @@ test("explicit ipSrc overrides React Router context.ip and is stripped", async f
     { ipSrc: "" },
   );
   assert.equal(details.ip, "8.8.4.4");
+
+  await client.protect({
+    context: { ip: "application-context:not-an-ip" },
+    request: new Request("https://example.com/", {
+      headers: { "x-forwarded-for": "1.1.1.1" },
+    }),
+  });
+  assert.equal(details.ip, "1.1.1.1");
+
+  for (const context of [undefined, "not-an-object", {}]) {
+    await client.protect({
+      context: context as any,
+      request: new Request("https://example.com/", {
+        headers: { "x-forwarded-for": "9.9.9.9" },
+      }),
+    });
+    assert.equal(details.ip, "9.9.9.9");
+  }
 });

--- a/arcjet-react-router/test/ip-src.test.ts
+++ b/arcjet-react-router/test/ip-src.test.ts
@@ -37,9 +37,18 @@ test("explicit ipSrc overrides React Router context.ip and is stripped", async f
     ],
   });
   await client.protect(
-    { context: { ip: "192.0.2.1" }, request: new Request("https://example.com/") },
+    {
+      context: { ip: "192.0.2.1" },
+      request: new Request("https://example.com/", { headers: { cookie: "session=test" } }),
+    },
     { ipSrc: "203.0.113.10" },
   );
   assert.equal(details.ip, "203.0.113.10");
   assert.deepEqual(details.extra, {});
+
+  await client.protect(
+    { context: { ip: "8.8.4.4" }, request: new Request("https://example.com/") },
+    { ipSrc: "" },
+  );
+  assert.equal(details.ip, "8.8.4.4");
 });

--- a/arcjet-remix/src/index.ts
+++ b/arcjet-remix/src/index.ts
@@ -1,5 +1,11 @@
 import { readBodyWeb } from "@arcjet/body";
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import core from "arcjet";
 import type {
   ArcjetDecision,
@@ -249,6 +255,13 @@ export default function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(process.env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -265,18 +278,16 @@ export default function arcjet<
     const headers = new ArcjetHeaders(request.headers);
 
     const url = new URL(request.url);
-    const xArcjetIp = isDevelopment(process.env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          // The `getLoadContext` API will attach the `ip` to the context
-          ip: context?.ip,
-          headers,
-        },
-        { platform: platform(process.env), proxies },
-      );
+    const ipDetails = resolveClientIp(
+      {
+        // The `getLoadContext` API will attach the `ip` to the context
+        ip: context?.ip,
+        headers,
+      },
+      { development: isDevelopment(process.env), ipSrc, platform: platform(process.env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-sveltekit/src/index.ts
+++ b/arcjet-sveltekit/src/index.ts
@@ -1,5 +1,11 @@
 import { readBodyWeb } from "@arcjet/body";
-import { findIp, parseProxies, type ProxyService } from "@arcjet/ip";
+import {
+  createClientIpDiagnostics,
+  hasTrustAllProxy,
+  parseProxies,
+  resolveClientIp,
+  type ProxyService,
+} from "@arcjet/ip";
 import core from "arcjet";
 import type {
   ArcjetDecision,
@@ -285,6 +291,13 @@ export default function arcjet<
       });
 
   const proxies = Array.isArray(options.proxies) ? parseProxies(options.proxies) : undefined;
+  const reportClientIp = createClientIpDiagnostics(log);
+  if (proxies && hasTrustAllProxy(proxies)) {
+    log.warn(
+      { trustAll: true },
+      "Arcjet proxy configuration trusts an entire IP address family; use the narrowest proxy CIDRs possible.",
+    );
+  }
 
   if (isDevelopment(env)) {
     log.warn("Arcjet will use 127.0.0.1 when missing public IP address in development mode");
@@ -300,17 +313,15 @@ export default function arcjet<
     // We construct an ArcjetHeaders to normalize over Headers
     const headers = new ArcjetHeaders(event.request.headers);
 
-    const xArcjetIp = isDevelopment(env) ? headers.get("x-arcjet-ip") : undefined;
-    let ip =
-      ipSrc ||
-      xArcjetIp ||
-      findIp(
-        {
-          ip: event.getClientAddress(),
-          headers,
-        },
-        { platform: platform(env), proxies },
-      );
+    const ipDetails = resolveClientIp(
+      {
+        ip: ipSrc ? undefined : event.getClientAddress(),
+        headers,
+      },
+      { development: isDevelopment(env), ipSrc, platform: platform(env), proxies },
+    );
+    reportClientIp(ipDetails);
+    let ip = ipDetails.ip;
     if (ip === "") {
       // If the `ip` is empty but we're in development mode, we default the IP
       // so the request doesn't fail.

--- a/arcjet-sveltekit/src/index.ts
+++ b/arcjet-sveltekit/src/index.ts
@@ -315,6 +315,9 @@ export default function arcjet<
 
     const ipDetails = resolveClientIp(
       {
+        // `getClientAddress()` can throw when the SvelteKit adapter cannot
+        // determine a peer. A valid manual `ipSrc` has higher precedence and
+        // must not invoke that fallible framework lookup.
         ip: ipSrc ? undefined : event.getClientAddress(),
         headers,
       },

--- a/ip/src/index.ts
+++ b/ip/src/index.ts
@@ -286,9 +286,10 @@ export function parseProxy(value: string): string | Cidr {
  * Parse a list of trusted proxies.
  *
  * CIDR range strings are parsed to {@linkcode Cidr} (so they match by range);
- * plain IP strings and {@linkcode ProxyService} objects (such as those created
- * by {@linkcode cloudflare}) are passed through unchanged. Use this to
- * normalize the `proxies` option before handing it to {@linkcode findIp}.
+ * plain IP strings are passed through unchanged. {@linkcode ProxyService}
+ * objects (such as those created by {@linkcode cloudflare}) are shallow-cloned
+ * with parsed ranges. Use this to normalize the `proxies` option before handing
+ * it to {@linkcode findIp}.
  *
  * @param proxies
  *   Trusted proxies to parse.
@@ -302,10 +303,12 @@ export function parseProxies(
     if (typeof proxy === "string") {
       return parseProxy(proxy);
     }
-    for (const range of proxy.ranges) {
-      if (typeof range === "string") parseProxy(range);
-    }
-    return proxy;
+    return {
+      ...proxy,
+      // Parse service ranges once here so validation, trust-all detection, and
+      // request-time matching reuse the same immutable CIDR objects.
+      ranges: proxy.ranges.map((range) => (typeof range === "string" ? parseProxy(range) : range)),
+    };
   });
 }
 
@@ -333,9 +336,9 @@ export function hasTrustAllProxy(proxies: ReadonlyArray<string | Cidr | ProxySer
 /**
  * Check whether a value is a syntactically valid IPv4 or IPv6 address.
  */
-export function isValidIp(value: unknown): value is string {
+function parseIp(value: unknown): Ipv4Tuple | Ipv6Tuple | undefined {
   if (typeof value !== "string" || value === "") {
-    return false;
+    return undefined;
   }
   const ipv4 = new Parser(value);
   const octets = ipv4.readIpv4Address();
@@ -344,10 +347,15 @@ export function isValidIp(value: unknown): value is string {
     ipv4.state.length === 0 &&
     octets.every((part) => part >= 0 && part <= 255)
   ) {
-    return true;
+    return octets;
   }
   const ipv6 = new Parser(value);
-  return isIpv6Tuple(ipv6.readIpv6Address()) && ipv6.state.length === 0;
+  const segments = ipv6.readIpv6Address();
+  return isIpv6Tuple(segments) && ipv6.state.length === 0 ? segments : undefined;
+}
+
+export function isValidIp(value: unknown): value is string {
+  return typeof parseIp(value) !== "undefined";
 }
 
 function isIpv4Tuple(segements?: ArrayLike<number>): segements is Ipv4Tuple {
@@ -997,11 +1005,24 @@ export interface Options {
 
 /** Options for framework integrations resolving a client IP. */
 export interface ResolveOptions extends Options {
+  /**
+   * Independently trusted client IP supplied by the application.
+   *
+   * A non-empty malformed value throws. An empty string means "not supplied"
+   * for compatibility and automatic detection continues.
+   */
   ipSrc?: string | null | undefined;
+  /** Enable the `X-Arcjet-Ip` override and loopback fallback for development. */
   development?: boolean | null | undefined;
 }
 
-/** Where Arcjet obtained a client IP address. */
+/**
+ * Where Arcjet obtained a client IP address.
+ *
+ * `unverified-header` means a forwarding header was used without a trusted
+ * direct peer. `verified` in {@linkcode ClientIpDetails} describes that source
+ * relationship; it does not certify the surrounding network configuration.
+ */
 export type ClientIpProvenance =
   | "direct"
   | "platform"
@@ -1014,9 +1035,13 @@ export type ClientIpProvenance =
 
 /** Debug information about Arcjet's client IP selection. */
 export interface ClientIpDetails {
+  /** Selected IPv4/IPv6 address, or an empty string when none was found. */
   ip: string;
+  /** Where Arcjet obtained `ip`. */
   provenance: ClientIpProvenance;
+  /** Whether the SDK tied the source to a direct request or trusted path. */
   verified: boolean;
+  /** Lowercase source header when a header supplied `ip`. */
   header?: string | undefined;
 }
 
@@ -1026,7 +1051,19 @@ export interface ClientIpLogger {
   warn(facets: Record<string, unknown>, message: string): void;
 }
 
-/** Create a per-client provenance logger with a coalesced fallback warning. */
+/**
+ * Create a provenance reporter for one Arcjet client instance.
+ *
+ * Every call emits debug facets. The first `unverified-header` result emits one
+ * warning for the lifetime of this reporter; later results still emit debug
+ * data.
+ *
+ * @example
+ * ```ts
+ * const report = createClientIpDiagnostics(log);
+ * report(findIpDetails(request));
+ * ```
+ */
 export function createClientIpDiagnostics(log: ClientIpLogger) {
   let warnedForUnverifiedHeader = false;
   return function reportClientIp(details: ClientIpDetails): void {
@@ -1068,14 +1105,11 @@ function configuredProxyMatches(
   proxies: ReadonlyArray<string | Cidr>,
   services: ReadonlyArray<ProxyService>,
 ): boolean {
-  if (typeof candidate !== "string" || !isValidIp(candidate)) {
+  if (typeof candidate !== "string") {
     return false;
   }
-  const parser = new Parser(candidate);
-  const ipv4 = parser.readIpv4Address();
-  const segments = (isIpv4Tuple(ipv4) ? ipv4 : new Parser(candidate).readIpv6Address()) as
-    | Ipv4Tuple
-    | Ipv6Tuple;
+  const segments = parseIp(candidate);
+  if (!segments) return false;
   if (isTrustedProxy(candidate, Array.from(segments), proxies)) {
     return true;
   }
@@ -1123,7 +1157,20 @@ function getHeader(headers: HeaderLike["headers"], headerKey: string) {
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 /**
- * Find a client IP address on a request-like object.
+ * Find a client IP address and explain its provenance.
+ *
+ * This function is side-effect-free: it does not log or send a decision. When
+ * no platform is selected and only a forwarding header supplies an address,
+ * the result uses `provenance: "unverified-header"` and `verified: false`.
+ *
+ * @example
+ * ```ts
+ * const details = findIpDetails(
+ *   { headers: request.headers, socket: request.socket },
+ *   { proxies: ["10.0.0.0/8"] },
+ * );
+ * console.log(details.ip, details.provenance, details.verified, details.header);
+ * ```
  *
  * @param request
  *   Request-like object.
@@ -1162,10 +1209,11 @@ export function findIpDetails(
     }
   }
 
-  const directPeerTrusted =
-    configuredProxyMatches(request.ip, proxies, services) ||
-    configuredProxyMatches(request.socket?.remoteAddress, proxies, services) ||
-    configuredProxyMatches(request.info?.remoteAddress, proxies, services);
+  // A framework's `request.ip` may already be derived from forwarding headers.
+  // Prefer transport-level peer fields when present so a spoofed request value
+  // cannot upgrade another forwarding header to `trusted-proxy` provenance.
+  const directPeer = request.socket?.remoteAddress ?? request.info?.remoteAddress ?? request.ip;
+  const directPeerTrusted = configuredProxyMatches(directPeer, proxies, services);
   const forwardingProvenance: ClientIpProvenance = directPeerTrusted
     ? "trusted-proxy"
     : "unverified-header";
@@ -1527,7 +1575,24 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
   return findIpDetails(request, options).ip;
 }
 
-/** Resolve a client IP including manual and development-mode overrides. */
+/**
+ * Resolve a client IP including manual and development-mode overrides.
+ *
+ * `ipSrc` has highest precedence. A non-empty malformed value throws; an empty
+ * string preserves the legacy "not supplied" behavior. This function does not
+ * log or send a decision.
+ *
+ * @example
+ * ```ts
+ * const details = resolveClientIp(
+ *   { headers: request.headers, socket: request.socket },
+ *   { ipSrc: trustedClientIp, proxies: ["10.0.0.0/8"] },
+ * );
+ * ```
+ *
+ * @throws {Error}
+ *   If a non-empty `ipSrc` is not a valid IPv4 or IPv6 address.
+ */
 export function resolveClientIp(
   request: RequestLike,
   options?: ResolveOptions | null | undefined,

--- a/ip/src/index.ts
+++ b/ip/src/index.ts
@@ -224,10 +224,17 @@ function parseCidr(cidr: `${string}/${string}`): Cidr {
   if (cidrParts.length !== 2) {
     throw new Error("invalid CIDR address: must be exactly 2 parts");
   }
+  if (!/^\d+$/.test(cidrParts[1])) {
+    throw new Error("invalid CIDR address: incorrect amount of bits");
+  }
 
   const parser = new Parser(cidrParts[0]);
   const maybeIpv4 = parser.readIpv4Address();
-  if (isIpv4Tuple(maybeIpv4)) {
+  if (
+    isIpv4Tuple(maybeIpv4) &&
+    parser.state.length === 0 &&
+    maybeIpv4.every((part) => part >= 0 && part <= 255)
+  ) {
     const bits = parseInt(cidrParts[1], 10);
     if (isNaN(bits) || bits < 0 || bits > 32) {
       throw new Error("invalid CIDR address: incorrect amount of bits");
@@ -237,7 +244,7 @@ function parseCidr(cidr: `${string}/${string}`): Cidr {
   }
 
   const maybeIpv6 = parser.readIpv6Address();
-  if (isIpv6Tuple(maybeIpv6)) {
+  if (isIpv6Tuple(maybeIpv6) && parser.state.length === 0) {
     const bits = parseInt(cidrParts[1], 10);
     if (isNaN(bits) || bits < 0 || bits > 128) {
       throw new Error("invalid CIDR address: incorrect amount of bits");
@@ -262,11 +269,17 @@ function isCidr(address: string): address is `${string}/${string}` {
  *   Parsed {@linkcode Cidr} if range or given `value` if IP.
  */
 export function parseProxy(value: string): string | Cidr {
-  if (isCidr(value)) {
-    return parseCidr(value);
-  } else {
-    return value;
+  const candidate = value.trim();
+  if (candidate === "") {
+    throw new Error("invalid proxy address: expected an IP address or CIDR range");
   }
+  if (isCidr(candidate)) {
+    return parseCidr(candidate);
+  }
+  if (!isValidIp(candidate)) {
+    throw new Error(`invalid proxy address: ${JSON.stringify(value)}`);
+  }
+  return candidate;
 }
 
 /**
@@ -285,7 +298,56 @@ export function parseProxy(value: string): string | Cidr {
 export function parseProxies(
   proxies: ReadonlyArray<string | ProxyService>,
 ): Array<string | Cidr | ProxyService> {
-  return proxies.map((proxy) => (typeof proxy === "string" ? parseProxy(proxy) : proxy));
+  return proxies.map((proxy) => {
+    if (typeof proxy === "string") {
+      return parseProxy(proxy);
+    }
+    for (const range of proxy.ranges) {
+      if (typeof range === "string") parseProxy(range);
+    }
+    return proxy;
+  });
+}
+
+/** Check whether proxy configuration trusts an entire IP address family. */
+export function hasTrustAllProxy(proxies: ReadonlyArray<string | Cidr | ProxyService>): boolean {
+  for (const proxy of proxies) {
+    if (isIpv4Cidr(proxy) || isIpv6Cidr(proxy)) {
+      if (proxy.bits === 0) return true;
+      continue;
+    }
+    if (isProxyService(proxy)) {
+      if (
+        proxy.ranges.some((range) => {
+          const parsed = typeof range === "string" ? parseProxy(range) : range;
+          return (isIpv4Cidr(parsed) || isIpv6Cidr(parsed)) && parsed.bits === 0;
+        })
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Check whether a value is a syntactically valid IPv4 or IPv6 address.
+ */
+export function isValidIp(value: unknown): value is string {
+  if (typeof value !== "string" || value === "") {
+    return false;
+  }
+  const ipv4 = new Parser(value);
+  const octets = ipv4.readIpv4Address();
+  if (
+    isIpv4Tuple(octets) &&
+    ipv4.state.length === 0 &&
+    octets.every((part) => part >= 0 && part <= 255)
+  ) {
+    return true;
+  }
+  const ipv6 = new Parser(value);
+  return isIpv6Tuple(ipv6.readIpv6Address()) && ipv6.state.length === 0;
 }
 
 function isIpv4Tuple(segements?: ArrayLike<number>): segements is Ipv4Tuple {
@@ -933,6 +995,95 @@ export interface Options {
   proxies?: ReadonlyArray<string | Cidr | ProxyService> | null | undefined;
 }
 
+/** Options for framework integrations resolving a client IP. */
+export interface ResolveOptions extends Options {
+  ipSrc?: string | null | undefined;
+  development?: boolean | null | undefined;
+}
+
+/** Where Arcjet obtained a client IP address. */
+export type ClientIpProvenance =
+  | "direct"
+  | "platform"
+  | "trusted-proxy"
+  | "unverified-header"
+  | "manual"
+  | "development"
+  | "request"
+  | "none";
+
+/** Debug information about Arcjet's client IP selection. */
+export interface ClientIpDetails {
+  ip: string;
+  provenance: ClientIpProvenance;
+  verified: boolean;
+  header?: string | undefined;
+}
+
+/** Logger shape used by client-IP diagnostics. */
+export interface ClientIpLogger {
+  debug(facets: Record<string, unknown>, message: string): void;
+  warn(facets: Record<string, unknown>, message: string): void;
+}
+
+/** Create a per-client provenance logger with a coalesced fallback warning. */
+export function createClientIpDiagnostics(log: ClientIpLogger) {
+  let warnedForUnverifiedHeader = false;
+  return function reportClientIp(details: ClientIpDetails): void {
+    log.debug(
+      {
+        client_ip_provenance: details.provenance,
+        client_ip_verified: details.verified,
+        client_ip_header: details.header,
+      },
+      "Arcjet client IP resolved",
+    );
+    if (details.provenance !== "unverified-header" || warnedForUnverifiedHeader) {
+      return;
+    }
+    warnedForUnverifiedHeader = true;
+    log.warn(
+      {
+        client_ip_provenance: details.provenance,
+        client_ip_header: details.header,
+      },
+      "Arcjet resolved the client IP from an unverified forwarding header. Ensure a trusted proxy overwrites or safely appends forwarding headers, configure `proxies`, use a proxy-service helper, or pass a validated `ipSrc`. See https://docs.arcjet.com/best-practices#configure-proxies-and-load-balancers",
+    );
+  };
+}
+
+function ipDetails(
+  ip: string,
+  provenance: ClientIpProvenance,
+  verified: boolean,
+  header?: string,
+): ClientIpDetails {
+  return typeof header === "string"
+    ? { ip, provenance, verified, header }
+    : { ip, provenance, verified };
+}
+
+function configuredProxyMatches(
+  candidate: unknown,
+  proxies: ReadonlyArray<string | Cidr>,
+  services: ReadonlyArray<ProxyService>,
+): boolean {
+  if (typeof candidate !== "string" || !isValidIp(candidate)) {
+    return false;
+  }
+  const parser = new Parser(candidate);
+  const ipv4 = parser.readIpv4Address();
+  const segments = (isIpv4Tuple(ipv4) ? ipv4 : new Parser(candidate).readIpv6Address()) as
+    | Ipv4Tuple
+    | Ipv6Tuple;
+  if (isTrustedProxy(candidate, Array.from(segments), proxies)) {
+    return true;
+  }
+  return services.some((service) =>
+    isTrustedProxy(candidate, Array.from(segments), service.ranges),
+  );
+}
+
 function isHeaders(val: HeaderLike["headers"]): val is Headers {
   return typeof val.get === "function";
 }
@@ -981,7 +1132,10 @@ function getHeader(headers: HeaderLike["headers"], headerKey: string) {
  * @returns
  *   Found IP address; empty string if not found.
  */
-export function findIp(request: RequestLike, options?: Options | null | undefined): string {
+export function findIpDetails(
+  request: RequestLike,
+  options?: Options | null | undefined,
+): ClientIpDetails {
   const { platform, proxies: rawProxies } = options || {};
   const proxies: Array<Cidr | string> = [];
   const services: Array<ProxyService> = [];
@@ -1008,12 +1162,24 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     }
   }
 
+  const directPeerTrusted =
+    configuredProxyMatches(request.ip, proxies, services) ||
+    configuredProxyMatches(request.socket?.remoteAddress, proxies, services) ||
+    configuredProxyMatches(request.info?.remoteAddress, proxies, services);
+  const forwardingProvenance: ClientIpProvenance = directPeerTrusted
+    ? "trusted-proxy"
+    : "unverified-header";
+
   // Prefer anything available via the platform over headers since headers can
   // be set by users. Only if we don't have an IP available in `request` do we
   // search the `headers`.
   const ipFromRequest = resolveCandidate(request.ip, services, proxies, request.headers);
   if (ipFromRequest) {
-    return ipFromRequest;
+    return ipDetails(
+      ipFromRequest,
+      configuredProxyMatches(request.ip, proxies, services) ? "trusted-proxy" : "request",
+      true,
+    );
   }
 
   const socketRemoteAddress = resolveCandidate(
@@ -1023,7 +1189,13 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (socketRemoteAddress) {
-    return socketRemoteAddress;
+    return ipDetails(
+      socketRemoteAddress,
+      configuredProxyMatches(request.socket?.remoteAddress, proxies, services)
+        ? "trusted-proxy"
+        : "direct",
+      true,
+    );
   }
 
   const infoRemoteAddress = resolveCandidate(
@@ -1033,7 +1205,13 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (infoRemoteAddress) {
-    return infoRemoteAddress;
+    return ipDetails(
+      infoRemoteAddress,
+      configuredProxyMatches(request.info?.remoteAddress, proxies, services)
+        ? "trusted-proxy"
+        : "direct",
+      true,
+    );
   }
 
   // AWS Api Gateway + Lambda
@@ -1044,12 +1222,12 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (requestContextIdentitySourceIp) {
-    return requestContextIdentitySourceIp;
+    return ipDetails(requestContextIdentitySourceIp, "request", true);
   }
 
   // Validate we have some object for `request.headers`
   if (typeof request.headers !== "object" || request.headers === null) {
-    return "";
+    return ipDetails("", "none", false);
   }
 
   // Platform-specific headers should only be accepted when we can determine
@@ -1061,19 +1239,19 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     // CF-Connecting-IPv6: https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ipv6
     const cfConnectingIpv6 = getHeader(request.headers, "cf-connecting-ipv6");
     if (isGlobalIpv6(cfConnectingIpv6, proxies)) {
-      return cfConnectingIpv6;
+      return ipDetails(cfConnectingIpv6, "platform", true, "cf-connecting-ipv6");
     }
 
     // CF-Connecting-IP: https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip
     const cfConnectingIp = getHeader(request.headers, "cf-connecting-ip");
     if (isGlobalIp(cfConnectingIp, proxies)) {
-      return cfConnectingIp;
+      return ipDetails(cfConnectingIp, "platform", true, "cf-connecting-ip");
     }
 
     // If we are using a platform check and don't have a Global IP, we exit
     // early with an empty IP since the more generic headers shouldn't be
     // trusted over the platform-specific headers.
-    return "";
+    return ipDetails("", "none", false);
   }
 
   // Firebase https://github.com/arcjet/arcjet-js/issues/5383
@@ -1085,7 +1263,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
       request.headers,
     );
     if (fahClientIp) {
-      return fahClientIp;
+      return ipDetails(fahClientIp, "platform", true, "x-fah-client-ip");
     }
 
     // https://cloud.google.com/functions/docs/reference/headers#x-forwarded-for
@@ -1098,14 +1276,14 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     for (const item of xForwardedForItems.reverse()) {
       const resolved = resolveCandidate(item, services, proxies, request.headers);
       if (resolved) {
-        return resolved;
+        return ipDetails(resolved, "platform", true, "x-forwarded-for");
       }
     }
 
     // If we are using a platform check and don't have a Global IP, we exit
     // early with an empty IP since the more generic headers shouldn't be
     // trusted over the platform-specific headers.
-    return "";
+    return ipDetails("", "none", false);
   }
 
   // Fly.io: https://fly.io/docs/machines/runtime-environment/#fly_app_name
@@ -1118,13 +1296,13 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
       request.headers,
     );
     if (flyClientIp) {
-      return flyClientIp;
+      return ipDetails(flyClientIp, "platform", true, "fly-client-ip");
     }
 
     // If we are using a platform check and don't have a Global IP, we exit
     // early with an empty IP since the more generic headers shouldn't be
     // trusted over the platform-specific headers.
-    return "";
+    return ipDetails("", "none", false);
   }
 
   if (platform === "vercel") {
@@ -1138,7 +1316,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
       request.headers,
     );
     if (xRealIp) {
-      return xRealIp;
+      return ipDetails(xRealIp, "platform", true, "x-real-ip");
     }
 
     // https://vercel.com/docs/edge-network/headers/request-headers#x-vercel-forwarded-for
@@ -1156,7 +1334,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     for (const item of xVercelForwardedForItems.reverse()) {
       const resolved = resolveCandidate(item, services, proxies, request.headers);
       if (resolved) {
-        return resolved;
+        return ipDetails(resolved, "platform", true, "x-vercel-forwarded-for");
       }
     }
 
@@ -1175,14 +1353,14 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     for (const item of xForwardedForItems.reverse()) {
       const resolved = resolveCandidate(item, services, proxies, request.headers);
       if (resolved) {
-        return resolved;
+        return ipDetails(resolved, "platform", true, "x-forwarded-for");
       }
     }
 
     // If we are using a platform check and don't have a Global IP, we exit
     // early with an empty IP since the more generic headers shouldn't be
     // trusted over the platform-specific headers.
-    return "";
+    return ipDetails("", "none", false);
   }
 
   if (platform === "render") {
@@ -1194,13 +1372,13 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
       request.headers,
     );
     if (trueClientIp) {
-      return trueClientIp;
+      return ipDetails(trueClientIp, "platform", true, "true-client-ip");
     }
 
     // If we are using a platform check and don't have a Global IP, we exit
     // early with an empty IP since the more generic headers shouldn't be
     // trusted over the platform-specific headers.
-    return "";
+    return ipDetails("", "none", false);
   }
 
   // Load-balancers (AWS ELB) or proxies.
@@ -1215,7 +1393,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
   for (const item of xForwardedForItems.reverse()) {
     const resolved = resolveCandidate(item, services, proxies, request.headers);
     if (resolved) {
-      return resolved;
+      return ipDetails(resolved, forwardingProvenance, directPeerTrusted, "x-forwarded-for");
     }
   }
 
@@ -1227,7 +1405,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (xClientIp) {
-    return xClientIp;
+    return ipDetails(xClientIp, forwardingProvenance, directPeerTrusted, "x-client-ip");
   }
 
   // DigitalOcean.
@@ -1239,7 +1417,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (doConnectingIp) {
-    return doConnectingIp;
+    return ipDetails(doConnectingIp, forwardingProvenance, directPeerTrusted, "do-connecting-ip");
   }
 
   // Fastly and Firebase hosting header (When forwared to cloud function)
@@ -1251,7 +1429,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (fastlyClientIp) {
-    return fastlyClientIp;
+    return ipDetails(fastlyClientIp, forwardingProvenance, directPeerTrusted, "fastly-client-ip");
   }
 
   // Akamai
@@ -1263,7 +1441,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (trueClientIp) {
-    return trueClientIp;
+    return ipDetails(trueClientIp, forwardingProvenance, directPeerTrusted, "true-client-ip");
   }
 
   // Default nginx proxy/fcgi; alternative to x-forwarded-for, used by some proxies
@@ -1275,7 +1453,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (xRealIp) {
-    return xRealIp;
+    return ipDetails(xRealIp, forwardingProvenance, directPeerTrusted, "x-real-ip");
   }
 
   // Rackspace LB and Riverbed's Stingray?
@@ -1286,7 +1464,12 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (xClusterClientIp) {
-    return xClusterClientIp;
+    return ipDetails(
+      xClusterClientIp,
+      forwardingProvenance,
+      directPeerTrusted,
+      "x-cluster-client-ip",
+    );
   }
 
   const xForwarded = resolveCandidate(
@@ -1296,7 +1479,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (xForwarded) {
-    return xForwarded;
+    return ipDetails(xForwarded, forwardingProvenance, directPeerTrusted, "x-forwarded");
   }
 
   const forwardedFor = resolveCandidate(
@@ -1306,7 +1489,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (forwardedFor) {
-    return forwardedFor;
+    return ipDetails(forwardedFor, forwardingProvenance, directPeerTrusted, "forwarded-for");
   }
 
   const forwarded = resolveCandidate(
@@ -1316,7 +1499,7 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (forwarded) {
-    return forwarded;
+    return ipDetails(forwarded, forwardingProvenance, directPeerTrusted, "forwarded");
   }
 
   // Google Cloud App Engine
@@ -1328,10 +1511,52 @@ export function findIp(request: RequestLike, options?: Options | null | undefine
     request.headers,
   );
   if (xAppEngineUserIp) {
-    return xAppEngineUserIp;
+    return ipDetails(
+      xAppEngineUserIp,
+      forwardingProvenance,
+      directPeerTrusted,
+      "x-appengine-user-ip",
+    );
   }
 
-  return "";
+  return ipDetails("", "none", false);
+}
+
+/** Find a client IP address while preserving the legacy string API. */
+export function findIp(request: RequestLike, options?: Options | null | undefined): string {
+  return findIpDetails(request, options).ip;
+}
+
+/** Resolve a client IP including manual and development-mode overrides. */
+export function resolveClientIp(
+  request: RequestLike,
+  options?: ResolveOptions | null | undefined,
+): ClientIpDetails {
+  const { ipSrc, development, platform, proxies } = options ?? {};
+  if (typeof ipSrc === "string" && ipSrc !== "") {
+    if (!isValidIp(ipSrc)) {
+      throw new Error(
+        `Invalid ipSrc: expected an IPv4 or IPv6 address, got ${JSON.stringify(ipSrc)}`,
+      );
+    }
+    return { ip: ipSrc, provenance: "manual", verified: true };
+  }
+  if (development) {
+    const value = getHeader(request.headers, "x-arcjet-ip");
+    if (typeof value === "string" && value !== "") {
+      return {
+        ip: value,
+        provenance: "development",
+        verified: false,
+        header: "x-arcjet-ip",
+      };
+    }
+  }
+  const details = findIpDetails(request, { platform, proxies });
+  if (details.ip === "" && development) {
+    return { ip: "127.0.0.1", provenance: "development", verified: false };
+  }
+  return details;
 }
 
 /**

--- a/ip/test/ip.test.ts
+++ b/ip/test/ip.test.ts
@@ -386,6 +386,33 @@ test("`parseProxies`", async (t) => {
 });
 
 test("`findIp`", async (t) => {
+  await t.test("remains the string projection of the diagnostics API", () => {
+    const forwardedRequest = {
+      headers: { "x-forwarded-for": "1.1.1.1, 8.8.8.8" },
+    };
+    assert.equal(findIp(forwardedRequest), findIpDetails(forwardedRequest).ip);
+
+    const trustedProxyRequest = {
+      headers: { "x-forwarded-for": "1.1.1.1, 10.0.0.1" },
+      socket: { remoteAddress: "10.0.0.1" },
+    };
+    const trustedProxyOptions = { proxies: ["10.0.0.0/8"] };
+    assert.equal(
+      findIp(trustedProxyRequest, trustedProxyOptions),
+      findIpDetails(trustedProxyRequest, trustedProxyOptions).ip,
+    );
+
+    const platformRequest = { headers: { "cf-connecting-ip": "1.1.1.1" } };
+    const platformOptions = { platform: "cloudflare" as const };
+    assert.equal(
+      findIp(platformRequest, platformOptions),
+      findIpDetails(platformRequest, platformOptions).ip,
+    );
+
+    const emptyRequest = { headers: {} };
+    assert.equal(findIp(emptyRequest), findIpDetails(emptyRequest).ip);
+  });
+
   await t.test("returns empty string if headers not set", () => {
     assert.equal(
       findIp(

--- a/ip/test/ip.test.ts
+++ b/ip/test/ip.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  cloudflare,
   createClientIpDiagnostics,
   findIp,
   findIpDetails,

--- a/ip/test/ip.test.ts
+++ b/ip/test/ip.test.ts
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { cloudflare, findIp, parseProxies, parseProxy } from "../dist/index.js";
+import {
+  cloudflare,
+  createClientIpDiagnostics,
+  findIp,
+  findIpDetails,
+  hasTrustAllProxy,
+  isValidIp,
+  parseProxies,
+  parseProxy,
+  resolveClientIp,
+} from "../dist/index.js";
 
 type Proxy = ReturnType<typeof parseProxy>;
 
@@ -133,12 +143,194 @@ test("@arcjet/ip", async function (t) {
   await t.test("should expose the public api", async function () {
     assert.deepEqual(Object.keys(await import("../dist/index.js")).sort(), [
       "cloudflare",
+      "createClientIpDiagnostics",
       "default",
       "findIp",
+      "findIpDetails",
+      "hasTrustAllProxy",
+      "isValidIp",
       "parseProxies",
       "parseProxy",
+      "resolveClientIp",
     ]);
   });
+
+  await t.test("validates every configured proxy", () => {
+    assert.throws(() => parseProxies(["not-an-ip"]), /invalid proxy address/);
+    assert.throws(() => parseProxies([""]), /invalid proxy address/);
+    assert.throws(
+      () => parseProxies([{ kind: "service", name: "bad", ranges: ["bad"], clientIp: [] }]),
+      /invalid proxy address/,
+    );
+  });
+
+  await t.test("detects trust-all ranges", () => {
+    assert.equal(hasTrustAllProxy(parseProxies(["0.0.0.0/0"])), true);
+    assert.equal(hasTrustAllProxy(parseProxies(["1.2.3.0/24"])), false);
+    assert.equal(hasTrustAllProxy(parseProxies(["1.2.3.4"])), false);
+    assert.equal(
+      hasTrustAllProxy([{ kind: "service", name: "all", ranges: ["::/0"], clientIp: [] }]),
+      true,
+    );
+    assert.equal(
+      hasTrustAllProxy([
+        { kind: "service", name: "all", ranges: [parseProxy("0.0.0.0/0")], clientIp: [] },
+      ]),
+      true,
+    );
+    assert.equal(
+      hasTrustAllProxy([{ kind: "service", name: "narrow", ranges: ["1.2.3.0/24"], clientIp: [] }]),
+      false,
+    );
+  });
+});
+
+test("client IP details", () => {
+  const proxyService = {
+    kind: "service" as const,
+    name: "test-proxy",
+    ranges: ["8.8.8.0/24", parseProxy("2606:4700::/32")],
+    clientIp: [{ header: "x-client-ip", format: "ip" as const }],
+  };
+  assert.deepEqual(findIpDetails({ headers: new Headers([["x-forwarded-for", "1.1.1.1"]]) }), {
+    ip: "1.1.1.1",
+    provenance: "unverified-header",
+    verified: false,
+    header: "x-forwarded-for",
+  });
+  assert.deepEqual(
+    findIpDetails(
+      {
+        socket: { remoteAddress: "10.0.0.1" },
+        headers: new Headers([["x-forwarded-for", "1.1.1.1"]]),
+      },
+      { proxies: ["10.0.0.0/8"] },
+    ),
+    {
+      ip: "1.1.1.1",
+      provenance: "trusted-proxy",
+      verified: true,
+      header: "x-forwarded-for",
+    },
+  );
+  assert.deepEqual(
+    findIpDetails(
+      {
+        ip: "10.0.0.1",
+        headers: new Headers([["x-forwarded-for", "1.1.1.1"]]),
+      },
+      { proxies: ["10.0.0.0/8"] },
+    ),
+    {
+      ip: "1.1.1.1",
+      provenance: "trusted-proxy",
+      verified: true,
+      header: "x-forwarded-for",
+    },
+  );
+  assert.deepEqual(findIpDetails({ ip: "1.1.1.1", headers: new Headers() }), {
+    ip: "1.1.1.1",
+    provenance: "request",
+    verified: true,
+  });
+  assert.deepEqual(
+    findIpDetails({ socket: { remoteAddress: "1.1.1.1" }, headers: new Headers() }),
+    { ip: "1.1.1.1", provenance: "direct", verified: true },
+  );
+  assert.deepEqual(findIpDetails({ info: { remoteAddress: "1.1.1.1" }, headers: new Headers() }), {
+    ip: "1.1.1.1",
+    provenance: "direct",
+    verified: true,
+  });
+  for (const request of [
+    { ip: "8.8.8.1", headers: { "x-client-ip": "1.1.1.1" } },
+    { socket: { remoteAddress: "8.8.8.1" }, headers: { "x-client-ip": "1.1.1.1" } },
+    {
+      info: { remoteAddress: "2606:4700::1" },
+      headers: { "x-client-ip": "1.1.1.1" },
+    },
+  ]) {
+    assert.deepEqual(findIpDetails(request, { proxies: [proxyService] }), {
+      ip: "1.1.1.1",
+      provenance: "trusted-proxy",
+      verified: true,
+    });
+  }
+  assert.deepEqual(
+    findIpDetails({ requestContext: { identity: { sourceIp: "1.1.1.1" } }, headers: {} }),
+    { ip: "1.1.1.1", provenance: "request", verified: true },
+  );
+  assert.deepEqual(findIpDetails({ headers: null }), {
+    ip: "",
+    provenance: "none",
+    verified: false,
+  });
+  assert.equal(isValidIp("10.0.0.1"), true);
+  assert.equal(isValidIp("::1"), true);
+  assert.equal(isValidIp(""), false);
+  assert.equal(isValidIp(1234), false);
+  assert.equal(isValidIp("999.0.0.1"), false);
+  assert.equal(isValidIp("not-an-ip"), false);
+
+  assert.deepEqual(
+    resolveClientIp({ headers: new Headers([["x-arcjet-ip", "10.0.0.1"]]) }, { development: true }),
+    {
+      ip: "10.0.0.1",
+      provenance: "development",
+      verified: false,
+      header: "x-arcjet-ip",
+    },
+  );
+  assert.deepEqual(resolveClientIp({ headers: new Headers() }, { development: true }), {
+    ip: "127.0.0.1",
+    provenance: "development",
+    verified: false,
+  });
+  assert.deepEqual(resolveClientIp({ headers: new Headers() }, { ipSrc: "10.0.0.1" }), {
+    ip: "10.0.0.1",
+    provenance: "manual",
+    verified: true,
+  });
+  assert.deepEqual(resolveClientIp({ headers: new Headers() }), {
+    ip: "",
+    provenance: "none",
+    verified: false,
+  });
+  assert.deepEqual(resolveClientIp({ headers: new Headers() }, { ipSrc: "" }), {
+    ip: "",
+    provenance: "none",
+    verified: false,
+  });
+  assert.throws(
+    () => resolveClientIp({ headers: new Headers() }, { ipSrc: "not-an-ip" }),
+    /Invalid ipSrc/,
+  );
+});
+
+test("client IP diagnostics", () => {
+  const debug: Array<Record<string, unknown>> = [];
+  const warnings: Array<Record<string, unknown>> = [];
+  const report = createClientIpDiagnostics({
+    debug(facets) {
+      debug.push(facets);
+    },
+    warn(facets) {
+      warnings.push(facets);
+    },
+  });
+  const details = {
+    ip: "1.1.1.1",
+    provenance: "unverified-header" as const,
+    verified: false,
+    header: "x-forwarded-for",
+  };
+  report(details);
+  report(details);
+  assert.equal(debug.length, 2);
+  assert.equal(debug[0].client_ip_provenance, "unverified-header");
+  assert.equal(warnings.length, 1);
+  report({ ip: "1.1.1.1", provenance: "direct", verified: true });
+  assert.equal(warnings.length, 1);
 });
 
 test("`parseProxies`", async (t) => {

--- a/ip/test/ip.test.ts
+++ b/ip/test/ip.test.ts
@@ -216,6 +216,24 @@ test("client IP details", () => {
   assert.deepEqual(
     findIpDetails(
       {
+        // A framework-level request IP may itself come from X-Forwarded-For.
+        // It must not override the transport peer when establishing trust.
+        ip: "10.0.0.1",
+        socket: { remoteAddress: "192.168.0.1" },
+        headers: new Headers([["x-forwarded-for", "1.1.1.1"]]),
+      },
+      { proxies: ["10.0.0.0/8"] },
+    ),
+    {
+      ip: "1.1.1.1",
+      provenance: "unverified-header",
+      verified: false,
+      header: "x-forwarded-for",
+    },
+  );
+  assert.deepEqual(
+    findIpDetails(
+      {
         ip: "10.0.0.1",
         headers: new Headers([["x-forwarded-for", "1.1.1.1"]]),
       },
@@ -271,6 +289,21 @@ test("client IP details", () => {
   assert.equal(isValidIp(1234), false);
   assert.equal(isValidIp("999.0.0.1"), false);
   assert.equal(isValidIp("not-an-ip"), false);
+
+  for (const [platform, header] of [
+    ["cloudflare", "cf-connecting-ip"],
+    ["firebase", "x-fah-client-ip"],
+    ["fly-io", "fly-client-ip"],
+    ["render", "true-client-ip"],
+    ["vercel", "x-real-ip"],
+  ] as const) {
+    assert.deepEqual(findIpDetails({ headers: new Headers([[header, "1.1.1.1"]]) }, { platform }), {
+      ip: "1.1.1.1",
+      provenance: "platform",
+      verified: true,
+      header,
+    });
+  }
 
   assert.deepEqual(
     resolveClientIp({ headers: new Headers([["x-arcjet-ip", "10.0.0.1"]]) }, { development: true }),
@@ -334,15 +367,22 @@ test("client IP diagnostics", () => {
 });
 
 test("`parseProxies`", async (t) => {
-  await t.test("parses CIDR strings while passing through IPs and services", () => {
-    const service = cloudflare();
+  await t.test("parses CIDR strings in top-level and service ranges", () => {
+    const service = {
+      kind: "service" as const,
+      name: "mixed-ranges",
+      ranges: ["8.8.8.0/24", parseProxy("2606:4700::/32")],
+      clientIp: [{ header: "x-client-ip", format: "ip" as const }],
+    };
     const result = parseProxies(["1.2.3.0/24", "1.2.3.4", service]);
     // A CIDR range string is parsed to a `Cidr` object.
     assert.equal(typeof result[0], "object");
     // A plain IP string is passed through unchanged.
     assert.equal(result[1], "1.2.3.4");
-    // A `ProxyService` object is passed through unchanged.
-    assert.equal(result[2], service);
+    // A `ProxyService` is cloned so its string ranges can be parsed once.
+    assert.notEqual(result[2], service);
+    assert.equal(typeof (result[2] as typeof service).ranges[0], "object");
+    assert.equal((result[2] as typeof service).ranges[1], service.ranges[1]);
   });
 });
 


### PR DESCRIPTION
## Summary

- add provenance-aware client IP resolution, structured debug facets, and a once-per-client unverified-header warning
- validate proxy ranges and manual `ipSrc` values, warning for trust-all proxy ranges
- expose `findIpDetails()`, `resolveClientIp()`, and the Node client `clientIpDetails()` API
- apply the shared behavior across all JavaScript framework adapters and document it in the README

## Validation

- `npm run format:check`
- `npm run lint`
- focused typecheck for all 12 modified packages
- focused Turbo test matrix for all 12 modified packages
