### PR TITLE
feat(guard): add TanStack AI support as @arcjet/guard/tanstack-ai/v0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,26 @@ change them:
   `@arcjet/guard/langgraph/v1`. There is no unversioned
   `@arcjet/guard/strands-agents` alias. Docs slug is
   `/guards/strands-agents/`.
+  `tanstack-ai/v0` is `chat({ middleware })` +
+  `ChatMiddleware.onBeforeToolCall`: there is no `guardTool` (a throw
+  from `execute` is swallowed into `{ error }` and is not a usable deny
+  envelope), tool calls go through `guardMiddleware`'s
+  `onBeforeToolCall` (default DENY is `{ type: "skip", result:
+  ArcjetDenialResult }`; optional `onDeny: "abort"` only; do not
+  throw), inbound is screened with `guard()` before `chat()`
+  (`guard()` fails open — check `hasFailedOpen()`), and
+  `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL
+  not policy. After a human yes, Guard still runs. Put Arcjet first
+  in the middleware array — `onBeforeToolCall` is first-win; if
+  `toolCacheMiddleware` skips first, Guard never runs. Brand-skip
+  inbound so `guardMiddleware` does not double-call a preceding
+  `guard()`. Correlation is a caller-owned id from helper options or
+  `chat({ context })`. Never mint. Never `ctx.threadId`. Never
+  `traceId` / `requestId` / `streamId`. There is no unversioned
+  `@arcjet/guard/tanstack-ai` alias and no `/v1` until TanStack AI
+  ships 1.x. Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.
+  Do not name anything `contentGuardMiddleware`. Docs slug is
+  `/guards/tanstack-ai/`.
 - **Flat** — a single level under `@arcjet/guard`, no further nesting.
 - **Explicitly versioned, with no unversioned alias.** `@arcjet/guard/vercel-ai`
   does not resolve, and neither does a wildcard `./vercel-ai/*`. An alias would

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,8 +137,10 @@ change them:
   not policy. After a human yes, Guard still runs. Put Arcjet first
   in the middleware array — `onBeforeToolCall` is first-win; if
   `toolCacheMiddleware` skips first, Guard never runs. Brand-skip
-  inbound so `guardMiddleware` does not double-call a preceding
-  `guard()`. Correlation is a caller-owned id from helper options or
+  tools already wrapped by a sibling `guardTool` so
+  `guardMiddleware` does not double-call. Inbound `guard()` before
+  `chat()` is a separate call and does not brand tools. Correlation
+  is a caller-owned id from helper options or
   `chat({ context })`. Never mint. Never `ctx.threadId`. Never
   `traceId` / `requestId` / `streamId`. There is no unversioned
   `@arcjet/guard/tanstack-ai` alias and no `/v1` until TanStack AI

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1531,6 +1531,100 @@ Correlation is a field the integrator puts on `invocationState`
 (`correlationId`, then `sessionId`, then `requestId`). Never mint.
 Never read `traceId`. Never use `SessionManager` or `agent.id`.
 
+- **`@arcjet/guard/tanstack-ai/v0`** — TanStack AI `chat({ middleware })`
+  - `ChatMiddleware.onBeforeToolCall` integration. Exports
+    `guardMiddleware` and `tanstackAiContext`. This is **not** the
+    Vercel AI SDK — do not also wrap with `@arcjet/guard/vercel-ai/v7`.
+    There is no `guardTool` (a throw from `execute` is swallowed into
+    `{ error }` and is not a usable deny envelope), no `guardInbound`
+    (screen with `guard()` before `chat()`; `guard()` fails open —
+    check `hasFailedOpen()`), and no `guardApproval` (`needsApproval` /
+    `defineInterrupt` / `onInterruptBoundary` is human HITL, not
+    policy). After a human yes, Guard still runs. Do not name anything
+    `contentGuardMiddleware` (TanStack already has that name). Docs
+    live at
+    [`/guards/tanstack-ai/`](https://docs.arcjet.com/guards/tanstack-ai/).
+
+  Put Arcjet **first** in the middleware array. `onBeforeToolCall` is
+  first-win; if `toolCacheMiddleware` (or anything else) skips first,
+  Guard never runs. Default DENY is `{ type: "skip", result:
+ArcjetDenialResult }` so the tool never runs and the model sees the
+  payload. Optional `onDeny: "abort"` stops the run. The hook does
+  not throw. Already-branded tools are skipped so a preceding
+  `guard()` is not double-called. Correlation is a caller-owned id
+  from helper options or `chat({ context })`. Never mint. Never
+  `ctx.threadId`. Never `traceId` / `requestId` / `streamId`. Client
+  tools and provider-native tools with no local `execute` are out of
+  scope.
+
+  ```ts
+  import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+  import { guardMiddleware, tanstackAiContext } from "@arcjet/guard/tanstack-ai/v0";
+  import { chat } from "@tanstack/ai";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const appContext = { sessionId: conversationId };
+  const inbound = detectPromptInjection();
+  const decision = await arcjet.guard({
+    label: "message.received",
+    rules: [inbound(userText)],
+    ...tanstackAiContext({ context: appContext }),
+  });
+
+  if (decision.conclusion === "DENY") {
+    throw new Error("message blocked");
+  }
+  if (decision.hasFailedOpen()) {
+    throw new Error("inbound screening failed open");
+  }
+
+  const stream = chat({
+    adapter,
+    messages,
+    tools: [lookupOrder],
+    context: appContext,
+    middleware: [
+      guardMiddleware(arcjet, {
+        action: ({ toolName }) => `${toolName}.invoked`,
+        rules: ({ toolName }) => [limit({ key: toolName, requested: 1 })],
+        sessionId: conversationId,
+      }),
+    ],
+  });
+  ```
+
+#### Screen inbound before `chat()` — there is no inbound hook.
+
+TanStack AI has no first-class inbound channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `chat()`. Call `guard()` directly. `guard()` fails
+open — callers must check `hasFailedOpen()`. TanStack's
+`contentGuardMiddleware` redacts the stream; it is not this policy
+gate.
+
+#### `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL, not a policy gate.
+
+`needsApproval` / `defineInterrupt` / `onInterruptBoundary` is
+human-in-the-loop, not policy. After a human yes, Guard still runs
+on the tool call. Same trap as Mastra `requireApproval`, Claude
+`canUseTool`, LangGraph `interrupt()`, Genkit `toolApproval`, OpenAI
+Agents `needsApproval`, and LangChain `humanInTheLoopMiddleware`.
+There is no `guardApproval`.
+
+#### Deny inside `guardMiddleware`'s `onBeforeToolCall`. There is no `guardTool`.
+
+`onBeforeToolCall` is the deny point. Default DENY is
+`{ type: "skip", result: ArcjetDenialResult }`. Optional
+`onDeny: "abort"` returns `{ type: "abort", reason }`. Do not throw
+from the hook. Put Arcjet first — first-win composition means a
+preceding `toolCacheMiddleware` skip skips Guard too.
+
 ### Naming and versions
 
 Integration paths are `@arcjet/guard/<vendor-sdk>/v<major>` — the SDK being
@@ -1596,6 +1690,10 @@ importing only core guards are not forced to install unneeded packages:
   The peer range is `>=1.1.0 <2`. The floor is 1.1.0 because `HookOrder`
   - `interrupt()` shipped then; `cancel` itself is 1.0.0. Zod is their
     peer, not ours.
+- **`@arcjet/guard/tanstack-ai/v0`** requires `@tanstack/ai` (optional
+  peer, installed only to use `@arcjet/guard/tanstack-ai/v0`). The peer
+  range is `>=0.8.0 <1`. There is no `/v1` until TanStack AI ships 1.x.
+  Node stays Guard's existing floor.
 
 **pnpm caveat**: pnpm does not reliably honour
 `peerDependenciesMeta.*.optional` (pnpm#5152, #8142), especially with
@@ -1651,6 +1749,11 @@ pnpm install @strands-agents/sdk
 ```
 
 ```sh
+# @arcjet/guard/tanstack-ai/v0
+pnpm install @tanstack/ai
+```
+
+```sh
 # or skip the peer install and relax the check:
 pnpm install --no-strict-peer-dependencies
 ```
@@ -1666,8 +1769,9 @@ is one path to learn and no layering to reason about.
 `@arcjet/guard/mastra/v1`, `@arcjet/guard/claude-agent-sdk/v0`,
 `@arcjet/guard/langchain/v1`, `@arcjet/guard/langgraph/v1`,
 `@arcjet/guard/openai-agents/v0`,
-`@arcjet/guard/genkit/v1`, and
-`@arcjet/guard/strands-agents/v1` now export
+`@arcjet/guard/genkit/v1`,
+`@arcjet/guard/strands-agents/v1`, and
+`@arcjet/guard/tanstack-ai/v0` now export
 these helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
 agnostic layer without installing a vendor peer. That change is a follow-up
@@ -1694,6 +1798,7 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 | OpenAI Agents `guardTool`                 | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Genkit `guardTool` / `guardMiddleware`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Strands Agents `guardTool` / `guardHooks` | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| TanStack AI `guardMiddleware`             | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -1967,6 +2072,7 @@ that a tool did not run:
 | LangChain        | Two envelopes: `guardTool` returns `{ arcjetDenied: true, … }` and `baseHandler` wraps it as a success `ToolMessage`; `guardMiddleware`'s `wrapToolCall` returns a real `ToolMessage` carrying the payload as `content` | `wrapToolCall`'s return skips `baseHandler`, so a bare object crashes the messages reducer, and a throw bubbles out of `invoke` and drops the fields |
 | Claude Agent SDK | MCP `CallToolResult` with `isError: true` and the payload on `structuredContent`                                                                                                                                        | A throw is a raw exception; omitting `isError` looks like success                                                                                    |
 | Vercel Eve       | Throw `ArcjetDeniedError`. Opt in to a returned payload with `onDeny: "result"`                                                                                                                                         | Eve projects a throw as a failed `action.result`. A silent return can violate `outputSchema`                                                         |
+| TanStack AI      | `{ type: "skip", result: ArcjetDenialResult }` from `onBeforeToolCall`. Optional `onDeny: "abort"` returns `{ type: "abort", reason }`                                                                                  | A throw from `execute` is swallowed into `{ error }`. A throw from the hook aborts the run as an error, not a policy denial                          |
 
 ```ts
 const result: ArcjetDenialResult = {
@@ -2072,6 +2178,8 @@ For an example with Genkit, see [`genkit-agent`](https://github.com/arcjet/examp
 
 For an example with Strands Agents, see [`strands-agent`](https://github.com/arcjet/examples/tree/main/examples/strands-agent) (follow-up on that same PR): inbound screening before `invoke()` / `stream()`, `guardTool` / `guardHooks` (deny, PII on args, rate limit, fail-closed), and a caller-owned id on `invocationState`. `interrupt()` is HITL, not a policy gate; `BeforeToolCallEvent.cancel` is the deny point for unwrapped tools. Docs slug: [`/guards/strands-agents/`](https://docs.arcjet.com/guards/strands-agents/).
 
+For an example with TanStack AI, see [`tanstack-agent`](https://github.com/arcjet/examples/tree/main/examples/tanstack-agent) (later follow-up; do not add it in this repo): inbound screening with `guard()` before `chat()` (check `hasFailedOpen()`), `guardMiddleware` first in the middleware array (skip-deny, abort-deny, rate limit, fail-closed), and a caller-owned id on `chat({ context })`. `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL, not a policy gate; `onBeforeToolCall` is the deny point. Docs slug: [`/guards/tanstack-ai/`](https://docs.arcjet.com/guards/tanstack-ai/).
+
 ## Agent skill
 
 For integration help in Claude Code or other AI coding agents, a skill file per integration is packaged with `@arcjet/guard`:
@@ -2167,6 +2275,16 @@ ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-strands-
 ```
 
 In Claude Code, use `/integrate-arcjet-guard-strands-agents` to start an integration session.
+
+**For TanStack AI:**
+
+```bash
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-tanstack-ai ~/.claude/skills/
+# or
+ln -s /path/to/node_modules/@arcjet/guard/skills/integrate-arcjet-guard-tanstack-ai ~/.claude/skills/
+```
+
+In Claude Code, use `/integrate-arcjet-guard-tanstack-ai` to start an integration session.
 
 Each skill guides you through wrapping tools, screening inbound messages, and recording lifecycle events joined by correlation ID.
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1549,9 +1549,12 @@ Never read `traceId`. Never use `SessionManager` or `agent.id`.
   first-win; if `toolCacheMiddleware` (or anything else) skips first,
   Guard never runs. Default DENY is `{ type: "skip", result:
 ArcjetDenialResult }` so the tool never runs and the model sees the
-  payload. Optional `onDeny: "abort"` stops the run. The hook does
-  not throw. Already-branded tools are skipped so a preceding
-  `guard()` is not double-called. Correlation is a caller-owned id
+  payload. Optional `onDeny: "abort"` stops the run with a reason
+  string — the model does not get `ArcjetDenialResult`. The hook
+  does not throw. Tools already branded by a sibling `guardTool`
+  are skipped so Guard is not double-called. Inbound `guard()`
+  before `chat()` does not brand tools and does not skip this
+  gate. Correlation is a caller-owned id
   from helper options or `chat({ context })`. Never mint. Never
   `ctx.threadId`. Never `traceId` / `requestId` / `streamId`. Client
   tools and provider-native tools with no local `execute` are out of
@@ -1621,9 +1624,14 @@ There is no `guardApproval`.
 
 `onBeforeToolCall` is the deny point. Default DENY is
 `{ type: "skip", result: ArcjetDenialResult }`. Optional
-`onDeny: "abort"` returns `{ type: "abort", reason }`. Do not throw
-from the hook. Put Arcjet first — first-win composition means a
-preceding `toolCacheMiddleware` skip skips Guard too.
+`onDeny: "abort"` returns `{ type: "abort", reason }` (the denial
+`message` string) and stops the run — the model does not get
+`ArcjetDenialResult`. `onDeny: "abort"` applies to real DENY only;
+unavailable stays skip. Do not throw from the hook. Put Arcjet
+first — first-win composition means a preceding
+`toolCacheMiddleware` skip skips Guard too. Sibling `guardTool`
+brands are skipped; inbound `guard()` is a separate call and does
+not skip this gate.
 
 ### Naming and versions
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1531,19 +1531,18 @@ Correlation is a field the integrator puts on `invocationState`
 (`correlationId`, then `sessionId`, then `requestId`). Never mint.
 Never read `traceId`. Never use `SessionManager` or `agent.id`.
 
-- **`@arcjet/guard/tanstack-ai/v0`** — TanStack AI `chat({ middleware })`
-  - `ChatMiddleware.onBeforeToolCall` integration. Exports
-    `guardMiddleware` and `tanstackAiContext`. This is **not** the
-    Vercel AI SDK — do not also wrap with `@arcjet/guard/vercel-ai/v7`.
-    There is no `guardTool` (a throw from `execute` is swallowed into
-    `{ error }` and is not a usable deny envelope), no `guardInbound`
-    (screen with `guard()` before `chat()`; `guard()` fails open —
-    check `hasFailedOpen()`), and no `guardApproval` (`needsApproval` /
-    `defineInterrupt` / `onInterruptBoundary` is human HITL, not
-    policy). After a human yes, Guard still runs. Do not name anything
-    `contentGuardMiddleware` (TanStack already has that name). Docs
-    live at
-    [`/guards/tanstack-ai/`](https://docs.arcjet.com/guards/tanstack-ai/).
+- **`@arcjet/guard/tanstack-ai/v0`** — TanStack AI `chat({ middleware })` +
+  `ChatMiddleware.onBeforeToolCall` integration. Exports `guardMiddleware`
+  and `tanstackAiContext`. This is **not** the Vercel AI SDK — do not also
+  wrap with `@arcjet/guard/vercel-ai/v7`. There is no `guardTool` (a throw
+  from `execute` is swallowed into `{ error }` and is not a usable deny
+  envelope), no `guardInbound` (screen with `guard()` before `chat()`;
+  `guard()` fails open — check `hasFailedOpen()`), and no `guardApproval`
+  (`needsApproval` / `defineInterrupt` / `onInterruptBoundary` is human
+  HITL, not policy). After a human yes, Guard still runs. Do not name
+  anything `contentGuardMiddleware` (TanStack already has that name). Docs
+  live at
+  [`/guards/tanstack-ai/`](https://docs.arcjet.com/guards/tanstack-ai/).
 
   Put Arcjet **first** in the middleware array. `onBeforeToolCall` is
   first-win; if `toolCacheMiddleware` (or anything else) skips first,

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -104,6 +104,10 @@
       "types": "./dist/strands-agents/v1/index.d.ts",
       "import": "./dist/strands-agents/v1/index.js"
     },
+    "./tanstack-ai/v0": {
+      "types": "./dist/tanstack-ai/v0/index.d.ts",
+      "import": "./dist/tanstack-ai/v0/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -116,7 +120,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts' 'test/strands-agents/**/*.test.ts'",
+    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts' 'test/strands-agents/**/*.test.ts' 'test/tanstack-ai/**/*.test.ts'",
     "test-peers-absent": "node scripts/test-peers-absent.mjs",
     "test-runtime-node": "npm run build && node --test test/runtime/node.test.ts",
     "test-runtime-fetch": "npm run build && node --test test/runtime/fetch.test.ts",
@@ -141,6 +145,7 @@
     "@mastra/core": "1.59.0",
     "@openai/agents": "0.17.0",
     "@strands-agents/sdk": "1.14.0",
+    "@tanstack/ai": "0.52.0",
     "@types/node": "22.20.1",
     "ai": "7.0.58",
     "eve": "0.46.0",
@@ -159,6 +164,7 @@
     "@mastra/core": ">=1 <2",
     "@openai/agents": ">=0.17.0 <1",
     "@strands-agents/sdk": ">=1.1.0 <2",
+    "@tanstack/ai": ">=0.8.0 <1",
     "ai": ">=7 <8",
     "eve": ">=0.34.0 <1",
     "genkit": ">=1.0.0 <2",
@@ -196,6 +202,9 @@
       "optional": true
     },
     "@strands-agents/sdk": {
+      "optional": true
+    },
+    "@tanstack/ai": {
       "optional": true
     }
   },

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -89,6 +89,13 @@ const CHECKS = [
     remove: ["@strands-agents/sdk"],
     resolve: ["@strands-agents/sdk"],
   },
+  {
+    name: "tanstack-ai",
+    dir: "tanstack-ai",
+    version: "v0",
+    remove: ["@tanstack/ai"],
+    resolve: ["@tanstack/ai"],
+  },
   // Last: deletes a shared devDependency.
   {
     name: "eve",

--- a/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: integrate-arcjet-guard-tanstack-ai
+description: Integrate Arcjet security into a TanStack AI chat() app using @arcjet/guard — put guardMiddleware first on chat({ middleware }) so onBeforeToolCall gates tools, and read a caller-owned id from chat({ context }). Use when asked to add Arcjet to TanStack AI, rate limit its tools, screen inbound messages, or block prompt injection / PII. This is TanStack AI, not the Vercel AI SDK.
+license: Apache-2.0
+compatibility: Requires the target app to use TanStack AI (@tanstack/ai >=0.8.0 <1) on Node.js >= 22. This is chat() + ChatMiddleware.onBeforeToolCall. There is no /v1 until TanStack AI ships 1.x. Do not use @arcjet/guard/vercel-ai/v7.
+metadata:
+  author: arcjet
+---
+
+# Integrate Arcjet Guard into TanStack AI
+
+`@arcjet/guard`'s TanStack AI v0 namespace wraps the agent's existing Arcjet
+client. It never talks to the Arcjet API itself. Two surfaces, one
+decision rule:
+
+- **Tool calls** → `guardMiddleware()`. A `chat({ middleware })`
+  middleware whose `onBeforeToolCall` is the chat()-wide gate. Default
+  DENY is `{ type: "skip", result: ArcjetDenialResult }` so the tool
+  never runs and the model sees the payload. Optional `onDeny: "abort"`
+  returns `{ type: "abort", reason }` and stops the run. Do not throw
+  from the hook. Already-branded tools are skipped so a preceding
+  `guard()` is not double-called.
+- **Correlation** → `tanstackAiContext()` reads a caller-owned id from
+  the helper options or `chat({ context })`. It never mints a new id.
+  It never reads `ctx.threadId` (TanStack auto-generates it). It never
+  reads `traceId` / `requestId` / `streamId`.
+
+There is **no `guardTool`**. A throw from `execute` is swallowed into
+`{ error }` and is not a usable deny envelope. There is no
+`guardInbound`, no `guardApproval`, and nothing named
+`contentGuardMiddleware` (TanStack already has that name).
+
+This namespace is TanStack AI **`chat({ middleware })` +
+`onBeforeToolCall`**. Not the Vercel AI SDK. Do not also wrap with
+`@arcjet/guard/vercel-ai/v7`. Client tools and provider-native tools
+with no local `execute` are out of scope.
+
+Docs live at
+[docs.arcjet.com/guards/tanstack-ai/](https://docs.arcjet.com/guards/tanstack-ai/).
+Do **not** overwrite any other `/guards/...` slug.
+
+Put Arcjet **first** in the middleware array. `onBeforeToolCall` is
+first-win; if `toolCacheMiddleware` (or anything else) skips first,
+Guard never runs.
+
+## Screen inbound before `chat()` — there is no inbound hook.
+
+There is no first-class inbound channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `chat()`. Call `guard()` directly. `guard()` fails
+open — callers must check `hasFailedOpen()`. TanStack's
+`contentGuardMiddleware` redacts the stream; it is not this policy
+gate.
+
+## `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL, not a policy gate.
+
+`needsApproval` / `defineInterrupt` / `onInterruptBoundary` is
+human-in-the-loop. After a human yes, Guard still runs on the tool
+call. Same trap as Mastra `requireApproval`, Claude `canUseTool`,
+LangGraph `interrupt()`, Genkit `toolApproval`, OpenAI Agents
+`needsApproval`, and LangChain `humanInTheLoopMiddleware`. There is no
+`guardApproval`.
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those are gated by `guardMiddleware`.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. Put the
+   conversation / session id you already have on
+   `chat({ context: { sessionId } })`. That id is the correlation id.
+   Do not use `ctx.threadId`.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound screening before
+   `chat()`: failing closed there means the chat does not run for the
+   duration of the outage, so `"allow"` is a routine and legitimate
+   choice at that one call site. `guard()` itself still fails open —
+   check `hasFailedOpen()`.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection before
+   `chat()` with `guard()`. Check `hasFailedOpen()`.
+   `contentGuardMiddleware` is not Guard.
+2. **`needsApproval` / `defineInterrupt` / `onInterruptBoundary` is not
+   a policy gate.** It is HITL. After a human yes, Guard still runs.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/tanstack-ai/v0`. `@arcjet/guard/tanstack-ai` does
+   not resolve. There is no `/v1` until TanStack AI ships 1.x. Docs
+   are `/guards/tanstack-ai/`.
+4. **Correlation is read, never minted.** Do not call
+   `createAgentContext` inside a middleware callback — that generates
+   a second id and splits the Sequence. Put the id you already chose
+   on `chat({ context })`. Do not read `ctx.threadId`, `traceId`,
+   `requestId`, or `streamId`.
+5. **Put Arcjet first.** `onBeforeToolCall` is first-win. If
+   `toolCacheMiddleware` skips first, Guard never runs.
+6. **Do not add `guardTool` and do not double-wrap with
+   `@arcjet/guard/vercel-ai/v7`.** TanStack AI is not the Vercel AI
+   SDK. A throw from `execute` becomes `{ error }`.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `@tanstack/ai` (optional
+peer, needed for `@arcjet/guard/tanstack-ai/v0`). Always use the
+versioned path: `@arcjet/guard/tanstack-ai/v0` resolves;
+`@arcjet/guard/tanstack-ai` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+The peer range is `>=0.8.0 <1`. Node 22+ — do not bump Node for this
+adapter.
+
+```sh
+npm install @arcjet/guard @tanstack/ai
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate tool calls — Arcjet first
+
+```ts
+import { chat } from "@tanstack/ai";
+import { toolCacheMiddleware } from "@tanstack/ai/middlewares";
+import { guardMiddleware } from "@arcjet/guard/tanstack-ai/v0";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+const detectPii = localDetectSensitiveInfo();
+
+const stream = chat({
+  adapter,
+  messages,
+  tools: [lookupOrder, ...mcpTools],
+  context: { sessionId: conversationId },
+  middleware: [
+    guardMiddleware(arcjet, {
+      action: ({ toolName }) => `${toolName}.invoked`,
+      rules: ({ toolName, input }) => {
+        const note =
+          typeof input === "object" && input !== null && "note" in input
+            ? String((input as { note?: unknown }).note ?? "")
+            : "";
+        return [
+          lookupLimit({ key: toolName, requested: 1 }),
+          ...(note.length > 0 ? [detectPii(note)] : []),
+        ];
+      },
+      sessionId: conversationId,
+    }),
+    toolCacheMiddleware(),
+  ],
+});
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the original `execute` never runs. Default delivery is
+  `{ type: "skip", result: { arcjetDenied: true, reason, message, retryable } }`.
+- `onDeny: "abort"` stops the chat run instead.
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+- Already-branded tools skip the middleware guard so a preceding
+  `guard()` is not double-called.
+
+## Step 3: Screen inbound before chat
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { tanstackAiContext } from "@arcjet/guard/tanstack-ai/v0";
+
+import { arcjet } from "./arcjet.js";
+
+const inbound = detectPromptInjection();
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...tanstackAiContext({ context: { sessionId: conversationId } }),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+if (decision.hasFailedOpen()) {
+  throw new Error("inbound screening failed open");
+}
+
+await chat({
+  adapter,
+  messages: [{ role: "user", content: userText }],
+  context: { sessionId: conversationId },
+  middleware: [guardMiddleware(arcjet, { sessionId: conversationId })],
+});
+```
+
+There is no `guardInbound`. `guard()` fails open — always check
+`hasFailedOpen()`.
+
+## Step 4: Correlation
+
+Put the id you already have on `chat({ context })`:
+
+```ts
+await chat({
+  adapter,
+  messages,
+  context: { sessionId: conversationId },
+  middleware: [guardMiddleware(arcjet, { sessionId: conversationId })],
+});
+```
+
+Preference order: `context.correlationId`, then `context.sessionId`,
+then `context.conversationId`, then `init.sessionId` /
+`init.correlationId`. If none is a valid 1–256 printable-ASCII
+string, the call is uncorrelated rather than joined to a generated
+id nobody has.
+
+Never mint a new id. Never read `ctx.threadId` (TanStack
+auto-generates it). Never read `traceId` / `requestId` / `streamId`.
+`needsApproval` resumes after a human yes — Guard still runs on the
+tool call. Do not treat the interrupt or its resume value as
+correlation.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI (before `chat()`, including `hasFailedOpen()`),
+   a middleware skip-deny, an abort-deny, first-win ordering (Arcjet
+   before `toolCacheMiddleware`), no-throw, never-mint, and
+   fail-closed (an unreachable guard). Confirm the denial is
+   `{ type: "skip", result }` (or abort) and the run is not an
+   interrupt.
+3. Confirm in the Arcjet dashboard that decisions share the
+   caller-owned session id as their correlation id — not
+   `threadId`.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo will land in
+[`arcjet/examples` `tanstack-agent`](https://github.com/arcjet/examples/tree/main/examples/tanstack-agent)
+as a later follow-up. Do not add an example under `examples/` in the
+JS SDK repo.
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
@@ -17,9 +17,11 @@ decision rule:
   middleware whose `onBeforeToolCall` is the chat()-wide gate. Default
   DENY is `{ type: "skip", result: ArcjetDenialResult }` so the tool
   never runs and the model sees the payload. Optional `onDeny: "abort"`
-  returns `{ type: "abort", reason }` and stops the run. Do not throw
-  from the hook. Already-branded tools are skipped so a preceding
-  `guard()` is not double-called.
+  returns `{ type: "abort", reason }` and stops the run — the model
+  does not get `ArcjetDenialResult`. Do not throw from the hook.
+  Tools already branded by a sibling `guardTool` are skipped so
+  Guard is not double-called. Inbound `guard()` before `chat()`
+  does not brand tools and does not skip this gate.
 - **Correlation** → `tanstackAiContext()` reads a caller-owned id from
   the helper options or `chat({ context })`. It never mints a new id.
   It never reads `ctx.threadId` (TanStack auto-generates it). It never
@@ -168,10 +170,18 @@ const stream = chat({
 - Omit `rules` to submit none. The guard call still happens.
 - On DENY the original `execute` never runs. Default delivery is
   `{ type: "skip", result: { arcjetDenied: true, reason, message, retryable } }`.
-- `onDeny: "abort"` stops the chat run instead.
+- `onDeny: "abort"` stops the chat run with `{ type: "abort", reason }`
+  (the denial `message` string). The model does not get
+  `ArcjetDenialResult`. Prefer default skip when the model should
+  see the payload. `onDeny: "abort"` applies to real DENY only;
+  unavailable stays skip.
 - Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
-- Already-branded tools skip the middleware guard so a preceding
-  `guard()` is not double-called.
+- ALLOW captures `outcome: "success"` when the policy lets the tool
+  run, not when `execute` finishes. `onBeforeToolCall` cannot wrap
+  the tool; a later tool throw does not flip that capture.
+- Tools already branded by a sibling `guardTool` skip the middleware
+  so Guard is not double-called. This namespace has no `guardTool`.
+  Inbound `guard()` before `chat()` does not stamp that brand.
 
 ## Step 3: Screen inbound before chat
 
@@ -225,6 +235,11 @@ then `context.conversationId`, then `init.sessionId` /
 string, the call is uncorrelated rather than joined to a generated
 id nobody has.
 
+Pass a caller-owned bag as `tanstackAiContext({ context: appContext })`
+or `chat({ context: appContext })`. A bare object that also has
+string `requestId` and `streamId` looks like TanStack's middleware
+envelope, so top-level `sessionId` on that object is ignored.
+
 Never mint a new id. Never read `ctx.threadId` (TanStack
 auto-generates it). Never read `traceId` / `requestId` / `streamId`.
 `needsApproval` resumes after a human yes — Guard still runs on the
@@ -235,11 +250,11 @@ correlation.
 
 1. `npm run typecheck` passes.
 2. Exercise inbound PI (before `chat()`, including `hasFailedOpen()`),
-   a middleware skip-deny, an abort-deny, first-win ordering (Arcjet
-   before `toolCacheMiddleware`), no-throw, never-mint, and
-   fail-closed (an unreachable guard). Confirm the denial is
-   `{ type: "skip", result }` (or abort) and the run is not an
-   interrupt.
+   a middleware skip-deny, an abort-deny, abort+unavailable still
+   skip, first-win ordering (Arcjet before `toolCacheMiddleware`),
+   no-throw, never-mint, and fail-closed (an unreachable guard).
+   Confirm the denial is `{ type: "skip", result }` (or abort) and
+   the run is not an interrupt.
 3. Confirm in the Arcjet dashboard that decisions share the
    caller-owned session id as their correlation id — not
    `threadId`.

--- a/arcjet-guard/src/agents/denial.test.ts
+++ b/arcjet-guard/src/agents/denial.test.ts
@@ -154,6 +154,7 @@ test("no vendor namespace declares its own denial payload", () => {
     "openai-agents",
     "genkit",
     "strands-agents",
+    "tanstack-ai",
   ];
   const forbidden = [
     ["interface ", "Arcjet", "DenialResult"].join(""),

--- a/arcjet-guard/src/agents/index.test.ts
+++ b/arcjet-guard/src/agents/index.test.ts
@@ -123,7 +123,9 @@ function walkForForbiddenImports(filePath: string, visited: Set<string>, errors:
       spec === "@genkit-ai/ai" ||
       spec.startsWith("@genkit-ai/ai/") ||
       spec === "@strands-agents/sdk" ||
-      spec.startsWith("@strands-agents/sdk/")
+      spec.startsWith("@strands-agents/sdk/") ||
+      spec === "@tanstack/ai" ||
+      spec.startsWith("@tanstack/ai/")
     ) {
       errors.push(`File ${absolutePath} imports forbidden package: "${spec}"`);
     }

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -9,7 +9,8 @@
  * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`,
  * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langchain/v1`,
  * `@arcjet/guard/langgraph/v1`, `@arcjet/guard/openai-agents/v0`,
- * `@arcjet/guard/genkit/v1`, and `@arcjet/guard/strands-agents/v1`. The
+ * `@arcjet/guard/genkit/v1`, `@arcjet/guard/strands-agents/v1`, and
+ * `@arcjet/guard/tanstack-ai/v0`. The
  * layer stays agnostic so multiple
  * vendor namespaces can share the same code. A public `@arcjet/guard/agents`
  * path is still a follow-up with its own ADR.

--- a/arcjet-guard/src/claude-agent-sdk/v0/index.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/index.test.ts
@@ -163,6 +163,7 @@ test("does not export Eve-only or Mastra-only APIs onto the Claude namespace", (
     "guardConnection",
     "mastraAgentContext",
     "strandsAgentContext",
+    "tanstackAiContext",
     "guardProcessor",
     "canUseTool",
     "guardCanUseTool",

--- a/arcjet-guard/src/genkit/v1/index.test.ts
+++ b/arcjet-guard/src/genkit/v1/index.test.ts
@@ -144,6 +144,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI-only APIs", () 
     "langchainContext",
     "openaiAgentsContext",
     "strandsAgentContext",
+    "tanstackAiContext",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",

--- a/arcjet-guard/src/langgraph/v1/index.test.ts
+++ b/arcjet-guard/src/langgraph/v1/index.test.ts
@@ -155,6 +155,7 @@ test("does not export Eve / Mastra-only APIs onto the LangGraph namespace", () =
     "genkitContext",
     "langchainContext",
     "strandsAgentContext",
+    "tanstackAiContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/openai-agents/v0/index.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/index.test.ts
@@ -151,6 +151,7 @@ test("does not export Eve / Mastra / Claude / LangGraph-only APIs", () => {
     "genkitContext",
     "langchainContext",
     "strandsAgentContext",
+    "tanstackAiContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/strands-agents/v1/index.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/index.test.ts
@@ -160,6 +160,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only A
     "langchainContext",
     "openaiAgentsContext",
     "genkitContext",
+    "tanstackAiContext",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",

--- a/arcjet-guard/src/tanstack-ai/v0/assignability.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/assignability.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Compile-time assignability: the helpers accept the values a TanStack
+ * AI `chat()` app actually has, with no casts at the call site.
+ *
+ * The declarations are types only (`declare const`, never executed) so
+ * this suite still runs in the tanstack-ai-absent CI job, where the
+ * peer is gone and the type-only import scan applies. Runtime
+ * behaviour against the real `chat()` / `toolCacheMiddleware` lives in
+ * `test/tanstack-ai/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ChatMiddleware } from "@tanstack/ai";
+
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { guardMiddleware } from "./guard-middleware.ts";
+
+declare const client: ArcjetAgentClient;
+
+// Never called: the declarations above have no runtime value. Typecheck is
+// the assertion.
+function typeProbe(): void {
+  const middleware = guardMiddleware(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+    onDeny: "abort",
+  });
+
+  const chatOpts: { middleware?: ChatMiddleware[] } = {
+    middleware: [middleware],
+  };
+
+  void [middleware, chatOpts];
+}
+
+test("helpers accept a chat({ middleware }) ChatMiddleware without casts", () => {
+  assert.equal(typeof typeProbe, "function");
+});

--- a/arcjet-guard/src/tanstack-ai/v0/context.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/context.test.ts
@@ -128,6 +128,8 @@ test("skips an invalid context session id and uses the next candidate", () => {
   });
 
   assert.equal(result.correlationId, "conv-ok");
+  assert.equal("tanstack-ai.session" in (result.metadata ?? {}), false);
+  assert.equal(result.metadata?.["tanstack-ai.conversation"], "conv-ok");
 });
 
 test("rejects a session id over 256 characters and does not mint", () => {
@@ -135,7 +137,7 @@ test("rejects a session id over 256 characters and does not mint", () => {
   const result = tanstackAiContext({ context: { sessionId: longId } });
 
   assert.equal(result.correlationId, undefined);
-  assert.equal(result.metadata?.["tanstack-ai.session"], longId);
+  assert.equal("tanstack-ai.session" in (result.metadata ?? {}), false);
 });
 
 test("a null context does not throw and does not mint", () => {
@@ -202,7 +204,17 @@ test("non-string candidates are skipped", () => {
 test("non-printable session id is rejected and does not mint", () => {
   const result = tanstackAiContext({ context: { sessionId: "bad\nid" } });
   assert.equal(result.correlationId, undefined);
-  assert.equal(result.metadata?.["tanstack-ai.session"], "bad\nid");
+  assert.equal("tanstack-ai.session" in (result.metadata ?? {}), false);
+});
+
+test("does not write an invalid session id into metadata when a later candidate is valid", () => {
+  const result = tanstackAiContext(
+    { context: { sessionId: "bad\nid" } },
+    { sessionId: "policy-sess" },
+  );
+
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["tanstack-ai.session"], "policy-sess");
 });
 
 test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {

--- a/arcjet-guard/src/tanstack-ai/v0/context.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/context.test.ts
@@ -1,0 +1,239 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { tanstackAiContext } from "./context.ts";
+
+test("prefers a field the integrator put on chat({ context })", () => {
+  const result = tanstackAiContext({
+    context: { sessionId: "sess-app", conversationId: "conv-app" },
+    sessionId: "sess-envelope",
+    conversationId: "conv-envelope",
+  });
+
+  assert.equal(result.correlationId, "sess-app");
+  assert.equal(result.metadata?.["tanstack-ai.session"], "sess-app");
+  assert.equal(result.metadata?.["tanstack-ai.conversation"], "conv-app");
+});
+
+test("prefers context.correlationId over context.sessionId", () => {
+  const result = tanstackAiContext({
+    context: { correlationId: "corr-1", sessionId: "sess-1" },
+  });
+
+  assert.equal(result.correlationId, "corr-1");
+  assert.equal(result.metadata?.["tanstack-ai.session"], "sess-1");
+});
+
+test("falls back to context.conversationId when sessionId is absent", () => {
+  const result = tanstackAiContext({
+    context: { conversationId: "conv-1" },
+  });
+
+  assert.equal(result.correlationId, "conv-1");
+  assert.equal(result.metadata?.["tanstack-ai.conversation"], "conv-1");
+});
+
+test("accepts a bare app context object", () => {
+  const result = tanstackAiContext({ sessionId: "direct-sess" });
+  assert.equal(result.correlationId, "direct-sess");
+  assert.equal(result.metadata?.["tanstack-ai.session"], "direct-sess");
+});
+
+test("init.sessionId is a last-resort caller-owned fallback", () => {
+  const result = tanstackAiContext({ context: { user: "alice" } }, { sessionId: "policy-sess" });
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["tanstack-ai.session"], "policy-sess");
+});
+
+test("never mints an id when nothing valid is present", () => {
+  const result = tanstackAiContext({});
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+});
+
+test("never mints an id when the only candidate is invalid", () => {
+  const result = tanstackAiContext({ context: { sessionId: "" } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("tanstack-ai.session" in (result.metadata ?? {}), false);
+});
+
+test("never reads ctx.threadId, even when it is the only string present", () => {
+  const result = tanstackAiContext({
+    requestId: "req-minted",
+    streamId: "stream-minted",
+    threadId: "thread-auto",
+    conversationId: "conv-alias-of-thread",
+    context: {},
+  } as never);
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("never reads requestId, streamId, runId, or traceId", () => {
+  const result = tanstackAiContext({
+    requestId: "req-1",
+    streamId: "stream-1",
+    runId: "run-1",
+    traceId: "trace-1",
+    context: {
+      requestId: "ctx-req",
+      streamId: "ctx-stream",
+      runId: "ctx-run",
+      traceId: "ctx-trace",
+    },
+  } as never);
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("reads chat({ context }) even when the envelope is a ChatMiddlewareContext", () => {
+  const result = tanstackAiContext({
+    requestId: "req-1",
+    streamId: "stream-1",
+    threadId: "thread-auto",
+    conversationId: "thread-auto",
+    context: { sessionId: "sess-from-chat" },
+  } as never);
+
+  assert.equal(result.correlationId, "sess-from-chat");
+  assert.equal(result.metadata?.["tanstack-ai.session"], "sess-from-chat");
+});
+
+test("skips an invalid context session id and uses the next candidate", () => {
+  const result = tanstackAiContext({
+    context: { sessionId: "" },
+    conversationId: "conv-ok",
+  });
+
+  assert.equal(result.correlationId, "conv-ok");
+});
+
+test("rejects a session id over 256 characters and does not mint", () => {
+  const longId = "x".repeat(257);
+  const result = tanstackAiContext({ context: { sessionId: longId } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["tanstack-ai.session"], longId);
+});
+
+test("a null context does not throw and does not mint", () => {
+  const result = tanstackAiContext({ context: null });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("caller metadata overrides derived keys", () => {
+  const result = tanstackAiContext(
+    { context: { sessionId: "sess-1" } },
+    { metadata: { "tanstack-ai.session": "override" } },
+  );
+
+  assert.equal(result.metadata?.["tanstack-ai.session"], "override");
+});
+
+test("derived metadata keys match /^[A-Za-z0-9._-]+$/", () => {
+  const result = tanstackAiContext({
+    context: { sessionId: "sess-1", conversationId: "conv-1" },
+  });
+
+  assert.ok(result.metadata);
+  const validKeyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const key of Object.keys(result.metadata)) {
+    assert.ok(
+      validKeyPattern.test(key),
+      `derived key "${key}" must match the metadata character class`,
+    );
+  }
+});
+
+test("encoder round-trip produces no AJ1017 warnings", () => {
+  const result = tanstackAiContext({
+    context: { sessionId: "sess-1", conversationId: "conv-1" },
+  });
+
+  assert.ok(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
+  assert.ok(metadataJson["tanstack-ai.session"]);
+  assert.ok(metadataJson["tanstack-ai.conversation"]);
+});
+
+test("undefined source does not throw and does not mint", () => {
+  const result = tanstackAiContext();
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("null and primitive sources do not mint", () => {
+  assert.equal("correlationId" in tanstackAiContext(null as never), false);
+  assert.equal("correlationId" in tanstackAiContext("sess" as never), false);
+  assert.equal("correlationId" in tanstackAiContext(12 as never), false);
+});
+
+test("non-string candidates are skipped", () => {
+  const result = tanstackAiContext({
+    context: { sessionId: 99, conversationId: { id: "nope" } },
+  });
+  assert.equal(result.correlationId, undefined);
+});
+
+test("non-printable session id is rejected and does not mint", () => {
+  const result = tanstackAiContext({ context: { sessionId: "bad\nid" } });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata?.["tanstack-ai.session"], "bad\nid");
+});
+
+test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "info";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    tanstackAiContext({ context: { sessionId: "" } });
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /rejected/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("does not warn when a later candidate is valid", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const result = tanstackAiContext({
+      context: { sessionId: "" },
+      conversationId: "conv-ok",
+    });
+    assert.equal(result.correlationId, "conv-ok");
+    assert.equal(warnings.length, 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/tanstack-ai/v0/context.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/context.test.ts
@@ -92,6 +92,22 @@ test("never reads requestId, streamId, runId, or traceId", () => {
   assert.equal(result.metadata, undefined);
 });
 
+test("a bare object with requestId and streamId is an envelope; nest caller ids on context", () => {
+  const bare = tanstackAiContext({
+    requestId: "req-1",
+    streamId: "stream-1",
+    sessionId: "sess-lost",
+  });
+  assert.equal(bare.correlationId, undefined);
+
+  const nested = tanstackAiContext({
+    requestId: "req-1",
+    streamId: "stream-1",
+    context: { sessionId: "sess-kept" },
+  });
+  assert.equal(nested.correlationId, "sess-kept");
+});
+
 test("reads chat({ context }) even when the envelope is a ChatMiddlewareContext", () => {
   const result = tanstackAiContext({
     requestId: "req-1",

--- a/arcjet-guard/src/tanstack-ai/v0/context.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/context.ts
@@ -1,0 +1,201 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `tanstackAiContext` can read.
+ *
+ * Correlation is a **caller-owned** id from helper options or
+ * `chat({ context })`. This helper never mints a new id. It never
+ * reads TanStack's auto-generated `threadId` (or the deprecated
+ * `conversationId` alias on `ChatMiddlewareContext`). It never reads
+ * `traceId`, `requestId`, `streamId`, or `runId`.
+ *
+ * Accepts:
+ * - `chat({ context })` / the user object on `ChatMiddlewareContext.context`
+ * - a `ChatMiddlewareContext`-shaped envelope (only `context` is read)
+ * - the app context object itself
+ * - helper `init.sessionId` / `init.correlationId`
+ */
+export interface TanStackAiContextSource {
+  context?: unknown;
+  correlationId?: unknown;
+  sessionId?: unknown;
+  conversationId?: unknown;
+  /** Present on TanStack's middleware envelope. Never used for correlation. */
+  requestId?: unknown;
+  /** Present on TanStack's middleware envelope. Never used for correlation. */
+  streamId?: unknown;
+}
+
+/**
+ * Context derived from a TanStack AI `chat()` run. `correlationId` is
+ * omitted when nothing valid was present — this helper never mints one.
+ */
+export interface TanStackAiAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asContextSource(source: unknown): TanStackAiContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+function asAppContext(value: unknown): TanStackAiContextSource | undefined {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * TanStack's `ChatMiddlewareContext` always carries `requestId` and
+ * `streamId` (both 0.8.0 and 0.52.x). Those fields are SDK-minted, so
+ * an envelope that looks like one must not be mined for correlation —
+ * including the 0.52 `threadId` / deprecated `conversationId` alias.
+ */
+function isMiddlewareEnvelope(source: TanStackAiContextSource): boolean {
+  return typeof source.requestId === "string" && typeof source.streamId === "string";
+}
+
+/**
+ * The integrator-owned app object. On a `chat({ context })` /
+ * `ChatMiddlewareContext` envelope that is `source.context`. On a bare
+ * app object it is the source itself.
+ */
+function readAppContext(
+  source: TanStackAiContextSource | undefined,
+): TanStackAiContextSource | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  const nested = asAppContext(source.context);
+  if (nested !== undefined) {
+    return nested;
+  }
+  if (isMiddlewareEnvelope(source)) {
+    return undefined;
+  }
+  return source;
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function firstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Derive correlation and metadata from a TanStack AI `chat({ context })`
+ * object or a `ChatMiddlewareContext`. Never mints a new id. Never
+ * calls `createAgentContext`. Never reads `ctx.threadId` (TanStack
+ * auto-generates it). Never reads `traceId` / `requestId` / `streamId`
+ * / `runId`.
+ *
+ * Preference order for `correlationId`:
+ * 1. Fields the integrator put on `chat({ context })`:
+ *    `correlationId`, then `sessionId`, then `conversationId`
+ * 2. Documented copies on a bare app object (not a middleware envelope)
+ * 3. `init.sessionId` / `init.correlationId` (a caller-owned fallback)
+ *
+ * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL`
+ * asks for warnings). If nothing valid remains, `correlationId` is
+ * omitted so the decision is uncorrelated rather than joined to a
+ * generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { tanstackAiContext } from "@arcjet/guard/tanstack-ai/v0";
+ *
+ * const appContext = { sessionId: conversationId };
+ * export function beforeChat() {
+ *   return tanstackAiContext({ context: appContext });
+ * }
+ * ```
+ */
+export function tanstackAiContext(
+  source?: TanStackAiContextSource,
+  init?: { sessionId?: string; correlationId?: string; metadata?: ArcjetMetadata },
+): TanStackAiAgentContext {
+  const envelope = asContextSource(source);
+  const app = readAppContext(envelope);
+  const envelopeIsMiddleware = envelope !== undefined && isMiddlewareEnvelope(envelope);
+
+  const fromApp = {
+    correlationId: app?.correlationId,
+    sessionId: app?.sessionId,
+    conversationId: app?.conversationId,
+  };
+  const fromEnvelope = envelopeIsMiddleware
+    ? { correlationId: undefined, sessionId: undefined, conversationId: undefined }
+    : {
+        correlationId: envelope?.correlationId,
+        sessionId: envelope?.sessionId,
+        conversationId: envelope?.conversationId,
+      };
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: fromApp.correlationId, label: "context.correlationId" },
+    { value: fromApp.sessionId, label: "context.sessionId" },
+    { value: fromApp.conversationId, label: "context.conversationId" },
+    { value: fromEnvelope.correlationId, label: "correlationId" },
+    { value: fromEnvelope.sessionId, label: "sessionId" },
+    { value: fromEnvelope.conversationId, label: "conversationId" },
+    { value: init?.correlationId, label: "init.correlationId" },
+    { value: init?.sessionId, label: "init.sessionId" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: TanStack AI ${rejected} rejected; no valid session/conversation id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const session = firstString([fromApp.sessionId, fromEnvelope.sessionId, init?.sessionId]);
+  if (session !== undefined) {
+    derivedMetadata["tanstack-ai.session"] = session;
+  }
+
+  const conversation = firstString([fromApp.conversationId, fromEnvelope.conversationId]);
+  if (conversation !== undefined) {
+    derivedMetadata["tanstack-ai.conversation"] = conversation;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: TanStackAiAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/tanstack-ai/v0/context.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/context.ts
@@ -100,11 +100,15 @@ function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string 
   return { id: undefined, rejected };
 }
 
-function firstString(values: unknown[]): string | undefined {
+function validMetadataString(values: unknown[]): string | undefined {
   for (const value of values) {
-    if (typeof value === "string" && value.length > 0) {
-      return value;
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
     }
+    if (correlationIdProblem(value) !== undefined) {
+      continue;
+    }
+    return value;
   }
   return undefined;
 }
@@ -182,12 +186,12 @@ export function tanstackAiContext(
 
   const derivedMetadata: ArcjetMetadata = {};
 
-  const session = firstString([fromApp.sessionId, fromEnvelope.sessionId, init?.sessionId]);
+  const session = validMetadataString([fromApp.sessionId, fromEnvelope.sessionId, init?.sessionId]);
   if (session !== undefined) {
     derivedMetadata["tanstack-ai.session"] = session;
   }
 
-  const conversation = firstString([fromApp.conversationId, fromEnvelope.conversationId]);
+  const conversation = validMetadataString([fromApp.conversationId, fromEnvelope.conversationId]);
   if (conversation !== undefined) {
     derivedMetadata["tanstack-ai.conversation"] = conversation;
   }

--- a/arcjet-guard/src/tanstack-ai/v0/context.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/context.ts
@@ -122,6 +122,11 @@ function firstString(values: unknown[]): string | undefined {
  * 2. Documented copies on a bare app object (not a middleware envelope)
  * 3. `init.sessionId` / `init.correlationId` (a caller-owned fallback)
  *
+ * Prefer `tanstackAiContext({ context: appContext })`. A bare object
+ * that also has string `requestId` and `streamId` is treated as a
+ * `ChatMiddlewareContext` envelope, so a top-level `sessionId` on
+ * that object is ignored.
+ *
  * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL`
  * asks for warnings). If nothing valid remains, `correlationId` is
  * omitted so the decision is uncorrelated rather than joined to a

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
@@ -204,6 +204,39 @@ test("policy factory throw fail-closes and does not throw from the hook", async 
   assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
 });
 
+test("onDeny abort does not abort unavailable: fail-open stays skip", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked", onDeny: "abort" });
+  const result = await runHook(mw, toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+});
+
+test("onDeny abort does not abort unavailable: policy factory throw stays skip", async () => {
+  const { client } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    onDeny: "abort",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await runHook(mw, toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+});
+
+test("onDeny abort does not abort unavailable: thrown guard() stays skip", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  const mw = guardMiddleware(client, { action: "tool.invoked", onDeny: "abort" });
+  const result = await runHook(mw, toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+});
+
 test("no-throw: a throwing guard() becomes a skip denial, not a thrown error", async () => {
   const { client } = stubClient(new Error("transport down"));
   const mw = guardMiddleware(client, { action: "tool.invoked" });
@@ -213,7 +246,7 @@ test("no-throw: a throwing guard() becomes a skip denial, not a thrown error", a
   assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
 });
 
-test("inbound brand-skip: a branded tool skips so a preceding guard() is not double-called", async () => {
+test("skips a sibling guardTool-branded tool so Guard is not double-called", async () => {
   const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
   const branded = { name: "lookup_order" };
   Object.defineProperty(branded, arcjetProtectedTool, { value: true });

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
@@ -1,0 +1,317 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/explicit-function-return-type, eslint/require-await, eslint/strict-boolean-expressions, typescript/strict-boolean-expressions, unicorn/no-useless-undefined, unicorn/no-object-as-default-parameter -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { guardMiddleware } from "./guard-middleware.ts";
+import type { TanStackAiGuardMiddleware } from "./guard-middleware.ts";
+
+function middlewareCtx(context: unknown = { sessionId: "sess-1" }) {
+  return {
+    requestId: "req-auto",
+    streamId: "stream-auto",
+    threadId: "thread-auto",
+    conversationId: "thread-auto",
+    context,
+  };
+}
+
+function toolHook(name: string, args: unknown = {}, tool?: object) {
+  return {
+    toolCall: { id: "call-1", type: "function" as const, function: { name, arguments: "{}" } },
+    tool,
+    args,
+    toolName: name,
+    toolCallId: "call-1",
+  };
+}
+
+async function runHook(
+  mw: TanStackAiGuardMiddleware,
+  hookCtx: unknown,
+  ctx: unknown = middlewareCtx(),
+) {
+  const hook = mw.onBeforeToolCall;
+  assert.ok(hook, "guardMiddleware must install onBeforeToolCall");
+  return hook(ctx as never, hookCtx as never);
+}
+
+/**
+ * TanStack 0.52 `MiddlewareRunner.runOnBeforeToolCall`: first non-void /
+ * non-null decision wins.
+ */
+async function firstWin(
+  middlewares: Array<{
+    onBeforeToolCall?: (...args: never[]) => unknown;
+  }>,
+  ctx: unknown,
+  hookCtx: unknown,
+): Promise<unknown> {
+  for (const mw of middlewares) {
+    if (mw.onBeforeToolCall === undefined) {
+      continue;
+    }
+    const decision = await mw.onBeforeToolCall(ctx as never, hookCtx as never);
+    if (decision !== undefined && decision !== null) {
+      return decision;
+    }
+  }
+  return undefined;
+}
+
+test("returns a named ChatMiddleware with onBeforeToolCall (not a raw function)", () => {
+  const { client } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  assert.equal(typeof mw, "object");
+  assert.equal(typeof mw.name, "string");
+  assert.ok(mw.name.startsWith("arcjet-guard-"));
+  assert.equal(typeof mw.onBeforeToolCall, "function");
+  assert.equal("onInterruptBoundary" in mw, false);
+  assert.equal("contentGuardMiddleware" in mw, false);
+});
+
+test("each call gets a unique name so two instances do not collide", () => {
+  const { client } = stubClient(decisionAllow());
+  const a = guardMiddleware(client);
+  const b = guardMiddleware(client);
+  assert.notEqual(a.name, b.name);
+});
+
+test("ALLOW → void decision so the tool can run", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolHook("lookup"));
+  assert.equal(result, undefined);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("skip-deny: DENY → { type: skip, result: ArcjetDenialResult }", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolHook("lookup", { note: "x" }));
+  assert.ok(result && typeof result === "object" && "type" in result);
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  const denial = asDenial<ArcjetDenialResult>(decision.result);
+  assert.equal(denial.arcjetDenied, true);
+  assert.equal(denial.reason, "PROMPT_INJECTION");
+});
+
+test("abort-deny: onDeny abort → { type: abort, reason }", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const mw = guardMiddleware(client, { action: "tool.invoked", onDeny: "abort" });
+  const result = await runHook(mw, toolHook("lookup", { note: "x" }));
+  assert.ok(result && typeof result === "object" && "type" in result);
+  const decision = result as { type: string; reason?: string };
+  assert.equal(decision.type, "abort");
+  assert.equal(typeof decision.reason, "string");
+  assert.match(String(decision.reason), /PROMPT_INJECTION/);
+});
+
+test("rules see hookCtx.args, not the opaque toolCallId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let scanned: unknown;
+  const mw = guardMiddleware(client, {
+    action: "note.read",
+    rules: ({ input, toolName }) => {
+      scanned = { input, toolName };
+      return [fakeRule];
+    },
+  });
+  await runHook(mw, toolHook("lookup", { note: "hello" }));
+  assert.deepEqual(scanned, { input: { note: "hello" }, toolName: "lookup" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("correlation comes from chat({ context }).sessionId, never threadId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  await runHook(mw, toolHook("lookup"), middlewareCtx({ sessionId: "sess-mw" }));
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-mw");
+});
+
+test("policy.sessionId is used when chat context has none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    sessionId: "policy-sess",
+  });
+  await runHook(mw, toolHook("lookup"), middlewareCtx({}));
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("never-mint: does not mint a correlation id when nothing is present", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  await runHook(mw, toolHook("lookup"), middlewareCtx({}));
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("never-mint: does not use auto-generated threadId / requestId / streamId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  await runHook(mw, toolHook("lookup"), {
+    requestId: "req-auto",
+    streamId: "stream-auto",
+    threadId: "thread-auto",
+    conversationId: "thread-auto",
+    runId: "run-auto",
+    context: {},
+  });
+  const call = recorded(guardCalls[0]);
+  assert.equal("correlationId" in call, false);
+  assert.notEqual(call["correlationId"], "thread-auto");
+  assert.notEqual(call["correlationId"], "req-auto");
+  assert.notEqual(call["correlationId"], "stream-auto");
+});
+
+test("fail-closed unavailable → skip with ERROR payload", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+});
+
+test("onGuardError allow → void so the tool still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked", onGuardError: "allow" });
+  const result = await runHook(mw, toolHook("lookup"));
+  assert.equal(result, undefined);
+});
+
+test("policy factory throw fail-closes and does not throw from the hook", async () => {
+  const { client } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await runHook(mw, toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+});
+
+test("no-throw: a throwing guard() becomes a skip denial, not a thrown error", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+});
+
+test("inbound brand-skip: a branded tool skips so a preceding guard() is not double-called", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const branded = { name: "lookup_order" };
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolHook("lookup_order", {}, branded));
+  assert.equal(result, undefined);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("still gates an unwrapped tool when hookCtx.tool is undefined", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, toolHook("mcp_search"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).arcjetDenied, true);
+});
+
+test("inbound guard() before chat() is a separate call; middleware still gates tools", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const inbound = await client.guard({
+    label: "message.received",
+    rules: [],
+  });
+  assert.equal(inbound.hasFailedOpen(), false);
+
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  await runHook(mw, toolHook("lookup"));
+  assert.equal(guardCalls.length, 2);
+  assert.equal(recorded(guardCalls[0])["label"], "message.received");
+  assert.equal(recorded(guardCalls[1])["label"], "tool.invoked");
+});
+
+test("a non-tool-call hook context is passed through without a guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await runHook(mw, { text: "not a tool" });
+  assert.equal(result, undefined);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("first-win: a preceding skip wins and Guard never runs", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const cache = {
+    name: "tool-cache",
+    onBeforeToolCall: async () => ({ type: "skip" as const, result: { cached: true } }),
+  };
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await firstWin([cache, mw], middlewareCtx(), toolHook("lookup"));
+  assert.deepEqual(result, { type: "skip", result: { cached: true } });
+  assert.equal(guardCalls.length, 0);
+});
+
+test("first-win: Arcjet first deny wins and later middleware never runs", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  let later = 0;
+  const laterMw = {
+    name: "later",
+    onBeforeToolCall: async () => {
+      later += 1;
+      return { type: "skip" as const, result: { later: true } };
+    },
+  };
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await firstWin([mw, laterMw], middlewareCtx(), toolHook("lookup"));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).arcjetDenied, true);
+  assert.equal(later, 0);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("action callback names the guard call from the tool name", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+  await runHook(mw, toolHook("mcp_search"));
+  assert.equal(recorded(guardCalls[0])["label"], "mcp_search.invoked");
+});
+
+test("defaults the guard label to tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client);
+  await runHook(mw, toolHook("mcp_search"));
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("sessionId callback receives the tool name and input", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let seen: unknown;
+  const mw = guardMiddleware(client, {
+    sessionId: (call) => {
+      seen = call;
+      return "sess-from-callback";
+    },
+  });
+  await runHook(mw, toolHook("mcp_search", { q: "hello" }), middlewareCtx({}));
+  assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
+});

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
@@ -212,16 +212,26 @@ function gateToolCall(
  *
  * Default DENY is `{ type: "skip", result: ArcjetDenialResult }` so
  * the tool never runs and the model sees the payload. Optional
- * `onDeny: "abort"` returns `{ type: "abort", reason }` and stops the
- * chat run. This helper does **not** throw from the hook (TanStack
+ * `onDeny: "abort"` returns `{ type: "abort", reason }` (the denial
+ * `message` string) and stops the chat run. Abort does **not** hand
+ * the model `ArcjetDenialResult` — prefer default skip when it
+ * should. `onDeny: "abort"` applies to real DENY only; unavailable
+ * stays skip. This helper does **not** throw from the hook (TanStack
  * swallows a throw from `execute` into `{ error }`, and a throw from
  * this hook would abort the run as an error rather than a policy
  * denial).
  *
- * Already-branded tools (`arcjetProtectedTool` from a preceding
- * `guard()` wrap) are skipped so Guard is not double-called. Tools
- * that are not branded — including when `hookCtx.tool` is undefined —
- * are still gated.
+ * Already-branded tools (`arcjetProtectedTool` from a sibling
+ * `guardTool`) are skipped so Guard is not double-called. This
+ * namespace has no `guardTool`, and inbound `guard()` before
+ * `chat()` does not stamp that brand — it is a separate call and
+ * tools are still gated. Tools that are not branded — including
+ * when `hookCtx.tool` is undefined — are still gated.
+ *
+ * On ALLOW this helper captures `outcome: "success"` when the
+ * policy lets the tool run, not when `execute` finishes.
+ * `onBeforeToolCall` cannot wrap the tool; a later tool throw does
+ * not flip that capture.
  *
  * There is no `guardTool`. Throwing from `execute` is swallowed into
  * `{ error }` and is not a usable deny envelope.
@@ -274,7 +284,7 @@ export function guardMiddleware(
     } catch (error) {
       if (shouldWarn()) {
         console.warn(
-          "@arcjet/guard: onBeforeToolCall for a TanStack AI tool threw; failing closed:",
+          "@arcjet/guard: onBeforeToolCall for a TanStack AI tool threw; treating as a guard error:",
           error,
         );
       }

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
@@ -1,0 +1,292 @@
+import type {
+  BeforeToolCallDecision,
+  ChatMiddleware,
+  ChatMiddlewareContext,
+  ToolCallHookContext,
+} from "@tanstack/ai";
+
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { tanstackAiContext } from "./context.ts";
+import type { TanStackAiContextSource } from "./context.ts";
+
+/**
+ * Input passed to `rules` / `metadata` / `action` callbacks on
+ * `guardMiddleware`. `input` is the tool's free-text args, not the
+ * opaque `toolCallId`.
+ */
+export interface GuardMiddlewareCall {
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Policy for `guardMiddleware()` — how to guard tools that execute
+ * through `chat({ middleware })` via `ChatMiddleware.onBeforeToolCall`.
+ *
+ * `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL,
+ * not a policy gate — this helper never installs those hooks. After a
+ * human yes, Guard still runs on the tool call.
+ */
+export interface GuardMiddlewarePolicy {
+  /**
+   * Guard label and capture action. Defaults to `"tool.invoked"`. May be a
+   * function of the tool name and args.
+   */
+  action?: string | ((call: GuardMiddlewareCall) => string);
+  /**
+   * Rules to evaluate before a tool runs. Omitting this still performs
+   * the guard call.
+   */
+  rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
+  /** Metadata merged over the derived TanStack AI context. */
+  metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
+  /**
+   * Fallback session id when `chat({ context })` does not carry one.
+   * Prefer putting the id you already chose on
+   * `chat({ context: { sessionId } })`. Never mint a new id here.
+   */
+  sessionId?: string | ((call: GuardMiddlewareCall) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+  /**
+   * How to deliver a real DENY decision. Default skip
+   * (`{ type: "skip", result: ArcjetDenialResult }`) so the tool never
+   * runs and the model sees the payload. `"abort"` returns
+   * `{ type: "abort", reason }` and stops the chat run. No other modes.
+   */
+  onDeny?: "abort";
+}
+
+/**
+ * The `chat({ middleware })` object this helper returns.
+ *
+ * This is TanStack AI's `ChatMiddleware` (via `import type` only — this
+ * module never value-imports `@tanstack/ai`). `chat({ middleware })`
+ * accepts it with no cast.
+ */
+export type TanStackAiGuardMiddleware = ChatMiddleware & {
+  name: string;
+  onBeforeToolCall: NonNullable<ChatMiddleware["onBeforeToolCall"]>;
+};
+
+function isContextSource(value: unknown): value is TanStackAiContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isToolCallHookContext(value: unknown): value is ToolCallHookContext {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return typeof value["toolName"] === "string";
+}
+
+function isBrandedTool(tool: unknown): boolean {
+  return tool !== null && typeof tool === "object" && arcjetProtectedTool in tool;
+}
+
+function resolveAction(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall): string {
+  if (typeof policy.action === "function") {
+    return policy.action(call);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "tool.invoked";
+}
+
+function resolveSessionId(
+  policy: GuardMiddlewarePolicy,
+  call: GuardMiddlewareCall,
+): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(call);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+function denyDecision(
+  policy: GuardMiddlewarePolicy,
+  payload: { message: string },
+  kind: "deny" | "unavailable",
+): BeforeToolCallDecision {
+  if (kind === "deny" && policy.onDeny === "abort") {
+    return { type: "abort", reason: payload.message };
+  }
+  return { type: "skip", result: payload };
+}
+
+let middlewareSeq = 0;
+
+/**
+ * A registry key, not a secret: `chat({ middleware })` composes
+ * middleware by name in logs, and two distinct instances sharing one
+ * would be indistinguishable. The counter alone is not enough because
+ * a second copy of this module starts counting at one again.
+ */
+function middlewareName(): string {
+  middlewareSeq += 1;
+  return `arcjet-guard-${middlewareSeq}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function gateToolCall(
+  client: ArcjetAgentClient,
+  policy: GuardMiddlewarePolicy,
+  ctx: ChatMiddlewareContext,
+  hookCtx: ToolCallHookContext,
+): Promise<BeforeToolCallDecision> {
+  if (isBrandedTool(hookCtx.tool)) {
+    return Promise.resolve();
+  }
+
+  const toolName = hookCtx.toolName;
+  const input = hookCtx.args ?? {};
+  const call: GuardMiddlewareCall = { toolName, input };
+
+  let action: string;
+  let sessionId: string | undefined;
+  let rules: RuleWithInput[] | undefined;
+  let policyMetadata: ArcjetMetadata | undefined;
+  try {
+    action = resolveAction(policy, call);
+    sessionId = resolveSessionId(policy, call);
+    rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
+    policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+  } catch (error) {
+    const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
+    if (shouldWarn()) {
+      console.warn(
+        '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+        actionLabel,
+        error,
+      );
+    }
+    if (policy.onGuardError === "allow") {
+      return Promise.resolve();
+    }
+    return Promise.resolve(denyDecision(policy, unavailableResult(), "unavailable"));
+  }
+
+  const source = isContextSource(ctx) ? ctx : undefined;
+  const agentCtx = tanstackAiContext(source, sessionId === undefined ? undefined : { sessionId });
+
+  const metadata: ArcjetMetadata = {
+    ...agentCtx.metadata,
+    ...(toolName.length > 0 && { "tanstack-ai.tool": toolName }),
+  };
+  const mergedMetadata = { ...metadata, ...policyMetadata };
+
+  return runGuarded<BeforeToolCallDecision>(client, {
+    action,
+    rules,
+    correlationId: agentCtx.correlationId,
+    metadata: mergedMetadata,
+    onDeny: (decision: DecisionDeny) => denyDecision(policy, denialResult(decision), "deny"),
+    onUnavailable: () => denyDecision(policy, unavailableResult(), "unavailable"),
+    execute: () => Promise.resolve(),
+    onGuardError: policy.onGuardError ?? "deny",
+  });
+}
+
+/**
+ * A `chat({ middleware })` middleware whose `onBeforeToolCall` is the
+ * tool-call gate.
+ *
+ * Put Arcjet **first** in the middleware array. `onBeforeToolCall` is
+ * first-win: the first middleware that returns a non-void decision
+ * wins, and the rest are skipped. If `toolCacheMiddleware` (or
+ * anything else) skips first, Guard never runs.
+ *
+ * Default DENY is `{ type: "skip", result: ArcjetDenialResult }` so
+ * the tool never runs and the model sees the payload. Optional
+ * `onDeny: "abort"` returns `{ type: "abort", reason }` and stops the
+ * chat run. This helper does **not** throw from the hook (TanStack
+ * swallows a throw from `execute` into `{ error }`, and a throw from
+ * this hook would abort the run as an error rather than a policy
+ * denial).
+ *
+ * Already-branded tools (`arcjetProtectedTool` from a preceding
+ * `guard()` wrap) are skipped so Guard is not double-called. Tools
+ * that are not branded — including when `hookCtx.tool` is undefined —
+ * are still gated.
+ *
+ * There is no `guardTool`. Throwing from `execute` is swallowed into
+ * `{ error }` and is not a usable deny envelope.
+ *
+ * Client tools and provider-native tools with no local `execute` are
+ * out of scope. Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.
+ * TanStack AI is not the Vercel AI SDK.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardMiddleware } from "@arcjet/guard/tanstack-ai/v0";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const mcpLimit = tokenBucket({
+ *   refillRate: 20,
+ *   intervalSeconds: 60,
+ *   maxTokens: 20,
+ * });
+ *
+ * const stream = chat({
+ *   adapter,
+ *   messages,
+ *   tools: [lookupOrder, ...mcpTools],
+ *   context: { sessionId: conversationId },
+ *   middleware: [
+ *     guardMiddleware(arcjet, {
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+ *       sessionId: conversationId,
+ *     }),
+ *     toolCacheMiddleware(),
+ *   ],
+ * });
+ * ```
+ */
+export function guardMiddleware(
+  client: ArcjetAgentClient,
+  policy: GuardMiddlewarePolicy = {},
+): TanStackAiGuardMiddleware {
+  const onBeforeToolCall = async (
+    ctx: ChatMiddlewareContext,
+    hookCtx: ToolCallHookContext,
+  ): Promise<BeforeToolCallDecision> => {
+    try {
+      if (!isToolCallHookContext(hookCtx)) {
+        return undefined;
+      }
+      return await gateToolCall(client, policy, ctx, hookCtx);
+    } catch (error) {
+      if (shouldWarn()) {
+        console.warn(
+          "@arcjet/guard: onBeforeToolCall for a TanStack AI tool threw; failing closed:",
+          error,
+        );
+      }
+      if (policy.onGuardError === "allow") {
+        return undefined;
+      }
+      return denyDecision(policy, unavailableResult(), "unavailable");
+    }
+  };
+
+  return {
+    name: middlewareName(),
+    onBeforeToolCall,
+  };
+}

--- a/arcjet-guard/src/tanstack-ai/v0/index.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/index.test.ts
@@ -10,14 +10,14 @@ import {
 } from "../../../test/_shared/source-scan.ts";
 import * as agentsBarrel from "../../agents/index.ts";
 import * as v7Namespace from "../../vercel-ai/v7/index.ts";
-import * as langchainNamespace from "./index.ts";
-import type { ArcjetDenialResult, GuardToolPolicy, LangChainAgentContext } from "./index.ts";
+import * as tanstackNamespace from "./index.ts";
+import type { ArcjetDenialResult, GuardMiddlewarePolicy, TanStackAiAgentContext } from "./index.ts";
 
 function verifyTypeExports(): void {
-  const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
+  const policy: GuardMiddlewarePolicy | undefined = undefined;
   const denialResult: ArcjetDenialResult | undefined = undefined;
-  const agentContext: LangChainAgentContext | undefined = undefined;
-  void [toolPolicy, denialResult, agentContext];
+  const agentContext: TanStackAiAgentContext | undefined = undefined;
+  void [policy, denialResult, agentContext];
 }
 
 verifyTypeExports();
@@ -39,20 +39,20 @@ function objectField(
   return undefined;
 }
 
-test("exports the three own helpers as functions", () => {
-  const ownExports = ["langchainContext", "guardTool", "guardMiddleware"] as const;
+test("exports the two own helpers as functions", () => {
+  const ownExports = ["tanstackAiContext", "guardMiddleware"] as const;
 
   for (const funcName of ownExports) {
-    const func = (langchainNamespace as Record<string, unknown>)[funcName];
+    const func = (tanstackNamespace as Record<string, unknown>)[funcName];
     assert.equal(
       typeof func,
       "function",
-      `@arcjet/guard/langchain/v1 must export ${funcName} as a function`,
+      `@arcjet/guard/tanstack-ai/v0 must export ${funcName} as a function`,
     );
   }
 });
 
-test("langchain namespace exports the agnostic helpers", () => {
+test("tanstack-ai namespace exports the agnostic helpers", () => {
   const requiredSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -62,12 +62,12 @@ test("langchain namespace exports the agnostic helpers", () => {
   ] as const;
 
   for (const symbol of requiredSymbols) {
-    const value = (langchainNamespace as Record<string, unknown>)[symbol];
-    assert.ok(value !== undefined, `@arcjet/guard/langchain/v1 must export ${symbol}`);
+    const value = (tanstackNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/tanstack-ai/v0 must export ${symbol}`);
   }
 });
 
-test("agnostic exports have same identity across LangChain and v7 namespaces", () => {
+test("agnostic exports have same identity across TanStack AI and v7 namespaces", () => {
   const agnosticSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -78,82 +78,88 @@ test("agnostic exports have same identity across LangChain and v7 namespaces", (
   ] as const;
 
   for (const symbol of agnosticSymbols) {
-    const langchainValue = (langchainNamespace as Record<string, unknown>)[symbol];
+    const tanstackValue = (tanstackNamespace as Record<string, unknown>)[symbol];
     const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
 
     assert.strictEqual(
-      langchainValue,
+      tanstackValue,
       v7Value,
-      `${symbol} must be the same object identity from both @arcjet/guard/langchain/v1 and @arcjet/guard/vercel-ai/v7`,
+      `${symbol} must be the same object identity from both @arcjet/guard/tanstack-ai/v0 and @arcjet/guard/vercel-ai/v7`,
     );
   }
 });
 
-test("LangChain namespace is a strict superset of the agents barrel with same identity", () => {
-  const langchainKeys = Object.keys(langchainNamespace);
+test("TanStack AI namespace is a strict superset of the agents barrel with same identity", () => {
+  const tanstackKeys = Object.keys(tanstackNamespace);
   const agentKeys = Object.keys(agentsBarrel);
 
   for (const key of agentKeys) {
     assert.ok(
-      langchainKeys.includes(key),
-      `agents barrel key "${key}" must be present in langchain namespace`,
+      tanstackKeys.includes(key),
+      `agents barrel key "${key}" must be present in tanstack-ai namespace`,
     );
     assert.strictEqual(
-      (langchainNamespace as Record<string, unknown>)[key],
+      (tanstackNamespace as Record<string, unknown>)[key],
       (agentsBarrel as Record<string, unknown>)[key],
       `${key} must be the same object identity from both imports`,
     );
   }
 
-  const expectedAdditions = 3;
+  const expectedAdditions = 2;
   assert.equal(
-    langchainKeys.length,
+    tanstackKeys.length,
     agentKeys.length + expectedAdditions,
-    `langchain namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+    `tanstack-ai namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
   );
 
-  const langchainOnlyKeys = langchainKeys.filter((key) => !agentKeys.includes(key));
-  const ownExportsArray = ["guardTool", "guardMiddleware", "langchainContext"];
+  const tanstackOnlyKeys = tanstackKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["guardMiddleware", "tanstackAiContext"];
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
   const expectedOwnExports: readonly string[] = ownExportsArray.sort();
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-  const sorted: readonly string[] = langchainOnlyKeys.sort();
+  const sorted: readonly string[] = tanstackOnlyKeys.sort();
   assert.deepEqual(sorted, expectedOwnExports);
 });
 
-test("export map has no unversioned ./langchain and no wildcard subpaths", () => {
+test("export map has no unversioned ./tanstack-ai, no ./tanstack-ai/v1, and no wildcard subpaths", () => {
   const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
   const exportsMap = objectField(packageJson, "exports");
   assert.ok(exportsMap, "package.json must have an exports field");
 
   const exportKeys = Object.keys(exportsMap);
 
-  assert.ok(!exportKeys.includes("./langchain"), 'export map must not have "./langchain"');
-  assert.ok(exportKeys.includes("./langchain/v1"), 'export map must have "./langchain/v1"');
+  assert.ok(!exportKeys.includes("./tanstack-ai"), 'export map must not have "./tanstack-ai"');
+  assert.ok(
+    !exportKeys.includes("./tanstack-ai/v1"),
+    'export map must not have "./tanstack-ai/v1"',
+  );
+  assert.ok(exportKeys.includes("./tanstack-ai/v0"), 'export map must have "./tanstack-ai/v0"');
 
   for (const key of exportKeys) {
-    if (key.startsWith("./langchain/")) {
+    if (key.startsWith("./tanstack-ai/")) {
       assert.equal(
         key,
-        "./langchain/v1",
-        `export map must not have wildcard langchain subpaths; found "${key}"`,
+        "./tanstack-ai/v0",
+        `export map must not have wildcard tanstack-ai subpaths; found "${key}"`,
       );
     }
   }
 });
 
-test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only APIs", () => {
+test("does not export guardTool, inbound, approval, or sibling-only APIs", () => {
   const forbidden = [
+    "guardTool",
+    "guardInbound",
+    "guardApproval",
+    "contentGuardMiddleware",
     "eveAgentContext",
     "mastraAgentContext",
     "claudeAgentContext",
     "langgraphAgentContext",
+    "langchainContext",
     "openaiAgentsContext",
     "genkitContext",
     "strandsAgentContext",
-    "tanstackAiContext",
-    "guardInbound",
-    "guardApproval",
     "guardInterrupt",
     "guardHooks",
     "guardToolNode",
@@ -164,9 +170,9 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only A
   ];
   for (const key of forbidden) {
     assert.equal(
-      (langchainNamespace as Record<string, unknown>)[key],
+      (tanstackNamespace as Record<string, unknown>)[key],
       undefined,
-      `langchain namespace must not export "${key}"`,
+      `tanstack-ai namespace must not export "${key}"`,
     );
   }
 });

--- a/arcjet-guard/src/tanstack-ai/v0/index.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/index.ts
@@ -30,9 +30,11 @@
  *   `onBeforeToolCall` is the `chat()`-wide gate. Default DENY is
  *   `{ type: "skip", result: ArcjetDenialResult }` so the tool never
  *   runs and the model sees the payload. Optional `onDeny: "abort"`
- *   returns `{ type: "abort", reason }` and stops the run. The hook
- *   does not throw. Already-branded tools are skipped so a preceding
- *   `guard()` is not double-called.
+ *   returns `{ type: "abort", reason }` and stops the run — the model
+ *   does not get `ArcjetDenialResult`. The hook does not throw.
+ *   Tools already branded by a sibling `guardTool` are skipped so
+ *   Guard is not double-called. Inbound `guard()` before `chat()`
+ *   does not brand tools and does not skip this gate.
  * - **Correlation** → `tanstackAiContext()` reads a caller-owned id
  *   from the helper options or `chat({ context })`. It never mints a
  *   new id. It never reads `ctx.threadId` (TanStack auto-generates

--- a/arcjet-guard/src/tanstack-ai/v0/index.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/index.ts
@@ -1,0 +1,122 @@
+/**
+ * @packageDocumentation
+ *
+ * TanStack AI namespace for Arcjet Guards.
+ *
+ * This module provides TanStack AI `chat()` helpers plus the
+ * framework-agnostic layer they build on, so a TanStack AI app needs
+ * one import path and no notion of layering.
+ *
+ * **Requires the optional peer dependency `@tanstack/ai`
+ * (`>=0.8.0 <1`)**. Nothing in this module imports that package at
+ * runtime: every TanStack AI type arrives through `import type`, so
+ * installing `@arcjet/guard` never pulls it in. Latest supported
+ * development pin is 0.52.x. There is no `/v1` until TanStack AI
+ * ships 1.x.
+ *
+ * **Note:** the version segment is `v0` because `@tanstack/ai` is
+ * pre-1.0. There is deliberately no unversioned
+ * `@arcjet/guard/tanstack-ai` alias. A `v1` namespace is added when
+ * the SDK reaches 1.0; the segment names the SDK's major, not this
+ * integration's iteration. 0.x minors can break.
+ *
+ * v0 is `chat({ middleware })` + `ChatMiddleware.onBeforeToolCall`.
+ * Not the Vercel AI SDK — do not also wrap with
+ * `@arcjet/guard/vercel-ai/v7`.
+ *
+ * Two surfaces, and the things this namespace does not build:
+ *
+ * - **Tool calls** → `guardMiddleware()`. A `ChatMiddleware` whose
+ *   `onBeforeToolCall` is the `chat()`-wide gate. Default DENY is
+ *   `{ type: "skip", result: ArcjetDenialResult }` so the tool never
+ *   runs and the model sees the payload. Optional `onDeny: "abort"`
+ *   returns `{ type: "abort", reason }` and stops the run. The hook
+ *   does not throw. Already-branded tools are skipped so a preceding
+ *   `guard()` is not double-called.
+ * - **Correlation** → `tanstackAiContext()` reads a caller-owned id
+ *   from the helper options or `chat({ context })`. It never mints a
+ *   new id. It never reads `ctx.threadId` (TanStack auto-generates
+ *   it). It never reads `traceId` / `requestId` / `streamId`.
+ *
+ * There is no `guardTool`. A throw from `execute` is swallowed into
+ * `{ error }` and is not a usable deny envelope. There is no
+ * `guardInbound`, no `guardApproval`, and nothing named
+ * `contentGuardMiddleware` (TanStack already has that name).
+ *
+ * Put Arcjet **first** in the middleware array. `onBeforeToolCall` is
+ * first-win; if `toolCacheMiddleware` (or anything else) skips first,
+ * Guard never runs.
+ *
+ * ## Screen inbound before `chat()` — there is no inbound hook.
+ *
+ * There is no first-class inbound channel, so there is no
+ * `guardInbound`. Put prompt-injection (and other inbound rules) in
+ * the application before `chat()`. Call `guard()` directly.
+ * `guard()` fails open — callers must check `hasFailedOpen()`.
+ * `contentGuardMiddleware` redacts the stream; it is not this policy
+ * gate.
+ *
+ * ## `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL, not a policy gate.
+ *
+ * `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is
+ * human-in-the-loop. After a human yes, Guard still runs on the tool
+ * call. Same trap as Mastra `requireApproval`, Claude `canUseTool`,
+ * LangGraph `interrupt()`, Genkit `toolApproval`, OpenAI Agents
+ * `needsApproval`, and LangChain `humanInTheLoopMiddleware`. There is
+ * no `guardApproval`.
+ *
+ * Client tools and provider-native tools with no local `execute` are
+ * out of scope.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardMiddleware, tanstackAiContext } from "@arcjet/guard/tanstack-ai/v0";
+ * import { chat } from "@tanstack/ai";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const appContext = { sessionId: conversationId };
+ * const inbound = detectPromptInjection();
+ * const decision = await client.guard({
+ *   label: "message.received",
+ *   rules: [inbound(userText)],
+ *   ...tanstackAiContext({ context: appContext }),
+ * });
+ * if (decision.conclusion === "DENY") {
+ *   throw new Error("message blocked");
+ * }
+ * if (decision.hasFailedOpen()) {
+ *   throw new Error("inbound screening failed open");
+ * }
+ *
+ * const stream = chat({
+ *   adapter,
+ *   messages,
+ *   tools: [lookupOrder],
+ *   context: appContext,
+ *   middleware: [
+ *     guardMiddleware(client, {
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [lookupLimit({ key: toolName, requested: 1 })],
+ *       sessionId: conversationId,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+
+export { tanstackAiContext } from "./context.ts";
+export type { TanStackAiAgentContext, TanStackAiContextSource } from "./context.ts";
+export { guardMiddleware } from "./guard-middleware.ts";
+export type {
+  GuardMiddlewareCall,
+  GuardMiddlewarePolicy,
+  TanStackAiGuardMiddleware,
+} from "./guard-middleware.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/tanstack-ai/v0/peer.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/peer.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("@tanstack/ai is an optional peer and not a dependency", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+
+  const peerDependencies = objectField(packageJson, "peerDependencies");
+  assert.ok(peerDependencies);
+  assert.equal(peerDependencies["@tanstack/ai"], ">=0.8.0 <1");
+
+  const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
+  assert.ok(peerDependenciesMeta);
+  const tanstackMeta = objectField(peerDependenciesMeta, "@tanstack/ai");
+  assert.ok(tanstackMeta);
+  assert.equal(tanstackMeta["optional"], true);
+
+  const dependencies = objectField(packageJson, "dependencies");
+  assert.ok(!(dependencies && "@tanstack/ai" in dependencies));
+
+  const devDependencies = objectField(packageJson, "devDependencies");
+  assert.ok(devDependencies);
+  assert.equal(
+    devDependencies["@tanstack/ai"],
+    "0.52.0",
+    'devDependencies["@tanstack/ai"] must be pinned to "0.52.0"',
+  );
+
+  const engines = objectField(packageJson, "engines");
+  assert.ok(engines);
+  assert.equal(engines["node"], ">=22.21.0 <23 || >=24.5.0");
+});

--- a/arcjet-guard/src/tanstack-ai/v0/type-only.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/type-only.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+function isTanStackAiPeer(specifier: string): boolean {
+  return specifier === "@tanstack/ai" || specifier.startsWith("@tanstack/ai/");
+}
+
+test("type-only import scanner works on @tanstack/ai fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of @tanstack/ai",
+      content: 'import { chat } from "@tanstack/ai";\nvoid chat;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of @tanstack/ai",
+      content: 'import type { ChatMiddleware } from "@tanstack/ai";\nvoid 0;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content: 'import { type ChatMiddleware, chat } from "@tanstack/ai";\nvoid chat;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of @tanstack/ai",
+      content: 'export type { ChatMiddleware } from "@tanstack/ai";',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { chat } from "@tanstack/start";\nvoid chat;',
+      shouldHaveImport: false,
+    },
+    {
+      name: "detects dynamic import of @tanstack/ai",
+      content: 'const ai = await import("@tanstack/ai");\nvoid ai;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const peerImports = imports.filter((imp) => isTanStackAiPeer(imp.specifier));
+
+    if (fixture.shouldHaveImport === false) {
+      assert.equal(peerImports.length, 0, `${fixture.name}: should not have @tanstack/ai imports`);
+    } else {
+      assert.equal(
+        peerImports.length,
+        1,
+        `${fixture.name}: should have exactly one @tanstack/ai import`,
+      );
+      assert.equal(
+        peerImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all @tanstack/ai imports in the tanstack-ai namespace are type-only", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (isTanStackAiPeer(imp.specifier) && !imp.typeOnly) {
+        errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+      }
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in tanstack-ai namespace:\n${errors.join("\n")}`,
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-tanstack-ai-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, 'import { chat } from "@tanstack/ai";\nvoid chat;');
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const peerImports = imports.filter((imp) => isTanStackAiPeer(imp.specifier));
+    assert.equal(peerImports.length, 1);
+    assert.equal(peerImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/src/vendor-isolation.test.ts
+++ b/arcjet-guard/src/vendor-isolation.test.ts
@@ -31,6 +31,7 @@ const NAMESPACES = [
   { dir: "openai-agents", packages: ["@openai/agents"] },
   { dir: "genkit", packages: ["genkit", "@genkit-ai"] },
   { dir: "strands-agents", packages: ["@strands-agents/sdk"] },
+  { dir: "tanstack-ai", packages: ["@tanstack/ai"] },
 ] as const;
 
 /**
@@ -111,6 +112,7 @@ test("the scanner detects a cross-vendor import when one is introduced", () => {
     { from: "vercel-ai", content: 'const m = await import("@openai/agents");\nvoid m;' },
     { from: "genkit", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
     { from: "strands-agents", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
+    { from: "tanstack-ai", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
     { from: "genkit", content: 'import type { Plugin } from "@strands-agents/sdk";\nvoid 0;' },
     {
       from: "mastra",

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -300,6 +300,7 @@ export const EXPECTED_ROOT_KEYS = [
   "./openai-agents/v0",
   "./package.json",
   "./strands-agents/v1",
+  "./tanstack-ai/v0",
   // The in-memory client for application tests. Deliberately a single entry
   // rather than a runtime-conditional one: it has no transport, so there is
   // nothing for a condition to select.

--- a/arcjet-guard/test/tanstack-ai/real-middleware.test.ts
+++ b/arcjet-guard/test/tanstack-ai/real-middleware.test.ts
@@ -1,0 +1,114 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-type-assertion -- test fixtures built from the real SDK types
+/**
+ * Behaviour against the real `@tanstack/ai` `ChatMiddleware` /
+ * `toolCacheMiddleware`, rather than the structural fakes in
+ * `src/tanstack-ai/v0/*.test.ts`.
+ *
+ * These assertions live outside `src/tanstack-ai/` — that directory is
+ * globbed by the tanstack-ai-absent CI job and scanned for type-only
+ * imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { BeforeToolCallDecision, ChatMiddleware, ToolCallHookContext } from "@tanstack/ai";
+import { toolCacheMiddleware } from "@tanstack/ai/middlewares";
+
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { guardMiddleware } from "../../src/tanstack-ai/v0/guard-middleware.ts";
+import { asDenial } from "../_shared/source-scan.ts";
+import { decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+function middlewareCtx(context?: unknown): {
+  requestId: string;
+  streamId: string;
+  threadId: string;
+  conversationId: string;
+  context: unknown;
+} {
+  return {
+    requestId: "req-auto",
+    streamId: "stream-auto",
+    threadId: "thread-auto",
+    conversationId: "thread-auto",
+    context: context ?? { sessionId: "sess-1" },
+  };
+}
+
+function toolHook(name: string, args: unknown = {}): ToolCallHookContext {
+  return {
+    toolCall: { id: "call-1", type: "function", function: { name, arguments: "{}" } },
+    tool: undefined,
+    args,
+    toolName: name,
+    toolCallId: "call-1",
+  };
+}
+
+/**
+ * TanStack 0.52 `MiddlewareRunner.runOnBeforeToolCall`: first non-void /
+ * non-null decision wins.
+ */
+async function firstWin(
+  middlewares: ChatMiddleware[],
+  ctx: unknown,
+  hookCtx: ToolCallHookContext,
+): Promise<BeforeToolCallDecision> {
+  for (const mw of middlewares) {
+    if (mw.onBeforeToolCall === undefined) {
+      continue;
+    }
+    const decision = await mw.onBeforeToolCall(ctx as never, hookCtx);
+    if (decision !== undefined && decision !== null) {
+      return decision;
+    }
+  }
+  return undefined;
+}
+
+test("guardMiddleware is a ChatMiddleware chat({ middleware }) accepts without a cast", () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const middleware: ChatMiddleware[] = [guardMiddleware(client)];
+  assert.equal(typeof middleware[0]?.onBeforeToolCall, "function");
+});
+
+test("toolCacheMiddleware first-win skip means Guard never runs", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const cache = toolCacheMiddleware({
+    storage: {
+      getItem: () => ({ result: { cached: true }, timestamp: Date.now() }),
+      setItem: () => {
+        /* first-win probe: cache writes unused */
+      },
+      deleteItem: () => {
+        /* first-win probe: cache deletes unused */
+      },
+    },
+  });
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await firstWin([cache, mw], middlewareCtx(), toolHook("lookup", { q: "1" }));
+  assert.deepEqual(result, { type: "skip", result: { cached: true } });
+  assert.equal(guardCalls.length, 0);
+});
+
+test("Arcjet first deny wins over a later toolCacheMiddleware", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const cache = toolCacheMiddleware({
+    storage: {
+      getItem: () => ({ result: { cached: true }, timestamp: Date.now() }),
+      setItem: () => {
+        /* first-win probe: cache writes unused */
+      },
+      deleteItem: () => {
+        /* first-win probe: cache deletes unused */
+      },
+    },
+  });
+  const mw = guardMiddleware(client, { action: "tool.invoked" });
+  const result = await firstWin([mw, cache], middlewareCtx(), toolHook("lookup", { q: "1" }));
+  assert.ok(result && typeof result === "object" && "type" in result);
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).arcjetDenied, true);
+  assert.equal(guardCalls.length, 1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,7 @@
         "@mastra/core": "1.59.0",
         "@openai/agents": "0.17.0",
         "@strands-agents/sdk": "1.14.0",
+        "@tanstack/ai": "0.52.0",
         "@types/node": "22.20.1",
         "ai": "7.0.58",
         "eve": "0.46.0",
@@ -213,6 +214,7 @@
         "@mastra/core": ">=1 <2",
         "@openai/agents": ">=0.17.0 <1",
         "@strands-agents/sdk": ">=1.1.0 <2",
+        "@tanstack/ai": ">=0.8.0 <1",
         "ai": ">=7 <8",
         "eve": ">=0.34.0 <1",
         "genkit": ">=1.0.0 <2",
@@ -238,6 +240,9 @@
           "optional": true
         },
         "@strands-agents/sdk": {
+          "optional": true
+        },
+        "@tanstack/ai": {
           "optional": true
         },
         "ai": {
@@ -1030,6 +1035,21 @@
           "optional": true
         },
         "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ag-ui/core": {
+      "version": "0.1.1-canary.beta.0",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.1.1-canary.beta.0.tgz",
+      "integrity": "sha512-zcP3RH5p3HJTZ0kyQxNOL1blnVFTDpaShitR7UMS/thwFdl48V6CAG+WQBcYEu/dfa8mKonRez88N0Ok+nEI+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^3.25.18 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -9368,6 +9388,77 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/ai": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/ai/-/ai-0.52.0.tgz",
+      "integrity": "sha512-a2a+A+QguzZ3b8D7dqaA94A+CT42WUgxGYfscLrKJ+e2gHuEI8VNFGLq17KFuJI60A481bGpoGZ17fKpJF7q1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/core": "0.1.1-canary.beta.0",
+        "@standard-schema/spec": "^1.1.0",
+        "@tanstack/ai-event-client": "^0.11.2",
+        "@tanstack/ai-utils": "^0.4.0",
+        "partial-json": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/ai-event-client": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/ai-event-client/-/ai-event-client-0.11.2.tgz",
+      "integrity": "sha512-SlBC0jzlsjcdwYZqbvd7Wjny7GkGJGOZepHyJShDsfaiFNFUzGSP4SjOwV49YPfKwsFmR8hX67jQtBAmsnZWqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/ai-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/ai-utils/-/ai-utils-0.4.0.tgz",
+      "integrity": "sha512-xqvAgPJkIuGk1m+jZKyb7vBTQIaBmUD9EVzlPkDWWMp80n69uwL0TnBZCVk+OwL9goTQiFy648dnBfLsiJgl6A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/devtools-event-client": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.4.tgz",
+      "integrity": "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tokenizer/inflate": {

--- a/renovate.json
+++ b/renovate.json
@@ -90,9 +90,16 @@
       "allowedVersions": "<2"
     },
     {
-      "description": "Never automerge @openai/agents. It is pre-1.0, so a minor release may break. `@arcjet/guard/openai-agents/v0` types against FunctionTool, tool({ execute }), RunContext, and run() / Runner. A green typecheck is necessary but not sufficient. Keep the range below 1.0; openai-agents/v1 is added deliberately, not by a bump. This rule is last in packageRules so it wins over the devDependencies and patch automerge rules above.",
+      "description": "Never automerge @openai/agents. It is pre-1.0, so a minor release may break. `@arcjet/guard/openai-agents/v0` types against FunctionTool, tool({ execute }), RunContext, and run() / Runner. A green typecheck is necessary but not sufficient. Keep the range below 1.0; openai-agents/v1 is added deliberately, not by a bump.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["@openai/agents"],
+      "automerge": false,
+      "allowedVersions": "<1"
+    },
+    {
+      "description": "Never automerge @tanstack/ai. It is pre-1.0, so a minor release may break. `@arcjet/guard/tanstack-ai/v0` types against ChatMiddleware, onBeforeToolCall, BeforeToolCallDecision, and chat({ context }). A green typecheck is necessary but not sufficient: the namespace also depends on onBeforeToolCall first-win composition (a preceding toolCacheMiddleware skip means Guard never runs) and on execute throws being swallowed into { error } — runtime contracts a typecheck cannot see. Keep the range below 1.0; tanstack-ai/v1 is added deliberately, not by a bump. This rule is last in packageRules so it wins over the devDependencies and patch automerge rules above.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@tanstack/ai"],
       "automerge": false,
       "allowedVersions": "<1"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `@arcjet/guard/tanstack-ai/v0` for TanStack AI `chat({ middleware })` + `ChatMiddleware.onBeforeToolCall`.

**Exports:** `guardMiddleware`, `tanstackAiContext` (+ shared `agents` barrel). No `guardTool`, `guardInbound`, `guardApproval`, or `contentGuardMiddleware`. No unversioned `@arcjet/guard/tanstack-ai` alias and no `/v1` until TanStack AI 1.x.

- **`guardMiddleware`** — `chat({ middleware })` gate on `onBeforeToolCall`. Default DENY is `{ type: "skip", result: ArcjetDenialResult }`. Optional `onDeny: "abort"` returns `{ type: "abort", reason }` (real DENY only; unavailable stays skip). The hook does not throw. Put Arcjet first: `onBeforeToolCall` is first-win.
- **`tanstackAiContext`** — reads a caller-owned id from helper options or `chat({ context })`. Never mints. Never reads `threadId` / `requestId` / `streamId` / `traceId`.
- Optional peer `@tanstack/ai` `>=0.8.0 <1`, pinned at `0.52.0`. Type-only imports so adapter `src/` tests still run when the peer is absent. Guard’s Node floor is unchanged.

Inbound screening is `guard()` before `chat()` (`guard()` fails open — check `hasFailedOpen()`). That call does not brand tools and does not skip the middleware. Brand-skip is only for a sibling `guardTool` stamp. `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL; after a human yes, Guard still runs.

```ts
import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
import { guardMiddleware, tanstackAiContext } from "@arcjet/guard/tanstack-ai/v0";
import { chat } from "@tanstack/ai";

const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
const limit = tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 10 });
const appContext = { sessionId: conversationId };

const inbound = detectPromptInjection();
const decision = await arcjet.guard({
  label: "message.received",
  rules: [inbound(userText)],
  ...tanstackAiContext({ context: appContext }),
});
if (decision.conclusion === "DENY" || decision.hasFailedOpen()) {
  throw new Error("message blocked");
}

const stream = chat({
  adapter,
  messages,
  tools: [lookupOrder],
  context: appContext,
  middleware: [
    guardMiddleware(arcjet, {
      action: ({ toolName }) => `${toolName}.invoked`,
      rules: ({ toolName }) => [limit({ key: toolName, requested: 1 })],
      sessionId: conversationId,
    }),
  ],
});
```

Also includes the integration skill, README/CONTRIBUTING notes, and docs slug `/guards/tanstack-ai/`. No `tanstack-agent` example in this repo.

**Tests:** adapter + isolation 77 passed (plus 4 new cases for abort+unavailable skip and envelope nesting). Full Guard unit suite 1485 passed. Absent-peer `tanstack-ai` 58 passed. `npm run typecheck --workspace=@arcjet/guard` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d2714ff-f380-4411-b9df-6116b9f112f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d2714ff-f380-4411-b9df-6116b9f112f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

