### PR TITLE
feat(guard): add Google ADK support as @arcjet/guard/google-adk/v2

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -111,6 +111,11 @@
         },
         {
           "type": "generic",
+          "path": "skills/integrate-arcjet-guard-google-adk/SKILL.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
           "path": "skills/integrate-arcjet-guard-langchain/SKILL.md",
           "glob": false
         },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,30 @@ change them:
   ships 1.x. Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.
   Do not name anything `contentGuardMiddleware`. Docs slug is
   `/guards/tanstack-ai/`.
+  `google-adk/v2` is JS `@google/adk` `Runner` +
+  `BasePlugin.beforeToolCallback`: there is no `guardTool` (skip is
+  the plugin return, not throw-from-execute), tool calls go through
+  `guardPlugin`'s `beforeToolCallback` (DENY is a dictionary —
+  `ArcjetDenialResult` — so ADK skips `runAsync`; `undefined`
+  executes; do not throw — PluginManager treats a throw as a plugin
+  error, not skip), inbound is screened with `guard()` before
+  `Runner.runAsync` (`guard()` fails open — check `hasFailedOpen()`),
+  and `requireConfirmation` / `requestConfirmation` /
+  `SecurityPlugin` CONFIRM is HITL not policy. After a human yes,
+  Guard still runs. Put Arcjet first in `new Runner({ plugins })` —
+  PluginManager is first-win; returning a value short-circuits
+  remaining plugins. Do not use ADK `SecurityPlugin` as the Arcjet
+  policy gate. Brand-skip tools already wrapped by a sibling
+  `guardTool`. The plugin does not implement an inbound /
+  before-model prompt gate so a preceding `guard()` does not
+  double-call. Correlation is a caller-owned id from helper options
+  or context. Never mint. Never `invocationId`. Never `traceId`.
+  Never session auto-ids (`toolContext.sessionId` / `session.id`).
+  There is no unversioned `@arcjet/guard/google-adk` alias. Path is
+  `/v2` to match ADK 2.x. Do not double-wrap with
+  `@arcjet/guard/vercel-ai/v7`. This is Google ADK JS, not
+  `@google/genai`, not Python google-adk. Docs slug is
+  `/guards/google-adk/`.
 - **Flat** — a single level under `@arcjet/guard`, no further nesting.
 - **Explicitly versioned, with no unversioned alias.** `@arcjet/guard/vercel-ai`
   does not resolve, and neither does a wildcard `./vercel-ai/*`. An alias would

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,8 +164,10 @@ change them:
   `guardTool`. The plugin does not implement an inbound /
   before-model prompt gate so a preceding `guard()` does not
   double-call. Correlation is a caller-owned id from helper options
-  or context. Never mint. Never `invocationId`. Never `traceId`.
-  Never session auto-ids (`toolContext.sessionId` / `session.id`).
+  (`guardPlugin({ sessionId })`), which wins over durable session
+  `state`. ADK `Context` has no nested `context` field. Never mint.
+  Never `invocationId`. Never `traceId`. Never session auto-ids
+  (`toolContext.sessionId` / `session.id`).
   There is no unversioned `@arcjet/guard/google-adk` alias. Path is
   `/v2` to match ADK 2.x. Do not double-wrap with
   `@arcjet/guard/vercel-ai/v7`. This is Google ADK JS, not

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1632,6 +1632,105 @@ first — first-win composition means a preceding
 brands are skipped; inbound `guard()` is a separate call and does
 not skip this gate.
 
+- **`@arcjet/guard/google-adk/v2`** — Google ADK JS `@google/adk`
+  `Runner` + `BasePlugin.beforeToolCallback` integration. Exports
+  `guardPlugin` and `googleAdkContext`. This is **not** `@google/genai`
+  and **not** the Python google-adk SDK. There is no `guardTool`
+  (skip is the plugin return, not throw-from-execute), no
+  `guardInbound` (screen with `guard()` before `Runner.runAsync`;
+  `guard()` fails open — check `hasFailedOpen()`), and no
+  `guardApproval` (`requireConfirmation` / `requestConfirmation` /
+  `SecurityPlugin` CONFIRM is human HITL, not policy). After a human
+  yes, Guard still runs. Do not use ADK `SecurityPlugin` as the
+  Arcjet policy gate. Docs live at
+  [`/guards/google-adk/`](https://docs.arcjet.com/guards/google-adk/).
+
+  Put Arcjet **first** in `new Runner({ plugins })`. PluginManager
+  is first-win; if another plugin returns a value first, Guard never
+  runs. DENY is a dictionary (`ArcjetDenialResult`) so ADK skips
+  `runAsync` and the model sees the payload. `undefined` lets the
+  tool execute. The callback does not throw — PluginManager treats a
+  throw as a plugin error, not skip. On Guard error this helper
+  fail-closes: it ALWAYS returns a deny dict, never `undefined`
+  (unless `onGuardError: "allow"`). Tools already branded by a
+  sibling `guardTool` are skipped so Guard is not double-called.
+  Inbound `guard()` before `Runner.runAsync` does not brand tools
+  and does not skip this gate. The plugin does not implement an
+  inbound / before-model prompt gate so a preceding `guard()` does
+  not double-call. Correlation is a caller-owned id from helper
+  options or context. Never mint. Never `invocationId`. Never
+  `traceId`. Never session auto-ids.
+
+  ```ts
+  import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+  import { guardPlugin, googleAdkContext } from "@arcjet/guard/google-adk/v2";
+  import { Runner } from "@google/adk";
+
+  const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+  const limit = tokenBucket({
+    refillRate: 10,
+    intervalSeconds: 60,
+    maxTokens: 10,
+  });
+
+  const appContext = { sessionId: conversationId };
+  const inbound = detectPromptInjection();
+  const decision = await arcjet.guard({
+    label: "message.received",
+    rules: [inbound(userText)],
+    ...googleAdkContext({ context: appContext }),
+  });
+  if (decision.conclusion === "DENY") {
+    throw new Error("message blocked");
+  }
+  if (decision.hasFailedOpen()) {
+    throw new Error("inbound screening failed open");
+  }
+
+  const runner = new Runner({
+    appName: "my_app",
+    agent,
+    sessionService,
+    plugins: [
+      guardPlugin(arcjet, {
+        action: ({ toolName }) => `${toolName}.invoked`,
+        rules: ({ toolName }) => [limit({ key: toolName, requested: 1 })],
+        sessionId: conversationId,
+      }),
+    ],
+  });
+  ```
+
+#### Screen inbound before `Runner.runAsync` — there is no inbound hook.
+
+There is no first-class inbound deny-dict channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `runner.runAsync()`. Call `guard()` directly.
+`guard()` fails open — callers must check `hasFailedOpen()`.
+`onUserMessageCallback` replaces the user message; it is not this
+policy gate.
+
+#### `requireConfirmation` / `requestConfirmation` is HITL, not a policy gate.
+
+`requireConfirmation` / `toolContext.requestConfirmation` /
+`SecurityPlugin` CONFIRM is human-in-the-loop, not policy. After a
+human yes, Guard still runs on the tool call. Same trap as Mastra
+`requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+Genkit `toolApproval`, OpenAI Agents `needsApproval`, LangChain
+`humanInTheLoopMiddleware`, and TanStack `needsApproval`. There is
+no `guardApproval`. Do not use ADK `SecurityPlugin` as the Arcjet
+policy gate.
+
+#### Deny inside `guardPlugin`'s `beforeToolCallback`. There is no `guardTool`.
+
+`beforeToolCallback` is the deny point. DENY is a dictionary
+(`ArcjetDenialResult`). ADK treats a returned dict as skip:
+`runAsync` does not run. `undefined` lets the tool execute. Do not
+throw from the callback. Put Arcjet first — first-win composition
+means a preceding plugin return skips Guard too. Sibling `guardTool`
+brands are skipped; inbound `guard()` is a separate call and does
+not skip this gate.
+
 ### Naming and versions
 
 Integration paths are `@arcjet/guard/<vendor-sdk>/v<major>` — the SDK being
@@ -1701,6 +1800,10 @@ importing only core guards are not forced to install unneeded packages:
   peer, installed only to use `@arcjet/guard/tanstack-ai/v0`). The peer
   range is `>=0.8.0 <1`. There is no `/v1` until TanStack AI ships 1.x.
   Node stays Guard's existing floor.
+- **`@arcjet/guard/google-adk/v2`** requires `@google/adk` (optional
+  peer, installed only to use `@arcjet/guard/google-adk/v2`). The peer
+  range is `>=2 <3`. Path is `/v2` to match ADK 2.x. Node stays
+  Guard's existing floor. This is Google ADK JS, not `@google/genai`.
 
 **pnpm caveat**: pnpm does not reliably honour
 `peerDependenciesMeta.*.optional` (pnpm#5152, #8142), especially with
@@ -1761,6 +1864,11 @@ pnpm install @tanstack/ai
 ```
 
 ```sh
+# @arcjet/guard/google-adk/v2
+pnpm install @google/adk
+```
+
+```sh
 # or skip the peer install and relax the check:
 pnpm install --no-strict-peer-dependencies
 ```
@@ -1777,8 +1885,9 @@ is one path to learn and no layering to reason about.
 `@arcjet/guard/langchain/v1`, `@arcjet/guard/langgraph/v1`,
 `@arcjet/guard/openai-agents/v0`,
 `@arcjet/guard/genkit/v1`,
-`@arcjet/guard/strands-agents/v1`, and
-`@arcjet/guard/tanstack-ai/v0` now export
+`@arcjet/guard/strands-agents/v1`,
+`@arcjet/guard/tanstack-ai/v0`, and
+`@arcjet/guard/google-adk/v2` now export
 these helpers. The open next step is
 promoting them to the root `@arcjet/guard` export so a caller can get the
 agnostic layer without installing a vendor peer. That change is a follow-up
@@ -1806,6 +1915,7 @@ with its own ADR; there is still no public `@arcjet/guard/agents`.
 | Genkit `guardTool` / `guardMiddleware`    | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | Strands Agents `guardTool` / `guardHooks` | Deny (fail closed)                          | `onGuardError: "allow"`            |
 | TanStack AI `guardMiddleware`             | Deny (fail closed)                          | `onGuardError: "allow"`            |
+| Google ADK `guardPlugin`                  | Deny (fail closed)                          | `onGuardError: "allow"`            |
 
 `onGuardError` is broader than Arcjet Cloud availability. It governs both an
 unexpected throw from `guard()` and an ALLOW decision whose `hasFailedOpen()`
@@ -2187,6 +2297,8 @@ For an example with Strands Agents, see [`strands-agent`](https://github.com/arc
 
 For an example with TanStack AI, see [`tanstack-agent`](https://github.com/arcjet/examples/tree/main/examples/tanstack-agent) (later follow-up; do not add it in this repo): inbound screening with `guard()` before `chat()` (check `hasFailedOpen()`), `guardMiddleware` first in the middleware array (skip-deny, abort-deny, rate limit, fail-closed), and a caller-owned id on `chat({ context })`. `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL, not a policy gate; `onBeforeToolCall` is the deny point. Docs slug: [`/guards/tanstack-ai/`](https://docs.arcjet.com/guards/tanstack-ai/).
 
+For an example with Google ADK JS, see [`google-adk-agent`](https://github.com/arcjet/examples/tree/main/examples/google-adk-agent) (later follow-up; do not add it in this repo): inbound screening with `guard()` before `Runner.runAsync` (check `hasFailedOpen()`), `guardPlugin` first in `new Runner({ plugins })` (deny-dict skip, rate limit, fail-closed), and a caller-owned id on helper options or context. `requireConfirmation` / `requestConfirmation` / `SecurityPlugin` CONFIRM is HITL, not a policy gate; `beforeToolCallback` is the deny point. Docs slug: [`/guards/google-adk/`](https://docs.arcjet.com/guards/google-adk/).
+
 ## Agent skill
 
 Integration skills ship in this package's tarball (`skills/`) and are
@@ -2209,18 +2321,19 @@ npx @tanstack/intent@latest load @arcjet/guard#integrate-arcjet-guard-agents
 
 Load only the skill for the current vendor SDK:
 
-| SDK | Skill |
-| --- | --- |
-| Vercel AI SDK | `@arcjet/guard#integrate-arcjet-guard-agents` |
-| Vercel Eve | `@arcjet/guard#integrate-arcjet-guard-eve` |
-| Mastra | `@arcjet/guard#integrate-arcjet-guard-mastra` |
-| Claude Agent SDK | `@arcjet/guard#integrate-arcjet-guard-claude-agent-sdk` |
-| LangGraph | `@arcjet/guard#integrate-arcjet-guard-langgraph` |
-| LangChain JS `createAgent` | `@arcjet/guard#integrate-arcjet-guard-langchain` |
-| OpenAI Agents | `@arcjet/guard#integrate-arcjet-guard-openai-agents` |
-| Genkit | `@arcjet/guard#integrate-arcjet-guard-genkit` |
-| Strands Agents | `@arcjet/guard#integrate-arcjet-guard-strands-agents` |
-| TanStack AI | `@arcjet/guard#integrate-arcjet-guard-tanstack-ai` |
+| SDK                        | Skill                                                   |
+| -------------------------- | ------------------------------------------------------- |
+| Vercel AI SDK              | `@arcjet/guard#integrate-arcjet-guard-agents`           |
+| Vercel Eve                 | `@arcjet/guard#integrate-arcjet-guard-eve`              |
+| Mastra                     | `@arcjet/guard#integrate-arcjet-guard-mastra`           |
+| Claude Agent SDK           | `@arcjet/guard#integrate-arcjet-guard-claude-agent-sdk` |
+| LangGraph                  | `@arcjet/guard#integrate-arcjet-guard-langgraph`        |
+| LangChain JS `createAgent` | `@arcjet/guard#integrate-arcjet-guard-langchain`        |
+| OpenAI Agents              | `@arcjet/guard#integrate-arcjet-guard-openai-agents`    |
+| Genkit                     | `@arcjet/guard#integrate-arcjet-guard-genkit`           |
+| Strands Agents             | `@arcjet/guard#integrate-arcjet-guard-strands-agents`   |
+| TanStack AI                | `@arcjet/guard#integrate-arcjet-guard-tanstack-ai`      |
+| Google ADK JS              | `@arcjet/guard#integrate-arcjet-guard-google-adk`       |
 
 `intent.exclude` can drop a package or one skill. Editor hooks from
 `intent hooks install` are convenience, not a security boundary.

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -1658,8 +1658,10 @@ not skip this gate.
   and does not skip this gate. The plugin does not implement an
   inbound / before-model prompt gate so a preceding `guard()` does
   not double-call. Correlation is a caller-owned id from helper
-  options or context. Never mint. Never `invocationId`. Never
-  `traceId`. Never session auto-ids.
+  options (`guardPlugin({ sessionId })`), which wins over durable
+  session `state`. ADK `Context` has no nested `context` field.
+  Never mint. Never `invocationId`. Never `traceId`. Never session
+  auto-ids.
 
   ```ts
   import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
@@ -2297,7 +2299,7 @@ For an example with Strands Agents, see [`strands-agent`](https://github.com/arc
 
 For an example with TanStack AI, see [`tanstack-agent`](https://github.com/arcjet/examples/tree/main/examples/tanstack-agent) (later follow-up; do not add it in this repo): inbound screening with `guard()` before `chat()` (check `hasFailedOpen()`), `guardMiddleware` first in the middleware array (skip-deny, abort-deny, rate limit, fail-closed), and a caller-owned id on `chat({ context })`. `needsApproval` / `defineInterrupt` / `onInterruptBoundary` is HITL, not a policy gate; `onBeforeToolCall` is the deny point. Docs slug: [`/guards/tanstack-ai/`](https://docs.arcjet.com/guards/tanstack-ai/).
 
-For an example with Google ADK JS, see [`google-adk-agent`](https://github.com/arcjet/examples/tree/main/examples/google-adk-agent) (later follow-up; do not add it in this repo): inbound screening with `guard()` before `Runner.runAsync` (check `hasFailedOpen()`), `guardPlugin` first in `new Runner({ plugins })` (deny-dict skip, rate limit, fail-closed), and a caller-owned id on helper options or context. `requireConfirmation` / `requestConfirmation` / `SecurityPlugin` CONFIRM is HITL, not a policy gate; `beforeToolCallback` is the deny point. Docs slug: [`/guards/google-adk/`](https://docs.arcjet.com/guards/google-adk/).
+For an example with Google ADK JS, see [`google-adk-agent`](https://github.com/arcjet/examples/tree/main/examples/google-adk-agent) (later follow-up; do not add it in this repo): inbound screening with `guard()` before `Runner.runAsync` (check `hasFailedOpen()`), `guardPlugin` first in `new Runner({ plugins })` (deny-dict skip, rate limit, fail-closed), and a caller-owned id on helper options (`guardPlugin({ sessionId })`; wins over durable `state`). ADK `Context` has no nested `context` field. `requireConfirmation` / `requestConfirmation` / `SecurityPlugin` CONFIRM is HITL, not a policy gate; `beforeToolCallback` is the deny point. Docs slug: [`/guards/google-adk/`](https://docs.arcjet.com/guards/google-adk/).
 
 ## Agent skill
 

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -107,6 +107,10 @@
       "types": "./dist/genkit/v1/index.d.ts",
       "import": "./dist/genkit/v1/index.js"
     },
+    "./google-adk/v2": {
+      "types": "./dist/google-adk/v2/index.d.ts",
+      "import": "./dist/google-adk/v2/index.js"
+    },
     "./strands-agents/v1": {
       "types": "./dist/strands-agents/v1/index.d.ts",
       "import": "./dist/strands-agents/v1/index.js"
@@ -127,7 +131,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "npm run build && npm run lint && npm run test-unit",
-    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts' 'test/strands-agents/**/*.test.ts' 'test/tanstack-ai/**/*.test.ts'",
+    "test-unit": "node --test --experimental-test-coverage '--test-coverage-include=src/**' '--test-coverage-exclude=src/**/*.test.ts' 'src/**/*.test.ts' 'test/genkit/**/*.test.ts' 'test/google-adk/**/*.test.ts' 'test/langchain/**/*.test.ts' 'test/langgraph/**/*.test.ts' 'test/mastra/**/*.test.ts' 'test/openai-agents/**/*.test.ts' 'test/strands-agents/**/*.test.ts' 'test/tanstack-ai/**/*.test.ts'",
     "validate-skills": "node ../.github/scripts/intent-cli.mjs validate",
     "stale-skills": "node ../.github/scripts/intent-cli.mjs stale --json",
     "test-peers-absent": "node scripts/test-peers-absent.mjs",
@@ -149,6 +153,7 @@
   "devDependencies": {
     "@ai-sdk/provider-utils": "5.0.25",
     "@anthropic-ai/claude-agent-sdk": "0.3.233",
+    "@google/adk": "2.0.0",
     "@langchain/core": "1.2.9",
     "@langchain/langgraph": "1.4.10",
     "@mastra/core": "1.59.0",
@@ -169,6 +174,7 @@
   "peerDependencies": {
     "@ai-sdk/provider-utils": ">=5 <6",
     "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
+    "@google/adk": ">=2 <3",
     "@langchain/core": ">=1 <2",
     "@langchain/langgraph": ">=1 <2",
     "@mastra/core": ">=1 <2",
@@ -194,6 +200,9 @@
       "optional": true
     },
     "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@google/adk": {
       "optional": true
     },
     "@langchain/core": {

--- a/arcjet-guard/package.json
+++ b/arcjet-guard/package.json
@@ -157,6 +157,7 @@
     "@langchain/core": "1.2.9",
     "@langchain/langgraph": "1.4.10",
     "@mastra/core": "1.59.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@openai/agents": "0.17.0",
     "@strands-agents/sdk": "1.14.0",
     "@tanstack/ai": "0.52.0",

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -234,7 +234,12 @@ function runCheck(check) {
 
     // Node expands the glob itself; `spawnSync` without a shell passes it through
     // literally, which is what the quoting did in the YAML this replaced.
+    // Stay under `src/<dir>` — `test/<dir>` value-imports the peer
+    // (e.g. test/google-adk/real-plugin.test.ts) and runs in test-unit.
     const glob = `src/${check.dir}/**/*.test.ts`;
+    if (!glob.startsWith(`src/${check.dir}/`)) {
+      throw new Error(`peer-absent glob must stay under src/${check.dir}/; got ${glob}`);
+    }
     const result = spawnSync(process.execPath, ["--test", glob], {
       cwd: PACKAGE_ROOT,
       stdio: "inherit",

--- a/arcjet-guard/scripts/test-peers-absent.mjs
+++ b/arcjet-guard/scripts/test-peers-absent.mjs
@@ -96,6 +96,13 @@ const CHECKS = [
     remove: ["@tanstack/ai"],
     resolve: ["@tanstack/ai"],
   },
+  {
+    name: "google-adk",
+    dir: "google-adk",
+    version: "v2",
+    remove: ["@google/adk"],
+    resolve: ["@google/adk"],
+  },
   // Last: deletes a shared devDependency.
   {
     name: "eve",

--- a/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
@@ -255,6 +255,11 @@ or PII. Numbers are float64, so integers above `Number.MAX_SAFE_INTEGER`
 should be passed as strings. The SDK adds `AJ1017` warnings naming values it
 could not encode (`undefined`, a function, a `BigInt`, a circular reference).
 
+Human-in-the-loop APIs on other SDKs (`needsApproval`, `interrupt()`,
+`requireApproval`, Google ADK `requireConfirmation`) are not policy gates.
+This namespace gates with `guardTool` / `guardAction`. After a human yes,
+Guard still runs.
+
 ## Verify the integration
 
 1. `tsc --noEmit` (or the app's typecheck) passes.

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
@@ -42,7 +42,8 @@ and Claude Code erases the prompt.
 
 Claude's docs say `canUseTool` is skipped by `allowedTools`, allow rules,
 and `bypassPermissions` / `acceptEdits`. There is no `guardCanUseTool`.
-Do not put Arcjet policy on `canUseTool`.
+Do not put Arcjet policy on `canUseTool`. Same trap as Google ADK
+`requireConfirmation`: after a human yes, Guard still runs.
 
 ## PreToolUse is the only deny for unwrapped tools
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
@@ -81,7 +81,8 @@ State plainly why each applies to Eve, not other frameworks:
    policy is how you authorize who may approve the parked request. A rejected
    response leaves the approval pending; it does not deny the tool. HITL
    clients answer with `cancel`, not `deny`. Request-time denials are still
-   `{ type: "denied" }`.
+   `{ type: "denied" }`. Same trap as Google ADK `requireConfirmation`:
+   HITL is not a policy gate.
 
 5. **`defineDynamic` tools are not covered.** Eve's compiler hoists a dynamic
    tool's inline `execute` to a module-scope step function, so a wrapper is not

--- a/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
@@ -50,8 +50,9 @@ the model call, not user text. It is not this policy gate.
 `interrupt()` / `defineInterrupt` / `@genkit-ai/middleware`
 `toolApproval` / `restartTool` / `finishReason === "interrupted"` is
 human-in-the-loop. Same trap as Mastra `requireApproval`, Claude
-`canUseTool`, LangGraph `interrupt()`, and OpenAI Agents
-`needsApproval`. There is no `guardApproval`. Do not wrap them as Guard.
+`canUseTool`, LangGraph `interrupt()`, OpenAI Agents
+`needsApproval`, and Google ADK `requireConfirmation`. There is no
+`guardApproval`. Do not wrap them as Guard.
 
 ## Deny inside `defineTool` (and `guardMiddleware`'s `tool` hook). MCP and filesystem-injected tools skip an unwrapped handler.
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: integrate-arcjet-guard-google-adk
+description: Integrate Arcjet security into a Google ADK JS app using @arcjet/guard — put guardPlugin first on Runner({ plugins }) so beforeToolCallback gates tools, and read a caller-owned id from helper options or context. Use when asked to add Arcjet to Google ADK, @google/adk, rate limit its tools, screen inbound messages, or block prompt injection / PII. This is Google ADK JS, not @google/genai and not Python google-adk.
+license: Apache-2.0
+compatibility: Requires the target app to use Google ADK JS (@google/adk >=2 <3) on Node.js >= 22. This is Runner + BasePlugin.beforeToolCallback. Path is /v2 to match ADK 2.x. Do not use @arcjet/guard/vercel-ai/v7.
+metadata:
+  author: arcjet
+  type: core
+  library: "@arcjet/guard"
+  library_version: "1.11.0" # x-release-please-version
+sources:
+  - README.md
+---
+
+# Integrate Arcjet Guard into Google ADK JS
+
+`@arcjet/guard`'s Google ADK v2 namespace wraps the agent's existing Arcjet
+client. It never talks to the Arcjet API itself. Two surfaces, one
+decision rule:
+
+- **Tool calls** → `guardPlugin()`. A Runner `BasePlugin` whose
+  `beforeToolCallback` is the run-wide gate. DENY is a dictionary
+  (`ArcjetDenialResult`) so ADK skips `runAsync` and the model sees
+  the payload. `undefined` lets the tool execute. Do not throw from
+  the callback — PluginManager treats a throw as a plugin error, not
+  skip. Tools already branded by a sibling `guardTool` are skipped so
+  Guard is not double-called. Inbound `guard()` before
+  `Runner.runAsync` does not brand tools and does not skip this gate.
+  The plugin does not screen inbound (`onUserMessageCallback` /
+  `beforeModelCallback` are no-ops) so a preceding `guard()` does
+  not double-call.
+- **Correlation** → `googleAdkContext()` reads a caller-owned id from
+  the helper options or a bag the integrator put on the run. It never
+  mints a new id. It never reads `invocationId` (ADK always generates
+  it). It never reads `traceId`. It never reads
+  `toolContext.sessionId` / `session.id` (session auto-ids).
+
+There is **no `guardTool`**. Skip is the plugin return, not
+throw-from-execute. There is no `guardInbound`, no `guardApproval`,
+and this namespace does not use ADK `SecurityPlugin` as the Arcjet
+policy gate.
+
+This namespace is Google ADK JS **`Runner` +
+`BasePlugin.beforeToolCallback`**. Not `@google/genai`. Not the
+Python SDK. Do not also wrap with `@arcjet/guard/vercel-ai/v7`.
+
+Docs live at
+[docs.arcjet.com/guards/google-adk/](https://docs.arcjet.com/guards/google-adk/).
+Do **not** overwrite any other `/guards/...` slug.
+
+Put Arcjet **first** in `new Runner({ plugins })`. PluginManager is
+first-win; if another plugin (including `SecurityPlugin`) returns a
+value first, Guard never runs.
+
+## Screen inbound before `Runner.runAsync` — there is no inbound hook.
+
+There is no first-class inbound deny-dict channel, so there is no
+`guardInbound`. Put prompt-injection (and other inbound rules) in the
+application before `runner.runAsync()`. Call `guard()` directly.
+`guard()` fails open — callers must check `hasFailedOpen()`.
+`onUserMessageCallback` replaces the user message; it is not this
+policy gate.
+
+## `requireConfirmation` / `requestConfirmation` is HITL, not a policy gate.
+
+`requireConfirmation` / `toolContext.requestConfirmation` /
+`SecurityPlugin` CONFIRM is human-in-the-loop. After a human yes,
+Guard still runs on the tool call. Same trap as Mastra
+`requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+Genkit `toolApproval`, OpenAI Agents `needsApproval`, LangChain
+`humanInTheLoopMiddleware`, and TanStack `needsApproval`. There is no
+`guardApproval`.
+
+## Questions to ask the human first
+
+Ask only what you cannot infer from the code; suggest defaults.
+
+1. Which tools are **risky** (external side effects, irreversible, spends
+   money, sends messages)? Those are gated by `guardPlugin`.
+2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
+3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
+   Default: none. Pass it via `metadata` on the policy. Put the
+   conversation / session id you already have on helper options or
+   session `state`. That id is the correlation id. Do not use
+   `invocationId` or `toolContext.sessionId`.
+4. Is an Arcjet outage unacceptable? Every helper defaults to
+   `onGuardError: "deny"`. Ask explicitly about inbound screening before
+   `Runner.runAsync`: failing closed there means the run does not start
+   for the duration of the outage, so `"allow"` is a routine and
+   legitimate choice at that one call site. `guard()` itself still
+   fails open — check `hasFailedOpen()`.
+
+## The six things readers get wrong
+
+1. **There is no `guardInbound`.** Screen prompt injection before
+   `Runner.runAsync` with `guard()`. Check `hasFailedOpen()`.
+   `onUserMessageCallback` is not Guard.
+2. **`requireConfirmation` / `requestConfirmation` / `SecurityPlugin`
+   CONFIRM is not a policy gate.** It is HITL. After a human yes,
+   Guard still runs. Do not use `SecurityPlugin` as the Arcjet gate.
+3. **The import path is versioned and there is no alias.**
+   `@arcjet/guard/google-adk/v2`. `@arcjet/guard/google-adk` does
+   not resolve. Docs are `/guards/google-adk/`.
+4. **Correlation is read, never minted.** Do not call
+   `createAgentContext` inside a plugin callback — that generates
+   a second id and splits the Sequence. Put the id you already chose
+   on helper options or `state`. Do not read `invocationId`,
+   `traceId`, or `toolContext.sessionId`.
+5. **Put Arcjet first.** PluginManager is first-win. If another
+   plugin returns a dict first, Guard never runs.
+6. **Do not add `guardTool` and do not double-wrap with
+   `@arcjet/guard/vercel-ai/v7`.** Google ADK JS is not the Vercel
+   AI SDK. Skip is the plugin return.
+
+## Step 1: Install and find the guard client
+
+Install `@arcjet/guard` (required), plus `@google/adk` (optional
+peer, needed for `@arcjet/guard/google-adk/v2`). Always use the
+versioned path: `@arcjet/guard/google-adk/v2` resolves;
+`@arcjet/guard/google-adk` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+The peer range is `>=2 <3`. Node 22+ — do not bump Node for this
+adapter.
+
+```sh
+npm install @arcjet/guard @google/adk
+```
+
+If the agent has no guard client yet, launch one **once at module scope**:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Step 2: Gate tool calls — Arcjet first
+
+```ts
+import { Runner } from "@google/adk";
+import { guardPlugin } from "@arcjet/guard/google-adk/v2";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+const detectPii = localDetectSensitiveInfo();
+
+const runner = new Runner({
+  appName: "my_app",
+  agent,
+  sessionService,
+  plugins: [
+    guardPlugin(arcjet, {
+      action: ({ toolName }) => `${toolName}.invoked`,
+      rules: ({ toolName, input }) => {
+        const note =
+          typeof input === "object" && input !== null && "note" in input
+            ? String((input as { note?: unknown }).note ?? "")
+            : "";
+        return [
+          lookupLimit({ key: toolName, requested: 1 }),
+          ...(note.length > 0 ? [detectPii(note)] : []),
+        ];
+      },
+      sessionId: conversationId,
+    }),
+  ],
+});
+```
+
+- Omit `rules` to submit none. The guard call still happens.
+- On DENY the original `runAsync` never runs. Delivery is
+  `{ arcjetDenied: true, reason, message, retryable }` — the dict
+  ADK treats as skip.
+- Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.
+  A Guard error ALWAYS returns a deny dict, never `undefined`.
+- ALLOW captures `outcome: "success"` when the policy lets the tool
+  run, not when `runAsync` finishes. `beforeToolCallback` cannot wrap
+  the tool; a later tool throw does not flip that capture.
+- Tools already branded by a sibling `guardTool` skip the plugin
+  so Guard is not double-called. This namespace has no `guardTool`.
+  Inbound `guard()` before `Runner.runAsync` does not stamp that brand.
+
+## Step 3: Screen inbound before Runner.run
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { googleAdkContext } from "@arcjet/guard/google-adk/v2";
+
+import { arcjet } from "./arcjet.js";
+
+const inbound = detectPromptInjection();
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...googleAdkContext({ context: { sessionId: conversationId } }),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+if (decision.hasFailedOpen()) {
+  throw new Error("inbound screening failed open");
+}
+
+for await (const event of runner.runAsync({
+  userId,
+  sessionId: conversationId,
+  newMessage: { parts: [{ text: userText }] },
+})) {
+  void event;
+}
+```
+
+There is no `guardInbound`. `guard()` fails open — always check
+`hasFailedOpen()`. The plugin does not implement inbound screening,
+so this call does not double-call Guard.
+
+## Step 4: Correlation
+
+Put the id you already have on helper options or session `state`:
+
+```ts
+guardPlugin(arcjet, { sessionId: conversationId });
+```
+
+Preference order: `context.correlationId`, then `context.sessionId`,
+then `context.conversationId`, then the same keys on `state`, then
+`init.sessionId` / `init.correlationId`. If none is a valid 1–256
+printable-ASCII string, the call is uncorrelated rather than joined
+to a generated id nobody has.
+
+Pass a caller-owned bag as `googleAdkContext({ context: appContext })`.
+A `toolContext` that has `invocationId` looks like ADK's Context
+envelope, so top-level `sessionId` on that object is ignored.
+
+Never mint a new id. Never read `invocationId` (ADK always generates
+it). Never read `traceId`. Never read `toolContext.sessionId` /
+`session.id`. `requireConfirmation` resumes after a human yes —
+Guard still runs on the tool call. Do not treat the confirmation or
+its resume value as correlation.
+
+## Verify the integration
+
+1. `npm run typecheck` passes.
+2. Exercise inbound PI (before `Runner.runAsync`, including
+   `hasFailedOpen()`), a plugin deny-dict skip, undefined execute,
+   first-plugin short-circuit (Arcjet first), no-throw, never-mint,
+   and fail-closed (an unreachable guard → deny dict, never
+   `undefined`). Confirm the denial is a dict and the run is not a
+   confirmation / HITL pause.
+3. Confirm in the Arcjet dashboard that decisions share the
+   caller-owned session id as their correlation id — not
+   `invocationId` or an ephemeral session id.
+4. Manual E2E with a real `ARCJET_KEY` is still-to-verify until you run it.
+
+A full working demo will land in
+[`arcjet/examples` `google-adk-agent`](https://github.com/arcjet/examples/tree/main/examples/google-adk-agent)
+as a later follow-up. Do not add an example under `examples/` in the
+JS SDK repo.
+
+Note: capture events are fire-and-forget and batched, so events can lag the
+decisions they accompany by a few seconds. A dropped event is diagnosed,
+never thrown.

--- a/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
@@ -30,9 +30,11 @@ decision rule:
   `beforeModelCallback` are no-ops) so a preceding `guard()` does
   not double-call.
 - **Correlation** → `googleAdkContext()` reads a caller-owned id from
-  the helper options or a bag the integrator put on the run. It never
-  mints a new id. It never reads `invocationId` (ADK always generates
-  it). It never reads `traceId`. It never reads
+  helper options (`guardPlugin({ sessionId })`) or a wrap
+  (`googleAdkContext({ context: appContext })`). ADK `Context` has no
+  nested `context` field. Durable session `state` loses to helper
+  options. It never mints a new id. It never reads `invocationId`
+  (ADK always generates it). It never reads `traceId`. It never reads
   `toolContext.sessionId` / `session.id` (session auto-ids).
 
 There is **no `guardTool`**. Skip is the plugin return, not
@@ -80,9 +82,11 @@ Ask only what you cannot infer from the code; suggest defaults.
 2. What **limits**? (e.g. "10 lookups/min per order" → `tokenBucket`.)
 3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
    Default: none. Pass it via `metadata` on the policy. Put the
-   conversation / session id you already have on helper options or
-   session `state`. That id is the correlation id. Do not use
-   `invocationId` or `toolContext.sessionId`.
+   conversation / session id you already have on helper options
+   (`guardPlugin({ sessionId })`). That id is the correlation id and
+   wins over durable session `state`. Do not use `invocationId` or
+   `toolContext.sessionId`. ADK `Context` has no nested `context`
+   field.
 4. Is an Arcjet outage unacceptable? Every helper defaults to
    `onGuardError: "deny"`. Ask explicitly about inbound screening before
    `Runner.runAsync`: failing closed there means the run does not start
@@ -104,8 +108,10 @@ Ask only what you cannot infer from the code; suggest defaults.
 4. **Correlation is read, never minted.** Do not call
    `createAgentContext` inside a plugin callback — that generates
    a second id and splits the Sequence. Put the id you already chose
-   on helper options or `state`. Do not read `invocationId`,
-   `traceId`, or `toolContext.sessionId`.
+   on `guardPlugin({ sessionId })`. That wins over durable `state`.
+   Do not read `invocationId`, `traceId`, or `toolContext.sessionId`.
+   Do not expect `toolContext.context` — ADK `Context` has no such
+   field.
 5. **Put Arcjet first.** PluginManager is first-win. If another
    plugin returns a dict first, Guard never runs.
 6. **Do not add `guardTool` and do not double-wrap with
@@ -222,21 +228,22 @@ so this call does not double-call Guard.
 
 ## Step 4: Correlation
 
-Put the id you already have on helper options or session `state`:
+Put the id you already have on helper options:
 
 ```ts
 guardPlugin(arcjet, { sessionId: conversationId });
 ```
 
-Preference order: `context.correlationId`, then `context.sessionId`,
-then `context.conversationId`, then the same keys on `state`, then
-`init.sessionId` / `init.correlationId`. If none is a valid 1–256
-printable-ASCII string, the call is uncorrelated rather than joined
-to a generated id nobody has.
+Preference order: caller wrap `context.correlationId` /
+`context.sessionId` / `context.conversationId` (only for
+`googleAdkContext({ context: appContext })` — ADK `Context` has no
+such field), then `init.sessionId` / `init.correlationId` (helper
+options; wins over durable `state`), then the same keys on session
+`state`. If none is a valid 1–256 printable-ASCII string, the call
+is uncorrelated rather than joined to a generated id nobody has.
 
-Pass a caller-owned bag as `googleAdkContext({ context: appContext })`.
-A `toolContext` that has `invocationId` looks like ADK's Context
-envelope, so top-level `sessionId` on that object is ignored.
+A `toolContext` that has `invocationId` is ADK's Context envelope, so
+top-level `sessionId` on that object is ignored.
 
 Never mint a new id. Never read `invocationId` (ADK always generates
 it). Never read `traceId`. Never read `toolContext.sessionId` /

--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -62,8 +62,9 @@ this policy gate.
 
 `humanInTheLoopMiddleware` / `interrupt()` / approve-edit-reject-respond
 is human-in-the-loop. Same trap as Mastra `requireApproval`, Claude
-`canUseTool`, LangGraph `interrupt()`, Genkit `toolApproval`, and
-OpenAI Agents `needsApproval`. There is no `guardApproval`. Policy
+`canUseTool`, LangGraph `interrupt()`, Genkit `toolApproval`,
+OpenAI Agents `needsApproval`, and Google ADK `requireConfirmation`.
+There is no `guardApproval`. Policy
 sits on `wrapToolCall` only — do not deny in `afterModel`. HITL
 already lives there.
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
@@ -43,7 +43,8 @@ the application before `graph.invoke`, or in the graph's first node.
 ## `interrupt()` is not a policy gate
 
 `interrupt()` / `interrupt_before=["tools"]` is human-in-the-loop, not
-policy. Same trap as Mastra `requireApproval` and Claude `canUseTool`.
+policy. Same trap as Mastra `requireApproval`, Claude `canUseTool`,
+and Google ADK `requireConfirmation`.
 There is no `guardInterrupt` and no `guardApproval`. Do not wrap them as
 Guard.
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-mastra/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-mastra/SKILL.md
@@ -29,7 +29,8 @@ decision rule:
 - **Correlation** → `mastraAgentContext()` reads `MASTRA_THREAD_ID_KEY`, then
   resource, then run. It never mints a new id.
 
-Mastra `requireApproval` is human HITL, not policy. There is no
+Mastra `requireApproval` is human HITL, not policy — same trap as
+Google ADK `requireConfirmation`. There is no
 `guardApproval`. Do not also wrap these tools with
 `@arcjet/guard/vercel-ai/v7`.
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
@@ -42,7 +42,8 @@ own tripwires, not this policy gate. Do not wrap them as Guard.
 
 `needsApproval` / `requireApproval` / `onApproval` is human-in-the-loop.
 The run pauses; `result.state.approve` / `reject`. Same trap as Mastra
-`requireApproval`, Claude `canUseTool`, and LangGraph `interrupt()`.
+`requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`, and
+Google ADK `requireConfirmation`.
 There is no `guardApproval`. Do not wrap them as Guard.
 
 ## `tool()` execute is the deny point; hosted, MCP, and handoffs are not

--- a/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
@@ -50,8 +50,8 @@ this policy gate.
 
 `event.interrupt()` is human-in-the-loop. Same trap as Mastra
 `requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
-OpenAI Agents `needsApproval`, and LangChain
-`humanInTheLoopMiddleware`. There is no `guardApproval` /
+OpenAI Agents `needsApproval`, LangChain `humanInTheLoopMiddleware`,
+and Google ADK `requireConfirmation`. There is no `guardApproval` /
 `guardInterrupt`. Do not wrap `interrupt()` as Guard.
 
 ## Deny with `BeforeToolCallEvent.cancel` (and `guardTool` on authored callbacks). `BeforeToolsEvent.cancel` skips per-tool hooks — do not use it.

--- a/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
@@ -65,7 +65,8 @@ gate.
 human-in-the-loop. After a human yes, Guard still runs on the tool
 call. Same trap as Mastra `requireApproval`, Claude `canUseTool`,
 LangGraph `interrupt()`, Genkit `toolApproval`, OpenAI Agents
-`needsApproval`, and LangChain `humanInTheLoopMiddleware`. There is no
+`needsApproval`, LangChain `humanInTheLoopMiddleware`, and Google ADK
+`requireConfirmation`. There is no
 `guardApproval`.
 
 ## Questions to ask the human first

--- a/arcjet-guard/src/agents/denial.test.ts
+++ b/arcjet-guard/src/agents/denial.test.ts
@@ -153,6 +153,7 @@ test("no vendor namespace declares its own denial payload", () => {
     "langgraph",
     "openai-agents",
     "genkit",
+    "google-adk",
     "strands-agents",
     "tanstack-ai",
   ];

--- a/arcjet-guard/src/agents/index.test.ts
+++ b/arcjet-guard/src/agents/index.test.ts
@@ -125,7 +125,9 @@ function walkForForbiddenImports(filePath: string, visited: Set<string>, errors:
       spec === "@strands-agents/sdk" ||
       spec.startsWith("@strands-agents/sdk/") ||
       spec === "@tanstack/ai" ||
-      spec.startsWith("@tanstack/ai/")
+      spec.startsWith("@tanstack/ai/") ||
+      spec === "@google/adk" ||
+      spec.startsWith("@google/adk/")
     ) {
       errors.push(`File ${absolutePath} imports forbidden package: "${spec}"`);
     }

--- a/arcjet-guard/src/agents/index.ts
+++ b/arcjet-guard/src/agents/index.ts
@@ -9,7 +9,8 @@
  * `@arcjet/guard/vercel-eve/v0`, `@arcjet/guard/mastra/v1`,
  * `@arcjet/guard/claude-agent-sdk/v0`, `@arcjet/guard/langchain/v1`,
  * `@arcjet/guard/langgraph/v1`, `@arcjet/guard/openai-agents/v0`,
- * `@arcjet/guard/genkit/v1`, `@arcjet/guard/strands-agents/v1`, and
+ * `@arcjet/guard/genkit/v1`, `@arcjet/guard/google-adk/v2`,
+ * `@arcjet/guard/strands-agents/v1`, and
  * `@arcjet/guard/tanstack-ai/v0`. The
  * layer stays agnostic so multiple
  * vendor namespaces can share the same code. A public `@arcjet/guard/agents`

--- a/arcjet-guard/src/claude-agent-sdk/v0/index.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/index.test.ts
@@ -164,6 +164,7 @@ test("does not export Eve-only or Mastra-only APIs onto the Claude namespace", (
     "mastraAgentContext",
     "strandsAgentContext",
     "tanstackAiContext",
+    "googleAdkContext",
     "guardProcessor",
     "canUseTool",
     "guardCanUseTool",

--- a/arcjet-guard/src/genkit/v1/index.test.ts
+++ b/arcjet-guard/src/genkit/v1/index.test.ts
@@ -94,7 +94,10 @@ test("Genkit namespace is a strict superset of the agents barrel with same ident
   const agentKeys = Object.keys(agentsBarrel);
 
   for (const key of agentKeys) {
-    assert.ok(genkitKeys.includes(key), `agents barrel key "${key}" must be present in genkit namespace`);
+    assert.ok(
+      genkitKeys.includes(key),
+      `agents barrel key "${key}" must be present in genkit namespace`,
+    );
     assert.strictEqual(
       (genkitNamespace as Record<string, unknown>)[key],
       (agentsBarrel as Record<string, unknown>)[key],
@@ -130,7 +133,11 @@ test("export map has no unversioned ./genkit and no wildcard subpaths", () => {
 
   for (const key of exportKeys) {
     if (key.startsWith("./genkit/")) {
-      assert.equal(key, "./genkit/v1", `export map must not have wildcard genkit subpaths; found "${key}"`);
+      assert.equal(
+        key,
+        "./genkit/v1",
+        `export map must not have wildcard genkit subpaths; found "${key}"`,
+      );
     }
   }
 });
@@ -145,6 +152,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI-only APIs", () 
     "openaiAgentsContext",
     "strandsAgentContext",
     "tanstackAiContext",
+    "googleAdkContext",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",

--- a/arcjet-guard/src/google-adk/v2/assignability.test.ts
+++ b/arcjet-guard/src/google-adk/v2/assignability.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Compile-time assignability: the helpers accept the values a Google
+ * ADK `Runner` app actually has, with no casts at the call site.
+ *
+ * The declarations are types only (`declare const`, never executed) so
+ * this suite still runs in the google-adk-absent CI job, where the
+ * peer is gone and the type-only import scan applies. Runtime
+ * behaviour against the real `PluginManager` / `Runner` lives in
+ * `test/google-adk/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { BasePlugin } from "@google/adk";
+
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { guardPlugin } from "./guard-plugin.ts";
+
+declare const client: ArcjetAgentClient;
+
+// Never called: the declarations above have no runtime value. Typecheck is
+// the assertion.
+function typeProbe(): void {
+  const plugin = guardPlugin(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+
+  const runnerOpts: { plugins?: BasePlugin[] } = {
+    plugins: [plugin],
+  };
+
+  void [plugin, runnerOpts];
+}
+
+test("helpers accept a Runner({ plugins }) BasePlugin without casts", () => {
+  assert.equal(typeof typeProbe, "function");
+});

--- a/arcjet-guard/src/google-adk/v2/context.test.ts
+++ b/arcjet-guard/src/google-adk/v2/context.test.ts
@@ -1,0 +1,287 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/explicit-function-return-type, typescript/no-unnecessary-type-assertion -- test infrastructure
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { encodeMetadata } from "../../metadata.ts";
+import { googleAdkContext } from "./context.ts";
+
+test("prefers a field the integrator put on a nested context bag", () => {
+  const result = googleAdkContext({
+    context: { sessionId: "sess-app", conversationId: "conv-app" },
+    sessionId: "sess-envelope",
+    conversationId: "conv-envelope",
+  });
+
+  assert.equal(result.correlationId, "sess-app");
+  assert.equal(result.metadata?.["google-adk.session"], "sess-app");
+  assert.equal(result.metadata?.["google-adk.conversation"], "conv-app");
+});
+
+test("prefers context.correlationId over context.sessionId", () => {
+  const result = googleAdkContext({
+    context: { correlationId: "corr-1", sessionId: "sess-1" },
+  });
+
+  assert.equal(result.correlationId, "corr-1");
+  assert.equal(result.metadata?.["google-adk.session"], "sess-1");
+});
+
+test("falls back to context.conversationId when sessionId is absent", () => {
+  const result = googleAdkContext({
+    context: { conversationId: "conv-1" },
+  });
+
+  assert.equal(result.correlationId, "conv-1");
+  assert.equal(result.metadata?.["google-adk.conversation"], "conv-1");
+});
+
+test("reads caller-owned keys from state.toRecord()", () => {
+  const result = googleAdkContext({
+    invocationId: "inv-auto",
+    sessionId: "sess-auto",
+    state: {
+      toRecord: () => ({ sessionId: "sess-state" }),
+    },
+  });
+
+  assert.equal(result.correlationId, "sess-state");
+  assert.equal(result.metadata?.["google-adk.session"], "sess-state");
+});
+
+test("reads caller-owned keys from state.get()", () => {
+  const bag: Record<string, unknown> = { sessionId: "sess-get" };
+  const result = googleAdkContext({
+    invocationId: "inv-auto",
+    sessionId: "sess-auto",
+    state: {
+      get: (key: string) => bag[key],
+    },
+  });
+
+  assert.equal(result.correlationId, "sess-get");
+});
+
+test("accepts a bare app context object", () => {
+  const result = googleAdkContext({ sessionId: "direct-sess" });
+  assert.equal(result.correlationId, "direct-sess");
+  assert.equal(result.metadata?.["google-adk.session"], "direct-sess");
+});
+
+test("init.sessionId is a last-resort caller-owned fallback", () => {
+  const result = googleAdkContext({ context: { user: "alice" } }, { sessionId: "policy-sess" });
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["google-adk.session"], "policy-sess");
+});
+
+test("never mints an id when nothing valid is present", () => {
+  const result = googleAdkContext({});
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("correlationId" in result, false);
+});
+
+test("never mints an id when the only candidate is invalid", () => {
+  const result = googleAdkContext({ context: { sessionId: "" } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("google-adk.session" in (result.metadata ?? {}), false);
+});
+
+test("never reads toolContext.sessionId / invocationId on an ADK envelope", () => {
+  const result = googleAdkContext({
+    invocationId: "inv-auto",
+    sessionId: "sess-auto",
+    functionCallId: "call-auto",
+    context: {},
+  });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("never reads invocationId, functionCallId, or traceId", () => {
+  const result = googleAdkContext({
+    invocationId: "inv-1",
+    functionCallId: "call-1",
+    traceId: "trace-1",
+    context: {
+      invocationId: "ctx-inv",
+      functionCallId: "ctx-call",
+      traceId: "ctx-trace",
+    },
+  } as never);
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("a toolContext with invocationId is an envelope; nest caller ids on context or state", () => {
+  const bare = googleAdkContext({
+    invocationId: "inv-1",
+    sessionId: "sess-lost",
+  });
+  assert.equal(bare.correlationId, undefined);
+
+  const nested = googleAdkContext({
+    invocationId: "inv-1",
+    sessionId: "sess-lost",
+    context: { sessionId: "sess-kept" },
+  });
+  assert.equal(nested.correlationId, "sess-kept");
+});
+
+test("reads nested context even when the envelope is an ADK Context", () => {
+  const result = googleAdkContext({
+    invocationId: "inv-auto",
+    sessionId: "sess-auto",
+    context: { sessionId: "sess-from-run" },
+  });
+
+  assert.equal(result.correlationId, "sess-from-run");
+  assert.equal(result.metadata?.["google-adk.session"], "sess-from-run");
+});
+
+test("skips an invalid context session id and uses the next candidate", () => {
+  const result = googleAdkContext({
+    context: { sessionId: "" },
+    conversationId: "conv-ok",
+  });
+
+  assert.equal(result.correlationId, "conv-ok");
+  assert.equal("google-adk.session" in (result.metadata ?? {}), false);
+  assert.equal(result.metadata?.["google-adk.conversation"], "conv-ok");
+});
+
+test("rejects a session id over 256 characters and does not mint", () => {
+  const longId = "x".repeat(257);
+  const result = googleAdkContext({ context: { sessionId: longId } });
+
+  assert.equal(result.correlationId, undefined);
+  assert.equal("google-adk.session" in (result.metadata ?? {}), false);
+});
+
+test("a null context does not throw and does not mint", () => {
+  const result = googleAdkContext({ context: null });
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("caller metadata overrides derived keys", () => {
+  const result = googleAdkContext(
+    { context: { sessionId: "sess-1" } },
+    { metadata: { "google-adk.session": "override" } },
+  );
+
+  assert.equal(result.metadata?.["google-adk.session"], "override");
+});
+
+test("derived metadata keys match /^[A-Za-z0-9._-]+$/", () => {
+  const result = googleAdkContext({
+    context: { sessionId: "sess-1", conversationId: "conv-1" },
+  });
+
+  assert.ok(result.metadata);
+  const validKeyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const key of Object.keys(result.metadata)) {
+    assert.ok(
+      validKeyPattern.test(key),
+      `derived key "${key}" must match the metadata character class`,
+    );
+  }
+});
+
+test("encoder round-trip produces no AJ1017 warnings", () => {
+  const result = googleAdkContext({
+    context: { sessionId: "sess-1", conversationId: "conv-1" },
+  });
+
+  assert.ok(result.metadata);
+  const { metadataJson, localWarnings } = encodeMetadata(result.metadata);
+  assert.equal(localWarnings.length, 0);
+  assert.ok(metadataJson["google-adk.session"]);
+  assert.ok(metadataJson["google-adk.conversation"]);
+});
+
+test("undefined source does not throw and does not mint", () => {
+  const result = googleAdkContext();
+  assert.equal(result.correlationId, undefined);
+  assert.equal(result.metadata, undefined);
+});
+
+test("null and primitive sources do not mint", () => {
+  assert.equal("correlationId" in googleAdkContext(null as never), false);
+  assert.equal("correlationId" in googleAdkContext("sess" as never), false);
+  assert.equal("correlationId" in googleAdkContext(12 as never), false);
+});
+
+test("non-string candidates are skipped", () => {
+  const result = googleAdkContext({
+    context: { sessionId: 99, conversationId: { id: "nope" } },
+  });
+  assert.equal(result.correlationId, undefined);
+});
+
+test("non-printable session id is rejected and does not mint", () => {
+  const result = googleAdkContext({ context: { sessionId: "bad\nid" } });
+  assert.equal(result.correlationId, undefined);
+  assert.equal("google-adk.session" in (result.metadata ?? {}), false);
+});
+
+test("does not write an invalid session id into metadata when a later candidate is valid", () => {
+  const result = googleAdkContext(
+    { context: { sessionId: "bad\nid" } },
+    { sessionId: "policy-sess" },
+  );
+
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["google-adk.session"], "policy-sess");
+});
+
+test("warns when every candidate is invalid and ARCJET_LOG_LEVEL asks for warnings", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "info";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    googleAdkContext({ context: { sessionId: "" } });
+    assert.ok(warnings.length > 0);
+    assert.match(String(warnings[0]?.[0]), /rejected/);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});
+
+test("does not warn when a later candidate is valid", () => {
+  const previous = process.env["ARCJET_LOG_LEVEL"];
+  process.env["ARCJET_LOG_LEVEL"] = "warn";
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const result = googleAdkContext({
+      context: { sessionId: "" },
+      conversationId: "conv-ok",
+    });
+    assert.equal(result.correlationId, "conv-ok");
+    assert.equal(warnings.length, 0);
+  } finally {
+    console.warn = originalWarn;
+    if (previous === undefined) {
+      delete process.env["ARCJET_LOG_LEVEL"];
+    } else {
+      process.env["ARCJET_LOG_LEVEL"] = previous;
+    }
+  }
+});

--- a/arcjet-guard/src/google-adk/v2/context.test.ts
+++ b/arcjet-guard/src/google-adk/v2/context.test.ts
@@ -67,10 +67,31 @@ test("accepts a bare app context object", () => {
   assert.equal(result.metadata?.["google-adk.session"], "direct-sess");
 });
 
-test("init.sessionId is a last-resort caller-owned fallback", () => {
+test("init.sessionId is used when the caller bag has no id", () => {
   const result = googleAdkContext({ context: { user: "alice" } }, { sessionId: "policy-sess" });
   assert.equal(result.correlationId, "policy-sess");
   assert.equal(result.metadata?.["google-adk.session"], "policy-sess");
+});
+
+test("init.sessionId wins over durable session state", () => {
+  const result = googleAdkContext(
+    {
+      invocationId: "inv-auto",
+      sessionId: "sess-auto",
+      state: { sessionId: "sess-stale", conversationId: "conv-stale" },
+    },
+    { sessionId: "policy-sess" },
+  );
+  assert.equal(result.correlationId, "policy-sess");
+  assert.equal(result.metadata?.["google-adk.session"], "policy-sess");
+});
+
+test("nested caller wrap still wins over init.sessionId", () => {
+  const result = googleAdkContext(
+    { context: { sessionId: "sess-app" } },
+    { sessionId: "policy-sess" },
+  );
+  assert.equal(result.correlationId, "sess-app");
 });
 
 test("never mints an id when nothing valid is present", () => {
@@ -115,30 +136,25 @@ test("never reads invocationId, functionCallId, or traceId", () => {
   assert.equal(result.metadata, undefined);
 });
 
-test("a toolContext with invocationId is an envelope; nest caller ids on context or state", () => {
+test("a toolContext with invocationId is an envelope; sessionId is ignored", () => {
   const bare = googleAdkContext({
     invocationId: "inv-1",
     sessionId: "sess-lost",
   });
   assert.equal(bare.correlationId, undefined);
-
-  const nested = googleAdkContext({
-    invocationId: "inv-1",
-    sessionId: "sess-lost",
-    context: { sessionId: "sess-kept" },
-  });
-  assert.equal(nested.correlationId, "sess-kept");
 });
 
-test("reads nested context even when the envelope is an ADK Context", () => {
-  const result = googleAdkContext({
+test("ADK Context has no nested context field; caller wrap is not the SDK object", () => {
+  const adkShaped = googleAdkContext({
     invocationId: "inv-auto",
     sessionId: "sess-auto",
-    context: { sessionId: "sess-from-run" },
+    state: { sessionId: "sess-from-state" },
   });
+  assert.equal(adkShaped.correlationId, "sess-from-state");
+  assert.equal("context" in { invocationId: "inv-auto", sessionId: "sess-auto" }, false);
 
-  assert.equal(result.correlationId, "sess-from-run");
-  assert.equal(result.metadata?.["google-adk.session"], "sess-from-run");
+  const wrap = googleAdkContext({ context: { sessionId: "sess-from-wrap" } });
+  assert.equal(wrap.correlationId, "sess-from-wrap");
 });
 
 test("skips an invalid context session id and uses the next candidate", () => {

--- a/arcjet-guard/src/google-adk/v2/context.ts
+++ b/arcjet-guard/src/google-adk/v2/context.ts
@@ -1,0 +1,259 @@
+import { shouldWarn } from "../../agents/capture.ts";
+import { correlationIdProblem } from "../../agents/context.ts";
+import type { ArcjetMetadata } from "../../types.ts";
+
+/**
+ * Structural source `googleAdkContext` can read.
+ *
+ * Correlation is a **caller-owned** id from helper options or a bag the
+ * integrator put on the run (`state`, a nested `context`, or a bare
+ * object). This helper never mints a new id. It never reads ADK's
+ * `invocationId` (always generated). It never reads `traceId`. It never
+ * reads `functionCallId`. It never uses `toolContext.sessionId` /
+ * `session.id` — those can be ephemeral / session-service auto-ids.
+ *
+ * Accepts:
+ * - a `Context` / `toolContext` envelope (only `state` and nested
+ *   `context` are mined)
+ * - a session `state` bag (`toRecord()`, `get()`, or a plain object)
+ * - the app context object itself
+ * - helper `init.sessionId` / `init.correlationId`
+ */
+export interface GoogleAdkContextSource {
+  context?: unknown;
+  state?: unknown;
+  correlationId?: unknown;
+  sessionId?: unknown;
+  conversationId?: unknown;
+  /** Present on ADK `ReadonlyContext`. Never used for correlation. */
+  invocationId?: unknown;
+  /** Present on ADK tool context. Never used for correlation. */
+  functionCallId?: unknown;
+}
+
+/**
+ * Context derived from a Google ADK run. `correlationId` is omitted
+ * when nothing valid was present — this helper never mints one.
+ */
+export interface GoogleAdkAgentContext {
+  correlationId?: string;
+  metadata?: ArcjetMetadata;
+}
+
+function asContextSource(source: unknown): GoogleAdkContextSource | undefined {
+  if (source === undefined || source === null || typeof source !== "object") {
+    return undefined;
+  }
+  return source;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a non-null, non-array object is a property bag
+  return value as Record<string, unknown>;
+}
+
+function asAppContext(value: unknown): GoogleAdkContextSource | undefined {
+  return asRecord(value);
+}
+
+/**
+ * ADK `ReadonlyContext` / `Context` always carries `invocationId` (see
+ * `newInvocationContextId()`). An envelope that looks like one must not
+ * be mined for `sessionId` — that field is the session service id and
+ * can be ephemeral.
+ */
+function isAdkContextEnvelope(source: GoogleAdkContextSource): boolean {
+  return typeof source.invocationId === "string";
+}
+
+function readStateBag(state: unknown): Record<string, unknown> | undefined {
+  if (state === undefined || state === null || typeof state !== "object") {
+    return undefined;
+  }
+  const withToRecord = state as { toRecord?: unknown };
+  if (typeof withToRecord.toRecord === "function") {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by typeof
+    return asRecord((withToRecord as { toRecord: () => unknown }).toRecord());
+  }
+  const withGet = state as { get?: unknown };
+  if (typeof withGet.get === "function") {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by typeof
+    const get = (withGet as { get: (key: string) => unknown }).get.bind(state);
+    return {
+      correlationId: get("correlationId"),
+      sessionId: get("sessionId"),
+      conversationId: get("conversationId"),
+    };
+  }
+  return asRecord(state);
+}
+
+/**
+ * The integrator-owned app object. On a `toolContext` envelope that is
+ * `source.context` or caller keys on `state`. On a bare app object it
+ * is the source itself.
+ */
+function readAppContext(
+  source: GoogleAdkContextSource | undefined,
+): GoogleAdkContextSource | undefined {
+  if (source === undefined) {
+    return undefined;
+  }
+  const nested = asAppContext(source.context);
+  if (nested !== undefined) {
+    return nested;
+  }
+  if (isAdkContextEnvelope(source)) {
+    return undefined;
+  }
+  return source;
+}
+
+function firstValidId(candidates: ReadonlyArray<{ value: unknown; label: string }>): {
+  id: string | undefined;
+  rejected: string | undefined;
+} {
+  let rejected: string | undefined;
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== "string") {
+      continue;
+    }
+    const problem = correlationIdProblem(candidate.value);
+    if (problem === undefined) {
+      return { id: candidate.value, rejected: undefined };
+    }
+    rejected = `${candidate.label} (${problem})`;
+  }
+  return { id: undefined, rejected };
+}
+
+function validMetadataString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
+    }
+    if (correlationIdProblem(value) !== undefined) {
+      continue;
+    }
+    return value;
+  }
+  return undefined;
+}
+
+/**
+ * Derive correlation and metadata from a Google ADK `toolContext`,
+ * session `state`, or a caller-owned bag. Never mints a new id. Never
+ * calls `createAgentContext`. Never reads `invocationId` (ADK always
+ * generates it). Never reads `traceId` / `functionCallId`. Never reads
+ * `toolContext.sessionId` / `session.id` (session auto-ids).
+ *
+ * Preference order for `correlationId`:
+ * 1. Fields the integrator put on a nested `context` bag:
+ *    `correlationId`, then `sessionId`, then `conversationId`
+ * 2. The same keys on session `state` (`toRecord()` / `get()` / object)
+ * 3. Documented copies on a bare app object (not an ADK Context envelope)
+ * 4. `init.sessionId` / `init.correlationId` (a caller-owned fallback)
+ *
+ * Prefer `googleAdkContext({ context: appContext })` or put the id on
+ * `state` / helper options. A `toolContext` that has `invocationId` is
+ * treated as an ADK envelope, so a top-level `sessionId` on that object
+ * is ignored.
+ *
+ * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL`
+ * asks for warnings). If nothing valid remains, `correlationId` is
+ * omitted so the decision is uncorrelated rather than joined to a
+ * generated id nobody has.
+ *
+ * @example
+ * ```ts
+ * import { googleAdkContext } from "@arcjet/guard/google-adk/v2";
+ *
+ * const appContext = { sessionId: conversationId };
+ * export function beforeRun() {
+ *   return googleAdkContext({ context: appContext });
+ * }
+ * ```
+ */
+export function googleAdkContext(
+  source?: GoogleAdkContextSource,
+  init?: { sessionId?: string; correlationId?: string; metadata?: ArcjetMetadata },
+): GoogleAdkAgentContext {
+  const envelope = asContextSource(source);
+  const app = readAppContext(envelope);
+  const state = readStateBag(envelope?.state);
+  const envelopeIsAdk = envelope !== undefined && isAdkContextEnvelope(envelope);
+
+  const fromApp = {
+    correlationId: app?.correlationId,
+    sessionId: app?.sessionId,
+    conversationId: app?.conversationId,
+  };
+  const fromState = {
+    correlationId: state?.["correlationId"],
+    sessionId: state?.["sessionId"],
+    conversationId: state?.["conversationId"],
+  };
+  const fromEnvelope = envelopeIsAdk
+    ? { correlationId: undefined, sessionId: undefined, conversationId: undefined }
+    : {
+        correlationId: envelope?.correlationId,
+        sessionId: envelope?.sessionId,
+        conversationId: envelope?.conversationId,
+      };
+
+  const { id: correlationId, rejected } = firstValidId([
+    { value: fromApp.correlationId, label: "context.correlationId" },
+    { value: fromApp.sessionId, label: "context.sessionId" },
+    { value: fromApp.conversationId, label: "context.conversationId" },
+    { value: fromState.correlationId, label: "state.correlationId" },
+    { value: fromState.sessionId, label: "state.sessionId" },
+    { value: fromState.conversationId, label: "state.conversationId" },
+    { value: fromEnvelope.correlationId, label: "correlationId" },
+    { value: fromEnvelope.sessionId, label: "sessionId" },
+    { value: fromEnvelope.conversationId, label: "conversationId" },
+    { value: init?.correlationId, label: "init.correlationId" },
+    { value: init?.sessionId, label: "init.sessionId" },
+  ]);
+
+  if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
+    console.warn(
+      `@arcjet/guard: Google ADK ${rejected} rejected; no valid session/conversation id, leaving the call uncorrelated`,
+    );
+  }
+
+  const derivedMetadata: ArcjetMetadata = {};
+
+  const session = validMetadataString([
+    fromApp.sessionId,
+    fromState.sessionId,
+    fromEnvelope.sessionId,
+    init?.sessionId,
+  ]);
+  if (session !== undefined) {
+    derivedMetadata["google-adk.session"] = session;
+  }
+
+  const conversation = validMetadataString([
+    fromApp.conversationId,
+    fromState.conversationId,
+    fromEnvelope.conversationId,
+  ]);
+  if (conversation !== undefined) {
+    derivedMetadata["google-adk.conversation"] = conversation;
+  }
+
+  const metadata: ArcjetMetadata = { ...derivedMetadata, ...init?.metadata };
+  const result: GoogleAdkAgentContext = {};
+
+  if (correlationId !== undefined) {
+    result.correlationId = correlationId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    result.metadata = metadata;
+  }
+
+  return result;
+}

--- a/arcjet-guard/src/google-adk/v2/context.ts
+++ b/arcjet-guard/src/google-adk/v2/context.ts
@@ -13,11 +13,15 @@ import type { ArcjetMetadata } from "../../types.ts";
  * `session.id` — those can be ephemeral / session-service auto-ids.
  *
  * Accepts:
- * - a `Context` / `toolContext` envelope (only `state` and nested
- *   `context` are mined)
+ * - a `Context` / `toolContext` envelope (only session `state` is
+ *   mined — ADK `Context` has no nested `context` field)
+ * - a caller-owned wrap `{ context: appContext }` for inbound
+ *   `googleAdkContext({ context })` (that `context` bag is not an ADK
+ *   field)
  * - a session `state` bag (`toRecord()`, `get()`, or a plain object)
  * - the app context object itself
- * - helper `init.sessionId` / `init.correlationId`
+ * - helper `init.sessionId` / `init.correlationId` (wins over durable
+ *   `state`)
  */
 export interface GoogleAdkContextSource {
   context?: unknown;
@@ -151,16 +155,21 @@ function validMetadataString(values: unknown[]): string | undefined {
  * `toolContext.sessionId` / `session.id` (session auto-ids).
  *
  * Preference order for `correlationId`:
- * 1. Fields the integrator put on a nested `context` bag:
- *    `correlationId`, then `sessionId`, then `conversationId`
- * 2. The same keys on session `state` (`toRecord()` / `get()` / object)
- * 3. Documented copies on a bare app object (not an ADK Context envelope)
- * 4. `init.sessionId` / `init.correlationId` (a caller-owned fallback)
+ * 1. Fields the integrator put on a caller-owned wrap
+ *    (`googleAdkContext({ context: appContext })`):
+ *    `correlationId`, then `sessionId`, then `conversationId`.
+ *    ADK `Context` / `toolContext` has no such `context` field.
+ * 2. `init.sessionId` / `init.correlationId` (helper options /
+ *    `guardPlugin({ sessionId })`). This is the id for this helper and
+ *    wins over durable session `state`.
+ * 3. The same keys on session `state` (`toRecord()` / `get()` / object)
+ * 4. Documented copies on a bare app object (not an ADK Context envelope)
  *
- * Prefer `googleAdkContext({ context: appContext })` or put the id on
- * `state` / helper options. A `toolContext` that has `invocationId` is
- * treated as an ADK envelope, so a top-level `sessionId` on that object
- * is ignored.
+ * Prefer `guardPlugin({ sessionId })` or
+ * `googleAdkContext({ context: appContext })`. Putting the id only on
+ * `state` is a last resort — `state` persists across turns. A
+ * `toolContext` that has `invocationId` is treated as an ADK envelope,
+ * so a top-level `sessionId` on that object is ignored.
  *
  * An invalid candidate is skipped (and warned when `ARCJET_LOG_LEVEL`
  * asks for warnings). If nothing valid remains, `correlationId` is
@@ -208,14 +217,14 @@ export function googleAdkContext(
     { value: fromApp.correlationId, label: "context.correlationId" },
     { value: fromApp.sessionId, label: "context.sessionId" },
     { value: fromApp.conversationId, label: "context.conversationId" },
+    { value: init?.correlationId, label: "init.correlationId" },
+    { value: init?.sessionId, label: "init.sessionId" },
     { value: fromState.correlationId, label: "state.correlationId" },
     { value: fromState.sessionId, label: "state.sessionId" },
     { value: fromState.conversationId, label: "state.conversationId" },
     { value: fromEnvelope.correlationId, label: "correlationId" },
     { value: fromEnvelope.sessionId, label: "sessionId" },
     { value: fromEnvelope.conversationId, label: "conversationId" },
-    { value: init?.correlationId, label: "init.correlationId" },
-    { value: init?.sessionId, label: "init.sessionId" },
   ]);
 
   if (rejected !== undefined && correlationId === undefined && shouldWarn()) {
@@ -228,9 +237,9 @@ export function googleAdkContext(
 
   const session = validMetadataString([
     fromApp.sessionId,
+    init?.sessionId,
     fromState.sessionId,
     fromEnvelope.sessionId,
-    init?.sessionId,
   ]);
   if (session !== undefined) {
     derivedMetadata["google-adk.session"] = session;

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
@@ -1,0 +1,329 @@
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/explicit-function-return-type, eslint/require-await, eslint/strict-boolean-expressions, typescript/strict-boolean-expressions, typescript/unbound-method, unicorn/no-useless-undefined, unicorn/no-object-as-default-parameter -- test infrastructure and mocks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { asDenial, recorded } from "../../../test/_shared/source-scan.ts";
+import {
+  decisionAllow,
+  decisionDenyPromptInjection,
+  decisionFailOpenAllow,
+  fakeRule,
+  stubClient,
+} from "../../../test/_shared/stub-client.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { guardPlugin } from "./guard-plugin.ts";
+import type { GoogleAdkGuardPlugin } from "./guard-plugin.ts";
+
+function toolContext(context: unknown = { sessionId: "sess-1" }) {
+  return {
+    invocationId: "inv-auto",
+    sessionId: "sess-auto",
+    functionCallId: "call-auto",
+    userId: "user-auto",
+    context,
+  };
+}
+
+function beforeToolParams(name: string, args: Record<string, unknown> = {}, tool?: object) {
+  return {
+    tool: tool ?? { name },
+    toolArgs: args,
+    toolContext: toolContext(),
+  };
+}
+
+async function runHook(plugin: GoogleAdkGuardPlugin, params: unknown) {
+  assert.ok(plugin.beforeToolCallback, "guardPlugin must install beforeToolCallback");
+  return plugin.beforeToolCallback(params as never);
+}
+
+/**
+ * ADK 2.0.0 `PluginManager.runCallbacks`: first non-undefined result
+ * wins and remaining plugins are skipped.
+ */
+async function firstWin(
+  plugins: Array<{
+    beforeToolCallback?: (params: never) => unknown;
+  }>,
+  params: unknown,
+): Promise<unknown> {
+  for (const plugin of plugins) {
+    if (plugin.beforeToolCallback === undefined) {
+      continue;
+    }
+    const decision = await plugin.beforeToolCallback(params as never);
+    if (decision !== undefined) {
+      return decision;
+    }
+  }
+  return undefined;
+}
+
+test("returns a named BasePlugin with beforeToolCallback (not a raw function)", () => {
+  const { client } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  assert.equal(typeof plugin, "object");
+  assert.equal(typeof plugin.name, "string");
+  assert.ok(plugin.name.startsWith("arcjet-guard-"));
+  assert.equal(typeof plugin.beforeToolCallback, "function");
+  assert.equal(typeof plugin.onUserMessageCallback, "function");
+  assert.equal(typeof plugin.beforeModelCallback, "function");
+});
+
+test("each call gets a unique name so two instances do not collide", () => {
+  const { client } = stubClient(decisionAllow());
+  const a = guardPlugin(client);
+  const b = guardPlugin(client);
+  assert.notEqual(a.name, b.name);
+});
+
+test("ALLOW → undefined so the tool can run", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("lookup"));
+  assert.equal(result, undefined);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("deny-dict skip: DENY → ArcjetDenialResult, never undefined", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("lookup", { note: "x" }));
+  assert.notEqual(result, undefined);
+  const denial = asDenial<ArcjetDenialResult>(result);
+  assert.equal(denial.arcjetDenied, true);
+  assert.equal(denial.reason, "PROMPT_INJECTION");
+});
+
+test("rules see toolArgs, not the opaque functionCallId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let scanned: unknown;
+  const plugin = guardPlugin(client, {
+    action: "note.read",
+    rules: ({ input, toolName }) => {
+      scanned = { input, toolName };
+      return [fakeRule];
+    },
+  });
+  await runHook(plugin, beforeToolParams("lookup", { note: "hello" }));
+  assert.deepEqual(scanned, { input: { note: "hello" }, toolName: "lookup" });
+  assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
+});
+
+test("correlation comes from nested context.sessionId, never invocationId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  await runHook(plugin, {
+    tool: { name: "lookup" },
+    toolArgs: {},
+    toolContext: toolContext({ sessionId: "sess-mw" }),
+  });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-mw");
+});
+
+test("policy.sessionId is used when tool context has none", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, {
+    action: "tool.invoked",
+    sessionId: "policy-sess",
+  });
+  await runHook(plugin, {
+    tool: { name: "lookup" },
+    toolArgs: {},
+    toolContext: toolContext({}),
+  });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("never-mint: does not mint a correlation id when nothing is present", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  await runHook(plugin, {
+    tool: { name: "lookup" },
+    toolArgs: {},
+    toolContext: toolContext({}),
+  });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+test("never-mint: does not use auto-generated sessionId / invocationId / functionCallId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  await runHook(plugin, {
+    tool: { name: "lookup" },
+    toolArgs: {},
+    toolContext: {
+      invocationId: "inv-auto",
+      sessionId: "sess-auto",
+      functionCallId: "call-auto",
+      userId: "user-auto",
+      context: {},
+    },
+  });
+  const call = recorded(guardCalls[0]);
+  assert.equal("correlationId" in call, false);
+  assert.notEqual(call["correlationId"], "sess-auto");
+  assert.notEqual(call["correlationId"], "inv-auto");
+  assert.notEqual(call["correlationId"], "call-auto");
+});
+
+test("fail-closed unavailable → deny dict with ERROR, never undefined", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("lookup"));
+  assert.notEqual(result, undefined);
+  assert.equal(asDenial<ArcjetDenialResult>(result).reason, "ERROR");
+});
+
+test("onGuardError allow → undefined so the tool still runs on fail-open", async () => {
+  const { client } = stubClient(decisionFailOpenAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked", onGuardError: "allow" });
+  const result = await runHook(plugin, beforeToolParams("lookup"));
+  assert.equal(result, undefined);
+});
+
+test("policy factory throw fail-closes and does not throw from the callback", async () => {
+  const { client } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, {
+    action: "tool.invoked",
+    rules: () => {
+      throw new Error("rules exploded");
+    },
+  });
+  const result = await runHook(plugin, beforeToolParams("lookup"));
+  assert.notEqual(result, undefined);
+  assert.equal(asDenial<ArcjetDenialResult>(result).reason, "ERROR");
+});
+
+test("no-throw: a throwing guard() becomes a deny dict, not a thrown error", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("lookup"));
+  assert.notEqual(result, undefined);
+  assert.equal(asDenial<ArcjetDenialResult>(result).reason, "ERROR");
+});
+
+test("fail-closed: thrown guard() never returns undefined", async () => {
+  const { client } = stubClient(new Error("transport down"));
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("lookup"));
+  assert.notEqual(result, undefined);
+  assert.equal(typeof result, "object");
+});
+
+test("skips a sibling guardTool-branded tool so Guard is not double-called", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const branded = { name: "lookup_order" };
+  Object.defineProperty(branded, arcjetProtectedTool, { value: true });
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("lookup_order", {}, branded));
+  assert.equal(result, undefined);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("still gates an unwrapped tool", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, beforeToolParams("mcp_search"));
+  assert.notEqual(result, undefined);
+  assert.equal(asDenial<ArcjetDenialResult>(result).arcjetDenied, true);
+});
+
+test("inbound guard() before Runner.run is a separate call; plugin still gates tools", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const inbound = await client.guard({
+    label: "message.received",
+    rules: [],
+  });
+  assert.equal(inbound.hasFailedOpen(), false);
+
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  await runHook(plugin, beforeToolParams("lookup"));
+  assert.equal(guardCalls.length, 2);
+  assert.equal(recorded(guardCalls[0])["label"], "message.received");
+  assert.equal(recorded(guardCalls[1])["label"], "tool.invoked");
+});
+
+test("inbound callbacks are no-ops so a preceding guard() does not double-call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const inbound = await plugin.onUserMessageCallback({} as never);
+  const beforeModel = await plugin.beforeModelCallback({} as never);
+  const beforeRun = await plugin.beforeRunCallback({} as never);
+  assert.equal(inbound, undefined);
+  assert.equal(beforeModel, undefined);
+  assert.equal(beforeRun, undefined);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("a non-tool-call hook context is passed through without a guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await runHook(plugin, { text: "not a tool" });
+  assert.equal(result, undefined);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("first-plugin short-circuit: a preceding deny dict wins and Guard never runs", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const cache = {
+    name: "cache",
+    beforeToolCallback: async () => ({ cached: true }),
+  };
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await firstWin([cache, plugin], beforeToolParams("lookup"));
+  assert.deepEqual(result, { cached: true });
+  assert.equal(guardCalls.length, 0);
+});
+
+test("first-plugin short-circuit: Arcjet first deny wins and later plugins never run", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  let later = 0;
+  const laterPlugin = {
+    name: "later",
+    beforeToolCallback: async () => {
+      later += 1;
+      return { later: true };
+    },
+  };
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const result = await firstWin([plugin, laterPlugin], beforeToolParams("lookup"));
+  assert.equal(asDenial<ArcjetDenialResult>(result).arcjetDenied, true);
+  assert.equal(later, 0);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("action callback names the guard call from the tool name", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, {
+    action: ({ toolName }) => `${toolName}.invoked`,
+  });
+  await runHook(plugin, beforeToolParams("mcp_search"));
+  assert.equal(recorded(guardCalls[0])["label"], "mcp_search.invoked");
+});
+
+test("defaults the guard label to tool.invoked", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client);
+  await runHook(plugin, beforeToolParams("mcp_search"));
+  assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("sessionId callback receives the tool name and input", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let seen: unknown;
+  const plugin = guardPlugin(client, {
+    sessionId: (call) => {
+      seen = call;
+      return "sess-from-callback";
+    },
+  });
+  await runHook(plugin, {
+    tool: { name: "mcp_search" },
+    toolArgs: { q: "hello" },
+    toolContext: toolContext({}),
+  });
+  assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
+});

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
@@ -94,6 +94,8 @@ test("deny-dict skip: DENY → ArcjetDenialResult, never undefined", async () =>
   const denial = asDenial<ArcjetDenialResult>(result);
   assert.equal(denial.arcjetDenied, true);
   assert.equal(denial.reason, "PROMPT_INJECTION");
+  assert.equal(typeof denial.message, "string");
+  assert.equal(typeof denial.retryable, "boolean");
 });
 
 test("rules see toolArgs, not the opaque functionCallId", async () => {
@@ -348,7 +350,7 @@ test("defaults the guard label to tool.invoked", async () => {
   assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
 });
 
-test("unknown before/after/on hooks no-op so a later 2.x PluginManager method does not throw", async () => {
+test("unknown hook-shaped names no-op so a later 2.x PluginManager method does not throw", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const plugin = guardPlugin(client, { action: "tool.invoked" });
   const hooks = plugin as unknown as Record<string, unknown>;
@@ -358,8 +360,13 @@ test("unknown before/after/on hooks no-op so a later 2.x PluginManager method do
     // oxlint-disable-next-line typescript/no-unsafe-call -- runtime no-op from the Proxy
     await future();
   }
-  assert.equal(typeof hooks["afterFutureHook"], "function");
-  assert.equal(typeof hooks["onFutureEvent"], "function");
+  assert.equal(typeof hooks["afterFutureCallback"], "function");
+  assert.equal(typeof hooks["onFutureCallback"], "function");
+  assert.equal(typeof hooks["beforeFutureSelection"], "function");
+  assert.equal(typeof hooks["afterFutureCompaction"], "function");
+  assert.equal(hooks["onError"], undefined);
+  assert.equal(hooks["beforeVersion"], undefined);
+  assert.equal(hooks["afterFutureHook"], undefined);
   assert.equal(hooks["notAHook"], undefined);
   assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
@@ -111,15 +111,53 @@ test("rules see toolArgs, not the opaque functionCallId", async () => {
   assert.deepEqual(recorded(guardCalls[0])["rules"], [fakeRule]);
 });
 
-test("correlation comes from nested context.sessionId, never invocationId", async () => {
+test("correlation comes from policy.sessionId, never invocationId or session auto-id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked", sessionId: "policy-sess" });
+  await runHook(plugin, {
+    tool: { name: "lookup" },
+    toolArgs: {},
+    toolContext: {
+      invocationId: "inv-auto",
+      sessionId: "sess-auto",
+      functionCallId: "call-auto",
+      state: { sessionId: "sess-stale" },
+    },
+  });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("policy.sessionId wins over durable session state", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, {
+    action: "tool.invoked",
+    sessionId: "policy-sess",
+  });
+  await runHook(plugin, {
+    tool: { name: "lookup" },
+    toolArgs: {},
+    toolContext: {
+      invocationId: "inv-auto",
+      sessionId: "sess-auto",
+      state: { toRecord: () => ({ sessionId: "sess-stale" }) },
+    },
+  });
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("durable state is used only when helper options have no id", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const plugin = guardPlugin(client, { action: "tool.invoked" });
   await runHook(plugin, {
     tool: { name: "lookup" },
     toolArgs: {},
-    toolContext: toolContext({ sessionId: "sess-mw" }),
+    toolContext: {
+      invocationId: "inv-auto",
+      sessionId: "sess-auto",
+      state: { toRecord: () => ({ sessionId: "sess-state" }) },
+    },
   });
-  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-mw");
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-state");
 });
 
 test("policy.sessionId is used when tool context has none", async () => {
@@ -308,6 +346,22 @@ test("defaults the guard label to tool.invoked", async () => {
   const plugin = guardPlugin(client);
   await runHook(plugin, beforeToolParams("mcp_search"));
   assert.equal(recorded(guardCalls[0])["label"], "tool.invoked");
+});
+
+test("unknown before/after/on hooks no-op so a later 2.x PluginManager method does not throw", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const hooks = plugin as unknown as Record<string, unknown>;
+  const future = hooks["beforeFutureCallback"];
+  assert.equal(typeof future, "function");
+  if (typeof future === "function") {
+    // oxlint-disable-next-line typescript/no-unsafe-call -- runtime no-op from the Proxy
+    await future();
+  }
+  assert.equal(typeof hooks["afterFutureHook"], "function");
+  assert.equal(typeof hooks["onFutureEvent"], "function");
+  assert.equal(hooks["notAHook"], undefined);
+  assert.equal(guardCalls.length, 0);
 });
 
 test("sessionId callback receives the tool name and input", async () => {

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.ts
@@ -43,9 +43,10 @@ export interface GuardPluginPolicy {
   /** Metadata merged over the derived Google ADK context. */
   metadata?: ArcjetMetadata | ((call: GuardPluginCall) => ArcjetMetadata);
   /**
-   * Fallback session id when the tool context does not carry a
-   * caller-owned one. Prefer putting the id you already chose on
-   * helper options or session `state`. Never mint a new id here.
+   * Caller-owned session id for this helper. Wins over durable session
+   * `state`. ADK `Context` has no nested `context` bag and
+   * `toolContext.sessionId` is ignored, so this is the reliable way to
+   * correlate tool calls. Never mint a new id here.
    */
   sessionId?: string | ((call: GuardPluginCall) => string | undefined);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -195,6 +196,32 @@ function noopVoid(): Promise<void> {
 }
 
 /**
+ * PluginManager calls methods by name. A 2.x minor that adds a hook
+ * would otherwise throw `plugin.X is not a function` — a plugin error,
+ * not skip. Unknown `before*` / `after*` / `on*` names no-op.
+ */
+function isPluginHookName(prop: PropertyKey): prop is string {
+  return typeof prop === "string" && /^(?:before|after|on)[A-Z]/.test(prop);
+}
+
+function withUnknownHookNoops(plugin: GoogleAdkGuardPlugin): GoogleAdkGuardPlugin {
+  return new Proxy(plugin, {
+    get(target, prop, _receiver): unknown {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- property bag read for the Proxy
+      const bag = target as unknown as Record<PropertyKey, unknown>;
+      const value = bag[prop];
+      if (value !== undefined) {
+        return value;
+      }
+      if (isPluginHookName(prop)) {
+        return noopUndefined;
+      }
+      return value;
+    },
+  });
+}
+
+/**
  * Structural `BasePlugin` with every PluginManager callback present.
  *
  * PluginManager calls methods by name on every plugin for every
@@ -335,6 +362,8 @@ export function guardPlugin(
   policy: GuardPluginPolicy = {},
 ): GoogleAdkGuardPlugin {
   // PluginManager accepts any object with the callback methods; it does
-  // not check `instanceof BasePlugin`.
-  return createGuardPlugin(client, policy);
+  // not check `instanceof BasePlugin`. The Proxy no-ops unknown
+  // `before*` / `after*` / `on*` names so a later 2.x PluginManager
+  // hook does not throw.
+  return withUnknownHookNoops(createGuardPlugin(client, policy));
 }

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.ts
@@ -1,0 +1,340 @@
+import type { BasePlugin } from "@google/adk";
+
+import { shouldWarn } from "../../agents/capture.ts";
+import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import type { OnGuardError } from "../../agents/guard-action.ts";
+import { runGuarded } from "../../agents/guarded.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { googleAdkContext } from "./context.ts";
+import type { GoogleAdkContextSource } from "./context.ts";
+
+/**
+ * Input passed to `rules` / `metadata` / `action` callbacks on
+ * `guardPlugin`. `input` is the tool's free-text args, not the
+ * opaque `functionCallId`.
+ */
+export interface GuardPluginCall {
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Policy for `guardPlugin()` — how to guard tools that execute
+ * through a Runner `BasePlugin.beforeToolCallback`.
+ *
+ * `requireConfirmation` / `toolContext.requestConfirmation` /
+ * `SecurityPlugin` CONFIRM is HITL, not a policy gate — this helper
+ * never installs those hooks and does not use `SecurityPlugin`. After
+ * a human yes, Guard still runs on the tool call.
+ */
+export interface GuardPluginPolicy {
+  /**
+   * Guard label and capture action. Defaults to `"tool.invoked"`. May be a
+   * function of the tool name and args.
+   */
+  action?: string | ((call: GuardPluginCall) => string);
+  /**
+   * Rules to evaluate before a tool runs. Omitting this still performs
+   * the guard call.
+   */
+  rules?: RuleWithInput[] | ((call: GuardPluginCall) => RuleWithInput[]);
+  /** Metadata merged over the derived Google ADK context. */
+  metadata?: ArcjetMetadata | ((call: GuardPluginCall) => ArcjetMetadata);
+  /**
+   * Fallback session id when the tool context does not carry a
+   * caller-owned one. Prefer putting the id you already chose on
+   * helper options or session `state`. Never mint a new id here.
+   */
+  sessionId?: string | ((call: GuardPluginCall) => string | undefined);
+  /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
+  onGuardError?: OnGuardError;
+}
+
+type BeforeToolCallbackParams = Parameters<BasePlugin["beforeToolCallback"]>[0];
+
+/**
+ * The Runner plugin this helper returns.
+ *
+ * This is ADK's `BasePlugin` (via `import type` only — this module
+ * never value-imports `@google/adk`). `new Runner({ plugins })`
+ * accepts it with no cast. PluginManager does not check
+ * `instanceof`; it calls methods by name. Returning a dictionary
+ * from `beforeToolCallback` stops `runAsync` and short-circuits
+ * remaining plugins.
+ */
+export type GoogleAdkGuardPlugin = BasePlugin;
+
+function isContextSource(value: unknown): value is GoogleAdkContextSource {
+  return value !== null && typeof value === "object";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isBeforeToolParams(value: unknown): value is BeforeToolCallbackParams {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const tool = value["tool"];
+  return isRecord(tool) && typeof tool["name"] === "string";
+}
+
+function isBrandedTool(tool: unknown): boolean {
+  return tool !== null && typeof tool === "object" && arcjetProtectedTool in tool;
+}
+
+function resolveAction(policy: GuardPluginPolicy, call: GuardPluginCall): string {
+  if (typeof policy.action === "function") {
+    return policy.action(call);
+  }
+  if (typeof policy.action === "string" && policy.action.length > 0) {
+    return policy.action;
+  }
+  return "tool.invoked";
+}
+
+function resolveSessionId(policy: GuardPluginPolicy, call: GuardPluginCall): string | undefined {
+  if (typeof policy.sessionId === "function") {
+    return policy.sessionId(call);
+  }
+  if (typeof policy.sessionId === "string" && policy.sessionId.length > 0) {
+    return policy.sessionId;
+  }
+  return undefined;
+}
+
+function denyDict(payload: { message: string }): Record<string, unknown> {
+  return payload;
+}
+
+let pluginSeq = 0;
+
+/**
+ * A registry key, not a secret: `PluginManager` rejects two plugins
+ * that share a name, and two distinct instances sharing one would
+ * fail to register. The counter alone is not enough because a second
+ * copy of this module starts counting at one again.
+ */
+function pluginName(): string {
+  pluginSeq += 1;
+  return `arcjet-guard-${pluginSeq}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function gateToolCall(
+  client: ArcjetAgentClient,
+  policy: GuardPluginPolicy,
+  params: BeforeToolCallbackParams,
+): Promise<Record<string, unknown> | undefined> {
+  if (isBrandedTool(params.tool)) {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- ADK skip is `undefined`, not void
+    return Promise.resolve(undefined);
+  }
+
+  const toolName = params.tool.name;
+  const input = params.toolArgs ?? {};
+  const call: GuardPluginCall = { toolName, input };
+
+  let action: string;
+  let sessionId: string | undefined;
+  let rules: RuleWithInput[] | undefined;
+  let policyMetadata: ArcjetMetadata | undefined;
+  try {
+    action = resolveAction(policy, call);
+    sessionId = resolveSessionId(policy, call);
+    rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
+    policyMetadata =
+      typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+  } catch (error) {
+    const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
+    if (shouldWarn()) {
+      console.warn(
+        '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+        actionLabel,
+        error,
+      );
+    }
+    if (policy.onGuardError === "allow") {
+      // oxlint-disable-next-line unicorn/no-useless-undefined -- ADK skip is `undefined`, not void
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve(denyDict(unavailableResult()));
+  }
+
+  const source = isContextSource(params.toolContext) ? params.toolContext : undefined;
+  const agentCtx = googleAdkContext(source, sessionId === undefined ? undefined : { sessionId });
+
+  const metadata: ArcjetMetadata = {
+    ...agentCtx.metadata,
+    ...(toolName.length > 0 && { "google-adk.tool": toolName }),
+  };
+  const mergedMetadata = { ...metadata, ...policyMetadata };
+
+  return runGuarded<Record<string, unknown> | undefined>(client, {
+    action,
+    rules,
+    correlationId: agentCtx.correlationId,
+    metadata: mergedMetadata,
+    onDeny: (decision: DecisionDeny) => denyDict(denialResult(decision)),
+    onUnavailable: () => denyDict(unavailableResult()),
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- ALLOW is `undefined` so the tool runs
+    execute: () => Promise.resolve(undefined),
+    onGuardError: policy.onGuardError ?? "deny",
+  });
+}
+
+function noopUndefined(): Promise<undefined> {
+  // oxlint-disable-next-line unicorn/no-useless-undefined -- PluginManager skip is `undefined`, not void
+  return Promise.resolve(undefined);
+}
+
+function noopVoid(): Promise<void> {
+  return Promise.resolve();
+}
+
+/**
+ * Structural `BasePlugin` with every PluginManager callback present.
+ *
+ * PluginManager calls methods by name on every plugin for every
+ * lifecycle event. A missing method throws, and a throw from a
+ * plugin is re-raised as a plugin error — a different path than
+ * skip. No-op stubs return `undefined` so later plugins still run
+ * for those events. Only `beforeToolCallback` is the policy gate.
+ * Closures, not instance fields, so extracting the callback still
+ * fail-closes.
+ */
+function createGuardPlugin(
+  client: ArcjetAgentClient,
+  policy: GuardPluginPolicy,
+): GoogleAdkGuardPlugin {
+  const beforeToolCallback = async (
+    params: BeforeToolCallbackParams,
+  ): Promise<Record<string, unknown> | undefined> => {
+    try {
+      if (!isBeforeToolParams(params)) {
+        return undefined;
+      }
+      return await gateToolCall(client, policy, params);
+    } catch (error) {
+      if (shouldWarn()) {
+        console.warn(
+          "@arcjet/guard: beforeToolCallback for a Google ADK tool threw; treating as a guard error:",
+          error,
+        );
+      }
+      if (policy.onGuardError === "allow") {
+        return undefined;
+      }
+      return denyDict(unavailableResult());
+    }
+  };
+
+  return {
+    name: pluginName(),
+    beforeToolCallback,
+    onUserMessageCallback: noopUndefined,
+    beforeRunCallback: noopUndefined,
+    onEventCallback: noopUndefined,
+    afterRunCallback: noopVoid,
+    beforeAgentCallback: noopUndefined,
+    afterAgentCallback: noopUndefined,
+    beforeNodeCallback: noopUndefined,
+    afterNodeCallback: noopUndefined,
+    beforeModelCallback: noopUndefined,
+    afterModelCallback: noopUndefined,
+    onModelErrorCallback: noopUndefined,
+    beforeToolSelection: noopUndefined,
+    beforeContextCompaction: noopVoid,
+    afterContextCompaction: noopVoid,
+    afterToolCallback: noopUndefined,
+    onToolErrorCallback: noopUndefined,
+  };
+}
+
+/**
+ * A Runner `BasePlugin` whose `beforeToolCallback` is the tool-call
+ * gate.
+ *
+ * Put Arcjet **first** in `new Runner({ plugins })`. PluginManager
+ * is first-win: the first plugin that returns a non-`undefined`
+ * value short-circuits remaining plugins and agent callbacks. If
+ * another plugin (including `SecurityPlugin`) returns first, Guard
+ * never runs.
+ *
+ * DENY is a dictionary (`ArcjetDenialResult`). ADK treats a returned
+ * dict as skip: `runAsync` does not run and the model sees the
+ * payload. `undefined` lets the tool execute. This helper does
+ * **not** throw from the callback — PluginManager wraps a throw as a
+ * plugin error, which is a different path than skip.
+ *
+ * On Guard error this helper fail-closes: it ALWAYS returns a deny
+ * dict, never `undefined` (unless `onGuardError: "allow"`). Core
+ * `protect()` / `guard()` stay fail-open.
+ *
+ * Do not use ADK `SecurityPlugin` as the Arcjet policy gate.
+ * `requireConfirmation` / `requestConfirmation` is HITL. After a
+ * human yes, Guard still runs.
+ *
+ * Already-branded tools (`arcjetProtectedTool` from a sibling
+ * `guardTool`) are skipped so Guard is not double-called. This
+ * namespace has no `guardTool`, and inbound `guard()` before
+ * `Runner.runAsync` does not stamp that brand — it is a separate
+ * call and tools are still gated. The plugin does not implement an
+ * inbound / before-model prompt gate (`onUserMessageCallback` and
+ * `beforeModelCallback` are no-ops) so a preceding `guard()` does
+ * not double-call. Tools that are not branded — including when
+ * `params.tool` is unbranded — are still gated.
+ *
+ * On ALLOW this helper captures `outcome: "success"` when the
+ * policy lets the tool run, not when `runAsync` finishes.
+ * `beforeToolCallback` cannot wrap the tool; a later tool throw
+ * does not flip that capture.
+ *
+ * There is no `guardTool`. Skip is the plugin return, not
+ * throw-from-execute. There is no `guardInbound` and no
+ * `guardApproval`: `onUserMessageCallback` replaces the user
+ * message, `beforeRunCallback` / `beforeModelCallback` return
+ * `Content` / `LlmResponse` rather than a deny dict, and
+ * confirmation is HITL. Tool gate is enough for v2.
+ *
+ * Do not double-wrap with `@arcjet/guard/vercel-ai/v7`. This is
+ * Google ADK JS (`@google/adk` 2.x), not `@google/genai` and not
+ * Python google-adk.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, tokenBucket } from "@arcjet/guard";
+ * import { guardPlugin } from "@arcjet/guard/google-adk/v2";
+ * import { Runner } from "@google/adk";
+ *
+ * const arcjet = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const mcpLimit = tokenBucket({
+ *   refillRate: 20,
+ *   intervalSeconds: 60,
+ *   maxTokens: 20,
+ * });
+ *
+ * const runner = new Runner({
+ *   appName: "my_app",
+ *   agent,
+ *   sessionService,
+ *   plugins: [
+ *     guardPlugin(arcjet, {
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [mcpLimit({ key: toolName, requested: 1 })],
+ *       sessionId: conversationId,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function guardPlugin(
+  client: ArcjetAgentClient,
+  policy: GuardPluginPolicy = {},
+): GoogleAdkGuardPlugin {
+  // PluginManager accepts any object with the callback methods; it does
+  // not check `instanceof BasePlugin`.
+  return createGuardPlugin(client, policy);
+}

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.ts
@@ -2,7 +2,7 @@ import type { BasePlugin } from "@google/adk";
 
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
+import { denialResult, unavailableResult, type ArcjetDenialResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
@@ -107,8 +107,8 @@ function resolveSessionId(policy: GuardPluginPolicy, call: GuardPluginCall): str
   return undefined;
 }
 
-function denyDict(payload: { message: string }): Record<string, unknown> {
-  return payload;
+function denyDict(payload: ArcjetDenialResult): Record<string, unknown> {
+  return { ...payload };
 }
 
 let pluginSeq = 0;
@@ -196,12 +196,21 @@ function noopVoid(): Promise<void> {
 }
 
 /**
- * PluginManager calls methods by name. A 2.x minor that adds a hook
- * would otherwise throw `plugin.X is not a function` — a plugin error,
- * not skip. Unknown `before*` / `after*` / `on*` names no-op.
+ * PluginManager calls methods by name. A 2.x minor that adds a
+ * `*Callback` / `*Selection` / `*Compaction` hook would otherwise
+ * throw `plugin.X is not a function` — a plugin error, not skip.
+ *
+ * The suffix is required so a future non-hook property (`onError`,
+ * `beforeVersion`) is not turned into a callable no-op. Unknown
+ * hook-shaped names still no-op: a frozen allowlist would re-throw
+ * on the next 2.x hook, and majors get a new `/v3` namespace
+ * (Renovate `allowedVersions: <3`, no automerge).
  */
 function isPluginHookName(prop: PropertyKey): prop is string {
-  return typeof prop === "string" && /^(?:before|after|on)[A-Z]/.test(prop);
+  return (
+    typeof prop === "string" &&
+    /^(?:before|after|on)[A-Z]\w*(?:Callback|Selection|Compaction)$/.test(prop)
+  );
 }
 
 function withUnknownHookNoops(plugin: GoogleAdkGuardPlugin): GoogleAdkGuardPlugin {
@@ -363,7 +372,7 @@ export function guardPlugin(
 ): GoogleAdkGuardPlugin {
   // PluginManager accepts any object with the callback methods; it does
   // not check `instanceof BasePlugin`. The Proxy no-ops unknown
-  // `before*` / `after*` / `on*` names so a later 2.x PluginManager
-  // hook does not throw.
+  // hook-shaped names (`*Callback` / `*Selection` / `*Compaction`) so
+  // a later 2.x PluginManager hook does not throw.
   return withUnknownHookNoops(createGuardPlugin(client, policy));
 }

--- a/arcjet-guard/src/google-adk/v2/index.test.ts
+++ b/arcjet-guard/src/google-adk/v2/index.test.ts
@@ -10,20 +10,14 @@ import {
 } from "../../../test/_shared/source-scan.ts";
 import * as agentsBarrel from "../../agents/index.ts";
 import * as v7Namespace from "../../vercel-ai/v7/index.ts";
-import * as strandsNamespace from "./index.ts";
-import type {
-  ArcjetDenialResult,
-  GuardHooksPolicy,
-  GuardToolPolicy,
-  StrandsAgentContext,
-} from "./index.ts";
+import * as googleAdkNamespace from "./index.ts";
+import type { ArcjetDenialResult, GoogleAdkAgentContext, GuardPluginPolicy } from "./index.ts";
 
 function verifyTypeExports(): void {
-  const toolPolicy: GuardToolPolicy<Record<string, unknown>> | undefined = undefined;
-  const hooksPolicy: GuardHooksPolicy | undefined = undefined;
+  const policy: GuardPluginPolicy | undefined = undefined;
   const denialResult: ArcjetDenialResult | undefined = undefined;
-  const agentContext: StrandsAgentContext | undefined = undefined;
-  void [toolPolicy, hooksPolicy, denialResult, agentContext];
+  const agentContext: GoogleAdkAgentContext | undefined = undefined;
+  void [policy, denialResult, agentContext];
 }
 
 verifyTypeExports();
@@ -45,20 +39,20 @@ function objectField(
   return undefined;
 }
 
-test("exports the three own helpers as functions", () => {
-  const ownExports = ["strandsAgentContext", "guardTool", "guardHooks"] as const;
+test("exports the two own helpers as functions", () => {
+  const ownExports = ["googleAdkContext", "guardPlugin"] as const;
 
   for (const funcName of ownExports) {
-    const func = (strandsNamespace as Record<string, unknown>)[funcName];
+    const func = (googleAdkNamespace as Record<string, unknown>)[funcName];
     assert.equal(
       typeof func,
       "function",
-      `@arcjet/guard/strands-agents/v1 must export ${funcName} as a function`,
+      `@arcjet/guard/google-adk/v2 must export ${funcName} as a function`,
     );
   }
 });
 
-test("strands-agents namespace exports the agnostic helpers", () => {
+test("google-adk namespace exports the agnostic helpers", () => {
   const requiredSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -68,12 +62,12 @@ test("strands-agents namespace exports the agnostic helpers", () => {
   ] as const;
 
   for (const symbol of requiredSymbols) {
-    const value = (strandsNamespace as Record<string, unknown>)[symbol];
-    assert.ok(value !== undefined, `@arcjet/guard/strands-agents/v1 must export ${symbol}`);
+    const value = (googleAdkNamespace as Record<string, unknown>)[symbol];
+    assert.ok(value !== undefined, `@arcjet/guard/google-adk/v2 must export ${symbol}`);
   }
 });
 
-test("agnostic exports have same identity across Strands and v7 namespaces", () => {
+test("agnostic exports have same identity across Google ADK and v7 namespaces", () => {
   const agnosticSymbols = [
     "createAgentContext",
     "securityMetadata",
@@ -84,78 +78,78 @@ test("agnostic exports have same identity across Strands and v7 namespaces", () 
   ] as const;
 
   for (const symbol of agnosticSymbols) {
-    const strandsValue = (strandsNamespace as Record<string, unknown>)[symbol];
+    const googleAdkValue = (googleAdkNamespace as Record<string, unknown>)[symbol];
     const v7Value = (v7Namespace as Record<string, unknown>)[symbol];
 
     assert.strictEqual(
-      strandsValue,
+      googleAdkValue,
       v7Value,
-      `${symbol} must be the same object identity from both @arcjet/guard/strands-agents/v1 and @arcjet/guard/vercel-ai/v7`,
+      `${symbol} must be the same object identity from both @arcjet/guard/google-adk/v2 and @arcjet/guard/vercel-ai/v7`,
     );
   }
 });
 
-test("Strands namespace is a strict superset of the agents barrel with same identity", () => {
-  const strandsKeys = Object.keys(strandsNamespace);
+test("Google ADK namespace is a strict superset of the agents barrel with same identity", () => {
+  const googleAdkKeys = Object.keys(googleAdkNamespace);
   const agentKeys = Object.keys(agentsBarrel);
 
   for (const key of agentKeys) {
     assert.ok(
-      strandsKeys.includes(key),
-      `agents barrel key "${key}" must be present in strands-agents namespace`,
+      googleAdkKeys.includes(key),
+      `agents barrel key "${key}" must be present in google-adk namespace`,
     );
     assert.strictEqual(
-      (strandsNamespace as Record<string, unknown>)[key],
+      (googleAdkNamespace as Record<string, unknown>)[key],
       (agentsBarrel as Record<string, unknown>)[key],
       `${key} must be the same object identity from both imports`,
     );
   }
 
-  const expectedAdditions = 3;
+  const expectedAdditions = 2;
   assert.equal(
-    strandsKeys.length,
+    googleAdkKeys.length,
     agentKeys.length + expectedAdditions,
-    `strands-agents namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
+    `google-adk namespace must have agents barrel exports plus ${expectedAdditions} own exports`,
   );
 
-  const strandsOnlyKeys = strandsKeys.filter((key) => !agentKeys.includes(key));
-  const ownExportsArray = ["guardTool", "guardHooks", "strandsAgentContext"];
+  const googleAdkOnlyKeys = googleAdkKeys.filter((key) => !agentKeys.includes(key));
+  const ownExportsArray = ["googleAdkContext", "guardPlugin"];
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
   const expectedOwnExports: readonly string[] = ownExportsArray.sort();
   // oxlint-disable-next-line unicorn/no-array-sort -- sort is necessary for comparison
-  const sorted: readonly string[] = strandsOnlyKeys.sort();
+  const sorted: readonly string[] = googleAdkOnlyKeys.sort();
   assert.deepEqual(sorted, expectedOwnExports);
 });
 
-test("export map has no unversioned ./strands-agents and no wildcard subpaths", () => {
+test("export map has no unversioned ./google-adk, no ./google-adk/v0, and no wildcard subpaths", () => {
   const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
   const exportsMap = objectField(packageJson, "exports");
   assert.ok(exportsMap, "package.json must have an exports field");
 
   const exportKeys = Object.keys(exportsMap);
 
-  assert.ok(
-    !exportKeys.includes("./strands-agents"),
-    'export map must not have "./strands-agents"',
-  );
-  assert.ok(
-    exportKeys.includes("./strands-agents/v1"),
-    'export map must have "./strands-agents/v1"',
-  );
+  assert.ok(!exportKeys.includes("./google-adk"), 'export map must not have "./google-adk"');
+  assert.ok(!exportKeys.includes("./google-adk/v0"), 'export map must not have "./google-adk/v0"');
+  assert.ok(!exportKeys.includes("./google-adk/v1"), 'export map must not have "./google-adk/v1"');
+  assert.ok(exportKeys.includes("./google-adk/v2"), 'export map must have "./google-adk/v2"');
 
   for (const key of exportKeys) {
-    if (key.startsWith("./strands-agents/")) {
+    if (key.startsWith("./google-adk/")) {
       assert.equal(
         key,
-        "./strands-agents/v1",
-        `export map must not have wildcard strands-agents subpaths; found "${key}"`,
+        "./google-adk/v2",
+        `export map must not have wildcard google-adk subpaths; found "${key}"`,
       );
     }
   }
 });
 
-test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only APIs", () => {
+test("does not export guardTool, inbound, approval, or sibling-only APIs", () => {
   const forbidden = [
+    "guardTool",
+    "guardInbound",
+    "guardApproval",
+    "guardMiddleware",
     "eveAgentContext",
     "mastraAgentContext",
     "claudeAgentContext",
@@ -163,23 +157,22 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only A
     "langchainContext",
     "openaiAgentsContext",
     "genkitContext",
+    "strandsAgentContext",
     "tanstackAiContext",
-    "googleAdkContext",
-    "guardInbound",
-    "guardApproval",
     "guardInterrupt",
+    "guardHooks",
     "guardToolNode",
-    "guardMiddleware",
     "guardProcessor",
     "arcjetHooks",
     "guardConnection",
     "guardCanUseTool",
+    "SecurityPlugin",
   ];
   for (const key of forbidden) {
     assert.equal(
-      (strandsNamespace as Record<string, unknown>)[key],
+      (googleAdkNamespace as Record<string, unknown>)[key],
       undefined,
-      `strands-agents namespace must not export "${key}"`,
+      `google-adk namespace must not export "${key}"`,
     );
   }
 });

--- a/arcjet-guard/src/google-adk/v2/index.ts
+++ b/arcjet-guard/src/google-adk/v2/index.ts
@@ -1,0 +1,132 @@
+/**
+ * @packageDocumentation
+ *
+ * Google ADK namespace for Arcjet Guards.
+ *
+ * This module provides Google ADK JS Runner plugin helpers plus the
+ * framework-agnostic layer they build on, so a Google ADK app needs
+ * one import path and no notion of layering.
+ *
+ * **Requires the optional peer dependency `@google/adk`
+ * (`>=2 <3`)**. Nothing in this module imports that package at
+ * runtime: every Google ADK type arrives through `import type`, so
+ * installing `@arcjet/guard` never pulls it in. Latest supported
+ * development pin is 2.0.0.
+ *
+ * **Note:** the version segment is `v2` because it names Google ADK
+ * JS 2.x. There is deliberately no unversioned
+ * `@arcjet/guard/google-adk` alias. A `v3` namespace is added when
+ * the SDK reaches 3.x; the segment names the SDK's major, not this
+ * integration's iteration.
+ *
+ * v2 is JS `@google/adk` `Runner` + `BasePlugin.beforeToolCallback`.
+ * Not `@google/genai`. Not the Python google-adk SDK.
+ *
+ * Two surfaces, and the things this namespace does not build:
+ *
+ * - **Tool calls** → `guardPlugin()`. A Runner `BasePlugin` whose
+ *   `beforeToolCallback` is the run-wide gate. DENY is a dictionary
+ *   (`ArcjetDenialResult`) so ADK skips `runAsync` and the model
+ *   sees the payload. `undefined` lets the tool execute. The
+ *   callback does not throw — PluginManager treats a throw as a
+ *   plugin error, not skip. Tools already branded by a sibling
+ *   `guardTool` are skipped so Guard is not double-called. Inbound
+ *   `guard()` before `Runner.runAsync` does not brand tools and
+ *   does not skip this gate. The plugin does not screen inbound
+ *   (`onUserMessageCallback` / `beforeModelCallback` are no-ops) so
+ *   a preceding `guard()` does not double-call.
+ * - **Correlation** → `googleAdkContext()` reads a caller-owned id
+ *   from the helper options or a bag the integrator put on the run.
+ *   It never mints a new id. It never reads `invocationId` (ADK
+ *   always generates it). It never reads `traceId`. It never reads
+ *   `toolContext.sessionId` / `session.id` (session auto-ids).
+ *
+ * There is no `guardTool`. Skip is the plugin return, not
+ * throw-from-execute. There is no `guardInbound` and no
+ * `guardApproval`. `onUserMessageCallback` replaces the user
+ * message; `beforeRunCallback` / `beforeModelCallback` return
+ * `Content` / `LlmResponse` rather than a deny dict. Confirmation
+ * (`requireConfirmation` / `requestConfirmation`) is HITL, not
+ * policy. Do not use ADK `SecurityPlugin` as the Arcjet policy
+ * gate. Tool gate is enough for v2.
+ *
+ * Put Arcjet **first** in `new Runner({ plugins })`. PluginManager
+ * is first-win; if another plugin returns a value first, Guard
+ * never runs.
+ *
+ * ## Screen inbound before `Runner.runAsync` — there is no inbound hook.
+ *
+ * There is no first-class inbound deny-dict channel, so there is no
+ * `guardInbound`. Put prompt-injection (and other inbound rules) in
+ * the application before `runner.runAsync()`. Call `guard()`
+ * directly. `guard()` fails open — callers must check
+ * `hasFailedOpen()`. `onUserMessageCallback` replaces the user
+ * message; it is not this policy gate.
+ *
+ * ## `requireConfirmation` / `requestConfirmation` is HITL, not a policy gate.
+ *
+ * `requireConfirmation` / `toolContext.requestConfirmation` /
+ * `SecurityPlugin` CONFIRM is human-in-the-loop. After a human yes,
+ * Guard still runs on the tool call. Same trap as Mastra
+ * `requireApproval`, Claude `canUseTool`, LangGraph `interrupt()`,
+ * Genkit `toolApproval`, OpenAI Agents `needsApproval`, LangChain
+ * `humanInTheLoopMiddleware`, and TanStack
+ * `needsApproval`. There is no `guardApproval`.
+ *
+ * Do not double-wrap with `@arcjet/guard/vercel-ai/v7`.
+ *
+ * @example
+ * ```ts
+ * import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
+ * import { guardPlugin, googleAdkContext } from "@arcjet/guard/google-adk/v2";
+ * import { Runner } from "@google/adk";
+ *
+ * const client = launchArcjet({ key: process.env["ARCJET_KEY"]! });
+ * const lookupLimit = tokenBucket({
+ *   refillRate: 10,
+ *   intervalSeconds: 60,
+ *   maxTokens: 10,
+ * });
+ *
+ * const appContext = { sessionId: conversationId };
+ * const inbound = detectPromptInjection();
+ * const decision = await client.guard({
+ *   label: "message.received",
+ *   rules: [inbound(userText)],
+ *   ...googleAdkContext({ context: appContext }),
+ * });
+ * if (decision.conclusion === "DENY") {
+ *   throw new Error("message blocked");
+ * }
+ * if (decision.hasFailedOpen()) {
+ *   throw new Error("inbound screening failed open");
+ * }
+ *
+ * const runner = new Runner({
+ *   appName: "my_app",
+ *   agent,
+ *   sessionService,
+ *   plugins: [
+ *     guardPlugin(client, {
+ *       action: ({ toolName }) => `${toolName}.invoked`,
+ *       rules: ({ toolName }) => [lookupLimit({ key: toolName, requested: 1 })],
+ *       sessionId: conversationId,
+ *     }),
+ *   ],
+ * });
+ *
+ * for await (const event of runner.runAsync({
+ *   userId,
+ *   sessionId: conversationId,
+ *   newMessage: { parts: [{ text: userText }] },
+ * })) {
+ *   void event;
+ * }
+ * ```
+ */
+
+export { googleAdkContext } from "./context.ts";
+export type { GoogleAdkAgentContext, GoogleAdkContextSource } from "./context.ts";
+export { guardPlugin } from "./guard-plugin.ts";
+export type { GoogleAdkGuardPlugin, GuardPluginCall, GuardPluginPolicy } from "./guard-plugin.ts";
+export * from "../../agents/index.ts";

--- a/arcjet-guard/src/google-adk/v2/index.ts
+++ b/arcjet-guard/src/google-adk/v2/index.ts
@@ -36,10 +36,12 @@
  *   (`onUserMessageCallback` / `beforeModelCallback` are no-ops) so
  *   a preceding `guard()` does not double-call.
  * - **Correlation** → `googleAdkContext()` reads a caller-owned id
- *   from the helper options or a bag the integrator put on the run.
- *   It never mints a new id. It never reads `invocationId` (ADK
- *   always generates it). It never reads `traceId`. It never reads
- *   `toolContext.sessionId` / `session.id` (session auto-ids).
+ *   from helper options (`guardPlugin({ sessionId })`) or a wrap
+ *   (`googleAdkContext({ context: appContext })`). ADK `Context` has
+ *   no nested `context` field; `state` is durable and loses to helper
+ *   options. It never mints a new id. It never reads `invocationId`
+ *   (ADK always generates it). It never reads `traceId`. It never
+ *   reads `toolContext.sessionId` / `session.id` (session auto-ids).
  *
  * There is no `guardTool`. Skip is the plugin return, not
  * throw-from-execute. There is no `guardInbound` and no

--- a/arcjet-guard/src/google-adk/v2/peer.test.ts
+++ b/arcjet-guard/src/google-adk/v2/peer.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+function readJsonObject(path: string): Record<string, unknown> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function objectField(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by the checks above
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+test("@google/adk is an optional peer and not a dependency", () => {
+  const packageJson = readJsonObject(resolve(import.meta.dirname, "../../../package.json"));
+
+  const peerDependencies = objectField(packageJson, "peerDependencies");
+  assert.ok(peerDependencies);
+  assert.equal(peerDependencies["@google/adk"], ">=2 <3");
+
+  const peerDependenciesMeta = objectField(packageJson, "peerDependenciesMeta");
+  assert.ok(peerDependenciesMeta);
+  const googleAdkMeta = objectField(peerDependenciesMeta, "@google/adk");
+  assert.ok(googleAdkMeta);
+  assert.equal(googleAdkMeta["optional"], true);
+
+  const dependencies = objectField(packageJson, "dependencies");
+  assert.ok(!(dependencies && "@google/adk" in dependencies));
+
+  const devDependencies = objectField(packageJson, "devDependencies");
+  assert.ok(devDependencies);
+  assert.equal(
+    devDependencies["@google/adk"],
+    "2.0.0",
+    'devDependencies["@google/adk"] must be pinned to "2.0.0"',
+  );
+
+  const engines = objectField(packageJson, "engines");
+  assert.ok(engines);
+  assert.equal(engines["node"], ">=22.21.0 <23 || >=24.5.0");
+});

--- a/arcjet-guard/src/google-adk/v2/type-only.test.ts
+++ b/arcjet-guard/src/google-adk/v2/type-only.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
+
+function isGoogleAdkPeer(specifier: string): boolean {
+  return specifier === "@google/adk" || specifier.startsWith("@google/adk/");
+}
+
+test("type-only import scanner works on @google/adk fixtures", () => {
+  const fixtures: Array<{
+    name: string;
+    content: string;
+    shouldHaveImport?: boolean;
+    shouldBeTypeOnly?: boolean;
+  }> = [
+    {
+      name: "detects value import of @google/adk",
+      content: 'import { Runner } from "@google/adk";\nvoid Runner;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts type-only import of @google/adk",
+      content: 'import type { BasePlugin } from "@google/adk";\nvoid 0;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "detects mixed type and value import (counts as value)",
+      content: 'import { type BasePlugin, Runner } from "@google/adk";\nvoid Runner;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+    {
+      name: "accepts export type of @google/adk",
+      content: 'export type { BasePlugin } from "@google/adk";',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: true,
+    },
+    {
+      name: "does not match a different scoped package",
+      content: 'import { GoogleGenAI } from "@google/genai";\nvoid GoogleGenAI;',
+      shouldHaveImport: false,
+    },
+    {
+      name: "detects dynamic import of @google/adk",
+      content: 'const adk = await import("@google/adk");\nvoid adk;',
+      shouldHaveImport: true,
+      shouldBeTypeOnly: false,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const imports = extractTypedImportSpecifiers(fixture.content);
+    const peerImports = imports.filter((imp) => isGoogleAdkPeer(imp.specifier));
+
+    if (fixture.shouldHaveImport === false) {
+      assert.equal(peerImports.length, 0, `${fixture.name}: should not have @google/adk imports`);
+    } else {
+      assert.equal(
+        peerImports.length,
+        1,
+        `${fixture.name}: should have exactly one @google/adk import`,
+      );
+      assert.equal(
+        peerImports[0]?.typeOnly,
+        fixture.shouldBeTypeOnly ?? true,
+        `${fixture.name}: typeOnly should be ${fixture.shouldBeTypeOnly ?? true}`,
+      );
+    }
+  }
+});
+
+test("all @google/adk imports in the google-adk namespace are type-only", () => {
+  const namespaceDir = resolve(import.meta.dirname, "..");
+  const filesToCheck = collectTsFiles(namespaceDir);
+  const errors: string[] = [];
+
+  for (const filePath of filesToCheck) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const imports = extractTypedImportSpecifiers(content);
+    for (const imp of imports) {
+      if (isGoogleAdkPeer(imp.specifier) && !imp.typeOnly) {
+        errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+      }
+    }
+  }
+
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in google-adk namespace:\n${errors.join("\n")}`,
+  );
+});
+
+test("scanner detects value imports when temporarily added", () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "arcjet-google-adk-type-only-"));
+  try {
+    const testFile = resolve(tempDir, "test.ts");
+    writeFileSync(testFile, 'import { Runner } from "@google/adk";\nvoid Runner;');
+    const imports = extractTypedImportSpecifiers(readFileSync(testFile, "utf-8"));
+    const peerImports = imports.filter((imp) => isGoogleAdkPeer(imp.specifier));
+    assert.equal(peerImports.length, 1);
+    assert.equal(peerImports[0]?.typeOnly, false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/arcjet-guard/src/langchain/v1/index.test.ts
+++ b/arcjet-guard/src/langchain/v1/index.test.ts
@@ -152,6 +152,7 @@ test("does not export Eve / Mastra / Claude / LangGraph / OpenAI / Genkit-only A
     "genkitContext",
     "strandsAgentContext",
     "tanstackAiContext",
+    "googleAdkContext",
     "guardInbound",
     "guardApproval",
     "guardInterrupt",

--- a/arcjet-guard/src/langgraph/v1/index.test.ts
+++ b/arcjet-guard/src/langgraph/v1/index.test.ts
@@ -156,6 +156,7 @@ test("does not export Eve / Mastra-only APIs onto the LangGraph namespace", () =
     "langchainContext",
     "strandsAgentContext",
     "tanstackAiContext",
+    "googleAdkContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/openai-agents/v0/index.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/index.test.ts
@@ -152,6 +152,7 @@ test("does not export Eve / Mastra / Claude / LangGraph-only APIs", () => {
     "langchainContext",
     "strandsAgentContext",
     "tanstackAiContext",
+    "googleAdkContext",
     "guardMiddleware",
     "guardInbound",
     "guardApproval",

--- a/arcjet-guard/src/tanstack-ai/v0/index.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/index.test.ts
@@ -160,6 +160,7 @@ test("does not export guardTool, inbound, approval, or sibling-only APIs", () =>
     "openaiAgentsContext",
     "genkitContext",
     "strandsAgentContext",
+    "googleAdkContext",
     "guardInterrupt",
     "guardHooks",
     "guardToolNode",

--- a/arcjet-guard/src/vendor-isolation.test.ts
+++ b/arcjet-guard/src/vendor-isolation.test.ts
@@ -30,6 +30,7 @@ const NAMESPACES = [
   { dir: "langgraph", packages: ["@langchain/langgraph", "@langchain/core"] },
   { dir: "openai-agents", packages: ["@openai/agents"] },
   { dir: "genkit", packages: ["genkit", "@genkit-ai"] },
+  { dir: "google-adk", packages: ["@google/adk"] },
   { dir: "strands-agents", packages: ["@strands-agents/sdk"] },
   { dir: "tanstack-ai", packages: ["@tanstack/ai"] },
 ] as const;
@@ -113,6 +114,7 @@ test("the scanner detects a cross-vendor import when one is introduced", () => {
     { from: "genkit", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
     { from: "strands-agents", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
     { from: "tanstack-ai", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
+    { from: "google-adk", content: 'import { tool } from "@openai/agents";\nvoid tool;' },
     { from: "genkit", content: 'import type { Plugin } from "@strands-agents/sdk";\nvoid 0;' },
     {
       from: "mastra",

--- a/arcjet-guard/test/_shared/source-scan.ts
+++ b/arcjet-guard/test/_shared/source-scan.ts
@@ -293,6 +293,7 @@ export const EXPECTED_ROOT_KEYS = [
   "./claude-agent-sdk/v0",
   "./fetch",
   "./genkit/v1",
+  "./google-adk/v2",
   "./langchain/v1",
   "./langgraph/v1",
   "./mastra/v1",

--- a/arcjet-guard/test/google-adk/real-plugin.test.ts
+++ b/arcjet-guard/test/google-adk/real-plugin.test.ts
@@ -1,0 +1,102 @@
+// oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-type-assertion, typescript/require-await, eslint/require-await, eslint/max-classes-per-file -- two BasePlugin fixtures for first-win
+/**
+ * Behaviour against the real `@google/adk` `PluginManager` /
+ * `BasePlugin`, rather than the structural fakes in
+ * `src/google-adk/v2/*.test.ts`.
+ *
+ * These assertions live outside `src/google-adk/` — that directory is
+ * globbed by the google-adk-absent CI job and scanned for type-only
+ * imports.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { BasePlugin, BaseTool, Context } from "@google/adk";
+import { BasePlugin as AdkBasePlugin, PluginManager } from "@google/adk";
+
+import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
+import { guardPlugin } from "../../src/google-adk/v2/guard-plugin.ts";
+import { asDenial } from "../_shared/source-scan.ts";
+import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
+
+function beforeToolParams(name: string) {
+  return {
+    tool: { name } as BaseTool,
+    toolArgs: { q: "hello" },
+    toolContext: {
+      invocationId: "inv-auto",
+      sessionId: "sess-auto",
+      context: { sessionId: "sess-1" },
+    } as Context,
+  };
+}
+
+class CachePlugin extends AdkBasePlugin {
+  constructor() {
+    super("cache");
+  }
+
+  override async beforeToolCallback(): Promise<Record<string, unknown> | undefined> {
+    return { cached: true };
+  }
+}
+
+class LaterPlugin extends AdkBasePlugin {
+  later = 0;
+
+  constructor() {
+    super("later");
+  }
+
+  override async beforeToolCallback(): Promise<Record<string, unknown> | undefined> {
+    this.later += 1;
+    return { later: true };
+  }
+}
+
+test("guardPlugin is a BasePlugin Runner({ plugins }) accepts without a cast", () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const plugins: BasePlugin[] = [guardPlugin(client)];
+  assert.equal(typeof plugins[0]?.beforeToolCallback, "function");
+  assert.equal(typeof plugins[0]?.name, "string");
+});
+
+test("PluginManager registers the duck-typed plugin by name", () => {
+  const { client } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client);
+  const manager = new PluginManager([plugin]);
+  assert.equal(manager.getPlugin(plugin.name), plugin);
+});
+
+test("PluginManager first-plugin short-circuit: a preceding deny dict means Guard never runs", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const manager = new PluginManager([new CachePlugin(), guardPlugin(client)]);
+  const result = await manager.runBeforeToolCallback(beforeToolParams("lookup"));
+  assert.deepEqual(result, { cached: true });
+  assert.equal(guardCalls.length, 0);
+});
+
+test("PluginManager first-plugin short-circuit: Arcjet first deny skips later plugins", async () => {
+  const { client, guardCalls } = stubClient(decisionDenyPromptInjection());
+  const later = new LaterPlugin();
+  const manager = new PluginManager([guardPlugin(client, { action: "tool.invoked" }), later]);
+  const result = await manager.runBeforeToolCallback(beforeToolParams("lookup"));
+  assert.equal(asDenial<ArcjetDenialResult>(result).arcjetDenied, true);
+  assert.equal(later.later, 0);
+  assert.equal(guardCalls.length, 1);
+});
+
+test("PluginManager deny dict skips runAsync: ALLOW returns undefined", async () => {
+  const { client } = stubClient(decisionAllow());
+  const manager = new PluginManager([guardPlugin(client, { action: "tool.invoked" })]);
+  const result = await manager.runBeforeToolCallback(beforeToolParams("lookup"));
+  assert.equal(result, undefined);
+});
+
+test("PluginManager deny dict is the skip shape ADK treats as skip", async () => {
+  const { client } = stubClient(decisionDenyPromptInjection());
+  const manager = new PluginManager([guardPlugin(client, { action: "tool.invoked" })]);
+  const result = await manager.runBeforeToolCallback(beforeToolParams("lookup"));
+  assert.notEqual(result, undefined);
+  assert.equal(asDenial<ArcjetDenialResult>(result).arcjetDenied, true);
+});

--- a/arcjet-guard/test/google-adk/real-plugin.test.ts
+++ b/arcjet-guard/test/google-adk/real-plugin.test.ts
@@ -1,7 +1,7 @@
 // oxlint-disable typescript/explicit-function-return-type, typescript/no-unsafe-type-assertion, typescript/require-await, eslint/require-await, eslint/max-classes-per-file -- two BasePlugin fixtures for first-win
 /**
  * Behaviour against the real `@google/adk` `PluginManager` /
- * `BasePlugin`, rather than the structural fakes in
+ * `Context` / `State`, rather than the structural fakes in
  * `src/google-adk/v2/*.test.ts`.
  *
  * These assertions live outside `src/google-adk/` — that directory is
@@ -11,23 +11,40 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { BasePlugin, BaseTool, Context } from "@google/adk";
-import { BasePlugin as AdkBasePlugin, PluginManager } from "@google/adk";
+import type { BasePlugin, BaseTool } from "@google/adk";
+import {
+  BasePlugin as AdkBasePlugin,
+  Context,
+  InvocationContext,
+  PluginManager,
+  createSession,
+} from "@google/adk";
 
 import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
 import { guardPlugin } from "../../src/google-adk/v2/guard-plugin.ts";
-import { asDenial } from "../_shared/source-scan.ts";
+import { asDenial, recorded } from "../_shared/source-scan.ts";
 import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
 
-function beforeToolParams(name: string) {
+function realToolContext(state: Record<string, unknown> = {}) {
+  const session = createSession({
+    id: "sess-auto",
+    appName: "app",
+    userId: "user-auto",
+    state,
+  });
+  const invocationContext = new InvocationContext({
+    invocationId: "inv-auto",
+    session,
+    pluginManager: new PluginManager([]),
+  });
+  return new Context({ invocationContext, functionCallId: "call-auto" });
+}
+
+function beforeToolParams(name: string, state: Record<string, unknown> = {}) {
   return {
     tool: { name } as BaseTool,
     toolArgs: { q: "hello" },
-    toolContext: {
-      invocationId: "inv-auto",
-      sessionId: "sess-auto",
-      context: { sessionId: "sess-1" },
-    } as Context,
+    toolContext: realToolContext(state),
   };
 }
 
@@ -53,6 +70,15 @@ class LaterPlugin extends AdkBasePlugin {
     return { later: true };
   }
 }
+
+test("real ADK Context has no nested context field", () => {
+  const toolContext = realToolContext({ sessionId: "sess-state" });
+  assert.equal(toolContext.invocationId, "inv-auto");
+  assert.equal(toolContext.sessionId, "sess-auto");
+  assert.equal("context" in toolContext, false);
+  assert.equal((toolContext as { context?: unknown }).context, undefined);
+  assert.equal(toolContext.state.toRecord()["sessionId"], "sess-state");
+});
 
 test("guardPlugin is a BasePlugin Runner({ plugins }) accepts without a cast", () => {
   const { client } = stubClient(decisionDenyPromptInjection());
@@ -99,4 +125,58 @@ test("PluginManager deny dict is the skip shape ADK treats as skip", async () =>
   const result = await manager.runBeforeToolCallback(beforeToolParams("lookup"));
   assert.notEqual(result, undefined);
   assert.equal(asDenial<ArcjetDenialResult>(result).arcjetDenied, true);
+});
+
+test("PluginManager inbound no-ops do not throw and do not call Guard", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, { action: "tool.invoked" });
+  const manager = new PluginManager([plugin]);
+  const toolContext = realToolContext();
+  const invocationContext = toolContext.invocationContext;
+
+  const inbound = await manager.runOnUserMessageCallback({
+    userMessage: { role: "user", parts: [{ text: "hello" }] },
+    invocationContext,
+  });
+  const beforeRun = await manager.runBeforeRunCallback({ invocationContext });
+  await manager.runAfterRunCallback({ invocationContext });
+  const beforeModel = await manager.runBeforeModelCallback({
+    callbackContext: toolContext,
+    llmRequest: { contents: [], liveConnectConfig: {}, toolsDict: {} },
+  });
+
+  assert.equal(inbound, undefined);
+  assert.equal(beforeRun, undefined);
+  assert.equal(beforeModel, undefined);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("real Context: policy.sessionId is the correlation id, never session auto-id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const manager = new PluginManager([
+    guardPlugin(client, { action: "tool.invoked", sessionId: "policy-sess" }),
+  ]);
+  await manager.runBeforeToolCallback(beforeToolParams("lookup", { sessionId: "sess-stale" }));
+  assert.equal(recorded(guardCalls[0])["correlationId"], "policy-sess");
+});
+
+test("real Context: durable state is used only when helper options have no id", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const manager = new PluginManager([guardPlugin(client, { action: "tool.invoked" })]);
+  await manager.runBeforeToolCallback(beforeToolParams("lookup", { sessionId: "sess-state" }));
+  assert.equal(recorded(guardCalls[0])["correlationId"], "sess-state");
+});
+
+test("real Context: never reads Context.sessionId or invocationId", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const manager = new PluginManager([guardPlugin(client, { action: "tool.invoked" })]);
+  const toolContext = realToolContext();
+  assert.equal(toolContext.sessionId, "sess-auto");
+  assert.equal(toolContext.invocationId, "inv-auto");
+  await manager.runBeforeToolCallback({
+    tool: { name: "lookup" } as BaseTool,
+    toolArgs: {},
+    toolContext,
+  });
+  assert.equal("correlationId" in recorded(guardCalls[0]), false);
 });

--- a/arcjet-skills/docs/choose-protections.md
+++ b/arcjet-skills/docs/choose-protections.md
@@ -27,19 +27,23 @@ always need an explicit `key` and `bucket`.
 
 **Rule:** `detectPromptInjection` (request-based and Guard). Use on untrusted
 text before it reaches a model or tool argument, and on tool results that
-fetch untrusted content. The rule is a binary detect.
+fetch untrusted content. The rule is a binary detect — there is no
+`threshold` or `score`.
 
 ## Unsafe content
 
-**Rule:** Guard `moderateContent` only (not available on `protect()`). Check
+**Rule:** Guard `moderateContent` only (not available on `protect()`). The
+result is `{ detected, billing? }` (`text_units` when present). Check
 `hasFailedOpen()` when evaluation is incomplete.
 
 ## Data loss prevention
 
-Detection runs locally. The default WebAssembly backend finds card numbers,
-email addresses, phone numbers, and IP addresses. Names, addresses, and
-government or financial identifiers need `@arcjet/sensitive-info-rampart`
-(`rampart()`), which needs a server runtime with filesystem access.
+Detection runs locally. The default WebAssembly backend finds exactly four
+structured types: card numbers, email addresses, phone numbers, and IP
+addresses. Names, addresses, and government or financial identifiers need
+`@arcjet/sensitive-info-rampart` (`rampart()`), which needs a server runtime
+with filesystem access. Listing a Rampart-only entity without that backend
+never matches.
 
 **Rules:** `sensitiveInfo` (request-based) and `localDetectSensitiveInfo`
 (Guard).

--- a/arcjet-skills/docs/cli.md
+++ b/arcjet-skills/docs/cli.md
@@ -14,6 +14,8 @@ For frequent use:
 npm install -g @arcjet/cli
 # or
 brew install arcjet/tap/arcjet
+# or (macOS Apple Silicon/Intel, Linux x86_64/arm64)
+curl -sSfL https://arcjet.com/cli/install.sh | bash
 ```
 
 Or download a release from https://github.com/arcjet/cli/releases.

--- a/arcjet-skills/docs/guard.md
+++ b/arcjet-skills/docs/guard.md
@@ -24,6 +24,9 @@ Create the client once at module scope. Prefer passing the client explicitly.
 cannot thread a client. Free `guard()` fail-opens if nothing is registered —
 check `hasFailedOpen()` and do not treat that ALLOW as a pass.
 
+Declare rules at module scope so `.deniedResult(decision)` and
+`.errorResult(decision)` have a stable reference.
+
 ## One `guard()` per operation
 
 Call `guard()` where you already know the operation. Hardcode the `label`.
@@ -31,7 +34,8 @@ Do not interpolate names in a generic dispatcher.
 
 Labels are slugs: lowercase letters, digits, dash, and dot only; must start
 and end with a letter or digit; max 256 bytes. Use `tools.get-weather`, not
-`tools.get_weather`.
+`tools.get_weather`. Metadata keys may contain underscores; labels and
+rate-limit `bucket` names may not.
 
 ```ts
 const decision = await arcjet.guard("tools.get-weather", {
@@ -40,19 +44,46 @@ const decision = await arcjet.guard("tools.get-weather", {
 });
 
 if (decision.conclusion === "DENY") {
+  const rateLimited = toolCallLimit.deniedResult(decision);
+  if (rateLimited) {
+    throw new Error(`rate limited – retry after unix ${rateLimited.resetAtUnixSeconds}`);
+  }
+  if (decision.reason === "PROMPT_INJECTION") {
+    throw new Error("input flagged as prompt injection");
+  }
   return { error: decision.reason };
 }
 ```
+
+`decision.reason` is a flat string on DENY (`"RATE_LIMIT"`,
+`"PROMPT_INJECTION"`, `"SENSITIVE_INFO"`, `"MODERATE_CONTENT"`, …) and
+`undefined` on ALLOW. Branch on which rule denied, not only on `DENY`.
 
 `metadata` is nested JSON for the Console. It does not affect the decision.
 Do not put secrets or PII in it.
 
 Every rate-limit rule needs a `key` and a `bucket`. Use a user or session id
-when you have one; otherwise a stable identifier you control.
+when you have one; otherwise a stable identifier you control (`"default"`,
+deployment name). Do not pass an empty string.
 
 A denial by one rule still spends the others' budget in the same `guard()`
 call. Split rules across two calls if a PII false positive must not drain a
 rate-limit bucket.
+
+`guard()` never throws for runtime degradation. `hasFailedOpen()` is true
+when ALLOW means a rule or the decision could not be processed — that is
+the fail-closed gate. `warnings` are request-validation diagnostics; they
+never change the conclusion. Prefer `hasFailedOpen()` over deprecated
+`hasError()`.
+
+Pass `correlationId` to join a guard decision with a request or agent
+trace. It is a dedicated field, not metadata.
+
+`localDetectSensitiveInfo()` defaults to WASM and matches four types:
+card, email, phone, IP. Names, addresses, and government / financial
+identifiers need `@arcjet/sensitive-info-rampart` (`backend: rampart()`).
+Listing a Rampart-only entity without that backend never matches.
+`moderateContent()` is Guard-only.
 
 ## Framework wrappers
 
@@ -79,8 +110,25 @@ implementing. Those skills ship in the `@arcjet/guard` package.
 Framework wrappers fail closed by default when Guard is unavailable. Core
 `guard()` fails open — check `hasFailedOpen()`.
 
-Human-in-the-loop APIs (`needsApproval`, `interrupt()`, `requireApproval`)
-are not policy gates. After a human yes, Guard still runs.
+JS LangChain `createAgent` is `@arcjet/guard/langchain/v1`, not LangGraph.
+JS Google ADK is `guardPlugin` on the Runner — there is no `guardTool`.
+TanStack AI is `guardMiddleware` — do not use `guardTool` (an `execute`
+throw is swallowed). JS Strands Agents is official `@strands-agents/sdk`,
+not Python `strands`.
+
+Every adapter uses one `ArcjetDenialResult` payload
+(`{ arcjetDenied: true, reason, message, retryable }`). Delivery is
+per-framework: return the object (AI SDK, Mastra, OpenAI Agents, Genkit
+`toolResponse.output`, LangGraph, LangChain `guardTool`, Google ADK plugin
+dict, Strands `guardTool`); wrap it (Claude Agent SDK `isError: true`,
+LangChain `guardMiddleware` `ToolMessage`, Strands `guardHooks` cancel
+string, TanStack `onBeforeToolCall` skip); or throw `ArcjetDeniedError`
+(Eve, unless `onDeny: "result"`). A throw from a return-style adapter
+drops the fields.
+
+Human-in-the-loop APIs (`needsApproval`, `interrupt()`, `requireApproval`,
+`requireConfirmation`, `canUseTool`) are not policy gates. After a human
+yes, Guard still runs.
 
 ## Capture and flush
 

--- a/arcjet-skills/docs/guard.md
+++ b/arcjet-skills/docs/guard.md
@@ -68,6 +68,7 @@ Prefer the versioned Guard namespaces over hand-wrapping every tool:
 | LangChain JS `createAgent` | `@arcjet/guard/langchain/v1` |
 | OpenAI Agents | `@arcjet/guard/openai-agents/v0` |
 | Genkit JS | `@arcjet/guard/genkit/v1` |
+| Google ADK JS | `@arcjet/guard/google-adk/v2` |
 | Strands Agents JS | `@arcjet/guard/strands-agents/v1` |
 | TanStack AI | `@arcjet/guard/tanstack-ai/v0` |
 

--- a/arcjet-skills/docs/protect.md
+++ b/arcjet-skills/docs/protect.md
@@ -22,17 +22,25 @@ Use a framework adapter when the code has an HTTP request object (Next.js
 | SvelteKit | `@arcjet/sveltekit` |
 | Astro | `@arcjet/astro` |
 
+Hono on Node uses `@arcjet/node`. Hono on Bun uses `@arcjet/bun`.
+
 MCP servers, queue workers, and agent tool calls do **not** receive an HTTP
 request. Use `@arcjet/guard` instead.
 
 Server actions, tRPC, and other RPC-over-HTTP still have an HTTP request —
 use request protection.
 
+Runtime baseline: Node.js `>=22.21.0 <23 || >=24.5.0`, Bun ≥ 1.3.0, Deno
+`stable` / `lts`. Bump the runtime before installing if the project is below
+those floors.
+
 ## Client setup
 
-Create **one** `arcjet()` client at module scope. Use `withRule()` for
-route-specific extras so clones share the decision cache. Sibling `arcjet()`
-constructors do not share cache.
+Create **one** `arcjet()` client at module scope in a shared file. Use
+`withRule()` for route-specific extras so clones share the decision cache.
+Sibling `arcjet()` constructors do not share cache.
+
+Always include `shield({ mode: "LIVE" })` as a base rule.
 
 ```ts
 import arcjet, { shield, detectBot } from "@arcjet/next";
@@ -55,6 +63,38 @@ Never hardcode `ARCJET_KEY`. Write it to the project's env file. Prefer
 Install the adapter with the project's package manager. Do not hand-edit
 `package.json` and guess a version.
 
+### Frameworks that are not a shared client file
+
+- **Astro** — register the integration in `astro.config.mjs` and import
+  `arcjet:client`. There is no `lib/arcjet.ts` and no `withRule()`.
+  `@arcjet/astro` validates with Zod `.strict()`, so leftover
+  `detectPromptInjection({ threshold })` throws at startup.
+- **Nuxt** — register the `@arcjet/nuxt` module. The key lives in
+  `nuxt.config.ts`. Import from `#arcjet`. Each `arcjet()` call is its own
+  cache — share one server module.
+- **NestJS** — `ArcjetModule.forRoot()` plus `@InjectArcjet()`.
+- **Bun / Deno** — wrap the fetch handler with `aj.handler()` so Arcjet can
+  see the socket for client IP. Still call `protect()` inside. Deno imports
+  use the `npm:` prefix.
+- **Hono on Node** — type the app with `HttpBindings` from
+  `@hono/node-server` and pass `c.env.incoming` to `protect()`. Hono on Bun
+  passes `c.req.raw`.
+
+### What to pass to `protect()`
+
+| Framework | Argument |
+| --------- | -------- |
+| Express / Node.js | `req` |
+| Next.js App Router | `req` |
+| Next.js Server Components / actions | `await request()` from `@arcjet/next` |
+| Fastify | `request` (Fastify request, not raw Node) |
+| NestJS | `req` |
+| SvelteKit / Nuxt | `event` |
+| Remix / React Router | `args` |
+| Astro / Bun / Deno | `request` |
+| Hono on Node | `c.env.incoming` |
+| Hono on Bun | `c.req.raw` |
+
 ## Call `protect()` in the handler
 
 Call `protect()` inside each route handler, once per request. Do not call it
@@ -73,10 +113,26 @@ export async function GET(request: Request) {
 ```
 
 Map denial reasons to HTTP responses only when the status or body should
-differ. A Shield denial and a generic deny that both return 403 do not need
-separate branches.
+differ:
+
+- `decision.reason.isRateLimit()` → 429
+- `decision.reason.isEmail()` / `isSensitiveInfo()` / `isPromptInjection()` → 400
+- everything else (bot, shield, filter) → 403
+
+`decision.isErrored()` means the SDK failed open. Log it and allow.
 
 `detectBot` requires exactly one of `allow` or `deny`. Neither or both throws.
+
+`detectPromptInjection` takes `mode` only. Do not pass `threshold`. Do not
+read `score`; branch on `isPromptInjection()` / `injectionDetected`.
+
+Rules that need extra input at `protect()` time: `tokenBucket` needs
+`{ requested }`, `validateEmail` / `protectSignup` need `{ email }`,
+`sensitiveInfo` needs `{ sensitiveInfoValue }`, `detectPromptInjection`
+needs `{ detectPromptInjectionMessage }`.
+
+Pass `correlationId` when the decision must join another request, guard
+call, or agent trace. It does not affect fingerprinting.
 
 ## Characteristics and client IP
 
@@ -84,11 +140,30 @@ Put a `userId` characteristic on the rule that needs it, then pass a trusted,
 authenticated user ID at protection time. Never rate limit by a client-controlled
 header unless a trusted proxy strips and rewrites it.
 
-If the application already has a trusted client IP, pass it as `ipSrc`. The SDK
-trusts the value.
+Treat client-IP provenance as security configuration. When no usable public
+address is available, adapters may fall back to forwarding headers and log one
+`client_ip_provenance="unverified-header"` warning for the lifetime of each
+SDK client. Configure every trusted proxy (`proxies`, or a helper such as
+`cloudflare()`). The application must be reachable only through infrastructure
+that overwrites or safely appends those headers.
+
+If the application already has an independently trusted client IP, pass it as
+`ipSrc`. A non-empty value wins over automatic detection. An empty string is
+treated as omitted. Malformed values are rejected. Syntax validation does not
+prove provenance.
+
+Never silence an `unverified-header` warning by copying `X-Forwarded-For` (or
+another client-controlled header) into `ipSrc`. That relabels attacker input
+as trusted. Inspect representative requests with
+`client.clientIpDetails(request)` in `@arcjet/node`, or `findIpDetails()` /
+`resolveClientIp()` from `@arcjet/ip`. Check `ip`, `provenance`, `verified`,
+and `header`.
 
 `protect()` accepts nested-JSON `metadata`. It does not affect fingerprinting.
 Do not put secrets or PII in it.
+
+When present, `decision.ip.threat` is optional IP threat intelligence. Check
+before reading.
 
 ## Common mistakes
 
@@ -97,6 +172,8 @@ Do not put secrets or PII in it.
 - Calling `protect()` twice for the same request (double-counts rate limits)
 - Leaving rules in `DRY_RUN` and expecting them to block
 - Passing both `allow` and `deny` to `detectBot`
+- Passing `threshold` to `detectPromptInjection`
+- Copying `X-Forwarded-For` into `ipSrc` to hide an unverified-header warning
 - Hardcoding `ARCJET_KEY`
 
 ## Verify

--- a/arcjet-skills/skills/choose-protections/SKILL.md
+++ b/arcjet-skills/skills/choose-protections/SKILL.md
@@ -22,7 +22,7 @@ or `@arcjet/skills#guard` to implement them.
 | Bots, scrapers, automated clients | `detectBot` (`allow` **or** `deny`, not both) | Request only |
 | SQLi / XSS / common probes | `shield` (`mode: "LIVE"`) | Request only |
 | Cost / abuse quotas | `tokenBucket`, `fixedWindow`, `slidingWindow` | Request and Guard |
-| Jailbreaks, instruction overrides | `detectPromptInjection` | Request and Guard |
+| Jailbreaks, instruction overrides | `detectPromptInjection` (binary; no `threshold`) | Request and Guard |
 | Card / email / phone / IP in text | `sensitiveInfo` / `localDetectSensitiveInfo` | Request and Guard |
 | Names, addresses, gov IDs | same rules + `@arcjet/sensitive-info-rampart` | Server runtime |
 | Unsafe / abusive text | `moderateContent` | Guard only |
@@ -34,6 +34,9 @@ Token bucket: variable-cost AI (`requested` per call). Fixed window: hard cap.
 Sliding window: no boundary burst. Request rate limits default to IP; set
 `characteristics: ["userId"]` for a user key. Guard rate limits always need
 `key` and `bucket`.
+
+Default sensitive-info backend matches four structured types. Rampart-only
+entities never match without `backend: rampart()`.
 
 `capture()` records that an action happened. It is not a protection rule.
 

--- a/arcjet-skills/skills/cli/SKILL.md
+++ b/arcjet-skills/skills/cli/SKILL.md
@@ -30,6 +30,9 @@ npx -y @arcjet/cli@latest sites get-key --site-id <site_id> --output json --fiel
 Write `key` to the project's env file as `ARCJET_KEY=ajkey_...`. Match
 existing env-file conventions and `.gitignore`. Never hardcode the key.
 
+Frequent use: `npm install -g @arcjet/cli`, `brew install arcjet/tap/arcjet`,
+or `curl -sSfL https://arcjet.com/cli/install.sh | bash`.
+
 `--output json` and `--fields` keep agent context small. Confirm with the
 user before write or delete operations (`--confirm`).
 

--- a/arcjet-skills/skills/guard/SKILL.md
+++ b/arcjet-skills/skills/guard/SKILL.md
@@ -31,6 +31,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 ```
 
 One client at module scope. Get the key with `@arcjet/skills#cli` first.
+Declare rules at module scope so `.deniedResult(decision)` works.
 
 ## One `guard()` per operation
 
@@ -46,20 +47,38 @@ const decision = await arcjet.guard("tools.get-weather", {
 });
 
 if (decision.conclusion === "DENY") {
+  const rateLimited = toolCallLimit.deniedResult(decision);
+  if (rateLimited) {
+    return { error: `rate limited, retry after ${rateLimited.resetAtUnixSeconds}` };
+  }
   return { error: decision.reason };
+}
+if (decision.hasFailedOpen()) {
+  // ALLOW only because a rule could not run — deny here if the site is sensitive
 }
 ```
 
-Core `guard()` fails open — check `hasFailedOpen()`. Rate-limit rules need
-`key` and `bucket`. Nested `metadata` is Console-only; no secrets or PII.
+Core `guard()` fails open — check `hasFailedOpen()`. `warnings` never change
+the conclusion. Rate-limit rules need `key` and `bucket`. Nested `metadata`
+is Console-only; no secrets or PII. `decision.reason` is a flat string on
+DENY and `undefined` on ALLOW.
+
+`localDetectSensitiveInfo()` default backend matches card / email / phone /
+IP only. Names and government IDs need `backend: rampart()`.
+`moderateContent()` is Guard-only.
 
 `capture()` is visibility, never a deny. `flush()` on shutdown.
 
 ## Versioned wrappers
 
 Import `@arcjet/guard/<vendor>/v<major>` — unversioned paths do not resolve.
-Wrappers fail closed by default. HITL (`needsApproval`, `interrupt()`) is not
-a policy gate; Guard still runs after a human yes.
+Wrappers fail closed by default. HITL (`needsApproval`, `interrupt()`,
+`requireConfirmation`, `canUseTool`) is not a policy gate; Guard still runs
+after a human yes.
+
+Google ADK is `guardPlugin` (no `guardTool`). TanStack AI is
+`guardMiddleware` (do not wrap `execute`). LangChain `createAgent` is
+`/langchain/v1`, not LangGraph.
 
 Load `@arcjet/skills#choose-protections` to pick rules. Exact signatures live
 in the installed `@arcjet/guard` types.

--- a/arcjet-skills/skills/guard/SKILL.md
+++ b/arcjet-skills/skills/guard/SKILL.md
@@ -19,8 +19,8 @@ and agent tool calls are Guard. HTTP routes are `@arcjet/skills#protect`.
 
 For a specific vendor SDK, load the matching skill from `@arcjet/guard`
 (`@arcjet/guard#integrate-arcjet-guard-agents`, `-eve`, `-mastra`,
-`-langgraph`, `-langchain`, `-openai-agents`, `-genkit`, `-strands-agents`,
-`-tanstack-ai`, `-claude-agent-sdk`).
+`-langgraph`, `-langchain`, `-openai-agents`, `-genkit`, `-google-adk`,
+`-strands-agents`, `-tanstack-ai`, `-claude-agent-sdk`).
 
 ## Client
 

--- a/arcjet-skills/skills/protect/SKILL.md
+++ b/arcjet-skills/skills/protect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: protect
-description: Add Arcjet request protection to JavaScript and TypeScript HTTP handlers. Use when protecting Next.js, Express, Fastify, SvelteKit, Remix, Bun, Deno, NestJS, or Node.js routes with rate limiting, bot detection, Shield, email validation, or sensitive info detection.
+description: Add Arcjet request protection to JavaScript and TypeScript HTTP handlers. Use when protecting Next.js, Express, Fastify, SvelteKit, Remix, Astro, Nuxt, Bun, Deno, NestJS, or Node.js routes with rate limiting, bot detection, Shield, email validation, or sensitive info detection.
 license: Apache-2.0
 compatibility: JavaScript and TypeScript HTTP apps using an @arcjet/* framework adapter.
 metadata:
@@ -23,10 +23,12 @@ Load `@arcjet/skills#cli` to get an `ARCJET_KEY` before writing code.
 ## Checklist
 
 - [ ] Language is JS/TS (stop if not)
+- [ ] Runtime is Node `>=22.21.0 <23 || >=24.5.0`, Bun ≥ 1.3.0, or Deno stable
 - [ ] `ARCJET_KEY` is in the env file (CLI first; do not leave a TODO)
 - [ ] Shared `arcjet()` client at module scope, `withRule()` for extras
 - [ ] `protect()` inside each route handler, not middleware
 - [ ] Rules that should block use `mode: "LIVE"`
+- [ ] Client IP comes from trusted ingress, not a copied forwarding header
 - [ ] Decisions verified with a real request plus CLI or Console
 
 ## Client
@@ -48,10 +50,15 @@ Pick the adapter the app already uses (`@arcjet/next`, `@arcjet/node`,
 hand-edit `package.json` and guess a version.
 
 Omitted `mode` is `DRY_RUN`. `detectBot` requires exactly one of `allow` or
-`deny`.
+`deny`. `detectPromptInjection` takes `mode` only — no `threshold`.
 
 One client. `withRule()` clones share the decision cache. A second
 `arcjet()` constructor does not.
+
+Astro is an integration (`arcjet:client`), not a shared file. Nuxt is a
+module (`#arcjet`). NestJS is `ArcjetModule` + `@InjectArcjet()`. Bun and
+Deno wrap fetch with `aj.handler()` for IP detection, then still call
+`protect()`. Hono on Node passes `c.env.incoming`.
 
 ## Handler
 
@@ -70,9 +77,25 @@ export async function GET(request: Request) {
 Call `protect()` once per request, in the route handler. Not Express
 middleware. Not Next.js middleware.
 
-Pass a trusted `userId` on the rule that needs it. Pass `ipSrc` only when the
-app already has a trusted client IP. Nested `metadata` is for the Console —
-no secrets, no PII.
+Branch only when the status differs: rate limit → 429; email / PII /
+prompt injection → 400; everything else → 403. `isErrored()` is fail-open —
+log and allow.
+
+Pass a trusted `userId` on the rule that needs it. Pass `correlationId`
+when the decision must join another request or guard call.
+
+## Client IP
+
+If the app already has a trusted client IP, pass `ipSrc`. An empty string
+is omitted. Never copy `X-Forwarded-For` or another client-controlled header
+into `ipSrc` — that relabels attacker input as trusted.
+
+When no usable public address is available, adapters may fall back to
+forwarding headers and log one `unverified-header` warning per client.
+Configure `proxies` (or `cloudflare()`). Inspect with
+`clientIpDetails()` / `findIpDetails()` before shipping.
+
+Nested `metadata` is for the Console — no secrets, no PII.
 
 ## Common mistakes
 
@@ -81,6 +104,8 @@ no secrets, no PII.
 - Double `protect()` (double-counts rate limits)
 - Dry-run rules that look like they block
 - Both `allow` and `deny` on `detectBot`
+- `threshold` on `detectPromptInjection`
+- Copying `X-Forwarded-For` into `ipSrc`
 - Hardcoded `ARCJET_KEY`
 
 ## Verify

--- a/arcjet-skills/src/index.ts
+++ b/arcjet-skills/src/index.ts
@@ -36,7 +36,7 @@ export interface SkillManifest {
 }
 
 const protectDescription: string =
-  "Add Arcjet request protection to JavaScript and TypeScript HTTP handlers. Use when protecting Next.js, Express, Fastify, SvelteKit, Remix, Bun, Deno, NestJS, or Node.js routes with rate limiting, bot detection, Shield, email validation, or sensitive info detection.";
+  "Add Arcjet request protection to JavaScript and TypeScript HTTP handlers. Use when protecting Next.js, Express, Fastify, SvelteKit, Remix, Astro, Nuxt, Bun, Deno, NestJS, or Node.js routes with rate limiting, bot detection, Shield, email validation, or sensitive info detection.";
 
 const chooseProtectionsDescription: string =
   "Choose which Arcjet rules address a security problem. Use when deciding between detectBot, shield, rate limits, detectPromptInjection, sensitiveInfo, validateEmail, filter, or Guard-only content moderation.";

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,6 +188,7 @@
       "devDependencies": {
         "@ai-sdk/provider-utils": "5.0.25",
         "@anthropic-ai/claude-agent-sdk": "0.3.233",
+        "@google/adk": "2.0.0",
         "@langchain/core": "1.2.9",
         "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.59.0",
@@ -211,6 +212,7 @@
       "peerDependencies": {
         "@ai-sdk/provider-utils": ">=5 <6",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0 <1",
+        "@google/adk": ">=2 <3",
         "@langchain/core": ">=1 <2",
         "@langchain/langgraph": ">=1 <2",
         "@mastra/core": ">=1 <2",
@@ -227,6 +229,9 @@
           "optional": true
         },
         "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
           "optional": true
         },
         "@langchain/core": {
@@ -994,6 +999,35 @@
         "node": ">=22.21.0 <23 || >=24.5.0"
       }
     },
+    "node_modules/@a2a-js/sdk": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.14.tgz",
+      "integrity": "sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@a2a-js/sdk-v0_3": {
       "name": "@a2a-js/sdk",
       "version": "0.3.14",
@@ -1421,29 +1455,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.109.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.1.tgz",
-      "integrity": "sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@arcjet/analyze": {
       "resolved": "analyze",
@@ -2251,17 +2262,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
@@ -2789,7 +2789,6 @@
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -2845,24 +2844,10 @@
       "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -3350,15 +3335,6 @@
         "fast-uri": "^3.0.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.2.tgz",
-      "integrity": "sha512-yXSS27qPExaXeuLvMRMXOLtpipzfQYNjG3FkunDWKGfMYjKuhFXko9CVzqxm8jcF+lmtS9Fd89QNdh9XDjnbNg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
@@ -3452,149 +3428,6 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.5.tgz",
-      "integrity": "sha512-qId34pVZ2CXTmtu4ofW5leiI93DvnOvIcr/5GT7MZPw5WXAi6nZoU+g9cNRgl7K90UJSbK0cXxten4meYMPyZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@firebase/app-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.6.tgz",
-      "integrity": "sha512-yPLahy7Esfu2w/yme3msVK4xTkDXQqq6szfQn8yVOQpCKiT5GVFjqNpLbuz6NkX0WuTwUidkmPewW3r4xkvpeg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@firebase/logger": "0.5.2"
-      }
-    },
-    "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.6.tgz",
-      "integrity": "sha512-FgwZqDrBqgK0BHI70QTv1v/5wmuDF9f8fsJFvKSxoRlK2PPfSQtZAk2jhXu4pe9BZzFi/e4UYusU/bEQHdf6Qg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@firebase/component": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.5.tgz",
-      "integrity": "sha512-vuFDcL91Q+2ZuBJkyOh86T4q0B4ffNTDjc/A38tybO56odQABxRTFLTIowCWqAKeIcgo37GowWMVgFF73gD8Qw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@firebase/util": "1.15.3",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@firebase/database": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.5.tgz",
-      "integrity": "sha512-/JGpvszLoNXNgzilRXocigGfFF4hbcPA9wN1i1kjJx6oKkXgkHteZYl3lQs1lJX3ETDf6bv7zI15lPMVUp4sAQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.5",
-        "@firebase/auth-interop-types": "0.2.6",
-        "@firebase/component": "0.7.5",
-        "@firebase/logger": "0.5.2",
-        "@firebase/util": "1.15.3",
-        "faye-websocket": "0.11.4",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@firebase/database-compat": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.7.tgz",
-      "integrity": "sha512-lBq9sJm8MnJINKJnkAKSOj2MbC66xGoSVCcGkPtstl+lkoKEBtD46qHLbuDgW/WbLPoKVm17RIN8BxHj+Z2F2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@firebase/component": "0.7.5",
-        "@firebase/database": "1.1.5",
-        "@firebase/database-types": "1.0.22",
-        "@firebase/logger": "0.5.2",
-        "@firebase/util": "1.15.3",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x",
-        "@firebase/app-compat": "0.x"
-      },
-      "peerDependenciesMeta": {
-        "@firebase/app": {
-          "optional": true
-        },
-        "@firebase/app-compat": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@firebase/database-types": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.22.tgz",
-      "integrity": "sha512-YAZNXsjY9EQQ+pKw/3ax8n5FgolHC7Qew7EY5RceYdl0R2ZP+kCv1O0DkKlcceue8uQCOreHCNN7PWVFpY1Nug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@firebase/app-types": "0.9.6",
-        "@firebase/util": "1.15.3"
-      }
-    },
-    "node_modules/@firebase/logger": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.2.tgz",
-      "integrity": "sha512-J2VO4NFTc0xQFrxV1B/lm5balicm9cwuX2acR9Yn41fN8KgUeQFo+VJV222IqW2FPSXKDu9uo5WdQFWf9TPbYg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@firebase/util": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.3.tgz",
-      "integrity": "sha512-c/z/gaIlaaLZEuGbE6sLUuJ61tskg1JghvhcNQzW948ASBinbVBBRnZTC4b4yt4LaEtJQkYlyzqLHcutFwEIvA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@genkit-ai/ai": {
@@ -4785,172 +4618,733 @@
         "node": ">=14"
       }
     },
-    "node_modules/@google-cloud/storage": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.22.0.tgz",
-      "integrity": "sha512-W98gTQOAntEeEQ7/pZxSQXxfUO5CiQcXJRsxBpUa6UU25n8YN/VtogPBi0H+MAmUrn/6bY/sBhFansoWEsr2/g==",
+    "node_modules/@google-cloud/vertexai": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.12.0.tgz",
+      "integrity": "sha512-XMJIk7GIeavFLP5A3YEUlowKa5Y5PZRrnnuTJcqR0k+lFKkv7+IWpdRp+Xbqb8xNDrvQaE2hP2RYPUylyD5EdA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@google-cloud/paginator": "^5.0.0",
-        "@google-cloud/projectify": "^4.0.0",
-        "@google-cloud/promisify": "<4.1.0",
-        "abort-controller": "^3.0.0",
-        "async-retry": "^1.3.3",
-        "duplexify": "^4.1.3",
-        "fast-xml-parser": "^5.3.4",
-        "gaxios": "^6.0.2",
-        "google-auth-library": "^9.6.3",
-        "html-entities": "^2.5.2",
-        "mime": "^3.0.0",
-        "p-limit": "^3.0.1",
-        "retry-request": "^7.0.0",
-        "teeny-request": "^9.0.0"
+        "@google/genai": "^1.45.0",
+        "google-auth-library": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "node_modules/@google-cloud/vertexai/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "4"
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+    "node_modules/@google-cloud/vertexai/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/@google-cloud/vertexai/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 6"
+        "node": ">=14"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "node_modules/@google-cloud/vertexai/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@google/adk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@google/adk/-/adk-2.0.0.tgz",
+      "integrity": "sha512-510Vsu0/2wYky3DoK5PkO9jtH3YZ4aEF0U/BTar3f0w0r5ZcwQigkTgv6rQB6UnopTV3YJD6yPOlaCJ6p8zBMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@google-cloud/vertexai": "^1.12.0",
+        "@google/genai": "^2.9.0",
+        "@mikro-orm/core": "^6.6.10",
+        "@mikro-orm/reflection": "^6.6.6",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "^0.205.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.205.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.205.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+        "@opentelemetry/resource-detector-gcp": "^0.40.0",
+        "@opentelemetry/resources": "^2.1.0",
+        "@opentelemetry/sdk-logs": "^0.205.0",
+        "@opentelemetry/sdk-metrics": "^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^2.1.0",
+        "@opentelemetry/sdk-trace-node": "^2.1.0",
+        "adm-zip": "^0.5.17",
+        "google-auth-library": "^10.3.0",
+        "js-yaml": "^4.1.1",
+        "jsonpath-plus": "^10.4.0",
+        "lodash-es": "^4.18.1",
+        "winston": "^3.19.0",
+        "zod": "^4.2.1",
+        "zod-to-json-schema": "^3.25.1"
       },
       "peerDependencies": {
-        "encoding": "^0.1.0"
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+        "@google-cloud/storage": "^7.17.1",
+        "@mikro-orm/mariadb": "^6.6.6",
+        "@mikro-orm/mssql": "^6.6.6",
+        "@mikro-orm/mysql": "^6.6.6",
+        "@mikro-orm/postgresql": "^6.6.6",
+        "@mikro-orm/sqlite": "^6.6.6",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "express": "^4.22.1 || ^5.1.0"
       },
       "peerDependenciesMeta": {
-        "encoding": {
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+          "optional": true
+        },
+        "@google-cloud/opentelemetry-cloud-trace-exporter": {
+          "optional": true
+        },
+        "@google-cloud/storage": {
+          "optional": true
+        },
+        "@mikro-orm/mariadb": {
+          "optional": true
+        },
+        "@mikro-orm/mssql": {
+          "optional": true
+        },
+        "@mikro-orm/mysql": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "@mikro-orm/sqlite": {
+          "optional": true
+        },
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "express": {
           "optional": true
         }
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/retry-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
-      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/request": "^2.48.8",
-        "extend": "^3.0.2",
-        "teeny-request": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/teeny-request": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
-      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+    "node_modules/@google/adk/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/api-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+      "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.9",
-        "stream-events": "^1.0.5",
-        "uuid": "^9.0.0"
+        "@opentelemetry/api": "^1.3.0"
       },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.11.0.tgz",
+      "integrity": "sha512-Tr79DyWI8itsBdg+jH+opjfrwLzX+erk1/ExkIwhWoAVjVrJIn2y5+cGjTC0Vy8fyNIA/y8wuJPZwr1T3xCZeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.205.0.tgz",
+      "integrity": "sha512-vr2bwwPCSc9u7rbKc74jR+DXFvyMFQo9o5zs+H/fgbK672Whw/1izUKVf+xfWOdJOvuwTnfWxy+VAY+4TSo74Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.205.0",
+        "@opentelemetry/otlp-transformer": "0.205.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+      "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-transformer": "0.205.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+      "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.205.0",
+        "@opentelemetry/sdk-metrics": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+      "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/resource-detector-gcp": {
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.40.3.tgz",
+      "integrity": "sha512-C796YjBA5P1JQldovApYfFA/8bQwFfpxjUbOtGhn1YZkVTLoNQN+kvBwgALfTPWzug6fWsd0xhn9dzeiUcndag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "gcp-metadata": "^6.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/resources": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+      "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.11.0.tgz",
+      "integrity": "sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.11.0.tgz",
+      "integrity": "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/sdk-trace": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.11.0.tgz",
+      "integrity": "sha512-CuvCMJmZxswhNLlM2LfuLOW3h3fZujA4hsG4B+Sz4dX2zvaXO8Ng74cnDHWD64gLszTlhiG3c0iNUjj4g+0/sA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.11.0",
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/sdk-trace-base": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@google/adk/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/adk/node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/adk/node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/adk/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+    "node_modules/@google/genai": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.21.0.tgz",
+      "integrity": "sha512-+PDtco2/Z0ONdzCGekCoCT+O1VJS9xJQNN4XzQpXG/t3El/SWWMkCWlFRO1KmivOHPa4Q0VjUYu1HBKCZ/v33Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -5004,20 +5398,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@hono/node-server": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
-      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "node_modules/@huggingface/jinja": {
@@ -5657,6 +6037,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -5667,6 +6048,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -5677,6 +6059,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -5687,6 +6070,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -5697,6 +6081,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -5728,6 +6113,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -5750,6 +6136,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@langchain/core": {
@@ -5969,6 +6381,58 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@mikro-orm/core": {
+      "version": "6.6.16",
+      "resolved": "https://registry.npmjs.org/@mikro-orm/core/-/core-6.6.16.tgz",
+      "integrity": "sha512-ym26fbhTti7Zh6oN1y74byoUoMEq1ahckiV7BZX5pHU/0OaUESiQA+Zar2Tv2ZFuZA9946XQ805F7/4NH6oDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "2.2.3",
+        "dotenv": "17.3.1",
+        "esprima": "4.0.1",
+        "fs-extra": "11.3.3",
+        "globby": "11.1.0",
+        "mikro-orm": "6.6.16",
+        "reflect-metadata": "0.2.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/b4nan"
+      }
+    },
+    "node_modules/@mikro-orm/core/node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@mikro-orm/reflection": {
+      "version": "6.6.16",
+      "resolved": "https://registry.npmjs.org/@mikro-orm/reflection/-/reflection-6.6.16.tgz",
+      "integrity": "sha512-OXMhyWOag3Fyz+RyvptHKmwIPXE++5k7aFEt8JVK7YfEjqTvuB9Y7N3jQH08HQXe8VPsYs4RjAKz7DEk5E6JAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globby": "11.1.0",
+        "ts-morph": "27.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": "^6.0.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/client": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
@@ -6000,48 +6464,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
       }
     },
     "node_modules/@modelcontextprotocol/server": {
@@ -6264,20 +6686,43 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
-      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@nosecone/next": {
       "resolved": "nosecone-next",
@@ -6532,6 +6977,322 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.205.0.tgz",
+      "integrity": "sha512-5JteMyVWiro4ghF0tHQjfE6OJcF7UBUcoEqX3UIQ5jutKP1H+fxFdyhqjjpmeHMFxzOHaYuLlNR1Bn7FOjGyJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.205.0",
+        "@opentelemetry/otlp-transformer": "0.205.0",
+        "@opentelemetry/sdk-logs": "0.205.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+      "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+      "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-transformer": "0.205.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+      "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.205.0",
+        "@opentelemetry/sdk-metrics": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+      "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+      "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.205.0.tgz",
+      "integrity": "sha512-fFxNQ/HbbpLmh1pgU6HUVbFD1kNIjrkoluoKJkh88+gnmpFD92kMQ8WFNjPnSbjg2mNVnEkeKXgCYEowNW+p1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.205.0",
+        "@opentelemetry/otlp-transformer": "0.205.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-metrics": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+      "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+      "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-transformer": "0.205.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+      "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.205.0",
+        "@opentelemetry/sdk-metrics": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+      "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+      "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
@@ -7777,6 +8538,24 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.11.0.tgz",
+      "integrity": "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
@@ -7826,13 +8605,45 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
       "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -9363,7 +10174,6 @@
       "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color": "^5.0.2",
         "text-hex": "1.0.x"
@@ -9376,14 +10186,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -9395,6 +10197,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
       "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -9542,6 +10345,57 @@
       "optional": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@turbo/darwin-64": {
@@ -9707,6 +10561,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -9735,19 +10590,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
-      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/ms": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -9859,6 +10701,13 @@
         "form-data": "^2.5.5"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
@@ -9890,13 +10739,13 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -10687,25 +11536,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -10739,7 +11574,6 @@
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -10909,21 +11743,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/anynum": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
-      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/arcjet": {
       "resolved": "arcjet",
       "link": true
@@ -10951,6 +11770,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/arrify": {
       "version": "2.0.1",
@@ -11084,8 +11913,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -11095,18 +11923,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -11152,6 +11968,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -11216,7 +12033,6 @@
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -11237,47 +12053,6 @@
         "wasm-reduce": "bin/wasm-reduce",
         "wasm-shell": "bin/wasm-shell",
         "wasm2js": "bin/wasm2js"
-      }
-    },
-    "node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolbase": {
@@ -11312,13 +12087,25 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -11702,10 +12489,18 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "5.0.3",
@@ -11713,7 +12508,6 @@
       "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^3.1.3",
         "color-string": "^2.1.3"
@@ -11728,7 +12522,6 @@
       "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -11742,7 +12535,6 @@
       "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -11753,7 +12545,6 @@
       "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -11830,21 +12621,6 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -11875,17 +12651,6 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.6.0"
-      }
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -12039,6 +12804,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/db0": {
       "version": "0.3.4",
@@ -12226,6 +12998,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
       "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -12250,6 +13023,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -12439,7 +13225,6 @@
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -12473,8 +13258,7 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -12714,6 +13498,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esprima": {
@@ -12734,6 +13519,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
       "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -12829,6 +13615,7 @@
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -12873,83 +13660,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/exsolve": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
@@ -12991,6 +13701,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stringify": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
@@ -13025,14 +13752,6 @@
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "dev": true,
-      "license": "Unlicense",
-      "peer": true
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -13076,51 +13795,6 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
-      }
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
-      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "path-expression-matcher": "^1.6.2",
-        "xml-naming": "^0.3.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
-      "integrity": "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@nodable/entities": "^3.0.0",
-        "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^2.0.0",
-        "path-expression-matcher": "^1.6.2",
-        "strnum": "^2.4.2",
-        "xml-naming": "^0.3.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastify": {
@@ -13167,21 +13841,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/faye-websocket": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -13205,8 +13864,7 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -13267,27 +13925,17 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
+        "to-regex-range": "^5.0.1"
       },
       "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">=8"
       }
     },
     "node_modules/find-my-way": {
@@ -13360,214 +14008,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/firebase-admin": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.3.0.tgz",
-      "integrity": "sha512-FUxr5HI9C0RNJW3B+CKyJOnIt5uXn/XHheyCECVTLQGSJ/MaE1Zcwf+dCaaG+xx0+VX1A4sZ1t+hc35bu73dVw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@fastify/busboy": "^3.0.0",
-        "@firebase/database-compat": "^2.1.4",
-        "@firebase/database-types": "^1.0.20",
-        "fast-deep-equal": "^3.1.1",
-        "google-auth-library": "^10.6.2",
-        "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "optionalDependencies": {
-        "@google-cloud/firestore": "^8.7.1",
-        "@google-cloud/storage": "^7.22.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/@google-cloud/firestore": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.7.1.tgz",
-      "integrity": "sha512-Hp/WI8sH569ANitsko6RNvCUkzTCYudHoINOkQjiJq2FBG6kKnofBAW7PtS823cu6RMxHqK2RxRcspdjrRpUFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "fast-deep-equal": "^3.1.3",
-        "functional-red-black-tree": "^1.0.1",
-        "google-gax": "^5.0.1",
-        "protobufjs": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/@grpc/proto-loader": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
-      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.5.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/gaxios": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
-      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/google-auth-library": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
-      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/google-gax": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
-      "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@grpc/grpc-js": "^1.12.6",
-        "@grpc/proto-loader": "^0.8.0",
-        "duplexify": "^4.1.3",
-        "google-auth-library": "10.5.0",
-        "google-logging-utils": "1.1.3",
-        "node-fetch": "^3.3.2",
-        "object-hash": "^3.0.0",
-        "proto3-json-serializer": "3.0.4",
-        "protobufjs": "^7.5.4",
-        "retry-request": "^8.0.2",
-        "rimraf": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/google-gax/node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/proto3-json-serializer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
-      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "protobufjs": "^7.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/flatbuffers": {
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
@@ -13589,8 +14029,7 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fontace": {
       "version": "0.4.1",
@@ -13700,15 +14139,19 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+    "node_modules/fs-extra": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -13750,7 +14193,6 @@
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -13768,7 +14210,6 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -13782,7 +14223,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13804,7 +14244,6 @@
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -13974,6 +14413,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/global-agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
@@ -14007,13 +14459,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -14158,7 +14640,6 @@
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -14208,6 +14689,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -14262,7 +14750,6 @@
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -14492,17 +14979,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hono": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
-      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/hookable": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
@@ -14574,15 +15050,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-parser-js": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -14604,7 +15071,6 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -14628,24 +15094,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -14712,17 +15160,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
@@ -14785,6 +15222,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -14793,6 +15240,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-interactive": {
@@ -14821,6 +15281,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -14845,18 +15315,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -14887,21 +15350,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-unsafe": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
-      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -14997,13 +15445,22 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -15035,21 +15492,6 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-to-zod": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
@@ -15066,14 +15508,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -15101,29 +15535,36 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
       },
       "engines": {
-        "node": ">=12",
-        "npm": ">=6"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jwa": {
@@ -15132,31 +15573,10 @@
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jwks-rsa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.1.0.tgz",
-      "integrity": "sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/jsonwebtoken": "^9.0.4",
-        "debug": "^4.3.4",
-        "jose": "^6.1.3",
-        "limiter": "^1.1.5",
-        "lru-cache": "^11.0.0",
-        "lru-memoizer": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
       }
     },
     "node_modules/jws": {
@@ -15165,7 +15585,6 @@
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -15213,8 +15632,7 @@
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/langchain": {
       "version": "1.5.10",
@@ -15606,14 +16024,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/limiter": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
-      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/load-esm": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
@@ -15638,6 +16048,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -15646,69 +16064,6 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/lodash.mapvalues": {
       "version": "4.6.0",
@@ -15724,15 +16079,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",
@@ -15770,7 +16116,6 @@
       "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -15824,23 +16169,11 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/lru-memoizer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
-      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "^11.0.1"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -16133,33 +16466,14 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/media-typer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
-      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">= 8"
       }
     },
     "node_modules/methods": {
@@ -16763,48 +17077,41 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "mime-db": "^1.54.0"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mikro-orm": {
+      "version": "6.6.16",
+      "resolved": "https://registry.npmjs.org/mikro-orm/-/mikro-orm-6.6.16.tgz",
+      "integrity": "sha512-42bvve+XSzvBpOuZeZxJsM5aW4DQnDn23E5to4cvEjUdaPX7jg1bRh+l8f/8/WJJNzG1T05V5vHSe+SHzqN87A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
       }
     },
     "node_modules/mimic-function": {
@@ -16978,17 +17285,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/neo-async": {
@@ -17531,6 +17827,7 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -17541,7 +17838,6 @@
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "fn.name": "1.x.x"
       }
@@ -17926,23 +18222,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
-      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -17987,16 +18272,14 @@
       "license": "ISC",
       "optional": true
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -18123,6 +18406,7 @@
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -18426,6 +18710,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -18439,38 +18744,6 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/range-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
-      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/rc9": {
       "version": "3.0.1",
@@ -18541,7 +18814,6 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -18784,8 +19056,6 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -18956,22 +19226,28 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -19142,34 +19418,6 @@
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "license": "MIT"
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -19183,27 +19431,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -19430,6 +19657,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
@@ -19530,21 +19767,8 @@
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {
@@ -19602,7 +19826,6 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -19755,24 +19978,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
-      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anynum": "^1.0.1"
-      }
-    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -19846,44 +20051,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svelte": {
-      "version": "5.56.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.7.tgz",
-      "integrity": "sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.10",
-        "@types/estree": "^1.0.5",
-        "@types/trusted-types": "^2.0.7",
-        "acorn": "^8.12.1",
-        "aria-query": "5.3.1",
-        "axobject-query": "^4.1.0",
-        "clsx": "^2.1.1",
-        "devalue": "^5.8.1",
-        "esm-env": "^1.2.1",
-        "esrap": "^2.2.12",
-        "is-reference": "^3.0.3",
-        "locate-character": "^3.0.0",
-        "magic-string": "^0.30.11",
-        "zimmerframe": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/svelte/node_modules/aria-query": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
-      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/svgo": {
@@ -19970,8 +20137,7 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "4.2.0",
@@ -20047,6 +20213,19 @@
         "node": "^20.0.0 || >=22.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toad-cache": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
@@ -20108,8 +20287,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -20138,7 +20316,6 @@
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -20154,13 +20331,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
+      }
     },
     "node_modules/tsdown": {
       "version": "0.22.14",
@@ -20572,41 +20752,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typescript": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
@@ -20889,6 +21034,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -21033,8 +21188,7 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -21252,37 +21406,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true
-    },
-    "node_modules/websocket-driver": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
-      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "http-parser-js": ">=0.5.1",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/websocket-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -21290,7 +21414,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -21318,7 +21441,6 @@
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -21342,7 +21464,6 @@
       "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
@@ -21358,7 +21479,6 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -21531,7 +21651,8 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -21553,24 +21674,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
-      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {
@@ -21815,6 +21918,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,7 @@
         "@langchain/core": "1.2.9",
         "@langchain/langgraph": "1.4.10",
         "@mastra/core": "1.59.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@openai/agents": "0.17.0",
         "@strands-agents/sdk": "1.14.0",
         "@tanstack/ai": "0.52.0",
@@ -5400,6 +5401,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
@@ -6037,7 +6051,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6048,7 +6061,6 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -6059,7 +6071,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -6070,7 +6081,6 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -6081,7 +6091,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -6113,7 +6122,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -6464,6 +6472,47 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@modelcontextprotocol/server": {
@@ -10197,7 +10246,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
       "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -10561,7 +10609,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -11536,11 +11583,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -11968,7 +12028,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12053,6 +12112,45 @@
         "wasm-reduce": "bin/wasm-reduce",
         "wasm-shell": "bin/wasm-shell",
         "wasm2js": "bin/wasm2js"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolbase": {
@@ -12489,7 +12587,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12621,6 +12718,20 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -12651,6 +12762,16 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -12998,7 +13119,6 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
       "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -13498,7 +13618,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esprima": {
@@ -13519,7 +13638,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
       "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -13615,7 +13733,6 @@
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -13658,6 +13775,80 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/exsolve": {
@@ -13938,6 +14129,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
@@ -14137,6 +14350,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -14979,6 +15202,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookable": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
@@ -15096,6 +15329,23 @@
         "node": ">=18.18.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -15159,6 +15409,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.4.0",
@@ -15315,11 +15575,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -15508,6 +15774,13 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -16048,7 +16321,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -16173,7 +16445,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -16465,6 +16736,33 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -17114,6 +17412,33 @@
         "node": ">= 18.12.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -17285,6 +17610,37 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/neo-async": {
@@ -17827,7 +18183,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -18272,6 +18627,17 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -18406,7 +18772,6 @@
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -18744,6 +19109,36 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc9": {
       "version": "3.0.1",
@@ -19226,6 +19621,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -19418,6 +19830,33 @@
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -19431,6 +19870,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -20051,6 +20510,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.57.0.tgz",
+      "integrity": "sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte/node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/svgo": {
@@ -20750,6 +21246,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -21651,8 +22180,7 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -21918,7 +22446,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "packageManager": "npm@12.0.1",
   "allowScripts": {
     "@firebase/util": false,
+    "@google/genai": false,
     "esbuild": false,
     "fsevents": false,
     "onnxruntime-node": false,

--- a/renovate.json
+++ b/renovate.json
@@ -97,6 +97,13 @@
       "allowedVersions": "<1"
     },
     {
+      "description": "Never automerge @google/adk majors. `@arcjet/guard/google-adk/v2` types against BasePlugin.beforeToolCallback, Runner({ plugins }), PluginManager first-win short-circuit, and the deny-dict skip shape (a returned Record skips runAsync; undefined executes; a throw is a plugin error). A green typecheck is necessary but not sufficient: the namespace also depends on PluginManager calling methods by name (missing callbacks throw) and on returning a value short-circuiting remaining plugins — runtime contracts a typecheck cannot see. Keep the range on 2.x; google-adk/v3 is added deliberately, not by a bump.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@google/adk"],
+      "automerge": false,
+      "allowedVersions": "<3"
+    },
+    {
       "description": "Never automerge @tanstack/ai. It is pre-1.0, so a minor release may break. `@arcjet/guard/tanstack-ai/v0` types against ChatMiddleware, onBeforeToolCall, BeforeToolCallDecision, and chat({ context }). A green typecheck is necessary but not sufficient: the namespace also depends on onBeforeToolCall first-win composition (a preceding toolCacheMiddleware skip means Guard never runs) and on execute throws being swallowed into { error } — runtime contracts a typecheck cannot see. Keep the range below 1.0; tanstack-ai/v1 is added deliberately, not by a bump. This rule is last in packageRules so it wins over the devDependencies and patch automerge rules above.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["@tanstack/ai"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `@arcjet/guard/google-adk/v2` for Google ADK JS (`@google/adk` 2.x).

```ts
import { launchArcjet, detectPromptInjection, tokenBucket } from "@arcjet/guard";
import { guardPlugin, googleAdkContext } from "@arcjet/guard/google-adk/v2";
import { Runner } from "@google/adk";

const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
const limit = tokenBucket({ refillRate: 10, intervalSeconds: 60, maxTokens: 10 });

const inbound = await arcjet.guard({
  label: "message.received",
  rules: [detectPromptInjection()(userText)],
  ...googleAdkContext({ context: { sessionId: conversationId } }),
});
if (inbound.conclusion === "DENY" || inbound.hasFailedOpen()) {
  throw new Error("message blocked");
}

const runner = new Runner({
  appName: "my_app",
  agent,
  sessionService,
  plugins: [
    guardPlugin(arcjet, {
      action: ({ toolName }) => `${toolName}.invoked`,
      rules: ({ toolName }) => [limit({ key: toolName, requested: 1 })],
      sessionId: conversationId,
    }),
  ],
});
```

- Exports `guardPlugin` + `googleAdkContext` only (no `guardTool` / `guardInbound` / `guardApproval`)
- Path is `/v2` — `@arcjet/guard/google-adk` does not resolve
- Optional type-only peer `@google/adk` `>=2 <3` (dev pin `2.0.0`)
- DENY returns an `ArcjetDenialResult` dict (ADK skips `runAsync`); ALLOW returns `undefined`
- Put Arcjet first in `plugins`. Screen inbound with `guard()` before `runAsync`
- Docs: [`/guards/google-adk/`](https://docs.arcjet.com/guards/google-adk/)

Also syncs the versioned JS skills from [`arcjet/skills`](https://github.com/arcjet/skills) (client-IP provenance, framework-specific HTTP setup, Guard fail-open / Rampart notes) and reviews Guard vendor skills so HITL lists include Google ADK `requireConfirmation`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b377ce47-5ff0-4b38-8eca-b81553d72fa8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b377ce47-5ff0-4b38-8eca-b81553d72fa8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

