### PR TITLE
fix(analyze): report sensitive-info offsets as string indices

### DIFF
--- a/analyze/src/index.ts
+++ b/analyze/src/index.ts
@@ -83,6 +83,99 @@ export {
   type DetectSensitiveInfoFunction,
 };
 
+/**
+ * Number of bytes a code point occupies in UTF-8.
+ *
+ * @param codePoint
+ *   Code point.
+ * @returns
+ *   Byte length.
+ */
+function utf8Length(codePoint: number): number {
+  if (codePoint < 0x80) return 1;
+  if (codePoint < 0x800) return 2;
+  // A lone surrogate has no UTF-8 encoding; it reaches Wasm as U+FFFD, which is
+  // also three bytes, so the arithmetic stays aligned either way.
+  if (codePoint < 0x10000) return 3;
+  return 4;
+}
+
+/**
+ * Convert the UTF-8 byte offsets Wasm reports into UTF-16 code unit indices.
+ *
+ * `ArcjetIdentifiedEntity` documents `start`/`end` as indices into the value,
+ * and the Rampart backend fills them from `RegExp` match indices, which are
+ * code units. The Wasm detector counts bytes instead, so without this the two
+ * backends disagree and `value.slice(start, end)` returns the wrong substring
+ * for any value containing a multi-byte character.
+ *
+ * A span is only ever widened, never narrowed, so it still covers the entity
+ * even if an offset lands inside a character.
+ *
+ * @param value
+ *   Value the offsets refer to.
+ * @param entities
+ *   Detected entities carrying byte offsets.
+ * @returns
+ *   The same entities with code unit offsets.
+ */
+function toStringIndices(
+  value: string,
+  entities: ReadonlyArray<DetectedSensitiveInfoEntity>,
+): Array<DetectedSensitiveInfoEntity> {
+  if (entities.length === 0) {
+    return [];
+  }
+
+  const wanted = new Set<number>();
+  for (const entity of entities) {
+    wanted.add(entity.start);
+    wanted.add(entity.end);
+  }
+
+  const ascending = Array.from(wanted).sort((a, b) => a - b);
+  const floors = new Map<number, number>();
+  const ceilings = new Map<number, number>();
+  let cursor = 0;
+  let byteOffset = 0;
+  let stringIndex = 0;
+
+  while (cursor < ascending.length && ascending[cursor] <= 0) {
+    floors.set(ascending[cursor], 0);
+    ceilings.set(ascending[cursor], 0);
+    cursor++;
+  }
+
+  for (const character of value) {
+    if (cursor >= ascending.length) break;
+
+    const nextByteOffset = byteOffset + utf8Length(character.codePointAt(0)!);
+    const nextStringIndex = stringIndex + character.length;
+
+    while (cursor < ascending.length && ascending[cursor] <= nextByteOffset) {
+      const offset = ascending[cursor];
+      floors.set(offset, offset === nextByteOffset ? nextStringIndex : stringIndex);
+      ceilings.set(offset, nextStringIndex);
+      cursor++;
+    }
+
+    byteOffset = nextByteOffset;
+    stringIndex = nextStringIndex;
+  }
+
+  while (cursor < ascending.length) {
+    floors.set(ascending[cursor], value.length);
+    ceilings.set(ascending[cursor], value.length);
+    cursor++;
+  }
+
+  return entities.map((entity) => {
+    const start = floors.get(entity.start) ?? 0;
+    const end = ceilings.get(entity.end) ?? value.length;
+    return { ...entity, start, end: Math.max(start, end) };
+  });
+}
+
 const FREE_EMAIL_PROVIDERS = ["gmail.com", "yahoo.com", "hotmail.com", "aol.com", "hotmail.co.uk"];
 
 function noOpSensitiveInfoDetect(): SensitiveInfoEntity[] {
@@ -266,11 +359,18 @@ export async function detectSensitiveInfo(
 
   if (typeof analyze !== "undefined") {
     const skipCustomDetect = typeof detect !== "function";
-    return analyze.detectSensitiveInfo(value, {
+    const result = analyze.detectSensitiveInfo(value, {
       entities,
       contextWindowSize,
       skipCustomDetect,
     });
+    // Wasm reports UTF-8 byte offsets; the protocol type is documented in code
+    // units and the Rampart backend fills it that way.
+    return {
+      ...result,
+      allowed: toStringIndices(value, result.allowed),
+      denied: toStringIndices(value, result.denied),
+    };
     // Ignore the `else` branch as we test in places that have WebAssembly.
     /* node:coverage ignore next 4 */
   }

--- a/analyze/test/analyze.test.ts
+++ b/analyze/test/analyze.test.ts
@@ -116,6 +116,26 @@ test("detectSensitiveInfo", async function (t) {
     });
   });
 
+  await t.test("should report offsets as string indices", async function () {
+    // Wasm reports UTF-8 byte offsets. `ArcjetIdentifiedEntity.start`/`end` are
+    // documented as indices into the value and the Rampart backend fills them
+    // from `RegExp` match indices, so these have to be code units — otherwise
+    // `value.slice(start, end)` returns the wrong substring for any value with
+    // a multi-byte character in it. Reserved domain (RFC 2606).
+    for (const prefix of ["", "hello ", "Здравствуйте, ", "您好 ", "🙂🙂🙂🙂 ", "ééé "]) {
+      const value = `${prefix}mail b@c.d end`;
+      const result = await detectSensitiveInfo(exampleContext, value, { tag: "allow", val: [] }, 1);
+
+      assert.equal(result.denied.length, 1, `one entity for ${JSON.stringify(prefix)}`);
+      const entity = result.denied[0];
+      assert.equal(
+        value.slice(entity.start, entity.end),
+        "b@c.d",
+        `offsets index the string for ${JSON.stringify(prefix)}`,
+      );
+    }
+  });
+
   await t.test("should not detect non-sensitive info", async function () {
     const result = await detectSensitiveInfo(
       exampleContext,


### PR DESCRIPTION
`ArcjetIdentifiedEntity.start`/`end` are documented as indices into the value, and `@arcjet/sensitive-info-rampart` fills them from `RegExp` match indices — UTF-16 code units. The Wasm detector reports UTF-8 byte offsets and they were passed through unchanged, so the two sensitive-info backends disagreed about what the field means, and `value.slice(start, end)` returned the wrong substring for any value with a multi-byte character in it.

`detectSensitiveInfo` now converts them. A span is only ever widened, never narrowed, so it still covers the entity when an offset lands inside a character.

```js
// "你你 bob@a.io TAIL" — before
{ start: 7, end: 15 }   // value.slice(7, 15) === "a.io TAI"
// after
{ start: 3, end: 11 }   // value.slice(3, 11) === "bob@a.io"
```

**This is a behaviour change** for reported offsets on non-ASCII values — from wrong-per-the-docs to correct. ASCII values are unaffected, which is most of them. These offsets are diagnostic: nothing in the SDK slices with them, so the change is limited to what callers see on `ArcjetSensitiveInfoReason`.

The Go SDK needs no equivalent change — Go slices strings by byte, so the offsets are already the right unit there. The Python equivalent is a separate PR on arcjet-py.
