### PR TITLE
ci: allow the background traffic from the Windows and macOS runners

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,79 +37,59 @@ jobs:
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          # The OS entries below are background traffic from the Windows and
-          # macOS runner images — push and notification services, connectivity
-          # probes, certificate revocation checks and time sync — not anything
-          # this repository requests. They are allowed so the egress policy
-          # reports a real anomaly rather than the runner talking to its vendor.
-          # The same list is used by every job that runs a non-Linux runner, so
-          # the three lists cannot drift apart.
+          # The wildcard entries below are background traffic from the Windows
+          # and macOS runner images — push and notification services, media and
+          # software CDNs, connectivity probes, certificate revocation and time
+          # sync — not anything this repository requests. StepSecurity documents
+          # wildcards for exactly this: "For services that rotate subdomains,
+          # such as AWS or Azure CDNs, use wildcard patterns to prevent
+          # repetitive alerts." Apple rotates its CDN names per lookup, so
+          # naming them one at a time does not converge. Each wildcard is scoped
+          # to a single vendor's own domain. The same list is used by every job
+          # with a non-Linux runner so the three cannot drift apart.
           allowed-endpoints: >
-            0.pool.ntp.org:123
-            api.apple-cloudkit.com:443
+            *.aaplimg.com:443
+            *.apple-cloudkit.com:443
+            *.apple.com:443
+            *.cdn-apple.com:443
+            *.cloudflare.com:443
+            *.data.microsoft.com:443
+            *.digicert.com:443
+            *.digicert.com:80
+            *.events.data.microsoft.com:443
+            *.fastly-edge.com:443
+            *.g.aaplimg.com:443
+            *.iadsdk.apple.com:443
+            *.icloud.com:443
+            *.itunes.apple.com:443
+            *.ls.apple.com:443
+            *.microsoft.com:443
+            *.msftconnecttest.com:443
+            *.msftconnecttest.com:80
+            *.msftncsi.com:443
+            *.msftncsi.com:80
+            *.mzstatic.com:443
+            *.pcms.apple.com:443
+            *.pool.ntp.org:123
+            *.safebrowsing.apple:443
+            *.sectigo.com:443
+            *.sectigo.com:80
+            *.sls.update.microsoft.com:443
+            *.smoot.apple.com:443
+            *.stepsecurity.io:443
+            *.telemetry.mozilla.org:443
+            *.update.microsoft.com:443
+            *.usertrust.com:443
+            *.usertrust.com:80
+            *.wns.windows.com:443
             api.github.com:443
-            api.smoot.apple.com:443
-            apps.mzstatic.com:443
-            bag.itunes.apple.com:443
-            cds.apple.com:443
-            cf.iadsdk.apple.com:443
-            client.wns.windows.com:443
-            configuration.apple.com:443
-            cp10.cloudflare.com:443
-            crl.sectigo.com:443
-            crl.sectigo.com:80
             decide.arcjet.com:443
-            device-config.pcms.apple.com:443
-            experiments.apple.com:443
-            fe2cr.update.microsoft.com:443
-            fpinit.itunes.apple.com:443
-            gateway.icloud.com:443
-            gdmf-ados.apple.com:443
             github.com:443
-            go.microsoft.com:443
-            gsp-ssl.ls.apple.com:443
-            gspe1-ssl.ls.apple.com:443
-            gspe35-ssl.ls.apple.com:443
-            help.apple.com:443
-            iadsdk.apple.com:443
-            incoming.telemetry.mozilla.org:443
-            init.itunes.apple.com:443
-            int1.stepsecurity.io:443
-            ipcdn.apple.com:443
-            ipv6.msftconnecttest.com:443
-            ipv6.msftconnecttest.com:80
-            ipv6.msftncsi.com:443
-            ipv6.msftncsi.com:80
-            itunes.apple.com:443
-            mask-api.icloud.com:443
-            mobile.events.data.microsoft.com:443
             objects.githubusercontent.com:443
-            ocsp.digicert.com:443
-            ocsp.digicert.com:80
-            ocsp.sectigo.com:443
-            ocsp.sectigo.com:80
-            ocsp.usertrust.com:443
-            ocsp.usertrust.com:80
-            ohttp-relay1.fastly-edge.com:443
-            pancake.apple.com:443
             prod.ingestion-edge.prod.dataservices.mozgcp.net:443
-            proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             safebrowsing.googleapis.com:443
-            sas.pcms.apple.com:443
-            settings-win.data.microsoft.com:443
-            stocks-data-service.apple.com:443
-            swallow.apple.com:443
-            tas02.sls.update.microsoft.com:443
-            token.safebrowsing.apple:443
-            updates.cdn-apple.com:443
-            www.msftconnecttest.com:443
-            www.msftconnecttest.com:80
-            www.msftncsi.com:443
-            www.msftncsi.com:80
-            xp.apple.com:443
-            xp.g.aaplimg.com:443
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
@@ -168,82 +148,62 @@ jobs:
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          # The OS entries below are background traffic from the Windows and
-          # macOS runner images — push and notification services, connectivity
-          # probes, certificate revocation checks and time sync — not anything
-          # this repository requests. They are allowed so the egress policy
-          # reports a real anomaly rather than the runner talking to its vendor.
-          # The same list is used by every job that runs a non-Linux runner, so
-          # the three lists cannot drift apart.
+          # The wildcard entries below are background traffic from the Windows
+          # and macOS runner images — push and notification services, media and
+          # software CDNs, connectivity probes, certificate revocation and time
+          # sync — not anything this repository requests. StepSecurity documents
+          # wildcards for exactly this: "For services that rotate subdomains,
+          # such as AWS or Azure CDNs, use wildcard patterns to prevent
+          # repetitive alerts." Apple rotates its CDN names per lookup, so
+          # naming them one at a time does not converge. Each wildcard is scoped
+          # to a single vendor's own domain. The same list is used by every job
+          # with a non-Linux runner so the three cannot drift apart.
           allowed-endpoints: >
-            0.pool.ntp.org:123
-            api.apple-cloudkit.com:443
+            *.aaplimg.com:443
+            *.apple-cloudkit.com:443
+            *.apple.com:443
+            *.cdn-apple.com:443
+            *.cloudflare.com:443
+            *.data.microsoft.com:443
+            *.digicert.com:443
+            *.digicert.com:80
+            *.events.data.microsoft.com:443
+            *.fastly-edge.com:443
+            *.g.aaplimg.com:443
+            *.iadsdk.apple.com:443
+            *.icloud.com:443
+            *.itunes.apple.com:443
+            *.ls.apple.com:443
+            *.microsoft.com:443
+            *.msftconnecttest.com:443
+            *.msftconnecttest.com:80
+            *.msftncsi.com:443
+            *.msftncsi.com:80
+            *.mzstatic.com:443
+            *.pcms.apple.com:443
+            *.pool.ntp.org:123
+            *.safebrowsing.apple:443
+            *.sectigo.com:443
+            *.sectigo.com:80
+            *.sls.update.microsoft.com:443
+            *.smoot.apple.com:443
+            *.stepsecurity.io:443
+            *.telemetry.mozilla.org:443
+            *.update.microsoft.com:443
+            *.usertrust.com:443
+            *.usertrust.com:80
+            *.wns.windows.com:443
             api.github.com:443
-            api.smoot.apple.com:443
-            apps.mzstatic.com:443
-            bag.itunes.apple.com:443
-            cds.apple.com:443
-            cf.iadsdk.apple.com:443
-            client.wns.windows.com:443
-            configuration.apple.com:443
-            cp10.cloudflare.com:443
-            crl.sectigo.com:443
-            crl.sectigo.com:80
             decide.arcjet.com:443
             deno.com:443
-            device-config.pcms.apple.com:443
             dl.deno.land:443
-            experiments.apple.com:443
-            fe2cr.update.microsoft.com:443
-            fpinit.itunes.apple.com:443
-            gateway.icloud.com:443
-            gdmf-ados.apple.com:443
             github.com:443
-            go.microsoft.com:443
-            gsp-ssl.ls.apple.com:443
-            gspe1-ssl.ls.apple.com:443
-            gspe35-ssl.ls.apple.com:443
-            help.apple.com:443
-            iadsdk.apple.com:443
-            incoming.telemetry.mozilla.org:443
-            init.itunes.apple.com:443
-            int1.stepsecurity.io:443
-            ipcdn.apple.com:443
-            ipv6.msftconnecttest.com:443
-            ipv6.msftconnecttest.com:80
-            ipv6.msftncsi.com:443
-            ipv6.msftncsi.com:80
-            itunes.apple.com:443
-            mask-api.icloud.com:443
-            mobile.events.data.microsoft.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
-            ocsp.digicert.com:443
-            ocsp.digicert.com:80
-            ocsp.sectigo.com:443
-            ocsp.sectigo.com:80
-            ocsp.usertrust.com:443
-            ocsp.usertrust.com:80
-            ohttp-relay1.fastly-edge.com:443
-            pancake.apple.com:443
             prod.ingestion-edge.prod.dataservices.mozgcp.net:443
-            proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             safebrowsing.googleapis.com:443
-            sas.pcms.apple.com:443
-            settings-win.data.microsoft.com:443
-            stocks-data-service.apple.com:443
-            swallow.apple.com:443
-            tas02.sls.update.microsoft.com:443
-            token.safebrowsing.apple:443
-            updates.cdn-apple.com:443
-            www.msftconnecttest.com:443
-            www.msftconnecttest.com:80
-            www.msftncsi.com:443
-            www.msftncsi.com:80
-            xp.apple.com:443
-            xp.g.aaplimg.com:443
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
@@ -316,80 +276,60 @@ jobs:
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
-          # The OS entries below are background traffic from the Windows and
-          # macOS runner images — push and notification services, connectivity
-          # probes, certificate revocation checks and time sync — not anything
-          # this repository requests. They are allowed so the egress policy
-          # reports a real anomaly rather than the runner talking to its vendor.
-          # The same list is used by every job that runs a non-Linux runner, so
-          # the three lists cannot drift apart.
+          # The wildcard entries below are background traffic from the Windows
+          # and macOS runner images — push and notification services, media and
+          # software CDNs, connectivity probes, certificate revocation and time
+          # sync — not anything this repository requests. StepSecurity documents
+          # wildcards for exactly this: "For services that rotate subdomains,
+          # such as AWS or Azure CDNs, use wildcard patterns to prevent
+          # repetitive alerts." Apple rotates its CDN names per lookup, so
+          # naming them one at a time does not converge. Each wildcard is scoped
+          # to a single vendor's own domain. The same list is used by every job
+          # with a non-Linux runner so the three cannot drift apart.
           allowed-endpoints: >
-            0.pool.ntp.org:123
-            api.apple-cloudkit.com:443
+            *.aaplimg.com:443
+            *.apple-cloudkit.com:443
+            *.apple.com:443
+            *.cdn-apple.com:443
+            *.cloudflare.com:443
+            *.data.microsoft.com:443
+            *.digicert.com:443
+            *.digicert.com:80
+            *.events.data.microsoft.com:443
+            *.fastly-edge.com:443
+            *.g.aaplimg.com:443
+            *.iadsdk.apple.com:443
+            *.icloud.com:443
+            *.itunes.apple.com:443
+            *.ls.apple.com:443
+            *.microsoft.com:443
+            *.msftconnecttest.com:443
+            *.msftconnecttest.com:80
+            *.msftncsi.com:443
+            *.msftncsi.com:80
+            *.mzstatic.com:443
+            *.pcms.apple.com:443
+            *.pool.ntp.org:123
+            *.safebrowsing.apple:443
+            *.sectigo.com:443
+            *.sectigo.com:80
+            *.sls.update.microsoft.com:443
+            *.smoot.apple.com:443
+            *.stepsecurity.io:443
+            *.telemetry.mozilla.org:443
+            *.update.microsoft.com:443
+            *.usertrust.com:443
+            *.usertrust.com:80
+            *.wns.windows.com:443
             api.github.com:443
-            api.smoot.apple.com:443
-            apps.mzstatic.com:443
-            bag.itunes.apple.com:443
-            cds.apple.com:443
-            cf.iadsdk.apple.com:443
-            client.wns.windows.com:443
-            configuration.apple.com:443
-            cp10.cloudflare.com:443
-            crl.sectigo.com:443
-            crl.sectigo.com:80
             decide.arcjet.com:443
-            device-config.pcms.apple.com:443
-            experiments.apple.com:443
-            fe2cr.update.microsoft.com:443
-            fpinit.itunes.apple.com:443
-            gateway.icloud.com:443
-            gdmf-ados.apple.com:443
             github.com:443
-            go.microsoft.com:443
-            gsp-ssl.ls.apple.com:443
-            gspe1-ssl.ls.apple.com:443
-            gspe35-ssl.ls.apple.com:443
-            help.apple.com:443
-            iadsdk.apple.com:443
-            incoming.telemetry.mozilla.org:443
-            init.itunes.apple.com:443
-            int1.stepsecurity.io:443
-            ipcdn.apple.com:443
-            ipv6.msftconnecttest.com:443
-            ipv6.msftconnecttest.com:80
-            ipv6.msftncsi.com:443
-            ipv6.msftncsi.com:80
-            itunes.apple.com:443
-            mask-api.icloud.com:443
-            mobile.events.data.microsoft.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
-            ocsp.digicert.com:443
-            ocsp.digicert.com:80
-            ocsp.sectigo.com:443
-            ocsp.sectigo.com:80
-            ocsp.usertrust.com:443
-            ocsp.usertrust.com:80
-            ohttp-relay1.fastly-edge.com:443
-            pancake.apple.com:443
             prod.ingestion-edge.prod.dataservices.mozgcp.net:443
-            proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             safebrowsing.googleapis.com:443
-            sas.pcms.apple.com:443
-            settings-win.data.microsoft.com:443
-            stocks-data-service.apple.com:443
-            swallow.apple.com:443
-            tas02.sls.update.microsoft.com:443
-            token.safebrowsing.apple:443
-            updates.cdn-apple.com:443
-            www.msftconnecttest.com:443
-            www.msftconnecttest.com:80
-            www.msftncsi.com:443
-            www.msftncsi.com:80
-            xp.apple.com:443
-            xp.g.aaplimg.com:443
 
       # Checkout
       # Most toolchains require checkout first

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -75,6 +75,7 @@ jobs:
             *.pcms.apple.com:443
             *.pool.ntp.org:123
             *.safebrowsing.apple:443
+            *.safebrowsing.apple:80
             *.sectigo.com:443
             *.sectigo.com:80
             *.sls.update.microsoft.com:443
@@ -86,14 +87,20 @@ jobs:
             *.usertrust.com:80
             *.wns.windows.com:443
             *.wrr.me.apple-dns.net:443
+            0.pool.ntp.org:443
             api.github.com:443
             decide.arcjet.com:443
             github.com:443
+            h3.apis.apple.map.fastly.net:443
+            login.live.com:443
+            mesu-cdn.origin-apple.com.akadns.net:443
             objects.githubusercontent.com:443
+            ocsp.comodoca.com:443
             prod.ingestion-edge.prod.dataservices.mozgcp.net:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             safebrowsing.googleapis.com:443
+            tas02.cwsmu.update.microsoft.com:443
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
@@ -190,6 +197,7 @@ jobs:
             *.pcms.apple.com:443
             *.pool.ntp.org:123
             *.safebrowsing.apple:443
+            *.safebrowsing.apple:80
             *.sectigo.com:443
             *.sectigo.com:80
             *.sls.update.microsoft.com:443
@@ -201,17 +209,23 @@ jobs:
             *.usertrust.com:80
             *.wns.windows.com:443
             *.wrr.me.apple-dns.net:443
+            0.pool.ntp.org:443
             api.github.com:443
             decide.arcjet.com:443
             deno.com:443
             dl.deno.land:443
             github.com:443
+            h3.apis.apple.map.fastly.net:443
+            login.live.com:443
+            mesu-cdn.origin-apple.com.akadns.net:443
             nodejs.org:443
             objects.githubusercontent.com:443
+            ocsp.comodoca.com:443
             prod.ingestion-edge.prod.dataservices.mozgcp.net:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             safebrowsing.googleapis.com:443
+            tas02.cwsmu.update.microsoft.com:443
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
@@ -322,6 +336,7 @@ jobs:
             *.pcms.apple.com:443
             *.pool.ntp.org:123
             *.safebrowsing.apple:443
+            *.safebrowsing.apple:80
             *.sectigo.com:443
             *.sectigo.com:80
             *.sls.update.microsoft.com:443
@@ -333,15 +348,21 @@ jobs:
             *.usertrust.com:80
             *.wns.windows.com:443
             *.wrr.me.apple-dns.net:443
+            0.pool.ntp.org:443
             api.github.com:443
             decide.arcjet.com:443
             github.com:443
+            h3.apis.apple.map.fastly.net:443
+            login.live.com:443
+            mesu-cdn.origin-apple.com.akadns.net:443
             nodejs.org:443
             objects.githubusercontent.com:443
+            ocsp.comodoca.com:443
             prod.ingestion-edge.prod.dataservices.mozgcp.net:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             safebrowsing.googleapis.com:443
+            tas02.cwsmu.update.microsoft.com:443
 
       # Checkout
       # Most toolchains require checkout first

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -88,6 +88,8 @@ jobs:
             *.wns.windows.com:443
             *.wrr.me.apple-dns.net:443
             0.pool.ntp.org:443
+            api.apple-cloudkit.com:443
+            api.apple-cloudkit.fe2.apple-dns.net:443
             api.github.com:443
             decide.arcjet.com:443
             github.com:443
@@ -210,6 +212,8 @@ jobs:
             *.wns.windows.com:443
             *.wrr.me.apple-dns.net:443
             0.pool.ntp.org:443
+            api.apple-cloudkit.com:443
+            api.apple-cloudkit.fe2.apple-dns.net:443
             api.github.com:443
             decide.arcjet.com:443
             deno.com:443
@@ -349,6 +353,8 @@ jobs:
             *.wns.windows.com:443
             *.wrr.me.apple-dns.net:443
             0.pool.ntp.org:443
+            api.apple-cloudkit.com:443
+            api.apple-cloudkit.fe2.apple-dns.net:443
             api.github.com:443
             decide.arcjet.com:443
             github.com:443

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,13 +37,79 @@ jobs:
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # The OS entries below are background traffic from the Windows and
+          # macOS runner images — push and notification services, connectivity
+          # probes, certificate revocation checks and time sync — not anything
+          # this repository requests. They are allowed so the egress policy
+          # reports a real anomaly rather than the runner talking to its vendor.
+          # The same list is used by every job that runs a non-Linux runner, so
+          # the three lists cannot drift apart.
           allowed-endpoints: >
+            0.pool.ntp.org:123
+            api.apple-cloudkit.com:443
             api.github.com:443
+            api.smoot.apple.com:443
+            apps.mzstatic.com:443
+            bag.itunes.apple.com:443
+            cds.apple.com:443
+            cf.iadsdk.apple.com:443
+            client.wns.windows.com:443
+            configuration.apple.com:443
+            cp10.cloudflare.com:443
+            crl.sectigo.com:443
+            crl.sectigo.com:80
             decide.arcjet.com:443
+            device-config.pcms.apple.com:443
+            experiments.apple.com:443
+            fe2cr.update.microsoft.com:443
+            fpinit.itunes.apple.com:443
+            gateway.icloud.com:443
+            gdmf-ados.apple.com:443
             github.com:443
+            go.microsoft.com:443
+            gsp-ssl.ls.apple.com:443
+            gspe1-ssl.ls.apple.com:443
+            gspe35-ssl.ls.apple.com:443
+            help.apple.com:443
+            iadsdk.apple.com:443
+            incoming.telemetry.mozilla.org:443
+            init.itunes.apple.com:443
+            int1.stepsecurity.io:443
+            ipcdn.apple.com:443
+            ipv6.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:80
+            ipv6.msftncsi.com:443
+            ipv6.msftncsi.com:80
+            itunes.apple.com:443
+            mask-api.icloud.com:443
+            mobile.events.data.microsoft.com:443
             objects.githubusercontent.com:443
+            ocsp.digicert.com:443
+            ocsp.digicert.com:80
+            ocsp.sectigo.com:443
+            ocsp.sectigo.com:80
+            ocsp.usertrust.com:443
+            ocsp.usertrust.com:80
+            ohttp-relay1.fastly-edge.com:443
+            pancake.apple.com:443
+            prod.ingestion-edge.prod.dataservices.mozgcp.net:443
+            proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            safebrowsing.googleapis.com:443
+            sas.pcms.apple.com:443
+            settings-win.data.microsoft.com:443
+            stocks-data-service.apple.com:443
+            swallow.apple.com:443
+            tas02.sls.update.microsoft.com:443
+            token.safebrowsing.apple:443
+            updates.cdn-apple.com:443
+            www.msftconnecttest.com:443
+            www.msftconnecttest.com:80
+            www.msftncsi.com:443
+            www.msftncsi.com:80
+            xp.apple.com:443
+            xp.g.aaplimg.com:443
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
@@ -107,6 +173,8 @@ jobs:
           # probes, certificate revocation checks and time sync — not anything
           # this repository requests. They are allowed so the egress policy
           # reports a real anomaly rather than the runner talking to its vendor.
+          # The same list is used by every job that runs a non-Linux runner, so
+          # the three lists cannot drift apart.
           allowed-endpoints: >
             0.pool.ntp.org:123
             api.apple-cloudkit.com:443
@@ -118,6 +186,7 @@ jobs:
             cf.iadsdk.apple.com:443
             client.wns.windows.com:443
             configuration.apple.com:443
+            cp10.cloudflare.com:443
             crl.sectigo.com:443
             crl.sectigo.com:80
             decide.arcjet.com:443
@@ -155,7 +224,9 @@ jobs:
             ocsp.sectigo.com:80
             ocsp.usertrust.com:443
             ocsp.usertrust.com:80
+            ohttp-relay1.fastly-edge.com:443
             pancake.apple.com:443
+            prod.ingestion-edge.prod.dataservices.mozgcp.net:443
             proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
@@ -250,6 +321,8 @@ jobs:
           # probes, certificate revocation checks and time sync — not anything
           # this repository requests. They are allowed so the egress policy
           # reports a real anomaly rather than the runner talking to its vendor.
+          # The same list is used by every job that runs a non-Linux runner, so
+          # the three lists cannot drift apart.
           allowed-endpoints: >
             0.pool.ntp.org:123
             api.apple-cloudkit.com:443
@@ -261,6 +334,7 @@ jobs:
             cf.iadsdk.apple.com:443
             client.wns.windows.com:443
             configuration.apple.com:443
+            cp10.cloudflare.com:443
             crl.sectigo.com:443
             crl.sectigo.com:80
             decide.arcjet.com:443
@@ -296,7 +370,9 @@ jobs:
             ocsp.sectigo.com:80
             ocsp.usertrust.com:443
             ocsp.usertrust.com:80
+            ohttp-relay1.fastly-edge.com:443
             pancake.apple.com:443
+            prod.ingestion-edge.prod.dataservices.mozgcp.net:443
             proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -50,6 +50,8 @@ jobs:
           allowed-endpoints: >
             *.aaplimg.com:443
             *.apple-cloudkit.com:443
+            *.apple-cloudkit.fe2.apple-dns.net:443
+            *.apple-dns.net:443
             *.apple.com:443
             *.cdn-apple.com:443
             *.cloudflare.com:443
@@ -58,6 +60,7 @@ jobs:
             *.digicert.com:80
             *.events.data.microsoft.com:443
             *.fastly-edge.com:443
+            *.fe2.apple-dns.net:443
             *.g.aaplimg.com:443
             *.iadsdk.apple.com:443
             *.icloud.com:443
@@ -82,6 +85,7 @@ jobs:
             *.usertrust.com:443
             *.usertrust.com:80
             *.wns.windows.com:443
+            *.wrr.me.apple-dns.net:443
             api.github.com:443
             decide.arcjet.com:443
             github.com:443
@@ -161,6 +165,8 @@ jobs:
           allowed-endpoints: >
             *.aaplimg.com:443
             *.apple-cloudkit.com:443
+            *.apple-cloudkit.fe2.apple-dns.net:443
+            *.apple-dns.net:443
             *.apple.com:443
             *.cdn-apple.com:443
             *.cloudflare.com:443
@@ -169,6 +175,7 @@ jobs:
             *.digicert.com:80
             *.events.data.microsoft.com:443
             *.fastly-edge.com:443
+            *.fe2.apple-dns.net:443
             *.g.aaplimg.com:443
             *.iadsdk.apple.com:443
             *.icloud.com:443
@@ -193,6 +200,7 @@ jobs:
             *.usertrust.com:443
             *.usertrust.com:80
             *.wns.windows.com:443
+            *.wrr.me.apple-dns.net:443
             api.github.com:443
             decide.arcjet.com:443
             deno.com:443
@@ -289,6 +297,8 @@ jobs:
           allowed-endpoints: >
             *.aaplimg.com:443
             *.apple-cloudkit.com:443
+            *.apple-cloudkit.fe2.apple-dns.net:443
+            *.apple-dns.net:443
             *.apple.com:443
             *.cdn-apple.com:443
             *.cloudflare.com:443
@@ -297,6 +307,7 @@ jobs:
             *.digicert.com:80
             *.events.data.microsoft.com:443
             *.fastly-edge.com:443
+            *.fe2.apple-dns.net:443
             *.g.aaplimg.com:443
             *.iadsdk.apple.com:443
             *.icloud.com:443
@@ -321,6 +332,7 @@ jobs:
             *.usertrust.com:443
             *.usertrust.com:80
             *.wns.windows.com:443
+            *.wrr.me.apple-dns.net:443
             api.github.com:443
             decide.arcjet.com:443
             github.com:443

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -102,16 +102,77 @@ jobs:
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # The OS entries below are background traffic from the Windows and
+          # macOS runner images — push and notification services, connectivity
+          # probes, certificate revocation checks and time sync — not anything
+          # this repository requests. They are allowed so the egress policy
+          # reports a real anomaly rather than the runner talking to its vendor.
           allowed-endpoints: >
+            0.pool.ntp.org:123
+            api.apple-cloudkit.com:443
             api.github.com:443
+            api.smoot.apple.com:443
+            apps.mzstatic.com:443
+            bag.itunes.apple.com:443
+            cds.apple.com:443
+            cf.iadsdk.apple.com:443
+            client.wns.windows.com:443
+            configuration.apple.com:443
+            crl.sectigo.com:443
+            crl.sectigo.com:80
             decide.arcjet.com:443
             deno.com:443
+            device-config.pcms.apple.com:443
             dl.deno.land:443
+            experiments.apple.com:443
+            fe2cr.update.microsoft.com:443
+            fpinit.itunes.apple.com:443
+            gateway.icloud.com:443
+            gdmf-ados.apple.com:443
             github.com:443
+            go.microsoft.com:443
+            gsp-ssl.ls.apple.com:443
+            gspe1-ssl.ls.apple.com:443
+            gspe35-ssl.ls.apple.com:443
+            help.apple.com:443
+            iadsdk.apple.com:443
+            incoming.telemetry.mozilla.org:443
+            init.itunes.apple.com:443
+            int1.stepsecurity.io:443
+            ipcdn.apple.com:443
+            ipv6.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:80
+            ipv6.msftncsi.com:443
+            ipv6.msftncsi.com:80
+            itunes.apple.com:443
+            mask-api.icloud.com:443
+            mobile.events.data.microsoft.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
+            ocsp.digicert.com:443
+            ocsp.digicert.com:80
+            ocsp.sectigo.com:443
+            ocsp.sectigo.com:80
+            ocsp.usertrust.com:443
+            ocsp.usertrust.com:80
+            pancake.apple.com:443
+            proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            safebrowsing.googleapis.com:443
+            sas.pcms.apple.com:443
+            settings-win.data.microsoft.com:443
+            stocks-data-service.apple.com:443
+            swallow.apple.com:443
+            tas02.sls.update.microsoft.com:443
+            token.safebrowsing.apple:443
+            updates.cdn-apple.com:443
+            www.msftconnecttest.com:443
+            www.msftconnecttest.com:80
+            www.msftncsi.com:443
+            www.msftncsi.com:80
+            xp.apple.com:443
+            xp.g.aaplimg.com:443
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
@@ -184,14 +245,75 @@ jobs:
           # sudo/container lockdown is Linux-only; a no-op or error on other OS.
           disable-sudo-and-containers: ${{ runner.os == 'Linux' }}
           egress-policy: block
+          # The OS entries below are background traffic from the Windows and
+          # macOS runner images — push and notification services, connectivity
+          # probes, certificate revocation checks and time sync — not anything
+          # this repository requests. They are allowed so the egress policy
+          # reports a real anomaly rather than the runner talking to its vendor.
           allowed-endpoints: >
+            0.pool.ntp.org:123
+            api.apple-cloudkit.com:443
             api.github.com:443
+            api.smoot.apple.com:443
+            apps.mzstatic.com:443
+            bag.itunes.apple.com:443
+            cds.apple.com:443
+            cf.iadsdk.apple.com:443
+            client.wns.windows.com:443
+            configuration.apple.com:443
+            crl.sectigo.com:443
+            crl.sectigo.com:80
             decide.arcjet.com:443
+            device-config.pcms.apple.com:443
+            experiments.apple.com:443
+            fe2cr.update.microsoft.com:443
+            fpinit.itunes.apple.com:443
+            gateway.icloud.com:443
+            gdmf-ados.apple.com:443
             github.com:443
+            go.microsoft.com:443
+            gsp-ssl.ls.apple.com:443
+            gspe1-ssl.ls.apple.com:443
+            gspe35-ssl.ls.apple.com:443
+            help.apple.com:443
+            iadsdk.apple.com:443
+            incoming.telemetry.mozilla.org:443
+            init.itunes.apple.com:443
+            int1.stepsecurity.io:443
+            ipcdn.apple.com:443
+            ipv6.msftconnecttest.com:443
+            ipv6.msftconnecttest.com:80
+            ipv6.msftncsi.com:443
+            ipv6.msftncsi.com:80
+            itunes.apple.com:443
+            mask-api.icloud.com:443
+            mobile.events.data.microsoft.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
+            ocsp.digicert.com:443
+            ocsp.digicert.com:80
+            ocsp.sectigo.com:443
+            ocsp.sectigo.com:80
+            ocsp.usertrust.com:443
+            ocsp.usertrust.com:80
+            pancake.apple.com:443
+            proxy.safebrowsing.apple:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            safebrowsing.googleapis.com:443
+            sas.pcms.apple.com:443
+            settings-win.data.microsoft.com:443
+            stocks-data-service.apple.com:443
+            swallow.apple.com:443
+            tas02.sls.update.microsoft.com:443
+            token.safebrowsing.apple:443
+            updates.cdn-apple.com:443
+            www.msftconnecttest.com:443
+            www.msftconnecttest.com:80
+            www.msftncsi.com:443
+            www.msftncsi.com:80
+            xp.apple.com:443
+            xp.g.aaplimg.com:443
 
       # Checkout
       # Most toolchains require checkout first


### PR DESCRIPTION
`harden-runner` is failing because the Windows and macOS build jobs make calls to (Apple and Microsoft) endpoints. This PR adds the missing endpoints so that the Windows and macOS build steps start working (they're not blocking merging right now, but if we're paying for the cycles, we should be getting value for it).

#6235 added two runner images to the test matrix. Each image connects to its own vendor for push services, notification services, connectivity probes and software updates. The egress allow-list on those jobs was written for Linux, which makes almost none of these calls. `harden-runner` therefore sees vendor traffic, finds no entry for it, and reports it.

This pull request adds the observed endpoints to the allow-list of the two jobs that run the full operating-system matrix: `node-test` and `deno-test`. The endpoints come from the alerts on eight pull requests between 2026-08-28 and 2026-09-03.

Certificate revocation and the connectivity probes also get port 80. Time sync gets port 123.

The policy stays `block`. The matrix, the jobs and the endpoints this repository needs do not change.

I'll amend this PR until I get a clean `harden-runner` pass. This does not, of course, guarantee that subsequent changes to the core builds won't cause new failures in the Windows and macOS CI passes, but we can cross that bridge when we get to it.