### PR TITLE
feat(guard): add actor and inputs to every adapter policy

### DIFF
--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -856,7 +856,9 @@ const decision = await arcjet.guard({
 
 Vendor-specific wrappers that integrate with particular SDKs, plus every agent
 helper. Every wrapper policy accepts optional `actor` and `inputs` — static
-values or resolvers over the adapter's call argument. Build each input with
+values or resolvers over that adapter's native call (parsed input plus the
+framework's trusted runtime or context, the same idea as Vercel AI's
+`(input, ctx)`). Build each input with
 `policyInput` so a remote Guard policy that declares those names can evaluate.
 Omit them and the remote policy has nothing to read, so its rules do not fire.
 

--- a/arcjet-guard/README.md
+++ b/arcjet-guard/README.md
@@ -855,7 +855,12 @@ const decision = await arcjet.guard({
 ### Vendor SDK integration (`@arcjet/guard/<vendor-sdk>/v<major>`)
 
 Vendor-specific wrappers that integrate with particular SDKs, plus every agent
-helper. Currently available:
+helper. Every wrapper policy accepts optional `actor` and `inputs` — static
+values or resolvers over the adapter's call argument. Build each input with
+`policyInput` so a remote Guard policy that declares those names can evaluate.
+Omit them and the remote policy has nothing to read, so its rules do not fire.
+
+Currently available:
 
 - **`@arcjet/guard/vercel-ai/v7`** — Vercel AI SDK v7 integration. Exports
   `guardTool` and `aiToolsContext` for tool wrapping, alongside the helpers

--- a/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
@@ -93,13 +93,17 @@ Never stash it in module state or AsyncLocalStorage.
 
 ```ts
 import { guardTool, securityMetadata } from "@arcjet/guard/vercel-ai/v7";
-import { tokenBucket } from "@arcjet/guard";
+import { tokenBucket, policyInput } from "@arcjet/guard";
 
 const lookupLimit = tokenBucket({ bucket: "lookups", refillRate: 5, intervalSeconds: 60, maxTokens: 10 });
 
 const tools = {
   lookupOrder: guardTool(arcjet, lookupOrderTool, {
     action: "order.looked-up", // "resource.verb", past tense
+    actor: userId,
+    inputs: ({ orderNumber }) => ({
+      orderNumber: policyInput.server.string(orderNumber),
+    }),
     rules: ({ orderNumber }) => [lookupLimit({ key: `order:${orderNumber}`, requested: 1 })],
     // securityMetadata() maps the flat vocabulary to wire keys, so its fields
     // are strings. Nested values go alongside it in the raw metadata object.
@@ -111,6 +115,9 @@ const tools = {
 };
 ```
 
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - Omit `rules` to submit none. The guard call still happens, so the decision is
   correlatable and the call site stays reachable by policy configured outside
   the code — but it costs a round trip. Use `captureAction()` instead when you

--- a/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
@@ -120,7 +120,7 @@ const tools = {
 };
 ```
 
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - Omit `rules` to submit none. The guard call still happens, so the decision is

--- a/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-agents/SKILL.md
@@ -95,7 +95,12 @@ Never stash it in module state or AsyncLocalStorage.
 import { guardTool, securityMetadata } from "@arcjet/guard/vercel-ai/v7";
 import { tokenBucket, policyInput } from "@arcjet/guard";
 
-const lookupLimit = tokenBucket({ bucket: "lookups", refillRate: 5, intervalSeconds: 60, maxTokens: 10 });
+const lookupLimit = tokenBucket({
+  bucket: "lookups",
+  refillRate: 5,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
 
 const tools = {
   lookupOrder: guardTool(arcjet, lookupOrderTool, {
@@ -231,8 +236,8 @@ two distinguishable in a handler. The fail-closed tool result carries a fixed
 `retryAfterSeconds: 5` backoff hint. The capture `outcome` on that path is
 `"unavailable"`, not `"denied"`, so an operator can query the two separately. The
 layering resolves a potential confusion: the core `@arcjet/guard` client still
-fails open by construction and *reports* it via `hasFailedOpen()`; these helpers
-*decide* to block on it.
+fails open by construction and _reports_ it via `hasFailedOpen()`; these helpers
+_decide_ to block on it.
 
 ## Metadata vocabulary
 
@@ -250,12 +255,12 @@ Metadata accepts any JSON-serializable value — nested objects and arrays
 included. The server enforces the following limits, dropping keys that exceed
 them and reporting each drop on `decision.warnings`:
 
-| Limit | Value | Over the limit |
-|---|---|---|
-| Top-level keys | 128 | extra keys dropped |
-| Serialized bytes per value | 4 KiB | that key dropped |
-| Nesting depth per value | 10 | that key dropped |
-| Key names | letters, digits, `-`, `.`, `_` | that key dropped |
+| Limit                      | Value                          | Over the limit     |
+| -------------------------- | ------------------------------ | ------------------ |
+| Top-level keys             | 128                            | extra keys dropped |
+| Serialized bytes per value | 4 KiB                          | that key dropped   |
+| Nesting depth per value    | 10                             | that key dropped   |
+| Key names                  | letters, digits, `-`, `.`, `_` | that key dropped   |
 
 Nothing about metadata can fail a call or change a decision; it is excluded
 from fingerprinting. Metadata is untrusted and **not redacted** — no secrets

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
@@ -122,7 +122,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/claude-agent-sdk/v0";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -149,12 +149,19 @@ export const lookupOrder = guardTool(
   ),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderId: policyInput.server.string(input.orderId),
+    }),
     rules: (input) => [lookupLimit({ key: input.orderId, requested: 1 }), detectPii(input.note)],
   },
 );
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the tool's handler never runs. The model receives
   `{ content, structuredContent: { arcjetDenied, reason, message, retryable }, isError: true }`.
 - Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-agent-sdk/SKILL.md
@@ -159,7 +159,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the tool's handler never runs. The model receives

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-managed-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-managed-agents/SKILL.md
@@ -147,7 +147,7 @@ events and send them only on ALLOW.
 ## Step 3: Gate custom tools you execute
 
 ```ts
-import { tokenBucket } from "@arcjet/guard";
+import { tokenBucket, policyInput } from "@arcjet/guard";
 import { guardCustomTool } from "@arcjet/guard/claude-managed-agents/v0";
 
 import { arcjet } from "./arcjet.js";
@@ -169,6 +169,10 @@ if (event.type === "agent.custom_tool_use") {
     },
     {
       action: "order.looked-up",
+      actor: userId,
+      inputs: (input) => ({
+        orderNumber: policyInput.server.string(String(input["orderNumber"])),
+      }),
       rules: (input) => [lookupLimit({ key: String(input["orderNumber"]), requested: 1 })],
       context: ctx,
     },
@@ -188,6 +192,10 @@ if (event.type === "agent.custom_tool_use") {
 Self-hosted: wrap `betaTool({ run })` with the same `guardCustomTool`
 (pass the tool as the second argument). The CLI worker cannot register
 custom tools.
+
+Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+guard call so a remote policy that declares those names can evaluate.
+Build each input with `policyInput`.
 
 ## Step 4: Correlation
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-managed-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-managed-agents/SKILL.md
@@ -191,7 +191,7 @@ Self-hosted: wrap `betaTool({ run })` with the same `guardCustomTool`
 (pass the tool as the second argument). The CLI worker cannot register
 custom tools.
 
-Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
 guard call so a remote policy that declares those names can evaluate.
 Build each input with `policyInput`.
 

--- a/arcjet-guard/skills/integrate-arcjet-guard-claude-managed-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-claude-managed-agents/SKILL.md
@@ -111,10 +111,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 
 ```ts
 import { detectPromptInjection } from "@arcjet/guard";
-import {
-  claudeManagedAgentsContext,
-  guardEvents,
-} from "@arcjet/guard/claude-managed-agents/v0";
+import { claudeManagedAgentsContext, guardEvents } from "@arcjet/guard/claude-managed-agents/v0";
 
 import { arcjet } from "./arcjet.js";
 
@@ -164,8 +161,7 @@ if (event.type === "agent.custom_tool_use") {
     {
       event,
       execute: (input) => lookupOrder(input),
-      send: (result) =>
-        client.beta.sessions.events.send(session.id, { events: [result] }),
+      send: (result) => client.beta.sessions.events.send(session.id, { events: [result] }),
     },
     {
       action: "order.looked-up",
@@ -179,11 +175,13 @@ if (event.type === "agent.custom_tool_use") {
   );
   if (gated.allowed) {
     await client.beta.sessions.events.send(session.id, {
-      events: [{
-        type: "user.custom_tool_result",
-        custom_tool_use_id: event.id,
-        content: [{ type: "text", text: JSON.stringify(gated.output) }],
-      }],
+      events: [
+        {
+          type: "user.custom_tool_result",
+          custom_tool_use_id: event.id,
+          content: [{ type: "text", text: JSON.stringify(gated.output) }],
+        },
+      ],
     });
   }
 }

--- a/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
@@ -127,7 +127,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/vercel-eve/v0";
-import { tokenBucket } from "@arcjet/guard";
+import { tokenBucket, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "../arcjet.js";
 
@@ -149,6 +149,10 @@ export default guardTool(
   }),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderId: policyInput.server.string(input.orderId),
+    }),
     rules: (input) => [lookupLimit({ key: input.orderId, requested: 1 })],
   },
 );
@@ -157,6 +161,9 @@ export default guardTool(
 - Omit `rules` to submit none. The guard call still happens, so the decision is
   correlatable and the tool can be managed via policy configured outside the
   code.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - `rules` may be a callback over the tool's parsed input, computed from the
   data being acted on.
 - On DENY the tool's `execute` never runs; Eve projects it as a failed

--- a/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
@@ -161,7 +161,7 @@ export default guardTool(
 - Omit `rules` to submit none. The guard call still happens, so the decision is
   correlatable and the tool can be managed via policy configured outside the
   code.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - `rules` may be a callback over the tool's parsed input, computed from the

--- a/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-eve/SKILL.md
@@ -76,7 +76,7 @@ State plainly why each applies to Eve, not other frameworks:
 
 4. **`approval` is one field per tool or connection.** It can be a function
    (request-time only) or `{ request, response }`. You still cannot assign
-   `always()`/`once()`/`never()` from `eve/tools/approval` *alongside*
+   `always()`/`once()`/`never()` from `eve/tools/approval` _alongside_
    `guardApproval` — the slot holds one value. `onAllow: "user-approval"` is
    how you require a human after the request-time gate. The optional `response`
    policy is how you authorize who may approve the parked request. A rejected

--- a/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
@@ -191,7 +191,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the closed-over handler never runs. The model receives

--- a/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
@@ -71,8 +71,9 @@ result. Throwing `ToolInterruptError` sets `finishReason: "interrupted"`
 (do not do this).
 
 `generate({ use })` must receive a **plain object `{ name, instantiate }`**.
-A raw function becomes a *model* hook only. A function with `instantiate`
-+ `plugin` throws “must be called with ()”.
+A raw function becomes a _model_ hook only. A function with `instantiate`
+
+- `plugin` throws “must be called with ()”.
 
 ## Questions to ask the human first
 
@@ -85,7 +86,7 @@ Ask only what you cannot infer from the code; suggest defaults.
 3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
    Default: none. Pass it via `metadata` on the policy. Put the
    conversation / session id you already have on
-   `ai.generate({ context: { sessionId } })` *and* on
+   `ai.generate({ context: { sessionId } })` _and_ on
    `guardMiddleware({ sessionId })` — the tool hook does not receive ALS
    context today. That id is the correlation id, not the user.
 4. Is an Arcjet outage unacceptable? Every helper defaults to
@@ -114,7 +115,7 @@ Ask only what you cannot infer from the code; suggest defaults.
    throws if the tool already carries the Arcjet protection brand.
 6. **A denial from `guardTool` is a structured object, not a throw.**
    Wrap the returned `ToolAction` (the callable `generate()` invokes),
-   not the inner handler. `outputSchema` validation runs *inside*
+   not the inner handler. `outputSchema` validation runs _inside_
    `action()`. Wrapping outside means DENY returns `ArcjetDenialResult`
    without schema check, so the model still sees a completed tool
    result. Wrapping the inner handler would throw on schema mismatch
@@ -150,7 +151,7 @@ import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guar
 
 import { arcjet } from "./arcjet.js";
 
-const ai = genkit({ /* plugins, default model */ });
+const ai = genkit({/* plugins, default model */});
 
 const lookupLimit = tokenBucket({
   refillRate: 10,

--- a/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-genkit/SKILL.md
@@ -146,7 +146,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 ```ts
 import { genkit, z } from "genkit";
 import { guardTool } from "@arcjet/guard/genkit/v1";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -177,6 +177,10 @@ export const lookupOrder = guardTool(
   ),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderNumber: policyInput.server.string(input.orderNumber),
+    }),
     rules: (input) => [
       lookupLimit({ key: input.orderNumber, requested: 1 }),
       detectPii(input.note),
@@ -186,6 +190,9 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the closed-over handler never runs. The model receives
   `{ arcjetDenied: true, reason, message, retryable }` as
   `toolResponse.output`.

--- a/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
@@ -185,7 +185,7 @@ const runner = new Runner({
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the original `runAsync` never runs. Delivery is

--- a/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-google-adk/SKILL.md
@@ -146,7 +146,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 ```ts
 import { Runner } from "@google/adk";
 import { guardPlugin } from "@arcjet/guard/google-adk/v2";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -164,6 +164,10 @@ const runner = new Runner({
   plugins: [
     guardPlugin(arcjet, {
       action: ({ toolName }) => `${toolName}.invoked`,
+      actor: conversationId,
+      inputs: ({ toolName }) => ({
+        tool: policyInput.server.string(toolName),
+      }),
       rules: ({ toolName, input }) => {
         const note =
           typeof input === "object" && input !== null && "note" in input
@@ -181,6 +185,9 @@ const runner = new Runner({
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the original `runAsync` never runs. Delivery is
   `{ arcjetDenied: true, reason, message, retryable }` — the dict
   ADK treats as skip.

--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -160,7 +160,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/langchain/v1";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -189,6 +189,10 @@ export const lookupOrder = guardTool(
   ),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderNumber: policyInput.server.string(input.orderNumber),
+    }),
     rules: (input) => [
       lookupLimit({ key: input.orderNumber, requested: 1 }),
       detectPii(input.note),
@@ -198,6 +202,9 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the original `func` / `invoke` never runs. The caller
   receives `{ arcjetDenied: true, reason, message, retryable }`.
   Through `createAgent`, `baseHandler` wraps that object in a success

--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -186,7 +186,8 @@ export const lookupOrder = guardTool(
   }),
   {
     action: "order.looked-up",
-    actor: userId,
+    // Invoke config is the trusted half of LangChain `func`/`invoke`.
+    actor: (_input, runtime) => String(runtime?.configurable?.thread_id ?? userId),
     inputs: (input) => ({
       orderNumber: policyInput.server.string(input.orderNumber),
     }),
@@ -199,7 +200,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the original `func` / `invoke` never runs. The caller

--- a/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langchain/SKILL.md
@@ -176,17 +176,14 @@ const detectPii = localDetectSensitiveInfo();
 
 export const lookupOrder = guardTool(
   arcjet,
-  tool(
-    async ({ orderNumber, note }) => ({ orderNumber, note, status: "shipped" }),
-    {
-      name: "lookup_order",
-      description: "Look up an order by number",
-      schema: z.object({
-        orderNumber: z.string(),
-        note: z.string(),
-      }),
-    },
-  ),
+  tool(async ({ orderNumber, note }) => ({ orderNumber, note, status: "shipped" }), {
+    name: "lookup_order",
+    description: "Look up an order by number",
+    schema: z.object({
+      orderNumber: z.string(),
+      note: z.string(),
+    }),
+  }),
   {
     action: "order.looked-up",
     actor: userId,

--- a/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
@@ -167,7 +167,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the tool's `func` / `invoke` never runs. The model receives

--- a/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-langgraph/SKILL.md
@@ -130,7 +130,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/langgraph/v1";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -157,12 +157,19 @@ export const lookupOrder = guardTool(
   }),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderId: policyInput.server.string(input.orderId),
+    }),
     rules: (input) => [lookupLimit({ key: input.orderId, requested: 1 }), detectPii(input.note)],
   },
 );
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the tool's `func` / `invoke` never runs. The model receives
   `{ arcjetDenied: true, reason, message, retryable }` as the tool result
   content. If you invoke a guarded tool outside `ToolNode`, read that

--- a/arcjet-guard/skills/integrate-arcjet-guard-mastra/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-mastra/SKILL.md
@@ -140,7 +140,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the tool's `execute` never runs. The model receives

--- a/arcjet-guard/skills/integrate-arcjet-guard-mastra/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-mastra/SKILL.md
@@ -96,7 +96,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/mastra/v1";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -126,6 +126,10 @@ export const lookupOrder = guardTool(
   }),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderId: policyInput.server.string(input.orderId),
+    }),
     rules: (input) => [
       lookupLimit({ key: input.orderId, requested: 1 }),
       // Right: factory already bound above; pass free text, not orderId.
@@ -136,6 +140,9 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the tool's `execute` never runs. The model receives
   `{ arcjetDenied: true, reason, message, retryable }`.
 - Default `onGuardError: "deny"` blocks the tool if Arcjet is unreachable.

--- a/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
@@ -168,7 +168,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the closed-over `execute` never runs. The model receives

--- a/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md
@@ -127,7 +127,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { tool } from "@openai/agents";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/openai-agents/v0";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -155,6 +155,10 @@ export const lookupOrder = guardTool(
   }),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input: { orderId: string; note: string }) => ({
+      orderId: policyInput.server.string(input.orderId),
+    }),
     rules: (input: { orderId: string; note: string }) => [
       lookupLimit({ key: input.orderId, requested: 1 }),
       detectPii(input.note),
@@ -164,6 +168,9 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the closed-over `execute` never runs. The model receives
   `{ arcjetDenied: true, reason, message, retryable }` as the tool
   result (stringified by the runner).

--- a/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
@@ -176,7 +176,7 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the authored callback never runs. The model receives

--- a/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
@@ -77,7 +77,7 @@ Ask only what you cannot infer from the code; suggest defaults.
 3. Who is the **user** for metadata — an opaque user/tenant ID (never PII)?
    Default: none. Pass it via `metadata` on the policy. Put the
    conversation / session id you already have on
-   `agent.invoke(..., { invocationState: { sessionId } })` *and* on
+   `agent.invoke(..., { invocationState: { sessionId } })` _and_ on
    `guardHooks({ sessionId })`. That id is the correlation id, not the
    user.
 4. Is an Arcjet outage unacceptable? Every helper defaults to

--- a/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-strands-agents/SKILL.md
@@ -136,7 +136,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { tool } from "@strands-agents/sdk";
 import { z } from "zod";
 import { guardTool } from "@arcjet/guard/strands-agents/v1";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -163,6 +163,10 @@ export const lookupOrder = guardTool(
   }),
   {
     action: "order.looked-up",
+    actor: userId,
+    inputs: (input) => ({
+      orderNumber: policyInput.server.string(input.orderNumber),
+    }),
     rules: (input) => [
       lookupLimit({ key: input.orderNumber, requested: 1 }),
       detectPii(input.note),
@@ -172,6 +176,9 @@ export const lookupOrder = guardTool(
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the authored callback never runs. The model receives
   `{ arcjetDenied: true, reason, message, retryable }` as the
   callback return (`FunctionTool` wraps that object in a `JsonBlock`).

--- a/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
@@ -179,7 +179,7 @@ const stream = chat({
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
-- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+- Optional `actor` and `inputs` (static, or a resolver over this adapter's native call — parsed input plus trusted runtime/context) are forwarded on the
   guard call so a remote policy that declares those names can evaluate.
   Build each input with `policyInput`.
 - On DENY the original `execute` never runs. Default delivery is

--- a/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
+++ b/arcjet-guard/skills/integrate-arcjet-guard-tanstack-ai/SKILL.md
@@ -138,7 +138,7 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 import { chat } from "@tanstack/ai";
 import { toolCacheMiddleware } from "@tanstack/ai/middlewares";
 import { guardMiddleware } from "@arcjet/guard/tanstack-ai/v0";
-import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { tokenBucket, localDetectSensitiveInfo, policyInput } from "@arcjet/guard";
 
 import { arcjet } from "./arcjet.js";
 
@@ -157,6 +157,10 @@ const stream = chat({
   middleware: [
     guardMiddleware(arcjet, {
       action: ({ toolName }) => `${toolName}.invoked`,
+      actor: conversationId,
+      inputs: ({ toolName }) => ({
+        tool: policyInput.server.string(toolName),
+      }),
       rules: ({ toolName, input }) => {
         const note =
           typeof input === "object" && input !== null && "note" in input
@@ -175,6 +179,9 @@ const stream = chat({
 ```
 
 - Omit `rules` to submit none. The guard call still happens.
+- Optional `actor` and `inputs` (static or a resolver) are forwarded on the
+  guard call so a remote policy that declares those names can evaluate.
+  Build each input with `policyInput`.
 - On DENY the original `execute` never runs. Default delivery is
   `{ type: "skip", result: { arcjetDenied: true, reason, message, retryable } }`.
 - `onDeny: "abort"` stops the chat run with `{ type: "abort", reason }`

--- a/arcjet-guard/src/agents/actor-inputs.test.ts
+++ b/arcjet-guard/src/agents/actor-inputs.test.ts
@@ -28,6 +28,25 @@ test("resolves actor and inputs from the call argument", async () => {
   assert.deepEqual(resolved.inputs, { id: policyInput.server.string("one") });
 });
 
+test("forwards every native argument to the resolvers", async () => {
+  const resolved = await resolveActorInputs(
+    {
+      actor: (_input: { id: string }, runtime: { userId: string }) => runtime.userId,
+      inputs: (input: { id: string }, runtime: { userId: string }) => ({
+        id: policyInput.server.string(input.id),
+        user: policyInput.server.string(runtime.userId),
+      }),
+    },
+    { id: "one" },
+    { userId: "user-9" },
+  );
+  assert.equal(resolved.actor, "user-9");
+  assert.deepEqual(resolved.inputs, {
+    id: policyInput.server.string("one"),
+    user: policyInput.server.string("user-9"),
+  });
+});
+
 test("awaits async resolvers", async () => {
   const resolved = await resolveActorInputs(
     {
@@ -48,7 +67,7 @@ test("propagates a resolver throw so the caller can fail closed", async () => {
     () =>
       resolveActorInputs(
         {
-          inputs: () => {
+          inputs: (_arg: { id: string }) => {
             throw new Error("mapping failed");
           },
         },

--- a/arcjet-guard/src/agents/actor-inputs.test.ts
+++ b/arcjet-guard/src/agents/actor-inputs.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { policyInput } from "../policy-input.ts";
+import { resolveActorInputs } from "./actor-inputs.ts";
+
+test("omits actor and inputs when the policy does not set them", async () => {
+  const resolved = await resolveActorInputs({}, { id: "one" });
+  assert.deepEqual(resolved, {});
+});
+
+test("passes static actor and inputs through", async () => {
+  const inputs = { id: policyInput.server.string("one") };
+  const resolved = await resolveActorInputs({ actor: "user-1", inputs }, { id: "ignored" });
+  assert.equal(resolved.actor, "user-1");
+  assert.deepEqual(resolved.inputs, inputs);
+});
+
+test("resolves actor and inputs from the call argument", async () => {
+  const resolved = await resolveActorInputs(
+    {
+      actor: (input: { id: string }) => `actor-${input.id}`,
+      inputs: (input: { id: string }) => ({ id: policyInput.server.string(input.id) }),
+    },
+    { id: "one" },
+  );
+  assert.equal(resolved.actor, "actor-one");
+  assert.deepEqual(resolved.inputs, { id: policyInput.server.string("one") });
+});
+
+test("awaits async resolvers", async () => {
+  const resolved = await resolveActorInputs(
+    {
+      actor: async (input: { id: string }) => `actor-${input.id}`,
+      inputs: async (input: { id: string }) => ({
+        id: policyInput.server.string(input.id),
+      }),
+    },
+    { id: "two" },
+  );
+  assert.equal(resolved.actor, "actor-two");
+  assert.deepEqual(resolved.inputs, { id: policyInput.server.string("two") });
+});
+
+test("propagates a resolver throw so the caller can fail closed", async () => {
+  await assert.rejects(
+    () =>
+      resolveActorInputs(
+        {
+          inputs: () => {
+            throw new Error("mapping failed");
+          },
+        },
+        { id: "one" },
+      ),
+    /mapping failed/,
+  );
+});

--- a/arcjet-guard/src/agents/actor-inputs.test.ts
+++ b/arcjet-guard/src/agents/actor-inputs.test.ts
@@ -31,10 +31,11 @@ test("resolves actor and inputs from the call argument", async () => {
 test("awaits async resolvers", async () => {
   const resolved = await resolveActorInputs(
     {
-      actor: async (input: { id: string }) => `actor-${input.id}`,
-      inputs: async (input: { id: string }) => ({
-        id: policyInput.server.string(input.id),
-      }),
+      actor: (input: { id: string }) => Promise.resolve(`actor-${input.id}`),
+      inputs: (input: { id: string }) =>
+        Promise.resolve({
+          id: policyInput.server.string(input.id),
+        }),
     },
     { id: "two" },
   );

--- a/arcjet-guard/src/agents/actor-inputs.ts
+++ b/arcjet-guard/src/agents/actor-inputs.ts
@@ -16,7 +16,7 @@ export type ActorResolver<TArgs extends readonly unknown[]> =
 
 /**
  * Typed remote-policy inputs, or a resolver over the adapter's native call.
- * Build each value with {@link policyInput}.
+ * Build each value with {@link ../policy-input.ts}.
  */
 export type InputsResolver<TArgs extends readonly unknown[]> =
   | PolicyInputMap

--- a/arcjet-guard/src/agents/actor-inputs.ts
+++ b/arcjet-guard/src/agents/actor-inputs.ts
@@ -6,9 +6,7 @@ import type { PolicyInputMap } from "../policy-input.ts";
  * model-produced tool input as the actor identity — a policy can be
  * conditioned on the actor, so a model-controlled value could escape scope.
  */
-export type ActorResolver<TArg> =
-  | string
-  | ((arg: TArg) => string | Promise<string>);
+export type ActorResolver<TArg> = string | ((arg: TArg) => string | Promise<string>);
 
 /**
  * Typed remote-policy inputs, or a resolver over the adapter's call argument.

--- a/arcjet-guard/src/agents/actor-inputs.ts
+++ b/arcjet-guard/src/agents/actor-inputs.ts
@@ -1,47 +1,54 @@
 import type { PolicyInputMap } from "../policy-input.ts";
 
 /**
- * Trusted actor identity, or a resolver over the adapter's call argument.
- * Derive it from authenticated server-side context; never trust a
+ * Trusted actor identity, or a resolver over the adapter's native call.
+ * Arguments match that framework's execute / invoke / hook — typically the
+ * parsed tool input plus the trusted runtime or context object, the same
+ * shape Vercel AI uses as `(input, ctx)`.
+ *
+ * Derive the actor from authenticated server-side context; never trust a
  * model-produced tool input as the actor identity — a policy can be
  * conditioned on the actor, so a model-controlled value could escape scope.
  */
-export type ActorResolver<TArg> = string | ((arg: TArg) => string | Promise<string>);
+export type ActorResolver<TArgs extends readonly unknown[]> =
+  | string
+  | ((...args: TArgs) => string | Promise<string>);
 
 /**
- * Typed remote-policy inputs, or a resolver over the adapter's call argument.
+ * Typed remote-policy inputs, or a resolver over the adapter's native call.
  * Build each value with {@link policyInput}.
  */
-export type InputsResolver<TArg> =
+export type InputsResolver<TArgs extends readonly unknown[]> =
   | PolicyInputMap
-  | ((arg: TArg) => PolicyInputMap | Promise<PolicyInputMap>);
+  | ((...args: TArgs) => PolicyInputMap | Promise<PolicyInputMap>);
 
 /** Optional `actor` / `inputs` fields shared by vendor wrapper policies. */
-export interface ActorInputsPolicy<TArg> {
-  actor?: ActorResolver<TArg>;
-  inputs?: InputsResolver<TArg>;
+export interface ActorInputsPolicy<TArgs extends readonly unknown[]> {
+  actor?: ActorResolver<TArgs>;
+  inputs?: InputsResolver<TArgs>;
 }
 
 /**
  * Resolve optional `actor` / `inputs` from a vendor policy. Static values are
- * returned as-is; functions are awaited. Omitted fields stay omitted so they
- * are not sent as `undefined` under `exactOptionalPropertyTypes`.
+ * returned as-is; functions are awaited with the adapter's native arguments.
+ * Omitted fields stay omitted so they are not sent as `undefined` under
+ * `exactOptionalPropertyTypes`.
  */
-export async function resolveActorInputs<TArg>(
-  policy: ActorInputsPolicy<TArg>,
-  arg: TArg,
+export async function resolveActorInputs<TArgs extends readonly unknown[]>(
+  policy: ActorInputsPolicy<TArgs>,
+  ...args: TArgs
 ): Promise<{ actor?: string; inputs?: PolicyInputMap }> {
   const actor =
     policy.actor === undefined
       ? undefined
       : typeof policy.actor === "function"
-        ? await policy.actor(arg)
+        ? await policy.actor(...args)
         : policy.actor;
   const inputs =
     policy.inputs === undefined
       ? undefined
       : typeof policy.inputs === "function"
-        ? await policy.inputs(arg)
+        ? await policy.inputs(...args)
         : policy.inputs;
   return {
     ...(actor !== undefined && { actor }),

--- a/arcjet-guard/src/agents/actor-inputs.ts
+++ b/arcjet-guard/src/agents/actor-inputs.ts
@@ -1,0 +1,52 @@
+import type { PolicyInputMap } from "../policy-input.ts";
+
+/**
+ * Trusted actor identity, or a resolver over the adapter's call argument.
+ * Derive it from authenticated server-side context; never trust a
+ * model-produced tool input as the actor identity — a policy can be
+ * conditioned on the actor, so a model-controlled value could escape scope.
+ */
+export type ActorResolver<TArg> =
+  | string
+  | ((arg: TArg) => string | Promise<string>);
+
+/**
+ * Typed remote-policy inputs, or a resolver over the adapter's call argument.
+ * Build each value with {@link policyInput}.
+ */
+export type InputsResolver<TArg> =
+  | PolicyInputMap
+  | ((arg: TArg) => PolicyInputMap | Promise<PolicyInputMap>);
+
+/** Optional `actor` / `inputs` fields shared by vendor wrapper policies. */
+export interface ActorInputsPolicy<TArg> {
+  actor?: ActorResolver<TArg>;
+  inputs?: InputsResolver<TArg>;
+}
+
+/**
+ * Resolve optional `actor` / `inputs` from a vendor policy. Static values are
+ * returned as-is; functions are awaited. Omitted fields stay omitted so they
+ * are not sent as `undefined` under `exactOptionalPropertyTypes`.
+ */
+export async function resolveActorInputs<TArg>(
+  policy: ActorInputsPolicy<TArg>,
+  arg: TArg,
+): Promise<{ actor?: string; inputs?: PolicyInputMap }> {
+  const actor =
+    policy.actor === undefined
+      ? undefined
+      : typeof policy.actor === "function"
+        ? await policy.actor(arg)
+        : policy.actor;
+  const inputs =
+    policy.inputs === undefined
+      ? undefined
+      : typeof policy.inputs === "function"
+        ? await policy.inputs(arg)
+        : policy.inputs;
+  return {
+    ...(actor !== undefined && { actor }),
+    ...(inputs !== undefined && { inputs }),
+  };
+}

--- a/arcjet-guard/src/claude-agent-sdk/v0/gate.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/gate.ts
@@ -1,5 +1,6 @@
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 import type {
   ArcjetMetadata,
   Decision,
@@ -7,7 +8,6 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
-import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something

--- a/arcjet-guard/src/claude-agent-sdk/v0/gate.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/gate.ts
@@ -7,6 +7,7 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something
@@ -23,6 +24,8 @@ export async function runGate<T>(
     rules: RuleWithInput[] | undefined;
     correlationId: string | undefined;
     metadata: ArcjetMetadata;
+    actor?: string;
+    inputs?: PolicyInputMap;
     onAllow: () => T;
     onDeny: (decision: DecisionDeny) => T;
     onUnavailable: (
@@ -42,6 +45,8 @@ export async function runGate<T>(
     onDeny,
     onUnavailable,
     onGuardError = "deny",
+    actor,
+    inputs,
   } = params;
 
   const correlation = correlationId === undefined ? {} : { correlationId };
@@ -50,7 +55,14 @@ export async function runGate<T>(
   let decisionId: string | undefined;
   let decision: Decision | undefined;
   try {
-    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+    decision = await client.guard({
+      label: action,
+      rules: rules ?? [],
+      ...correlation,
+      metadata,
+      ...(actor !== undefined && { actor }),
+      ...(inputs !== undefined && { inputs }),
+    });
   } catch (error) {
     if (failClosed) {
       warnUnavailable(action, "threw", true, error);

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
@@ -11,10 +11,10 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import type { DecisionDeny } from "../../types.ts";
 import type { ClaudeCallToolResult } from "./denial.ts";
 import type { ClaudeToolDefinition } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
@@ -520,7 +520,6 @@ test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
     }
   }
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
@@ -518,4 +519,41 @@ test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
       process.env["ARCJET_LOG_LEVEL"] = previous;
     }
   }
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createClaudeTool<{ id: string }>();
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    actor: (input) => `actor-${input.id}`,
+    inputs: (input) => ({ id: policyInput.server.string(input.id) }),
+  });
+  await wrapped.handler({ id: "one" }, sessionExtra("s"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createClaudeTool({
+    handler: async () => {
+      calls += 1;
+      return { content: [{ type: "text" as const, text: "ok" }] };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = denialFromResult(await wrapped.handler({ id: "one" }, sessionExtra("s")));
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
@@ -54,17 +54,16 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, extra) => …` matching the
+   * Claude MCP `handler`. Derive it from `extra.session_id` / hook context;
+   * never trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, extra) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -193,7 +192,7 @@ export function guardTool<TTool extends ClaudeToolDefinition<any>>(
       rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
       policyMetadata =
         typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
-      remote = await resolveActorInputs(policy, input);
+      remote = await resolveActorInputs(policy, input, extra);
     } catch (error) {
       if (shouldWarn()) {
         console.warn(

--- a/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -51,6 +53,18 @@ export interface GuardToolPolicy<TInput> {
    * call, which still costs a round trip and returns a decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -173,11 +187,13 @@ export function guardTool<TTool extends ClaudeToolDefinition<any>>(
     let sessionId: string | undefined;
     let rules: RuleWithInput[] | undefined;
     let policyMetadata: ArcjetMetadata | undefined;
+    let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
     try {
       sessionId = resolveSessionId(policy, input);
       rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
       policyMetadata =
         typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
+      remote = await resolveActorInputs(policy, input);
     } catch (error) {
       if (shouldWarn()) {
         console.warn(
@@ -213,6 +229,7 @@ export function guardTool<TTool extends ClaudeToolDefinition<any>>(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
+      ...remote,
       onDeny: (decision: DecisionDeny) => {
         const fallback = denialCallToolResult(decision);
         if (policy.onDeny === undefined) {

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.test.ts
@@ -462,7 +462,6 @@ test("exclude is inert when empty or absent", async () => {
   }
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const hooks = guardHooks(client, {

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.test.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.test.ts
@@ -12,6 +12,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardHooks } from "./hooks.ts";
 
 function preToolInput(input?: unknown): HookInput {
@@ -459,4 +460,52 @@ test("exclude is inert when empty or absent", async () => {
 
     assert.equal(guardCalls.length, 1);
   }
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    action: "tool.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await runHook(hooks.PreToolUse, preToolInput({ id: "one" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    action: "tool.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = (await runHook(hooks.PreToolUse, preToolInput({ id: "one" }))) as {
+    hookSpecificOutput?: { permissionDecision?: string };
+  };
+  assert.equal(result.hookSpecificOutput?.permissionDecision, "deny");
+  assert.equal(guardCalls.length, 0);
+});
+
+test("inbound resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    inbound: {
+      action: "message.received",
+      actor: (input) => `actor-${input.prompt.length}`,
+      inputs: (input) => ({ prompt: policyInput.local.string(input.prompt) }),
+    },
+  });
+  await runHook(hooks.UserPromptSubmit, userPromptInput("hello"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-5");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    prompt: policyInput.local.string("hello"),
+  });
 });

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
@@ -50,16 +50,16 @@ export interface GuardHooksInboundPolicy {
    */
   rules?: RuleWithInput[] | ((input: GuardHooksInbound) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the inbound prompt. Derive it
-   * from authenticated server-side context; never trust the prompt as the
-   * actor identity.
+   * Trusted actor identity, or a resolver `(inbound, hookInput) => …` matching
+   * Claude `UserPromptSubmit`. Derive it from `session_id` / hook input; never
+   * trust the prompt as the actor identity.
    */
-  actor?: ActorResolver<GuardHooksInbound>;
+  actor?: ActorResolver<[GuardHooksInbound, UserPromptSubmitHookInput]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the inbound prompt. Build
-   * each value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(inbound, hookInput) => …`.
+   * Build each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardHooksInbound>;
+  inputs?: InputsResolver<[GuardHooksInbound, UserPromptSubmitHookInput]>;
   /** Metadata merged over the derived Claude context. */
   metadata?: ArcjetMetadata | ((input: GuardHooksInbound) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -118,17 +118,16 @@ export interface GuardHooksPolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, hookInput) => …` matching
+   * Claude `PreToolUse`. Derive it from `session_id` / hook input; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<GuardHooksCall>;
+  actor?: ActorResolver<[GuardHooksCall, PreToolUseHookInput]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(call, hookInput) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardHooksCall>;
+  inputs?: InputsResolver<[GuardHooksCall, PreToolUseHookInput]>;
   /** Metadata merged over the derived Claude context for tool hooks. */
   metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
   /** How to respond when a tool-gate evaluation is unavailable. Default `"deny"`. */
@@ -322,7 +321,7 @@ export function guardHooks(
         ...(call.toolName.length > 0 && { "claude.tool": call.toolName }),
         ...policyMetadata,
       };
-      const remote = await resolveActorInputs(policy, call);
+      const remote = await resolveActorInputs(policy, call, hookInput);
 
       return await runGate<HookJSONOutput>(client, {
         action,
@@ -373,7 +372,7 @@ export function guardHooks(
         "claude.phase": "inbound",
         ...policyMetadata,
       };
-      const remote = await resolveActorInputs(inboundPolicy, inbound);
+      const remote = await resolveActorInputs(inboundPolicy, inbound, hookInput);
 
       return await runGate<HookJSONOutput>(client, {
         action,

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
@@ -12,11 +12,11 @@ import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, RuleWithInput } from "../../types.ts";
 import { claudeAgentContext } from "./context.ts";
 import type { ClaudeContextSource } from "./context.ts";
-import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import { runGate } from "./gate.ts";
 
 /**

--- a/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
+++ b/arcjet-guard/src/claude-agent-sdk/v0/hooks.ts
@@ -8,6 +8,8 @@ import type {
   UserPromptSubmitHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -47,6 +49,17 @@ export interface GuardHooksInboundPolicy {
    * performs the guard call.
    */
   rules?: RuleWithInput[] | ((input: GuardHooksInbound) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the inbound prompt. Derive it
+   * from authenticated server-side context; never trust the prompt as the
+   * actor identity.
+   */
+  actor?: ActorResolver<GuardHooksInbound>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the inbound prompt. Build
+   * each value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardHooksInbound>;
   /** Metadata merged over the derived Claude context. */
   metadata?: ArcjetMetadata | ((input: GuardHooksInbound) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -104,6 +117,18 @@ export interface GuardHooksPolicy {
    * this still performs the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardHooksCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardHooksCall>;
   /** Metadata merged over the derived Claude context for tool hooks. */
   metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
   /** How to respond when a tool-gate evaluation is unavailable. Default `"deny"`. */
@@ -297,12 +322,14 @@ export function guardHooks(
         ...(call.toolName.length > 0 && { "claude.tool": call.toolName }),
         ...policyMetadata,
       };
+      const remote = await resolveActorInputs(policy, call);
 
       return await runGate<HookJSONOutput>(client, {
         action,
         rules,
         correlationId: agentCtx.correlationId,
         metadata,
+        ...remote,
         onAllow: () => ({}),
         onDeny: (decision) => preToolUseDeny(deniedReason(decision)),
         onUnavailable: () => preToolUseDeny(unavailableReason()),
@@ -346,12 +373,14 @@ export function guardHooks(
         "claude.phase": "inbound",
         ...policyMetadata,
       };
+      const remote = await resolveActorInputs(inboundPolicy, inbound);
 
       return await runGate<HookJSONOutput>(client, {
         action,
         rules,
         correlationId: agentCtx.correlationId,
         metadata,
+        ...remote,
         onAllow: () => ({}),
         onDeny: (decision) => userPromptBlock(deniedReason(decision)),
         onUnavailable: () => userPromptBlock(unavailableReason()),

--- a/arcjet-guard/src/claude-managed-agents/v0/gate.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/gate.ts
@@ -1,5 +1,6 @@
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 import type {
   ArcjetMetadata,
   Decision,
@@ -7,7 +8,6 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
-import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * Permit-only gate for inbound Managed Agents events. Shared by `guardEvents`.

--- a/arcjet-guard/src/claude-managed-agents/v0/gate.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/gate.ts
@@ -7,6 +7,7 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * Permit-only gate for inbound Managed Agents events. Shared by `guardEvents`.
@@ -19,6 +20,8 @@ export async function runGate<T>(
     rules: RuleWithInput[] | undefined;
     correlationId: string | undefined;
     metadata: ArcjetMetadata;
+    actor?: string;
+    inputs?: PolicyInputMap;
     onAllow: () => T;
     onDeny: (decision: DecisionDeny) => T;
     onUnavailable: (
@@ -38,6 +41,8 @@ export async function runGate<T>(
     onDeny,
     onUnavailable,
     onGuardError = "deny",
+    actor,
+    inputs,
   } = params;
 
   const correlation = correlationId === undefined ? {} : { correlationId };
@@ -46,7 +51,14 @@ export async function runGate<T>(
   let decisionId: string | undefined;
   let decision: Decision | undefined;
   try {
-    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+    decision = await client.guard({
+      label: action,
+      rules: rules ?? [],
+      ...correlation,
+      metadata,
+      ...(actor !== undefined && { actor }),
+      ...(inputs !== undefined && { inputs }),
+    });
   } catch (error) {
     if (failClosed) {
       warnUnavailable(action, "threw", true, error);

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.test.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { claudeManagedAgentsContext } from "./context.ts";
 import { guardCustomTool } from "./guard-custom-tool.ts";
 import type { AgentCustomToolUseEvent, UserCustomToolResultEventParams } from "./types.ts";
@@ -377,4 +378,54 @@ test("wrapped betaTool factory throw fail-closes", async () => {
     },
   });
   await assert.rejects(() => wrapped.run({ orderNumber: "1" }), /could not be completed/i);
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const { send } = sendRecorder();
+  await guardCustomTool(
+    client,
+    {
+      event: customToolUse({ input: { id: "one" } }),
+      execute: () => Promise.resolve("ok"),
+      send,
+    },
+    {
+      action: "order.looked-up",
+      actor: (input) => `actor-${String(input["id"])}`,
+      inputs: (input) => ({ id: policyInput.server.string(String(input["id"])) }),
+    },
+  );
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const { send, calls } = sendRecorder();
+  let executed = 0;
+  const gated = await guardCustomTool(
+    client,
+    {
+      event: customToolUse({ input: { id: "one" } }),
+      execute: () => {
+        executed += 1;
+        return Promise.resolve("ok");
+      },
+      send,
+    },
+    {
+      action: "order.looked-up",
+      inputs: () => {
+        throw new Error("mapping failed");
+      },
+    },
+  );
+  assert.equal(gated.allowed, false);
+  assert.equal(executed, 0);
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls.length, 1);
 });

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.test.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.test.ts
@@ -380,7 +380,6 @@ test("wrapped betaTool factory throw fail-closes", async () => {
   await assert.rejects(() => wrapped.run({ orderNumber: "1" }), /could not be completed/i);
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const { send } = sendRecorder();

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.ts
@@ -28,17 +28,18 @@ export interface GuardCustomToolPolicy<TInput = { [key: string]: unknown }> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, eventOrContext) => …`.
+   * Hosted custom tools pass the `agent.custom_tool_use` event; self-hosted
+   * `run` passes the second `context` argument. Derive it from authenticated
+   * server-side context; never trust a model-produced tool input as the actor
+   * identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, eventOrContext) => …`.
+   * Build each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -238,7 +239,7 @@ async function runHostedCustomTool<TOutput>(
     rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
-    remote = await resolveActorInputs(policy, input);
+    remote = await resolveActorInputs(policy, input, event);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -319,7 +320,7 @@ function wrapRunnableTool<TTool extends ManagedAgentsRunnableTool<any, any>>(
       rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
       policyMetadata =
         typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
-      remote = await resolveActorInputs(policy, input);
+      remote = await resolveActorInputs(policy, input, context);
     } catch (error) {
       if (shouldWarn()) {
         console.warn(

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-custom-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { deniedReason, unavailableReason } from "../../agents/denial.ts";
@@ -25,6 +27,18 @@ export interface GuardCustomToolPolicy<TInput = { [key: string]: unknown }> {
    * or returning `[]`, still submits a guard call.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -219,10 +233,12 @@ async function runHostedCustomTool<TOutput>(
   const input = event.input;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
+    remote = await resolveActorInputs(policy, input);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -249,6 +265,7 @@ async function runHostedCustomTool<TOutput>(
     rules,
     correlationId: policy.context?.correlationId,
     metadata,
+    ...remote,
     onDeny: (decision: DecisionDeny): GuardCustomToolResult<TOutput> => ({
       allowed: false,
       result: errorResult(event, deniedReason(decision)),
@@ -297,10 +314,12 @@ function wrapRunnableTool<TTool extends ManagedAgentsRunnableTool<any, any>>(
   ): Promise<ReturnType<TTool["run"]>> => {
     let rules: RuleWithInput[] | undefined;
     let policyMetadata: ArcjetMetadata | undefined;
+    let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
     try {
       rules = typeof policy.rules === "function" ? policy.rules(input) : policy.rules;
       policyMetadata =
         typeof policy.metadata === "function" ? policy.metadata(input) : policy.metadata;
+      remote = await resolveActorInputs(policy, input);
     } catch (error) {
       if (shouldWarn()) {
         console.warn(
@@ -329,6 +348,7 @@ function wrapRunnableTool<TTool extends ManagedAgentsRunnableTool<any, any>>(
       rules,
       correlationId: policy.context?.correlationId,
       metadata,
+      ...remote,
       onDeny: (decision: DecisionDeny) => {
         throw new Error(deniedReason(decision));
       },

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-events.test.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-events.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { claudeManagedAgentsContext } from "./context.ts";
 import { guardEvents } from "./guard-events.ts";
 import type { EventSendBody, UserMessageEventParams } from "./types.ts";
@@ -298,4 +299,50 @@ test("concatenates text from multiple user.message events", async () => {
 
   assert.equal(seen, "first\nsecond");
   assert.equal(recorded(guardCalls[0])["label"], "message.received");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const { send } = sendRecorder();
+  const events = [userMessage("hello")];
+  await guardEvents(
+    client,
+    {
+      events,
+      inbound: {
+        action: "message.received",
+        actor: (input) => `actor-${input.text.length}`,
+        inputs: (input) => ({ text: policyInput.local.string(input.text) }),
+      },
+    },
+    send,
+  );
+  assert.equal(recorded(guardCalls[0]).actor, "actor-5");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    text: policyInput.local.string("hello"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const { send, calls } = sendRecorder();
+  const events = [userMessage("hello")];
+  const verdict = await guardEvents(
+    client,
+    {
+      events,
+      inbound: {
+        action: "message.received",
+        inputs: () => {
+          throw new Error("mapping failed");
+        },
+      },
+    },
+    send,
+  );
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.allowed === false ? verdict.outcome : undefined, "UNAVAILABLE");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls.length, 0);
 });

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-events.test.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-events.test.ts
@@ -301,7 +301,6 @@ test("concatenates text from multiple user.message events", async () => {
   assert.equal(recorded(guardCalls[0])["label"], "message.received");
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const { send } = sendRecorder();
@@ -342,7 +341,9 @@ test("an input resolver failure follows the fail-closed unavailable path", async
     send,
   );
   assert.equal(verdict.allowed, false);
-  assert.equal(verdict.allowed === false ? verdict.outcome : undefined, "UNAVAILABLE");
+  if (!verdict.allowed) {
+    assert.equal(verdict.outcome, "UNAVAILABLE");
+  }
   assert.equal(guardCalls.length, 0);
   assert.equal(calls.length, 0);
 });

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-events.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-events.ts
@@ -29,12 +29,12 @@ export interface GuardEventsInbound {
    * from authenticated server-side context; never trust the message text as
    * the actor identity.
    */
-  actor?: ActorResolver<{ text: string; events: readonly ManagedAgentsEventParams[] }>;
+  actor?: ActorResolver<[{ text: string; events: readonly ManagedAgentsEventParams[] }]>;
   /**
    * Typed remote-policy inputs, or a resolver over the inbound events. Build
    * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<{ text: string; events: readonly ManagedAgentsEventParams[] }>;
+  inputs?: InputsResolver<[{ text: string; events: readonly ManagedAgentsEventParams[] }]>;
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
   onGuardError?: OnGuardError;
 }

--- a/arcjet-guard/src/claude-managed-agents/v0/guard-events.ts
+++ b/arcjet-guard/src/claude-managed-agents/v0/guard-events.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { deniedReason, unavailableReason } from "../../agents/denial.ts";
@@ -22,6 +24,17 @@ export interface GuardEventsInbound {
   rules?:
     | RuleWithInput[]
     | ((input: { text: string; events: readonly ManagedAgentsEventParams[] }) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the inbound events. Derive it
+   * from authenticated server-side context; never trust the message text as
+   * the actor identity.
+   */
+  actor?: ActorResolver<{ text: string; events: readonly ManagedAgentsEventParams[] }>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the inbound events. Build
+   * each value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<{ text: string; events: readonly ManagedAgentsEventParams[] }>;
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
   onGuardError?: OnGuardError;
 }
@@ -126,13 +139,16 @@ export async function guardEvents<
 
   const text = inboundTextFromEvents(events);
   const action = policy.inbound.action ?? "message.received";
+  const inboundArg = { text, events };
 
   let rules: RuleWithInput[] | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     rules =
       typeof policy.inbound.rules === "function"
-        ? policy.inbound.rules({ text, events })
+        ? policy.inbound.rules(inboundArg)
         : policy.inbound.rules;
+    remote = await resolveActorInputs(policy.inbound, inboundArg);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -173,6 +189,7 @@ export async function guardEvents<
     rules,
     correlationId: policy.context?.correlationId,
     metadata,
+    ...remote,
     onAllow: (): Permit => ({ allowed: true }),
     onDeny: (decision: DecisionDeny): Permit => ({
       allowed: false,

--- a/arcjet-guard/src/genkit/v1/active-context.ts
+++ b/arcjet-guard/src/genkit/v1/active-context.ts
@@ -1,0 +1,63 @@
+/**
+ * The generate() context Genkit stores in async-local storage. Authored
+ * tool handlers see it on `{ context }` even when the ToolAction call's
+ * `options` omit it — `generate({ context })` does not copy that object
+ * onto the tool invocation.
+ *
+ * Dynamic import so this namespace stays loadable when the optional
+ * `genkit` peer is absent. Construction only runs on a live tool call,
+ * which is only reachable in an app that already installed Genkit.
+ */
+
+let loadedGetContext: (() => unknown) | undefined;
+let loadFailed = false;
+
+async function readActiveContext(): Promise<unknown> {
+  if (loadFailed) {
+    return undefined;
+  }
+  if (loadedGetContext === undefined) {
+    try {
+      const core = await import("@genkit-ai/core");
+      if (typeof core.getContext !== "function") {
+        loadFailed = true;
+        return undefined;
+      }
+      loadedGetContext = core.getContext;
+    } catch {
+      loadFailed = true;
+      return undefined;
+    }
+  }
+  try {
+    return loadedGetContext();
+  } catch {
+    return undefined;
+  }
+}
+
+function hasOwnContext(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || !("context" in value)) {
+    return false;
+  }
+  const context = (value as { context?: unknown }).context;
+  return context !== undefined && context !== null;
+}
+
+/**
+ * Attach the ALS generate context onto a tool-call options / middleware
+ * `ctx` object when that object does not already carry `context`.
+ */
+export async function withActiveGenkitContext(options: unknown): Promise<unknown> {
+  if (hasOwnContext(options)) {
+    return options;
+  }
+  const active = await readActiveContext();
+  if (active === undefined) {
+    return options;
+  }
+  if (options !== null && typeof options === "object") {
+    return { ...options, context: active };
+  }
+  return { context: active };
+}

--- a/arcjet-guard/src/genkit/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.test.ts
@@ -10,9 +10,9 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
 import { guardTool } from "./guard-tool.ts";
 import type { GenkitTool } from "./guard-tool.ts";
@@ -443,7 +443,6 @@ test("guardTool-wrapped fake is skipped when registered under its action name", 
   // The middleware skipped; the only guard calls would come from next() (none here).
   assert.equal(guardCalls.length, 0);
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/genkit/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
@@ -441,4 +442,42 @@ test("guardTool-wrapped fake is skipped when registered under its action name", 
   assert.equal(nextCalls, 1);
   // The middleware skipped; the only guard calls would come from next() (none here).
   assert.equal(guardCalls.length, 0);
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await runHook(mw, toolRequest("lookup", { id: "one" }), async () => ({
+    toolResponse: { name: "lookup", output: { ok: true } },
+  }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = await runHook(mw, toolRequest("lookup", { id: "one" }), async () => {
+    calls += 1;
+    return { toolResponse: { name: "lookup", output: { ok: true } } };
+  });
+  assert.equal(calls, 0);
+  assert.equal(guardCalls.length, 0);
+  const part = result as { toolResponse: { output: unknown } };
+  assert.equal(asDenial<ArcjetDenialResult>(part.toolResponse.output).reason, "ERROR");
 });

--- a/arcjet-guard/src/genkit/v1/guard-middleware.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.ts
@@ -7,6 +7,7 @@ import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { withActiveGenkitContext } from "./active-context.ts";
 import { genkitContext } from "./context.ts";
 import type { GenkitContextSource } from "./context.ts";
 
@@ -42,8 +43,9 @@ export interface GuardMiddlewarePolicy {
   /**
    * Trusted actor identity, or a resolver `(call, ctx) => …` matching the
    * Genkit middleware `tool(req, ctx, next)` context. Derive it from
-   * authenticated generate context; never trust a model-produced tool input
-   * as the actor identity.
+   * authenticated generate context — including the active
+   * `generate({ context })` ALS context when the hook `ctx` omits it.
+   * Never trust a model-produced tool input as the actor identity.
    */
   actor?: ActorResolver<[GuardMiddlewareCall, unknown?]>;
   /**
@@ -279,13 +281,15 @@ export function guardMiddleware(
           let rules: RuleWithInput[] | undefined;
           let policyMetadata: ArcjetMetadata | undefined;
           let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
+          let hookCtx = ctx;
           try {
             action = resolveAction(policy, call);
             sessionId = resolveSessionId(policy, call);
             rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
             policyMetadata =
               typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-            remote = await resolveActorInputs(policy, call, ctx);
+            hookCtx = await withActiveGenkitContext(ctx);
+            remote = await resolveActorInputs(policy, call, hookCtx);
           } catch (error) {
             const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
             if (shouldWarn()) {
@@ -301,7 +305,7 @@ export function guardMiddleware(
             return denialPart(req, unavailableResult());
           }
 
-          const source = isContextSource(ctx) ? ctx : undefined;
+          const source = isContextSource(hookCtx) ? hookCtx : undefined;
           const agentCtx = genkitContext(
             source,
             sessionId === undefined ? undefined : { sessionId },

--- a/arcjet-guard/src/genkit/v1/guard-middleware.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.ts
@@ -115,7 +115,10 @@ function resolveAction(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall)
   return "tool.invoked";
 }
 
-function resolveSessionId(policy: GuardMiddlewarePolicy, call: GuardMiddlewareCall): string | undefined {
+function resolveSessionId(
+  policy: GuardMiddlewarePolicy,
+  call: GuardMiddlewareCall,
+): string | undefined {
   if (typeof policy.sessionId === "function") {
     return policy.sessionId(call);
   }
@@ -253,7 +256,11 @@ export function guardMiddleware(
           : undefined;
 
       return {
-        tool: async (req: unknown, ctx: unknown, next: (req: unknown, ctx: unknown) => Promise<unknown>) => {
+        tool: async (
+          req: unknown,
+          ctx: unknown,
+          next: (req: unknown, ctx: unknown) => Promise<unknown>,
+        ) => {
           if (!isToolRequestPart(req)) {
             return next(req, ctx);
           }
@@ -295,7 +302,10 @@ export function guardMiddleware(
           }
 
           const source = isContextSource(ctx) ? ctx : undefined;
-          const agentCtx = genkitContext(source, sessionId === undefined ? undefined : { sessionId });
+          const agentCtx = genkitContext(
+            source,
+            sessionId === undefined ? undefined : { sessionId },
+          );
 
           const metadata: ArcjetMetadata = {
             ...agentCtx.metadata,

--- a/arcjet-guard/src/genkit/v1/guard-middleware.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -37,6 +39,18 @@ export interface GuardMiddlewarePolicy {
    * performs the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardMiddlewareCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardMiddlewareCall>;
   /** Metadata merged over the derived Genkit context. */
   metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
   /**
@@ -257,12 +271,14 @@ export function guardMiddleware(
           let sessionId: string | undefined;
           let rules: RuleWithInput[] | undefined;
           let policyMetadata: ArcjetMetadata | undefined;
+          let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
           try {
             action = resolveAction(policy, call);
             sessionId = resolveSessionId(policy, call);
             rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
             policyMetadata =
               typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+            remote = await resolveActorInputs(policy, call);
           } catch (error) {
             const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
             if (shouldWarn()) {
@@ -292,6 +308,7 @@ export function guardMiddleware(
             rules,
             correlationId: agentCtx.correlationId,
             metadata: mergedMetadata,
+            ...remote,
             onDeny: (decision: DecisionDeny) => {
               if (policy.onDeny === undefined) {
                 return denialPart(req, denialResult(decision));

--- a/arcjet-guard/src/genkit/v1/guard-middleware.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.ts
@@ -40,17 +40,17 @@ export interface GuardMiddlewarePolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, ctx) => …` matching the
+   * Genkit middleware `tool(req, ctx, next)` context. Derive it from
+   * authenticated generate context; never trust a model-produced tool input
+   * as the actor identity.
    */
-  actor?: ActorResolver<GuardMiddlewareCall>;
+  actor?: ActorResolver<[GuardMiddlewareCall, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * Typed remote-policy inputs, or a resolver `(call, ctx) => …`. Build each
    * value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardMiddlewareCall>;
+  inputs?: InputsResolver<[GuardMiddlewareCall, unknown?]>;
   /** Metadata merged over the derived Genkit context. */
   metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
   /**
@@ -285,7 +285,7 @@ export function guardMiddleware(
             rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
             policyMetadata =
               typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-            remote = await resolveActorInputs(policy, call);
+            remote = await resolveActorInputs(policy, call, ctx);
           } catch (error) {
             const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
             if (shouldWarn()) {

--- a/arcjet-guard/src/genkit/v1/guard-middleware.ts
+++ b/arcjet-guard/src/genkit/v1/guard-middleware.ts
@@ -281,7 +281,7 @@ export function guardMiddleware(
           let rules: RuleWithInput[] | undefined;
           let policyMetadata: ArcjetMetadata | undefined;
           let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
-          let hookCtx = ctx;
+          let hookCtx: unknown;
           try {
             action = resolveAction(policy, call);
             sessionId = resolveSessionId(policy, call);

--- a/arcjet-guard/src/genkit/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
@@ -777,4 +778,41 @@ test("policy factory throw warns when ARCJET_LOG_LEVEL asks for warnings", async
       process.env["ARCJET_LOG_LEVEL"] = previous;
     }
   }
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createToolAction();
+  const wrapped = guardTool(client, tool as GenkitTool, {
+    action: "test.action",
+    actor: (input: { id?: string }) => `actor-${input.id}`,
+    inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
+  });
+  await wrapped({ id: "one" }, toolOptions("t"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createToolAction({
+    handler: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool as GenkitTool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asToolResult(await wrapped({ id: "one" }, toolOptions("t")));
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/genkit/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.test.ts
@@ -11,10 +11,10 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import type { DecisionDeny } from "../../types.ts";
 import type { GenkitTool } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -780,11 +780,10 @@ test("policy factory throw warns when ARCJET_LOG_LEVEL asks for warnings", async
   }
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const tool = createToolAction();
-  const wrapped = guardTool(client, tool as GenkitTool, {
+  const wrapped = guardTool(client, tool, {
     action: "test.action",
     actor: (input: { id?: string }) => `actor-${input.id}`,
     inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
@@ -805,7 +804,7 @@ test("an input resolver failure follows the fail-closed unavailable path", async
       return { ok: true };
     },
   });
-  const wrapped = guardTool(client, tool as GenkitTool, {
+  const wrapped = guardTool(client, tool, {
     action: "test.action",
     inputs: () => {
       throw new Error("mapping failed");

--- a/arcjet-guard/src/genkit/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.test.ts
@@ -785,11 +785,12 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const tool = createToolAction();
   const wrapped = guardTool(client, tool, {
     action: "test.action",
-    actor: (input: { id?: string }) => `actor-${input.id}`,
+    actor: (_input, options) =>
+      String((options as { context?: { sessionId?: string } } | undefined)?.context?.sessionId),
     inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
   });
   await wrapped({ id: "one" }, toolOptions("t"));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "t");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/genkit/v1/guard-tool.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.ts
@@ -484,7 +484,7 @@ async function runGuardedTool<TInput>(
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
   let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
-  let callOptions = options;
+  let callOptions: unknown;
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
     const typedArgs = args as TInput;

--- a/arcjet-guard/src/genkit/v1/guard-tool.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.ts
@@ -66,17 +66,16 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, options) => …` matching
+   * a Genkit `ToolAction` call. Derive it from `options.context`; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, options) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -490,7 +489,7 @@ async function runGuardedTool<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
-    remote = await resolveActorInputs(policy, typedArgs);
+    remote = await resolveActorInputs(policy, typedArgs, options);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(

--- a/arcjet-guard/src/genkit/v1/guard-tool.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -63,6 +65,18 @@ export interface GuardToolPolicy<TInput> {
    * the guard call, which still costs a round trip and returns a decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -442,7 +456,7 @@ function denialEnvelope(
   return extras.wrapRunResult ? { result: shaped, telemetry: { traceId: "", spanId: "" } } : shaped;
 }
 
-function runGuardedTool<TInput>(
+async function runGuardedTool<TInput>(
   client: ArcjetAgentClient,
   tool: GenkitTool,
   policy: GuardToolPolicy<TInput>,
@@ -460,6 +474,7 @@ function runGuardedTool<TInput>(
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
     const typedArgs = args as TInput;
@@ -467,6 +482,7 @@ function runGuardedTool<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+    remote = await resolveActorInputs(policy, typedArgs);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -501,6 +517,7 @@ function runGuardedTool<TInput>(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => {
       if (policy.onDeny === undefined) {
         return asResult(denialResult(decision));

--- a/arcjet-guard/src/genkit/v1/guard-tool.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.ts
@@ -7,6 +7,7 @@ import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
+import { withActiveGenkitContext } from "./active-context.ts";
 import { genkitContext } from "./context.ts";
 import type { GenkitContextSource } from "./context.ts";
 
@@ -67,8 +68,9 @@ export interface GuardToolPolicy<TInput> {
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
    * Trusted actor identity, or a resolver `(input, options) => …` matching
-   * a Genkit `ToolAction` call. Derive it from `options.context`; never
-   * trust a model-produced tool input as the actor identity.
+   * a Genkit `ToolAction` call. Derive it from `options.context` — including
+   * the active `generate({ context })` ALS context when the call options
+   * omit it. Never trust a model-produced tool input as the actor identity.
    */
   actor?: ActorResolver<[TInput, unknown?]>;
   /**
@@ -482,6 +484,7 @@ async function runGuardedTool<TInput>(
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
   let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
+  let callOptions = options;
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
     const typedArgs = args as TInput;
@@ -489,7 +492,8 @@ async function runGuardedTool<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
-    remote = await resolveActorInputs(policy, typedArgs, options);
+    callOptions = await withActiveGenkitContext(options);
+    remote = await resolveActorInputs(policy, typedArgs, callOptions);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -504,7 +508,7 @@ async function runGuardedTool<TInput>(
     return denialEnvelope(unavailableResult(), envelope);
   }
 
-  const source = isContextSource(options) ? options : undefined;
+  const source = isContextSource(callOptions) ? callOptions : undefined;
   const agentCtx = genkitContext(source, sessionId === undefined ? undefined : { sessionId });
 
   const toolName =

--- a/arcjet-guard/src/genkit/v1/guard-tool.ts
+++ b/arcjet-guard/src/genkit/v1/guard-tool.ts
@@ -418,9 +418,17 @@ function wrapToolAction<TInput>(
 
   if (originalRun !== undefined) {
     const newRun = (input?: unknown, options?: unknown): Promise<unknown> =>
-      runGuardedTool(client, tool, policy, input, options, () => Promise.resolve(originalRun(input, options)), {
-        wrapRunResult: true,
-      });
+      runGuardedTool(
+        client,
+        tool,
+        policy,
+        input,
+        options,
+        () => Promise.resolve(originalRun(input, options)),
+        {
+          wrapRunResult: true,
+        },
+      );
     Object.defineProperty(wrapped, "run", {
       value: newRun,
       writable: true,
@@ -494,7 +502,7 @@ async function runGuardedTool<TInput>(
     if (policy.onGuardError === "allow") {
       return execute();
     }
-    return Promise.resolve(denialEnvelope(unavailableResult(), envelope));
+    return denialEnvelope(unavailableResult(), envelope);
   }
 
   const source = isContextSource(options) ? options : undefined;

--- a/arcjet-guard/src/genkit/v1/type-only.test.ts
+++ b/arcjet-guard/src/genkit/v1/type-only.test.ts
@@ -99,7 +99,11 @@ test("all genkit imports in the genkit namespace are type-only", () => {
     }
   }
 
-  assert.equal(errors.length, 0, `Type-only import violations in genkit namespace:\n${errors.join("\n")}`);
+  assert.equal(
+    errors.length,
+    0,
+    `Type-only import violations in genkit namespace:\n${errors.join("\n")}`,
+  );
 });
 
 test("scanner detects value imports when temporarily added", () => {

--- a/arcjet-guard/src/genkit/v1/type-only.test.ts
+++ b/arcjet-guard/src/genkit/v1/type-only.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { test } from "node:test";
 
 import { collectTsFiles, extractTypedImportSpecifiers } from "../../../test/_shared/source-scan.ts";
@@ -78,10 +78,13 @@ test("type-only import scanner works on genkit fixtures", () => {
   }
 });
 
-test("all genkit imports in the genkit namespace are type-only", () => {
+const ALLOWED_DYNAMIC_CONTEXT_IMPORT = "@genkit-ai/core";
+
+test("all genkit imports in the genkit namespace are type-only except the ALS context load", () => {
   const namespaceDir = resolve(import.meta.dirname, "..");
   const filesToCheck = collectTsFiles(namespaceDir);
   const errors: string[] = [];
+  let allowedDynamic = 0;
 
   for (const filePath of filesToCheck) {
     let content: string;
@@ -93,9 +96,17 @@ test("all genkit imports in the genkit namespace are type-only", () => {
 
     const imports = extractTypedImportSpecifiers(content);
     for (const imp of imports) {
-      if (isGenkitPeer(imp.specifier) && !imp.typeOnly) {
-        errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
+      if (!isGenkitPeer(imp.specifier) || imp.typeOnly) {
+        continue;
       }
+      if (
+        imp.specifier === ALLOWED_DYNAMIC_CONTEXT_IMPORT &&
+        basename(filePath) === "active-context.ts"
+      ) {
+        allowedDynamic += 1;
+        continue;
+      }
+      errors.push(`${filePath}: value import of "${imp.specifier}" found; must be type-only`);
     }
   }
 
@@ -103,6 +114,11 @@ test("all genkit imports in the genkit namespace are type-only", () => {
     errors.length,
     0,
     `Type-only import violations in genkit namespace:\n${errors.join("\n")}`,
+  );
+  assert.equal(
+    allowedDynamic,
+    1,
+    "expected exactly one dynamic getContext load in active-context.ts",
   );
 });
 

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
@@ -10,9 +10,9 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardPlugin } from "./guard-plugin.ts";
 import type { GoogleAdkGuardPlugin } from "./guard-plugin.ts";
 
@@ -389,7 +389,6 @@ test("sessionId callback receives the tool name and input", async () => {
   assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
   assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
@@ -394,13 +394,13 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const plugin = guardPlugin(client, {
     action: "tool.invoked",
-    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    actor: (_call, tc) => String((tc as { userId?: string } | undefined)?.userId),
     inputs: (call) => ({
       id: policyInput.server.string(String((call.input as { id?: string }).id)),
     }),
   });
   await runHook(plugin, beforeToolParams("lookup", { id: "one" }));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "user-auto");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import { guardPlugin } from "./guard-plugin.ts";
@@ -387,4 +388,34 @@ test("sessionId callback receives the tool name and input", async () => {
   });
   assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
   assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, {
+    action: "tool.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await runHook(plugin, beforeToolParams("lookup", { id: "one" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const plugin = guardPlugin(client, {
+    action: "tool.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = await runHook(plugin, beforeToolParams("lookup", { id: "one" }));
+  assert.equal(asDenial<ArcjetDenialResult>(result).reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.ts
@@ -1,5 +1,7 @@
 import type { BasePlugin } from "@google/adk";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult, type ArcjetDenialResult } from "../../agents/denial.ts";
@@ -40,6 +42,18 @@ export interface GuardPluginPolicy {
    * the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardPluginCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardPluginCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardPluginCall>;
   /** Metadata merged over the derived Google ADK context. */
   metadata?: ArcjetMetadata | ((call: GuardPluginCall) => ArcjetMetadata);
   /**
@@ -124,14 +138,14 @@ function pluginName(): string {
   return `arcjet-guard-${pluginSeq}-${crypto.randomUUID().slice(0, 8)}`;
 }
 
-function gateToolCall(
+async function gateToolCall(
   client: ArcjetAgentClient,
   policy: GuardPluginPolicy,
   params: BeforeToolCallbackParams,
 ): Promise<Record<string, unknown> | undefined> {
   if (isBrandedTool(params.tool)) {
     // oxlint-disable-next-line unicorn/no-useless-undefined -- ADK skip is `undefined`, not void
-    return Promise.resolve(undefined);
+    return undefined;
   }
 
   const toolName = params.tool.name;
@@ -142,12 +156,14 @@ function gateToolCall(
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     action = resolveAction(policy, call);
     sessionId = resolveSessionId(policy, call);
     rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+    remote = await resolveActorInputs(policy, call);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {
@@ -159,9 +175,9 @@ function gateToolCall(
     }
     if (policy.onGuardError === "allow") {
       // oxlint-disable-next-line unicorn/no-useless-undefined -- ADK skip is `undefined`, not void
-      return Promise.resolve(undefined);
+      return undefined;
     }
-    return Promise.resolve(denyDict(unavailableResult()));
+    return denyDict(unavailableResult());
   }
 
   const source = isContextSource(params.toolContext) ? params.toolContext : undefined;
@@ -178,6 +194,7 @@ function gateToolCall(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => denyDict(denialResult(decision)),
     onUnavailable: () => denyDict(unavailableResult()),
     // oxlint-disable-next-line unicorn/no-useless-undefined -- ALLOW is `undefined` so the tool runs

--- a/arcjet-guard/src/google-adk/v2/guard-plugin.ts
+++ b/arcjet-guard/src/google-adk/v2/guard-plugin.ts
@@ -22,6 +22,8 @@ export interface GuardPluginCall {
   input: unknown;
 }
 
+type BeforeToolCallbackParams = Parameters<BasePlugin["beforeToolCallback"]>[0];
+
 /**
  * Policy for `guardPlugin()` — how to guard tools that execute
  * through a Runner `BasePlugin.beforeToolCallback`.
@@ -43,17 +45,16 @@ export interface GuardPluginPolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardPluginCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, toolContext) => …` matching
+   * ADK `beforeToolCallback`. Derive it from `toolContext` / session `state`;
+   * never trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<GuardPluginCall>;
+  actor?: ActorResolver<[GuardPluginCall, BeforeToolCallbackParams["toolContext"]?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(call, toolContext) => …`.
+   * Build each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardPluginCall>;
+  inputs?: InputsResolver<[GuardPluginCall, BeforeToolCallbackParams["toolContext"]?]>;
   /** Metadata merged over the derived Google ADK context. */
   metadata?: ArcjetMetadata | ((call: GuardPluginCall) => ArcjetMetadata);
   /**
@@ -66,8 +67,6 @@ export interface GuardPluginPolicy {
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
   onGuardError?: OnGuardError;
 }
-
-type BeforeToolCallbackParams = Parameters<BasePlugin["beforeToolCallback"]>[0];
 
 /**
  * The Runner plugin this helper returns.
@@ -163,7 +162,7 @@ async function gateToolCall(
     rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-    remote = await resolveActorInputs(policy, call);
+    remote = await resolveActorInputs(policy, call, params.toolContext);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {

--- a/arcjet-guard/src/langchain/v1/assignability.test.ts
+++ b/arcjet-guard/src/langchain/v1/assignability.test.ts
@@ -10,8 +10,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { AgentMiddleware } from "langchain";
 import type { DynamicStructuredTool, StructuredToolInterface } from "@langchain/core/tools";
+import type { AgentMiddleware } from "langchain";
 
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { guardMiddleware } from "./guard-middleware.ts";

--- a/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
@@ -251,14 +251,27 @@ test("an input resolver failure follows the fail-closed unavailable path", async
       throw new Error("mapping failed");
     },
   });
+  let result: unknown;
   try {
-    await runHook(mw, toolRequest("lookup", { id: "one" }), async () => {
+    result = await runHook(mw, toolRequest("lookup", { id: "one" }), async () => {
       calls += 1;
       return { ok: true };
     });
   } catch {
     // Peer-absent CI cannot construct ToolMessage; the tool still must not run.
+    assert.equal(calls, 0);
+    assert.equal(guardCalls.length, 0);
+    return;
   }
   assert.equal(calls, 0);
   assert.equal(guardCalls.length, 0);
+  const content =
+    result !== null && typeof result === "object" && "content" in result ? result.content : result;
+  const payload = typeof content === "string" ? JSON.parse(content) : content;
+  assert.equal(
+    payload !== null && typeof payload === "object" && "reason" in payload
+      ? payload.reason
+      : undefined,
+    "ERROR",
+  );
 });

--- a/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
@@ -9,6 +9,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
 import { guardTool } from "./guard-tool.ts";
@@ -223,4 +224,42 @@ test("sessionId callback receives the tool name and input", async () => {
   );
   assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
   assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await runHook(mw, toolRequest("lookup", { id: "one" }), async () => ({ ok: true }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  try {
+    await runHook(mw, toolRequest("lookup", { id: "one" }), async () => {
+      calls += 1;
+      return { ok: true };
+    });
+  } catch {
+    // Peer-absent CI cannot construct ToolMessage; the tool still must not run.
+  }
+  assert.equal(calls, 0);
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.test.ts
@@ -9,8 +9,8 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
 import { guardTool } from "./guard-tool.ts";
 import type { LangChainTool } from "./guard-tool.ts";
@@ -225,7 +225,6 @@ test("sessionId callback receives the tool name and input", async () => {
   assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
   assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/langchain/v1/guard-middleware.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.ts
@@ -289,7 +289,10 @@ export function guardMiddleware(
   policy: GuardMiddlewarePolicy = {},
 ): LangChainGuardMiddleware {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- body is structural; the hook type is what createAgent assigns without a cast
-  const wrapToolCall = (async (request: unknown, handler: (request: unknown) => Promise<unknown>) => {
+  const wrapToolCall = (async (
+    request: unknown,
+    handler: (request: unknown) => Promise<unknown>,
+  ) => {
     if (!isToolCallRequest(request)) {
       return handler(request);
     }

--- a/arcjet-guard/src/langchain/v1/guard-middleware.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.ts
@@ -43,17 +43,17 @@ export interface GuardMiddlewarePolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, runtime) => …` matching
+   * `wrapToolCall`'s `request.runtime`. Derive it from
+   * `runtime.configurable`; never trust a model-produced tool input as the
+   * actor identity.
    */
-  actor?: ActorResolver<GuardMiddlewareCall>;
+  actor?: ActorResolver<[GuardMiddlewareCall, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(call, runtime) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardMiddlewareCall>;
+  inputs?: InputsResolver<[GuardMiddlewareCall, unknown?]>;
   /** Metadata merged over the derived LangChain context. */
   metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
   /**
@@ -316,7 +316,7 @@ export function guardMiddleware(
       rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
       policyMetadata =
         typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-      remote = await resolveActorInputs(policy, call);
+      remote = await resolveActorInputs(policy, call, request.runtime);
     } catch (error) {
       const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
       if (shouldWarn()) {

--- a/arcjet-guard/src/langchain/v1/guard-middleware.ts
+++ b/arcjet-guard/src/langchain/v1/guard-middleware.ts
@@ -1,5 +1,7 @@
 import type { AgentMiddleware, WrapToolCallHook } from "langchain";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -40,6 +42,18 @@ export interface GuardMiddlewarePolicy {
    * performs the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardMiddlewareCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardMiddlewareCall>;
   /** Metadata merged over the derived LangChain context. */
   metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
   /**
@@ -275,7 +289,7 @@ export function guardMiddleware(
   policy: GuardMiddlewarePolicy = {},
 ): LangChainGuardMiddleware {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- body is structural; the hook type is what createAgent assigns without a cast
-  const wrapToolCall = ((request: unknown, handler: (request: unknown) => Promise<unknown>) => {
+  const wrapToolCall = (async (request: unknown, handler: (request: unknown) => Promise<unknown>) => {
     if (!isToolCallRequest(request)) {
       return handler(request);
     }
@@ -292,12 +306,14 @@ export function guardMiddleware(
     let sessionId: string | undefined;
     let rules: RuleWithInput[] | undefined;
     let policyMetadata: ArcjetMetadata | undefined;
+    let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
     try {
       action = resolveAction(policy, call);
       sessionId = resolveSessionId(policy, call);
       rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
       policyMetadata =
         typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+      remote = await resolveActorInputs(policy, call);
     } catch (error) {
       const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
       if (shouldWarn()) {
@@ -327,6 +343,7 @@ export function guardMiddleware(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
+      ...remote,
       // Unlike guard-tool.ts, these handlers return a promise: building the
       // denial has to await the dynamic `@langchain/core/messages` import.
       // `runGuarded` is `async` and returns the handler's value directly, so

--- a/arcjet-guard/src/langchain/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.test.ts
@@ -534,11 +534,12 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const tool = createLangChainTool<{ id: string }>();
   const wrapped = guardTool(client, tool, {
     action: "test.action",
-    actor: (input) => `actor-${input.id}`,
+    actor: (_input, config) =>
+      String((config as { configurable?: { thread_id?: string } })?.configurable?.thread_id),
     inputs: (input) => ({ id: policyInput.server.string(input.id) }),
   });
   await wrapped.invoke!({ id: "one" }, threadConfig("t"));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "t");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/langchain/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
@@ -526,4 +527,41 @@ test("DENY through a tool_call envelope returns the denial and scans only args",
   assert.deepEqual(scanned, { note: "x" });
   assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangChainTool<{ id: string }>();
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    actor: (input) => `actor-${input.id}`,
+    inputs: (input) => ({ id: policyInput.server.string(input.id) }),
+  });
+  await wrapped.invoke!({ id: "one" }, threadConfig("t"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangChainTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asToolResult(await wrapped.invoke!({ id: "one" }, threadConfig("t")));
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/langchain/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.test.ts
@@ -11,10 +11,10 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import type { DecisionDeny } from "../../types.ts";
 import type { LangChainTool } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -528,7 +528,6 @@ test("DENY through a tool_call envelope returns the denial and scans only args",
   assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/langchain/v1/guard-tool.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -66,6 +68,18 @@ export interface GuardToolPolicy<TInput> {
    * decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -266,7 +280,7 @@ export function guardTool<TTool extends LangChainTool<any>>(
   return wrapped;
 }
 
-function runGuardedTool<TTool extends LangChainTool<any>>(
+async function runGuardedTool<TTool extends LangChainTool<any>>(
   client: ArcjetAgentClient,
   tool: TTool,
   policy: GuardToolPolicy<LangChainToolInput<TTool>>,
@@ -280,6 +294,7 @@ function runGuardedTool<TTool extends LangChainTool<any>>(
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's structured input; policy factories are typed against it
     const typedArgs = args as LangChainToolInput<TTool>;
@@ -288,6 +303,7 @@ function runGuardedTool<TTool extends LangChainTool<any>>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+    remote = await resolveActorInputs(policy, typedArgs);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {
@@ -320,6 +336,7 @@ function runGuardedTool<TTool extends LangChainTool<any>>(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => {
       if (policy.onDeny === undefined) {
         return denialResult(decision);

--- a/arcjet-guard/src/langchain/v1/guard-tool.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.ts
@@ -69,17 +69,17 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, config) => …` matching
+   * LangChain `func` / `invoke`. Derive it from authenticated server-side
+   * context (`configurable`, `ToolRuntime`); never trust a model-produced
+   * tool input as the actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, config) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -303,7 +303,7 @@ async function runGuardedTool<TTool extends LangChainTool<any>>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
-    remote = await resolveActorInputs(policy, typedArgs);
+    remote = await resolveActorInputs(policy, typedArgs, config);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {

--- a/arcjet-guard/src/langchain/v1/guard-tool.ts
+++ b/arcjet-guard/src/langchain/v1/guard-tool.ts
@@ -316,7 +316,7 @@ async function runGuardedTool<TTool extends LangChainTool<any>>(
     if (policy.onGuardError === "allow") {
       return execute();
     }
-    return Promise.resolve(unavailableResult());
+    return unavailableResult();
   }
 
   const source = isContextSource(config) ? config : undefined;

--- a/arcjet-guard/src/langchain/v1/type-only.test.ts
+++ b/arcjet-guard/src/langchain/v1/type-only.test.ts
@@ -44,7 +44,8 @@ test("type-only import scanner works on langchain fixtures", () => {
     },
     {
       name: "detects mixed type and value import (counts as value)",
-      content: 'import { type createAgent, createMiddleware } from "langchain";\nvoid createMiddleware;',
+      content:
+        'import { type createAgent, createMiddleware } from "langchain";\nvoid createMiddleware;',
       shouldHaveImport: true,
       shouldBeTypeOnly: false,
     },

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import type { LangGraphToolNodeLike } from "./guard-tool-node.ts";
@@ -260,4 +261,43 @@ test("throws when the argument is neither a node nor a tools array", () => {
     () => guardToolNode(client, { name: "not-a-node" } as never),
     /ToolNode or an array/,
   );
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mcp = createTool("mcp_search");
+  const wrapped = guardToolNode(client, [mcp], {
+    action: "mcp.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await wrapped[0]!.func!({ id: "one" }, threadConfig("t"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const mcp = createTool("mcp_search", async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  const wrapped = guardToolNode(client, [mcp], {
+    action: "mcp.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asDenial<ArcjetDenialResult>(
+    await wrapped[0]!.func!({ id: "one" }, threadConfig("t")),
+  );
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
@@ -268,13 +268,14 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const mcp = createTool("mcp_search");
   const wrapped = guardToolNode(client, [mcp], {
     action: "mcp.invoked",
-    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    actor: (call, config) =>
+      `${String((config as { configurable?: { thread_id?: string } })?.configurable?.thread_id)}:${String((call.input as { id?: string }).id)}`,
     inputs: (call) => ({
       id: policyInput.server.string(String((call.input as { id?: string }).id)),
     }),
   });
   await wrapped[0]!.func!({ id: "one" }, threadConfig("t"));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "t:one");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.test.ts
@@ -10,9 +10,9 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
 import type { LangGraphToolNodeLike } from "./guard-tool-node.ts";
 import { guardToolNode } from "./guard-tool-node.ts";
 import type { LangGraphTool } from "./guard-tool.ts";
@@ -262,7 +262,6 @@ test("throws when the argument is neither a node nor a tools array", () => {
     /ToolNode or an array/,
   );
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
@@ -1,3 +1,4 @@
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
@@ -35,6 +36,18 @@ export interface GuardToolNodePolicy {
    * performs the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardToolNodeCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardToolNodeCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardToolNodeCall>;
   /** Metadata merged over the derived LangGraph context. */
   metadata?: ArcjetMetadata | ((call: GuardToolNodeCall) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -93,6 +106,18 @@ function policyForTool(tool: LangGraphTool, policy: GuardToolNodePolicy): GuardT
         ? policy.metadata(call)
         : (policy.metadata ?? {});
     },
+    ...(policy.actor !== undefined && {
+      actor: (input) => {
+        const call = { toolName: tool.name, input };
+        return typeof policy.actor === "function" ? policy.actor(call) : policy.actor;
+      },
+    }),
+    ...(policy.inputs !== undefined && {
+      inputs: (input) => {
+        const call = { toolName: tool.name, input };
+        return typeof policy.inputs === "function" ? policy.inputs(call) : policy.inputs;
+      },
+    }),
     ...(policy.onGuardError !== undefined && { onGuardError: policy.onGuardError }),
     ...(policy.onDeny !== undefined && { onDeny: policy.onDeny }),
   };

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
@@ -37,17 +37,16 @@ export interface GuardToolNodePolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardToolNodeCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, config) => …` matching
+   * ToolNode `invoke(input, config)`. Derive it from `configurable`; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<GuardToolNodeCall>;
+  actor?: ActorResolver<[GuardToolNodeCall, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(call, config) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardToolNodeCall>;
+  inputs?: InputsResolver<[GuardToolNodeCall, unknown?]>;
   /** Metadata merged over the derived LangGraph context. */
   metadata?: ArcjetMetadata | ((call: GuardToolNodeCall) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -109,15 +108,15 @@ function policyForTool(tool: LangGraphTool, policy: GuardToolNodePolicy): GuardT
         : (policy.metadata ?? {});
     },
     ...(actor !== undefined && {
-      actor: (input: unknown): string | Promise<string> => {
+      actor: (input: unknown, config?: unknown): string | Promise<string> => {
         const call = { toolName: tool.name, input };
-        return typeof actor === "function" ? actor(call) : actor;
+        return typeof actor === "function" ? actor(call, config) : actor;
       },
     }),
     ...(inputs !== undefined && {
-      inputs: (input: unknown) => {
+      inputs: (input: unknown, config?: unknown) => {
         const call = { toolName: tool.name, input };
-        return typeof inputs === "function" ? inputs(call) : inputs;
+        return typeof inputs === "function" ? inputs(call, config) : inputs;
       },
     }),
     ...(policy.onGuardError !== undefined && { onGuardError: policy.onGuardError }),

--- a/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool-node.ts
@@ -94,6 +94,8 @@ function resolveAction(policy: GuardToolNodePolicy, call: GuardToolNodeCall): st
 }
 
 function policyForTool(tool: LangGraphTool, policy: GuardToolNodePolicy): GuardToolPolicy<unknown> {
+  const actor = policy.actor;
+  const inputs = policy.inputs;
   return {
     action: (input) => resolveAction(policy, { toolName: tool.name, input }),
     rules: (input) => {
@@ -106,16 +108,16 @@ function policyForTool(tool: LangGraphTool, policy: GuardToolNodePolicy): GuardT
         ? policy.metadata(call)
         : (policy.metadata ?? {});
     },
-    ...(policy.actor !== undefined && {
-      actor: (input) => {
+    ...(actor !== undefined && {
+      actor: (input: unknown): string | Promise<string> => {
         const call = { toolName: tool.name, input };
-        return typeof policy.actor === "function" ? policy.actor(call) : policy.actor;
+        return typeof actor === "function" ? actor(call) : actor;
       },
     }),
-    ...(policy.inputs !== undefined && {
-      inputs: (input) => {
+    ...(inputs !== undefined && {
+      inputs: (input: unknown) => {
         const call = { toolName: tool.name, input };
-        return typeof policy.inputs === "function" ? policy.inputs(call) : policy.inputs;
+        return typeof inputs === "function" ? inputs(call) : inputs;
       },
     }),
     ...(policy.onGuardError !== undefined && { onGuardError: policy.onGuardError }),

--- a/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
@@ -516,4 +517,41 @@ test("DENY through a tool_call envelope returns the denial and scans only args",
   assert.deepEqual(scanned, { note: "x" });
   assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createLangGraphTool<{ id: string }>();
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    actor: (input) => `actor-${input.id}`,
+    inputs: (input) => ({ id: policyInput.server.string(input.id) }),
+  });
+  await wrapped.invoke!({ id: "one" }, threadConfig("t"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createLangGraphTool({
+    func: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asToolResult(await wrapped.invoke!({ id: "one" }, threadConfig("t")));
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
@@ -524,11 +524,12 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const tool = createLangGraphTool<{ id: string }>();
   const wrapped = guardTool(client, tool, {
     action: "test.action",
-    actor: (input) => `actor-${input.id}`,
+    actor: (_input, config) =>
+      String((config as { configurable?: { thread_id?: string } })?.configurable?.thread_id),
     inputs: (input) => ({ id: policyInput.server.string(input.id) }),
   });
   await wrapped.invoke!({ id: "one" }, threadConfig("t"));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "t");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.test.ts
@@ -11,10 +11,10 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import type { DecisionDeny } from "../../types.ts";
 import type { LangGraphTool } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -518,7 +518,6 @@ test("DENY through a tool_call envelope returns the denial and scans only args",
   assert.equal(result.arcjetDenied, true);
   assert.equal(result.reason, "PROMPT_INJECTION");
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/langgraph/v1/guard-tool.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.ts
@@ -2,13 +2,13 @@ import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
 import { langgraphAgentContext } from "./context.ts";
 import type { LangGraphContextSource } from "./context.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
 
 /**
  * Structural LangChain `tool()` / `StructuredTool` / `RunnableToolLike`.
@@ -281,7 +281,7 @@ async function runGuardedTool<TTool extends LangGraphTool<any>>(
     if (policy.onGuardError === "allow") {
       return execute();
     }
-    return Promise.resolve(unavailableResult());
+    return unavailableResult();
   }
 
   const source = isContextSource(config) ? config : undefined;

--- a/arcjet-guard/src/langgraph/v1/guard-tool.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.ts
@@ -68,17 +68,17 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, config) => …` matching
+   * LangGraph `func` / `invoke`. Derive it from authenticated server-side
+   * context (`configurable`); never trust a model-produced tool input as the
+   * actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, config) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -268,7 +268,7 @@ async function runGuardedTool<TTool extends LangGraphTool<any>>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
-    remote = await resolveActorInputs(policy, typedArgs);
+    remote = await resolveActorInputs(policy, typedArgs, config);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {

--- a/arcjet-guard/src/langgraph/v1/guard-tool.ts
+++ b/arcjet-guard/src/langgraph/v1/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -65,6 +67,18 @@ export interface GuardToolPolicy<TInput> {
    * call, which still costs a round trip and returns a decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -233,7 +247,7 @@ export function guardTool<TTool extends LangGraphTool<any>>(
   return wrapped;
 }
 
-function runGuardedTool<TTool extends LangGraphTool<any>>(
+async function runGuardedTool<TTool extends LangGraphTool<any>>(
   client: ArcjetAgentClient,
   tool: TTool,
   policy: GuardToolPolicy<LangGraphToolInput<TTool>>,
@@ -246,6 +260,7 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
   let action: string;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's structured input; policy factories are typed against it
     const typedArgs = args as LangGraphToolInput<TTool>;
@@ -253,6 +268,7 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+    remote = await resolveActorInputs(policy, typedArgs);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {
@@ -285,6 +301,7 @@ function runGuardedTool<TTool extends LangGraphTool<any>>(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => {
       if (policy.onDeny === undefined) {
         return denialResult(decision);

--- a/arcjet-guard/src/mastra/v1/gate.ts
+++ b/arcjet-guard/src/mastra/v1/gate.ts
@@ -1,5 +1,6 @@
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 import type {
   ArcjetMetadata,
   Decision,
@@ -7,7 +8,6 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
-import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something

--- a/arcjet-guard/src/mastra/v1/gate.ts
+++ b/arcjet-guard/src/mastra/v1/gate.ts
@@ -7,6 +7,7 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something
@@ -23,6 +24,8 @@ export async function runGate<T>(
     rules: RuleWithInput[] | undefined;
     correlationId: string | undefined;
     metadata: ArcjetMetadata;
+    actor?: string;
+    inputs?: PolicyInputMap;
     onAllow: () => T;
     onDeny: (decision: DecisionDeny) => T;
     onUnavailable: (
@@ -42,6 +45,8 @@ export async function runGate<T>(
     onDeny,
     onUnavailable,
     onGuardError = "deny",
+    actor,
+    inputs,
   } = params;
 
   const correlation = correlationId === undefined ? {} : { correlationId };
@@ -50,7 +55,14 @@ export async function runGate<T>(
   let decisionId: string | undefined;
   let decision: Decision | undefined;
   try {
-    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+    decision = await client.guard({
+      label: action,
+      rules: rules ?? [],
+      ...correlation,
+      metadata,
+      ...(actor !== undefined && { actor }),
+      ...(inputs !== undefined && { inputs }),
+    });
   } catch (error) {
     if (failClosed) {
       warnUnavailable(action, "threw", true, error);

--- a/arcjet-guard/src/mastra/v1/guard-processor.test.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { MASTRA_THREAD_ID_KEY } from "./context.ts";
 import { guardProcessor } from "./guard-processor.ts";
 
@@ -634,4 +635,52 @@ test("output extraText is included when messages are empty", async () => {
   } as never);
 
   assert.equal(seen, "only-result");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const processor = guardProcessor(client, {
+    action: "message.received",
+    actor: (input) => `actor-${input.text.length}`,
+    inputs: (input) => ({ text: policyInput.local.string(input.text) }),
+  });
+  const { abort } = abortSpy();
+  await processor.processInput!({
+    messages: [userMessage("hello")],
+    abort,
+    requestContext: requestContext("thread-1"),
+    systemMessages: [],
+    state: {},
+    messageList: {} as never,
+    retryCount: 0,
+  } as never);
+  assert.equal(recorded(guardCalls[0]).actor, "actor-5");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    text: policyInput.local.string("hello"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const processor = guardProcessor(client, {
+    action: "message.received",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const { abort, calls } = abortSpy();
+  await assert.rejects(async () => {
+    await processor.processInput!({
+      messages: [userMessage("hello")],
+      abort,
+      requestContext: requestContext("thread-1"),
+      systemMessages: [],
+      state: {},
+      messageList: {} as never,
+      retryCount: 0,
+    } as never);
+  }, /tripwire/);
+  assert.equal(calls.length, 1);
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/mastra/v1/guard-processor.test.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.test.ts
@@ -637,7 +637,6 @@ test("output extraText is included when messages are empty", async () => {
   assert.equal(seen, "only-result");
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const processor = guardProcessor(client, {

--- a/arcjet-guard/src/mastra/v1/guard-processor.test.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.test.ts
@@ -683,3 +683,53 @@ test("an input resolver failure follows the fail-closed unavailable path", async
   assert.equal(calls.length, 1);
   assert.equal(guardCalls.length, 0);
 });
+
+test("onGuardError allow lets processInput continue when an actor resolver rejects", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const processor = guardProcessor(client, {
+    action: "message.received",
+    onGuardError: "allow",
+    actor: () => Promise.reject(new Error("actor failed")),
+  });
+  const { abort, calls } = abortSpy();
+  const messages = [userMessage("hello")];
+
+  const result = await processor.processInput!({
+    messages,
+    abort,
+    requestContext: requestContext("thread-1"),
+    systemMessages: [],
+    state: {},
+    messageList: {} as never,
+    retryCount: 0,
+  } as never);
+
+  assert.strictEqual(result, messages);
+  assert.equal(calls.length, 0);
+  assert.equal(guardCalls.length, 0);
+});
+
+test("onGuardError allow lets processInput continue when an input resolver rejects", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const processor = guardProcessor(client, {
+    action: "message.received",
+    onGuardError: "allow",
+    inputs: () => Promise.reject(new Error("mapping failed")),
+  });
+  const { abort, calls } = abortSpy();
+  const messages = [userMessage("hello")];
+
+  const result = await processor.processInput!({
+    messages,
+    abort,
+    requestContext: requestContext("thread-1"),
+    systemMessages: [],
+    state: {},
+    messageList: {} as never,
+    retryCount: 0,
+  } as never);
+
+  assert.strictEqual(result, messages);
+  assert.equal(calls.length, 0);
+  assert.equal(guardCalls.length, 0);
+});

--- a/arcjet-guard/src/mastra/v1/guard-processor.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.ts
@@ -10,11 +10,11 @@ import type {
 import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, RuleWithInput } from "../../types.ts";
 import { mastraAgentContext } from "./context.ts";
 import type { MastraRequestContextLike } from "./context.ts";
-import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import { runGate } from "./gate.ts";
 
 /**

--- a/arcjet-guard/src/mastra/v1/guard-processor.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.ts
@@ -48,17 +48,16 @@ export interface GuardProcessorPolicy {
    */
   rules?: RuleWithInput[] | ((input: GuardProcessorInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the processor input. Derive it
-   * from authenticated server-side context; never trust model-produced text as
-   * the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, requestContext) => …`
+   * matching Mastra processor args. Derive it from `requestContext`; never
+   * trust model-produced text as the actor identity.
    */
-  actor?: ActorResolver<GuardProcessorInput>;
+  actor?: ActorResolver<[GuardProcessorInput, MastraRequestContextLike?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the processor input. Build
-   * each value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, requestContext) => …`.
+   * Build each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardProcessorInput>;
+  inputs?: InputsResolver<[GuardProcessorInput, MastraRequestContextLike?]>;
   /** Metadata merged over the derived Mastra context. */
   metadata?: ArcjetMetadata | ((input: GuardProcessorInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -282,7 +281,7 @@ export function guardProcessor(
     };
     let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
     try {
-      remote = await resolveActorInputs(policy, input);
+      remote = await resolveActorInputs(policy, input, requestCtx);
     } catch {
       denyTurn(abort, unavailableReason());
     }

--- a/arcjet-guard/src/mastra/v1/guard-processor.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.ts
@@ -7,6 +7,8 @@ import type {
   Processor,
 } from "@mastra/core/processors";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, RuleWithInput } from "../../types.ts";
@@ -45,6 +47,18 @@ export interface GuardProcessorPolicy {
    * this still performs the guard call.
    */
   rules?: RuleWithInput[] | ((input: GuardProcessorInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the processor input. Derive it
+   * from authenticated server-side context; never trust model-produced text as
+   * the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardProcessorInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the processor input. Build
+   * each value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardProcessorInput>;
   /** Metadata merged over the derived Mastra context. */
   metadata?: ArcjetMetadata | ((input: GuardProcessorInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -266,12 +280,19 @@ export function guardProcessor(
       "mastra.phase": phase,
       ...policyMetadata,
     };
+    let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
+    try {
+      remote = await resolveActorInputs(policy, input);
+    } catch {
+      denyTurn(abort, unavailableReason());
+    }
 
     await runGate(client, {
       action: policy.action,
       rules,
       correlationId: agentCtx.correlationId,
       metadata,
+      ...remote,
       onAllow: () => {
         /* allow the turn to continue */
       },

--- a/arcjet-guard/src/mastra/v1/guard-processor.ts
+++ b/arcjet-guard/src/mastra/v1/guard-processor.ts
@@ -9,6 +9,7 @@ import type {
 
 import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
+import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -282,8 +283,18 @@ export function guardProcessor(
     let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
     try {
       remote = await resolveActorInputs(policy, input, requestCtx);
-    } catch {
-      denyTurn(abort, unavailableReason());
+    } catch (error) {
+      if (shouldWarn()) {
+        console.warn(
+          '@arcjet/guard: policy factory for "%s" threw; treating as a guard error:',
+          policy.action,
+          error,
+        );
+      }
+      if (policy.onGuardError === "allow") {
+        return;
+      }
+      return denyTurn(abort, unavailableReason());
     }
 
     await runGate(client, {

--- a/arcjet-guard/src/mastra/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/mastra/v1/guard-tool.test.ts
@@ -1,4 +1,4 @@
-// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions -- test infrastructure and mocks
+// oxlint-disable eslint/no-unsafe-type-assertion, eslint/no-unsafe-member-access, eslint/no-unsafe-assignment, eslint/no-unsafe-argument, eslint/explicit-function-return-type, eslint/require-await, eslint/no-unnecessary-type-assertion, eslint/strict-boolean-expressions, import/max-dependencies -- test infrastructure and mocks
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -13,11 +13,11 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
 import type { DecisionDeny } from "../../types.ts";
 import { MASTRA_THREAD_ID_KEY } from "./context.ts";
-import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { guardTool } from "./guard-tool.ts";
 
 const TOOL_MARKER = Symbol.for("mastra.core.tools.Tool");
@@ -377,7 +377,6 @@ test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
     }
   }
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/mastra/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/mastra/v1/guard-tool.test.ts
@@ -13,6 +13,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import { MASTRA_THREAD_ID_KEY } from "./context.ts";
@@ -375,4 +376,43 @@ test("onDeny throw warns when ARCJET_LOG_LEVEL asks for warnings", async () => {
       process.env["ARCJET_LOG_LEVEL"] = previous;
     }
   }
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createMastraTool<{ id: string }>();
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    actor: (input) => `actor-${input.id}`,
+    inputs: (input) => ({ id: policyInput.server.string(input.id) }),
+  });
+  await wrapped.execute!({ id: "one" }, threadContext("t"));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createMastraTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asDenial<ArcjetDenialResult>(
+    await wrapped.execute!({ id: "one" }, threadContext("t")),
+  );
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/mastra/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/mastra/v1/guard-tool.test.ts
@@ -383,11 +383,16 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const tool = createMastraTool<{ id: string }>();
   const wrapped = guardTool(client, tool, {
     action: "test.action",
-    actor: (input) => `actor-${input.id}`,
+    actor: (_input, context) =>
+      String(
+        (
+          context as { requestContext?: { get: (key: string) => unknown } } | undefined
+        )?.requestContext?.get(MASTRA_THREAD_ID_KEY),
+      ),
     inputs: (input) => ({ id: policyInput.server.string(input.id) }),
   });
   await wrapped.execute!({ id: "one" }, threadContext("t"));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "t");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/mastra/v1/guard-tool.ts
+++ b/arcjet-guard/src/mastra/v1/guard-tool.ts
@@ -70,17 +70,16 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, context) => …` matching
+   * Mastra `execute(input, context)`. Derive it from `requestContext`; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, context) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -201,7 +200,7 @@ export function guardTool<TTool extends MastraToolDefinition<any, any>>(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
-      resolvePolicy: () => resolveActorInputs(policy, input),
+      resolvePolicy: () => resolveActorInputs(policy, input, context),
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- onDeny may return a custom shape; the ALLOW path is TOutput
       onDeny: ((decision: DecisionDeny) => {
         if (policy.onDeny === undefined) {

--- a/arcjet-guard/src/mastra/v1/guard-tool.ts
+++ b/arcjet-guard/src/mastra/v1/guard-tool.ts
@@ -2,13 +2,13 @@ import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
 import { mastraAgentContext } from "./context.ts";
 import type { MastraContextSource } from "./context.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
 
 /**
  * Structural shape of a Mastra tool.

--- a/arcjet-guard/src/mastra/v1/guard-tool.ts
+++ b/arcjet-guard/src/mastra/v1/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -67,6 +69,18 @@ export interface GuardToolPolicy<TInput> {
    * call, which still costs a round trip and returns a decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -187,6 +201,7 @@ export function guardTool<TTool extends MastraToolDefinition<any, any>>(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
+      resolvePolicy: () => resolveActorInputs(policy, input),
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- onDeny may return a custom shape; the ALLOW path is TOutput
       onDeny: ((decision: DecisionDeny) => {
         if (policy.onDeny === undefined) {

--- a/arcjet-guard/src/mastra/v1/hooks.test.ts
+++ b/arcjet-guard/src/mastra/v1/hooks.test.ts
@@ -10,9 +10,9 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { policyInput } from "../../policy-input.ts";
 import { MASTRA_THREAD_ID_KEY } from "./context.ts";
-import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { guardHooks } from "./hooks.ts";
 
 function hookContext(input?: unknown) {
@@ -270,7 +270,6 @@ test("afterToolCall with non-object context does not throw", async () => {
   });
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const hooks = guardHooks(client, {
@@ -298,6 +297,9 @@ test("an input resolver failure follows the fail-closed unavailable path", async
   const result = await hooks.beforeToolCall!(hookContext({ id: "one" }));
   assert.ok(result);
   assert.equal((result as { proceed: boolean }).proceed, false);
-  assert.equal(asDenial<ArcjetDenialResult>((result as { output: unknown }).output).reason, "ERROR");
+  assert.equal(
+    asDenial<ArcjetDenialResult>((result as { output: unknown }).output).reason,
+    "ERROR",
+  );
   assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/mastra/v1/hooks.test.ts
+++ b/arcjet-guard/src/mastra/v1/hooks.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { MASTRA_THREAD_ID_KEY } from "./context.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { guardHooks } from "./hooks.ts";
@@ -267,4 +268,36 @@ test("afterToolCall with non-object context does not throw", async () => {
     context: undefined,
     output: {},
   });
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    action: "mcp.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await hooks.beforeToolCall!(hookContext({ id: "one" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const hooks = guardHooks(client, {
+    action: "mcp.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = await hooks.beforeToolCall!(hookContext({ id: "one" }));
+  assert.ok(result);
+  assert.equal((result as { proceed: boolean }).proceed, false);
+  assert.equal(asDenial<ArcjetDenialResult>((result as { output: unknown }).output).reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/mastra/v1/hooks.ts
+++ b/arcjet-guard/src/mastra/v1/hooks.ts
@@ -5,6 +5,8 @@ import type {
   ToolHooks,
 } from "@mastra/core/tools";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -37,6 +39,18 @@ export interface GuardHooksPolicy {
    * guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardHooksCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardHooksCall>;
   /** Metadata merged over the derived Mastra context. */
   metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -114,12 +128,14 @@ export function guardHooks(client: ArcjetAgentClient, policy: GuardHooksPolicy =
           ...(call.toolName.length > 0 && { "mastra.tool": call.toolName }),
           ...policyMetadata,
         };
+        const remote = await resolveActorInputs(policy, call);
 
         return await runGate<void | ToolBeforeHookResult>(client, {
           action,
           rules,
           correlationId: agentCtx.correlationId,
           metadata,
+          ...remote,
           onAllow: () => {
             /* allow the tool to proceed */
           },

--- a/arcjet-guard/src/mastra/v1/hooks.ts
+++ b/arcjet-guard/src/mastra/v1/hooks.ts
@@ -40,17 +40,17 @@ export interface GuardHooksPolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, context) => …` matching
+   * Mastra `beforeToolCall`'s `hookContext.context`. Derive it from
+   * `requestContext`; never trust a model-produced tool input as the actor
+   * identity.
    */
-  actor?: ActorResolver<GuardHooksCall>;
+  actor?: ActorResolver<[GuardHooksCall, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(call, context) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardHooksCall>;
+  inputs?: InputsResolver<[GuardHooksCall, unknown?]>;
   /** Metadata merged over the derived Mastra context. */
   metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -128,7 +128,7 @@ export function guardHooks(client: ArcjetAgentClient, policy: GuardHooksPolicy =
           ...(call.toolName.length > 0 && { "mastra.tool": call.toolName }),
           ...policyMetadata,
         };
-        const remote = await resolveActorInputs(policy, call);
+        const remote = await resolveActorInputs(policy, call, hookContext.context);
 
         return await runGate<void | ToolBeforeHookResult>(client, {
           action,

--- a/arcjet-guard/src/mastra/v1/hooks.ts
+++ b/arcjet-guard/src/mastra/v1/hooks.ts
@@ -9,11 +9,11 @@ import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, RuleWithInput } from "../../types.ts";
 import { mastraAgentContext } from "./context.ts";
 import type { MastraContextSource } from "./context.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import { runGate } from "./gate.ts";
 
 /**

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
@@ -11,10 +11,10 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import type { DecisionDeny } from "../../types.ts";
 import type { OpenAIAgentsTool } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -630,7 +630,6 @@ test("wraps invoke when the descriptor is non-writable", async () => {
   assert.equal(result.arcjetDenied, true);
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const tool = createFunctionTool();
@@ -661,9 +660,7 @@ test("an input resolver failure follows the fail-closed unavailable path", async
       throw new Error("mapping failed");
     },
   });
-  const result = asToolResult(
-    await wrapped.invoke(runContext("t"), JSON.stringify({ id: "one" })),
-  );
+  const result = asToolResult(await wrapped.invoke(runContext("t"), JSON.stringify({ id: "one" })));
   assert.equal(result.reason, "ERROR");
   assert.equal(guardCalls.length, 0);
   assert.equal(calls, 0);

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
@@ -635,11 +635,11 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const tool = createFunctionTool();
   const wrapped = guardTool(client, tool, {
     action: "test.action",
-    actor: (input: { id?: string }) => `actor-${input.id}`,
+    actor: (_input, rc) => String((rc as { context?: { sessionId?: string } })?.context?.sessionId),
     inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
   });
   await wrapped.invoke(runContext("t"), JSON.stringify({ id: "one" }));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "t");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
@@ -627,4 +628,43 @@ test("wraps invoke when the descriptor is non-writable", async () => {
   const result = asToolResult(await wrapped.invoke(runContext("t"), "{}"));
   assert.equal(calls, 0);
   assert.equal(result.arcjetDenied, true);
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createFunctionTool();
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    actor: (input: { id?: string }) => `actor-${input.id}`,
+    inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
+  });
+  await wrapped.invoke(runContext("t"), JSON.stringify({ id: "one" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createFunctionTool({
+    execute: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asToolResult(
+    await wrapped.invoke(runContext("t"), JSON.stringify({ id: "one" })),
+  );
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
@@ -42,6 +44,18 @@ export interface GuardToolPolicy<TInput> {
    * the guard call, which still costs a round trip and returns a decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -249,7 +263,7 @@ export function guardTool<TInput = unknown, TTool extends OpenAIAgentsTool = Ope
   return wrapped;
 }
 
-function runGuardedTool<TInput>(
+async function runGuardedTool<TInput>(
   client: ArcjetAgentClient,
   tool: OpenAIAgentsTool,
   policy: GuardToolPolicy<TInput>,
@@ -262,6 +276,7 @@ function runGuardedTool<TInput>(
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
     const typedArgs = args as TInput;
@@ -269,6 +284,7 @@ function runGuardedTool<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+    remote = await resolveActorInputs(policy, typedArgs);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -300,6 +316,7 @@ function runGuardedTool<TInput>(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => {
       if (policy.onDeny === undefined) {
         return denialResult(decision);

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.ts
@@ -45,17 +45,17 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, runContext) => …` matching
+   * the authored `execute(input, runContext)`. Derive it from
+   * `runContext.context`; never trust a model-produced tool input as the
+   * actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, runContext) => …`.
+   * Build each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -284,7 +284,7 @@ async function runGuardedTool<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
-    remote = await resolveActorInputs(policy, typedArgs);
+    remote = await resolveActorInputs(policy, typedArgs, runContext);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(

--- a/arcjet-guard/src/openai-agents/v0/guard-tool.ts
+++ b/arcjet-guard/src/openai-agents/v0/guard-tool.ts
@@ -2,13 +2,13 @@ import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
 import { openaiAgentsContext } from "./context.ts";
 import type { OpenAIAgentsContextSource } from "./context.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
 
 /**
  * Structural `tool()` / `FunctionTool`. Declared here so `guardTool` does
@@ -296,7 +296,7 @@ async function runGuardedTool<TInput>(
     if (policy.onGuardError === "allow") {
       return execute();
     }
-    return Promise.resolve(unavailableResult());
+    return unavailableResult();
   }
 
   const source = isContextSource(runContext) ? runContext : undefined;

--- a/arcjet-guard/src/strands-agents/v1/assignability.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/assignability.test.ts
@@ -14,8 +14,8 @@ import { test } from "node:test";
 import type { InvokableTool, Plugin } from "@strands-agents/sdk";
 
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
-import { guardHooks } from "./hooks.ts";
 import { guardTool } from "./guard-tool.ts";
+import { guardHooks } from "./hooks.ts";
 
 declare const client: ArcjetAgentClient;
 declare const authoredTool: InvokableTool<{ orderNumber: string }, { status: string }>;

--- a/arcjet-guard/src/strands-agents/v1/context.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/context.test.ts
@@ -57,7 +57,10 @@ test("reads documented envelope copies when the bag has no id", () => {
 });
 
 test("init.sessionId is a last-resort caller-owned fallback", () => {
-  const result = strandsAgentContext({ invocationState: { user: "alice" } }, { sessionId: "policy-sess" });
+  const result = strandsAgentContext(
+    { invocationState: { user: "alice" } },
+    { sessionId: "policy-sess" },
+  );
   assert.equal(result.correlationId, "policy-sess");
   assert.equal(result.metadata?.["strands.session"], "policy-sess");
 });

--- a/arcjet-guard/src/strands-agents/v1/gate.ts
+++ b/arcjet-guard/src/strands-agents/v1/gate.ts
@@ -1,5 +1,6 @@
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 import type {
   ArcjetMetadata,
   Decision,
@@ -7,7 +8,6 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
-import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something

--- a/arcjet-guard/src/strands-agents/v1/gate.ts
+++ b/arcjet-guard/src/strands-agents/v1/gate.ts
@@ -7,6 +7,7 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something
@@ -23,6 +24,8 @@ export async function runGate<T>(
     rules: RuleWithInput[] | undefined;
     correlationId: string | undefined;
     metadata: ArcjetMetadata;
+    actor?: string;
+    inputs?: PolicyInputMap;
     onAllow: () => T;
     onDeny: (decision: DecisionDeny) => T;
     onUnavailable: (
@@ -42,6 +45,8 @@ export async function runGate<T>(
     onDeny,
     onUnavailable,
     onGuardError = "deny",
+    actor,
+    inputs,
   } = params;
 
   const correlation = correlationId === undefined ? {} : { correlationId };
@@ -50,7 +55,14 @@ export async function runGate<T>(
   let decisionId: string | undefined;
   let decision: Decision | undefined;
   try {
-    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+    decision = await client.guard({
+      label: action,
+      rules: rules ?? [],
+      ...correlation,
+      metadata,
+      ...(actor !== undefined && { actor }),
+      ...(inputs !== undefined && { inputs }),
+    });
   } catch (error) {
     if (failClosed) {
       warnUnavailable(action, "threw", true, error);

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.test.ts
@@ -11,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
@@ -501,4 +502,48 @@ test("never reads traceId from invocationState", async () => {
   const wrapped = guardTool(client, tool, { action: "order.looked-up" }) as FakeTool;
   await wrapped._callback({}, { invocationState: { traceId: "trace-minted" } });
   assert.equal("correlationId" in recorded(guardCalls[0]), false);
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createTool();
+  const wrapped = guardTool(client, tool as never, {
+    action: "test.action",
+    actor: (input: { id?: string }) => `actor-${input.id}`,
+    inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
+  });
+  await (wrapped as unknown as { _callback: (input: unknown, ctx?: unknown) => Promise<unknown> })._callback(
+    { id: "one" },
+    { invocationState: { sessionId: "t" } },
+  );
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createTool({
+    callback: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const wrapped = guardTool(client, tool as never, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = asDenial<ArcjetDenialResult>(
+    await (wrapped as unknown as { _callback: (input: unknown) => Promise<unknown> })._callback({
+      id: "one",
+    }),
+  );
+  assert.equal(result.reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.test.ts
@@ -11,10 +11,10 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { DecisionDeny } from "../../types.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import type { DecisionDeny } from "../../types.ts";
 import type { StrandsTool } from "./guard-tool.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -485,9 +485,7 @@ test("ZodTool inner _functionTool callback is gated so stream() cannot bypass", 
   assert.ok(wrapped._functionTool);
   assert.notStrictEqual(wrapped._functionTool, tool._functionTool);
 
-  const result = asToolResult(
-    await wrapped._functionTool!._callback({}, toolContext("t")),
-  );
+  const result = asToolResult(await wrapped._functionTool!._callback({}, toolContext("t")));
   assert.equal(calls, 0);
   assert.equal(result.arcjetDenied, true);
 
@@ -504,7 +502,6 @@ test("never reads traceId from invocationState", async () => {
   assert.equal("correlationId" in recorded(guardCalls[0]), false);
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const tool = createTool();
@@ -513,10 +510,9 @@ test("resolves actor and typed inputs onto the guard call", async () => {
     actor: (input: { id?: string }) => `actor-${input.id}`,
     inputs: (input: { id?: string }) => ({ id: policyInput.server.string(String(input.id)) }),
   });
-  await (wrapped as unknown as { _callback: (input: unknown, ctx?: unknown) => Promise<unknown> })._callback(
-    { id: "one" },
-    { invocationState: { sessionId: "t" } },
-  );
+  await (
+    wrapped as unknown as { _callback: (input: unknown, ctx?: unknown) => Promise<unknown> }
+  )._callback({ id: "one" }, { invocationState: { sessionId: "t" } });
   assert.equal(recorded(guardCalls[0]).actor, "actor-one");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.ts
@@ -1,3 +1,5 @@
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -58,6 +60,18 @@ export interface GuardToolPolicy<TInput> {
    * the guard call, which still costs a round trip and returns a decision.
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -277,7 +291,7 @@ function installGuardedCallback<TInput>(
   });
 }
 
-function runGuardedCallback<TInput>(
+async function runGuardedCallback<TInput>(
   client: ArcjetAgentClient,
   tool: StrandsTool,
   policy: GuardToolPolicy<TInput>,
@@ -290,6 +304,7 @@ function runGuardedCallback<TInput>(
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args are the tool's parsed input; policy factories are typed against it
     const typedArgs = args as TInput;
@@ -297,6 +312,7 @@ function runGuardedCallback<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
+    remote = await resolveActorInputs(policy, typedArgs);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(
@@ -326,6 +342,7 @@ function runGuardedCallback<TInput>(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => {
       if (policy.onDeny === undefined) {
         return denialResult(decision);

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.ts
@@ -324,7 +324,7 @@ async function runGuardedCallback<TInput>(
     if (policy.onGuardError === "allow") {
       return execute();
     }
-    return Promise.resolve(unavailableResult());
+    return unavailableResult();
   }
 
   const source = contextSource(context);

--- a/arcjet-guard/src/strands-agents/v1/guard-tool.ts
+++ b/arcjet-guard/src/strands-agents/v1/guard-tool.ts
@@ -61,17 +61,16 @@ export interface GuardToolPolicy<TInput> {
    */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, context) => …` matching
+   * the Strands tool `_callback`. Derive it from `invocationState`; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(input, context) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, unknown?]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /**
@@ -312,7 +311,7 @@ async function runGuardedCallback<TInput>(
     rules = typeof policy.rules === "function" ? policy.rules(typedArgs) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(typedArgs) : policy.metadata;
-    remote = await resolveActorInputs(policy, typedArgs);
+    remote = await resolveActorInputs(policy, typedArgs, context);
   } catch (error) {
     if (shouldWarn()) {
       console.warn(

--- a/arcjet-guard/src/strands-agents/v1/hooks.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.test.ts
@@ -10,17 +10,16 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
-import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
-import {
-  createAfterToolCallHandler,
-  createBeforeToolCallHandler,
-  guardHooks,
-} from "./hooks.ts";
+import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
+import { createAfterToolCallHandler, createBeforeToolCallHandler, guardHooks } from "./hooks.ts";
 import type { StrandsBeforeToolCallEvent } from "./hooks.ts";
 
-function hookEvent(input?: unknown, extras?: Partial<StrandsBeforeToolCallEvent>): StrandsBeforeToolCallEvent {
+function hookEvent(
+  input?: unknown,
+  extras?: Partial<StrandsBeforeToolCallEvent>,
+): StrandsBeforeToolCallEvent {
   return {
     toolUse: {
       name: "mcp_search",
@@ -230,18 +229,14 @@ test("rules throw with onGuardError allow proceeds", async () => {
 test("empty toolName is omitted from metadata", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const handler = createBeforeToolCallHandler(client, {});
-  await handler(
-    hookEvent({}, { toolUse: { name: "", input: {} } }),
-  );
+  await handler(hookEvent({}, { toolUse: { name: "", input: {} } }));
   assert.equal("strands.tool" in recorded(recorded(guardCalls[0])["metadata"]), false);
 });
 
 test("non-string toolName is treated as empty", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const handler = createBeforeToolCallHandler(client, {});
-  await handler(
-    hookEvent({}, { toolUse: { name: 12, input: {} } }),
-  );
+  await handler(hookEvent({}, { toolUse: { name: 12, input: {} } }));
   assert.equal("strands.tool" in recorded(recorded(guardCalls[0])["metadata"]), false);
 });
 
@@ -336,7 +331,6 @@ test("handler never throws even when the guard client throws", async () => {
   await handler(event);
   assert.equal(denialFromCancel(event).reason, "ERROR");
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/strands-agents/v1/hooks.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import {
@@ -334,4 +335,36 @@ test("handler never throws even when the guard client throws", async () => {
   const event = hookEvent();
   await handler(event);
   assert.equal(denialFromCancel(event).reason, "ERROR");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const onBefore = createBeforeToolCallHandler(client, {
+    action: "tool.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await onBefore(hookEvent({ id: "one" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const onBefore = createBeforeToolCallHandler(client, {
+    action: "tool.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const event = hookEvent({ id: "one" });
+  await onBefore(event);
+  assert.equal(typeof event.cancel, "string");
+  assert.equal(denialFromCancel(event).reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/strands-agents/v1/hooks.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.ts
@@ -1,5 +1,7 @@
 import type { Plugin } from "@strands-agents/sdk";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -55,6 +57,18 @@ export interface GuardHooksPolicy {
    * performs the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardHooksCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardHooksCall>;
   /** Metadata merged over the derived Strands context. */
   metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
   /**
@@ -239,12 +253,14 @@ export function createBeforeToolCallHandler(
       let sessionId: string | undefined;
       let rules: RuleWithInput[] | undefined;
       let policyMetadata: ArcjetMetadata | undefined;
+      let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
       try {
         action = resolveAction(policy, call);
         sessionId = resolveSessionId(policy, call);
         rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
         policyMetadata =
           typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+        remote = await resolveActorInputs(policy, call);
       } catch (error) {
         const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
         if (shouldWarn()) {
@@ -279,6 +295,7 @@ export function createBeforeToolCallHandler(
         rules,
         correlationId: agentCtx.correlationId,
         metadata: mergedMetadata,
+        ...remote,
         onAllow: () => {
           /* allow the tool to proceed — do not set event.cancel */
         },

--- a/arcjet-guard/src/strands-agents/v1/hooks.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.ts
@@ -58,17 +58,16 @@ export interface GuardHooksPolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardHooksCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, event) => …` matching
+   * Strands `BeforeToolCallEvent`. Derive it from `invocationState`; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<GuardHooksCall>;
+  actor?: ActorResolver<[GuardHooksCall, unknown?]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(call, event) => …`. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardHooksCall>;
+  inputs?: InputsResolver<[GuardHooksCall, unknown?]>;
   /** Metadata merged over the derived Strands context. */
   metadata?: ArcjetMetadata | ((call: GuardHooksCall) => ArcjetMetadata);
   /**
@@ -264,7 +263,7 @@ export function createBeforeToolCallHandler(
         rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
         policyMetadata =
           typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-        remote = await resolveActorInputs(policy, call);
+        remote = await resolveActorInputs(policy, call, event);
       } catch (error) {
         const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
         if (shouldWarn()) {

--- a/arcjet-guard/src/strands-agents/v1/hooks.ts
+++ b/arcjet-guard/src/strands-agents/v1/hooks.ts
@@ -160,7 +160,11 @@ async function loadStrandsHooks(): Promise<StrandsHookSdk> {
       "@arcjet/guard: guardHooks() could not load BeforeToolCallEvent / AfterToolCallEvent from @strands-agents/sdk; the Plugin cannot register.",
     );
   }
-  if (hookOrder === null || typeof hookOrder !== "object" || typeof hookOrder.SDK_FIRST !== "number") {
+  if (
+    hookOrder === null ||
+    typeof hookOrder !== "object" ||
+    typeof hookOrder.SDK_FIRST !== "number"
+  ) {
     // oxlint-disable-next-line unicorn/prefer-type-error -- Error preserves backward compatibility with the other vendor namespaces
     throw new Error(
       "@arcjet/guard: guardHooks() could not load HookOrder from @strands-agents/sdk; the Plugin cannot register.",
@@ -326,7 +330,10 @@ export function createBeforeToolCallHandler(
       // A non-InterruptError throw from a hook aborts the invocation
       // and drops the envelope. Fail closed by setting cancel instead.
       if (shouldWarn()) {
-        console.warn("@arcjet/guard: guardHooks BeforeToolCallEvent threw; denying the tool:", error);
+        console.warn(
+          "@arcjet/guard: guardHooks BeforeToolCallEvent threw; denying the tool:",
+          error,
+        );
       }
       if (policy.onGuardError === "allow") {
         return;

--- a/arcjet-guard/src/strands-agents/v1/type-only.test.ts
+++ b/arcjet-guard/src/strands-agents/v1/type-only.test.ts
@@ -71,7 +71,11 @@ test("type-only import scanner works on @strands-agents/sdk fixtures", () => {
     if (fixture.shouldHaveImport === false) {
       assert.equal(peerImports.length, 0, `${fixture.name}: should not have strands imports`);
     } else {
-      assert.equal(peerImports.length, 1, `${fixture.name}: should have exactly one strands import`);
+      assert.equal(
+        peerImports.length,
+        1,
+        `${fixture.name}: should have exactly one strands import`,
+      );
       assert.equal(
         peerImports[0]?.typeOnly,
         fixture.shouldBeTypeOnly ?? true,

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
@@ -10,6 +10,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
@@ -347,4 +348,36 @@ test("sessionId callback receives the tool name and input", async () => {
   await runHook(mw, toolHook("mcp_search", { q: "hello" }), middlewareCtx({}));
   assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
   assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    inputs: (call) => ({
+      id: policyInput.server.string(String((call.input as { id?: string }).id)),
+    }),
+  });
+  await runHook(mw, toolHook("lookup", { id: "one" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const mw = guardMiddleware(client, {
+    action: "tool.invoked",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const result = await runHook(mw, toolHook("lookup", { id: "one" }));
+  const decision = result as { type: string; result: unknown };
+  assert.equal(decision.type, "skip");
+  assert.equal(asDenial<ArcjetDenialResult>(decision.result).reason, "ERROR");
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
@@ -354,13 +354,13 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const mw = guardMiddleware(client, {
     action: "tool.invoked",
-    actor: (call) => `actor-${String((call.input as { id?: string }).id)}`,
+    actor: (_call, ctx) => String((ctx.context as { sessionId?: string } | undefined)?.sessionId),
     inputs: (call) => ({
       id: policyInput.server.string(String((call.input as { id?: string }).id)),
     }),
   });
   await runHook(mw, toolHook("lookup", { id: "one" }));
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "sess-1");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.test.ts
@@ -10,9 +10,9 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
 import type { ArcjetDenialResult } from "../../agents/denial.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardMiddleware } from "./guard-middleware.ts";
 import type { TanStackAiGuardMiddleware } from "./guard-middleware.ts";
 
@@ -349,7 +349,6 @@ test("sessionId callback receives the tool name and input", async () => {
   assert.deepEqual(seen, { toolName: "mcp_search", input: { q: "hello" } });
   assert.equal(recorded(guardCalls[0])["correlationId"], "sess-from-callback");
 });
-
 
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
@@ -5,6 +5,8 @@ import type {
   ToolCallHookContext,
 } from "@tanstack/ai";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { denialResult, unavailableResult } from "../../agents/denial.ts";
@@ -44,6 +46,18 @@ export interface GuardMiddlewarePolicy {
    * the guard call.
    */
   rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool call. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<GuardMiddlewareCall>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<GuardMiddlewareCall>;
   /** Metadata merged over the derived TanStack AI context. */
   metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
   /**
@@ -141,14 +155,14 @@ function middlewareName(): string {
   return `arcjet-guard-${middlewareSeq}-${crypto.randomUUID().slice(0, 8)}`;
 }
 
-function gateToolCall(
+async function gateToolCall(
   client: ArcjetAgentClient,
   policy: GuardMiddlewarePolicy,
   ctx: ChatMiddlewareContext,
   hookCtx: ToolCallHookContext,
 ): Promise<BeforeToolCallDecision> {
   if (isBrandedTool(hookCtx.tool)) {
-    return Promise.resolve();
+    return undefined;
   }
 
   const toolName = hookCtx.toolName;
@@ -159,12 +173,14 @@ function gateToolCall(
   let sessionId: string | undefined;
   let rules: RuleWithInput[] | undefined;
   let policyMetadata: ArcjetMetadata | undefined;
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
   try {
     action = resolveAction(policy, call);
     sessionId = resolveSessionId(policy, call);
     rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
+    remote = await resolveActorInputs(policy, call);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {
@@ -175,9 +191,9 @@ function gateToolCall(
       );
     }
     if (policy.onGuardError === "allow") {
-      return Promise.resolve();
+      return undefined;
     }
-    return Promise.resolve(denyDecision(policy, unavailableResult(), "unavailable"));
+    return denyDecision(policy, unavailableResult(), "unavailable");
   }
 
   const source = isContextSource(ctx) ? ctx : undefined;
@@ -194,6 +210,7 @@ function gateToolCall(
     rules,
     correlationId: agentCtx.correlationId,
     metadata: mergedMetadata,
+    ...remote,
     onDeny: (decision: DecisionDeny) => denyDecision(policy, denialResult(decision), "deny"),
     onUnavailable: () => denyDecision(policy, unavailableResult(), "unavailable"),
     execute: () => Promise.resolve(),

--- a/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
+++ b/arcjet-guard/src/tanstack-ai/v0/guard-middleware.ts
@@ -47,17 +47,16 @@ export interface GuardMiddlewarePolicy {
    */
   rules?: RuleWithInput[] | ((call: GuardMiddlewareCall) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool call. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(call, ctx) => …` matching
+   * `onBeforeToolCall(ctx, hookCtx)`. Derive it from `chat({ context })`;
+   * never trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<GuardMiddlewareCall>;
+  actor?: ActorResolver<[GuardMiddlewareCall, ChatMiddlewareContext]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool call. Build each
+   * Typed remote-policy inputs, or a resolver `(call, ctx) => …`. Build each
    * value with {@link policyInput}.
    */
-  inputs?: InputsResolver<GuardMiddlewareCall>;
+  inputs?: InputsResolver<[GuardMiddlewareCall, ChatMiddlewareContext]>;
   /** Metadata merged over the derived TanStack AI context. */
   metadata?: ArcjetMetadata | ((call: GuardMiddlewareCall) => ArcjetMetadata);
   /**
@@ -180,7 +179,7 @@ async function gateToolCall(
     rules = typeof policy.rules === "function" ? policy.rules(call) : policy.rules;
     policyMetadata =
       typeof policy.metadata === "function" ? policy.metadata(call) : policy.metadata;
-    remote = await resolveActorInputs(policy, call);
+    remote = await resolveActorInputs(policy, call, ctx);
   } catch (error) {
     const actionLabel = typeof policy.action === "string" ? policy.action : "tool.invoked";
     if (shouldWarn()) {

--- a/arcjet-guard/src/vercel-ai/v7/guard-tool.test.ts
+++ b/arcjet-guard/src/vercel-ai/v7/guard-tool.test.ts
@@ -103,17 +103,21 @@ test("resolves actor and typed inputs from parsed tool input", async () => {
   const { tool: testTool } = createTestTool();
   const wrapped = guardTool(client, testTool, {
     action: "test.action",
-    actor: (input) => `actor-${input.id}`,
+    actor: (_input, ctx) => String(ctx?.metadata?.["userId"]),
     inputs: (input) => ({ id: policyInput.server.string(input.id) }),
   });
 
   assert.ok(wrapped.execute !== undefined);
   await wrapped.execute(
     { id: "one" },
-    { toolCallId: "t1", messages: [], context: createAgentContext() },
+    {
+      toolCallId: "t1",
+      messages: [],
+      context: createAgentContext({ metadata: { userId: "user-9" } }),
+    },
   );
 
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "user-9");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/vercel-ai/v7/guard-tool.ts
+++ b/arcjet-guard/src/vercel-ai/v7/guard-tool.ts
@@ -1,15 +1,16 @@
 import { jsonSchema } from "ai";
 import type { InferToolInput, InferToolOutput, Tool } from "ai";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { ArcjetAgentContext } from "../../agents/context.ts";
+import { denialResult, unavailableResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import { arcjetProtectedTool } from "../../agents/internal.ts";
-import type { PolicyInputMap } from "../../policy-input.ts";
 import type { DecisionDeny, RuleWithInput, ArcjetMetadata } from "../../types.ts";
-import { denialResult, unavailableResult } from "../../agents/denial.ts";
 
 // Re-exported because this is the module the type was declared in before it
 // became shared, and `guardTool`'s callers already import from here.
@@ -51,15 +52,10 @@ export interface GuardToolPolicy<T extends Tool> {
    * actor: (input, ctx) => ctx?.userId ?? "anonymous",
    * ```
    */
-  actor?:
-    | string
-    | ((
-        input: InferToolInput<T>,
-        context: ArcjetAgentContext | undefined,
-      ) => string | Promise<string>);
+  actor?: ActorResolver<[InferToolInput<T>, ArcjetAgentContext | undefined]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the parsed tool input. Build
-   * each value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver over the parsed tool input and
+   * trusted context. Build each value with {@link policyInput}.
    *
    * @example
    * ```ts
@@ -69,12 +65,7 @@ export interface GuardToolPolicy<T extends Tool> {
    * }),
    * ```
    */
-  inputs?:
-    | PolicyInputMap
-    | ((
-        input: InferToolInput<T>,
-        context: ArcjetAgentContext | undefined,
-      ) => PolicyInputMap | Promise<PolicyInputMap>);
+  inputs?: InputsResolver<[InferToolInput<T>, ArcjetAgentContext | undefined]>;
   /** Metadata merged over the context's (object, or per-call function of the tool input). */
   metadata?: ArcjetMetadata | ((input: InferToolInput<T>) => ArcjetMetadata);
   /** Explicit correlation ID; overrides the context's when set. */
@@ -278,16 +269,7 @@ export function guardTool<T extends Tool>(
         rules,
         correlationId,
         metadata,
-        resolvePolicy: async () => ({
-          ...(policy.actor !== undefined && {
-            actor:
-              typeof policy.actor === "function" ? await policy.actor(input, ctx) : policy.actor,
-          }),
-          ...(policy.inputs !== undefined && {
-            inputs:
-              typeof policy.inputs === "function" ? await policy.inputs(input, ctx) : policy.inputs,
-          }),
-        }),
+        resolvePolicy: () => resolveActorInputs(policy, input, ctx),
         ...(policy.onGuardError !== undefined && { onGuardError: policy.onGuardError }),
         onDeny: (decision) =>
           policy.onDeny === undefined ? denialResult(decision) : policy.onDeny(decision),

--- a/arcjet-guard/src/vercel-eve/v0/gate.ts
+++ b/arcjet-guard/src/vercel-eve/v0/gate.ts
@@ -1,5 +1,6 @@
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 import type {
   ArcjetMetadata,
   Decision,
@@ -7,7 +8,6 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
-import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something

--- a/arcjet-guard/src/vercel-eve/v0/gate.ts
+++ b/arcjet-guard/src/vercel-eve/v0/gate.ts
@@ -7,6 +7,7 @@ import type {
   DecisionDeny,
   RuleWithInput,
 } from "../../types.ts";
+import type { PolicyInputMap } from "../../policy-input.ts";
 
 /**
  * The guard → capture sequence for a call site that decides whether something
@@ -48,6 +49,8 @@ export async function runGate<T>(
     rules: RuleWithInput[] | undefined;
     correlationId: string | undefined;
     metadata: ArcjetMetadata;
+    actor?: string;
+    inputs?: PolicyInputMap;
     onAllow: () => T;
     onDeny: (decision: DecisionDeny) => T;
     onUnavailable: (
@@ -67,6 +70,8 @@ export async function runGate<T>(
     onDeny,
     onUnavailable,
     onGuardError = "deny",
+    actor,
+    inputs,
   } = params;
 
   // Spread onto every guard/capture payload so `correlationId` is included
@@ -83,7 +88,14 @@ export async function runGate<T>(
     // call: it still produces a decision, which is what makes this call site
     // reachable by policy configured outside the code, and gives a
     // capture-only call a `decisionId` to correlate against.
-    decision = await client.guard({ label: action, rules: rules ?? [], ...correlation, metadata });
+    decision = await client.guard({
+      label: action,
+      rules: rules ?? [],
+      ...correlation,
+      metadata,
+      ...(actor !== undefined && { actor }),
+      ...(inputs !== undefined && { inputs }),
+    });
   } catch (error) {
     // Signal (a): the guard call itself threw. Rare — the client converts
     // transport failures into decisions rather than throwing.

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -12,6 +12,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import type { DecisionDeny } from "../../types.ts";
 import type {
   ApprovalContext,
@@ -1090,4 +1091,32 @@ test("response last-resort catch fails open when extra evaluation throws with on
       process.env.ARCJET_LOG_LEVEL = oldLogLevel;
     }
   }
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    actor: (ctx) => `actor-${ctx.toolName}`,
+    inputs: (ctx) => ({ tool: policyInput.server.string(ctx.toolName) }),
+  });
+  await approval(createApprovalContext({ toolName: "lookup" }));
+  assert.equal(recorded(guardCalls[0]).actor, "actor-lookup");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    tool: policyInput.server.string("lookup"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const approval = guardApproval(client, {
+    action: "resource.read",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  const status = await approval(createApprovalContext());
+  assert.equal((status as { type?: string }).type, "denied");
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.test.ts
@@ -1093,7 +1093,6 @@ test("response last-resort catch fails open when extra evaluation throws with on
   }
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const approval = guardApproval(client, {

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -35,16 +35,16 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
   /** Rules to evaluate, static or computed from the approval context. */
   rules?: RuleWithInput[] | ((ctx: ApprovalContext<TInput>) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the approval context. Derive it
-   * from authenticated server-side context; never trust a model-produced tool
-   * input as the actor identity.
+   * Trusted actor identity, or a resolver `(ctx) => …` matching Eve's
+   * `ApprovalPolicy`. Derive it from `ctx.session`; never trust
+   * model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<ApprovalContext<TInput>>;
+  actor?: ActorResolver<[ApprovalContext<TInput>]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the approval context. Build
-   * each value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver `(ctx) => …` over the approval
+   * context. Build each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<ApprovalContext<TInput>>;
+  inputs?: InputsResolver<[ApprovalContext<TInput>]>;
   /** Metadata merged over the session-derived context's. */
   metadata?: ArcjetMetadata | ((ctx: ApprovalContext<TInput>) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -72,16 +72,16 @@ export interface GuardApprovalResponsePolicy<TInput = Record<string, unknown>> {
   /** Rules to evaluate, static or computed from the response context. */
   rules?: RuleWithInput[] | ((ctx: ApprovalResponseContext<TInput>) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the response context. Derive it
-   * from authenticated server-side context; never trust a model-produced tool
-   * input as the actor identity.
+   * Trusted actor identity, or a resolver `(ctx) => …` matching Eve's
+   * response-time approval callback. Derive it from the responder session;
+   * never trust model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<ApprovalResponseContext<TInput>>;
+  actor?: ActorResolver<[ApprovalResponseContext<TInput>]>;
   /**
    * Typed remote-policy inputs, or a resolver over the response context. Build
    * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<ApprovalResponseContext<TInput>>;
+  inputs?: InputsResolver<[ApprovalResponseContext<TInput>]>;
   /** Metadata merged over the session-derived context's. */
   metadata?: ArcjetMetadata | ((ctx: ApprovalResponseContext<TInput>) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -317,8 +317,8 @@ type ApprovalPolicyOptions<TResult> = {
 type ApprovalPolicyConfig<TCtx> = {
   action: string;
   rules?: RuleWithInput[] | ((ctx: TCtx) => RuleWithInput[]);
-  actor?: ActorResolver<TCtx>;
-  inputs?: InputsResolver<TCtx>;
+  actor?: ActorResolver<[TCtx]>;
+  inputs?: InputsResolver<[TCtx]>;
   metadata?: ArcjetMetadata | ((ctx: TCtx) => ArcjetMetadata);
   onGuardError?: OnGuardError;
 };

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -1,5 +1,7 @@
 import type { SessionContext } from "eve/context";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { captureEvent, shouldWarn } from "../../agents/capture.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import { deniedReason, unavailableReason } from "../../agents/denial.ts";
@@ -32,6 +34,17 @@ export interface GuardApprovalPolicy<TInput = Record<string, unknown>> {
   action: string;
   /** Rules to evaluate, static or computed from the approval context. */
   rules?: RuleWithInput[] | ((ctx: ApprovalContext<TInput>) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the approval context. Derive it
+   * from authenticated server-side context; never trust a model-produced tool
+   * input as the actor identity.
+   */
+  actor?: ActorResolver<ApprovalContext<TInput>>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the approval context. Build
+   * each value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<ApprovalContext<TInput>>;
   /** Metadata merged over the session-derived context's. */
   metadata?: ArcjetMetadata | ((ctx: ApprovalContext<TInput>) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -58,6 +71,17 @@ export interface GuardApprovalResponsePolicy<TInput = Record<string, unknown>> {
   action: string;
   /** Rules to evaluate, static or computed from the response context. */
   rules?: RuleWithInput[] | ((ctx: ApprovalResponseContext<TInput>) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the response context. Derive it
+   * from authenticated server-side context; never trust a model-produced tool
+   * input as the actor identity.
+   */
+  actor?: ActorResolver<ApprovalResponseContext<TInput>>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the response context. Build
+   * each value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<ApprovalResponseContext<TInput>>;
   /** Metadata merged over the session-derived context's. */
   metadata?: ArcjetMetadata | ((ctx: ApprovalResponseContext<TInput>) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -293,23 +317,31 @@ type ApprovalPolicyOptions<TResult> = {
 type ApprovalPolicyConfig<TCtx> = {
   action: string;
   rules?: RuleWithInput[] | ((ctx: TCtx) => RuleWithInput[]);
+  actor?: ActorResolver<TCtx>;
+  inputs?: InputsResolver<TCtx>;
   metadata?: ArcjetMetadata | ((ctx: TCtx) => ArcjetMetadata);
   onGuardError?: OnGuardError;
 };
 
 type CallbackResolution<TResult> =
-  | { status: "resolved"; rules: RuleWithInput[] | undefined; metadata: ArcjetMetadata }
+  | {
+      status: "resolved";
+      rules: RuleWithInput[] | undefined;
+      metadata: ArcjetMetadata;
+      actor?: string;
+      inputs?: Awaited<ReturnType<typeof resolveActorInputs>>["inputs"];
+    }
   | { status: "failed"; result: TResult };
 
-function resolveApprovalCallbacks<TCtx, TResult>(
+async function resolveApprovalCallbacks<TCtx, TResult>(
   client: ArcjetAgentClient,
   policy: ApprovalPolicyConfig<TCtx>,
   ctx: TCtx,
   options: ApprovalPolicyOptions<TResult>,
   agentCtx: ReturnType<typeof eveAgentContext>,
   metadata: ArcjetMetadata,
-): CallbackResolution<TResult> {
-  // Resolve both callbacks independently so a throw in one cannot skip
+): Promise<CallbackResolution<TResult>> {
+  // Resolve callbacks independently so a throw in one cannot skip
   // the other. Merge extra metadata only when the metadata callback resolves.
   let ruleResolutionFailed = false;
   let ruleResolutionError: unknown;
@@ -333,11 +365,25 @@ function resolveApprovalCallbacks<TCtx, TResult>(
     metadataResolutionError = error;
   }
 
-  if (ruleResolutionFailed || metadataResolutionFailed) {
+  let remote: Awaited<ReturnType<typeof resolveActorInputs>> = {};
+  let remoteResolutionFailed = false;
+  let remoteResolutionError: unknown;
+  try {
+    remote = await resolveActorInputs(policy, ctx);
+  } catch (error) {
+    remoteResolutionFailed = true;
+    remoteResolutionError = error;
+  }
+
+  if (ruleResolutionFailed || metadataResolutionFailed || remoteResolutionFailed) {
     const failClosed = policy.onGuardError !== "allow";
     const correlation =
       agentCtx.correlationId === undefined ? {} : { correlationId: agentCtx.correlationId };
-    const error = ruleResolutionFailed ? ruleResolutionError : metadataResolutionError;
+    const error = ruleResolutionFailed
+      ? ruleResolutionError
+      : metadataResolutionFailed
+        ? metadataResolutionError
+        : remoteResolutionError;
     warnCallbackFailure(options.warnKind, policy.action, failClosed, error);
     captureEvent(client, {
       action: policy.action,
@@ -350,7 +396,7 @@ function resolveApprovalCallbacks<TCtx, TResult>(
     };
   }
 
-  return { status: "resolved", rules, metadata: resolvedMetadata };
+  return { status: "resolved", rules, metadata: resolvedMetadata, ...remote };
 }
 
 async function evaluateApprovalPolicy<TCtx, TResult>(
@@ -369,7 +415,7 @@ async function evaluateApprovalPolicy<TCtx, TResult>(
       ...options.extraMetadata(),
     };
 
-    const resolved = resolveApprovalCallbacks(client, policy, ctx, options, agentCtx, metadata);
+    const resolved = await resolveApprovalCallbacks(client, policy, ctx, options, agentCtx, metadata);
     if (resolved.status === "failed") {
       return resolved.result;
     }
@@ -379,6 +425,8 @@ async function evaluateApprovalPolicy<TCtx, TResult>(
       rules: resolved.rules,
       correlationId: agentCtx.correlationId,
       metadata: resolved.metadata,
+      ...(resolved.actor !== undefined && { actor: resolved.actor }),
+      ...(resolved.inputs !== undefined && { inputs: resolved.inputs }),
       onAllow: options.onAllow,
       onDeny: options.onDeny,
       onUnavailable: options.onUnavailable,

--- a/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-approval.ts
@@ -415,7 +415,14 @@ async function evaluateApprovalPolicy<TCtx, TResult>(
       ...options.extraMetadata(),
     };
 
-    const resolved = await resolveApprovalCallbacks(client, policy, ctx, options, agentCtx, metadata);
+    const resolved = await resolveApprovalCallbacks(
+      client,
+      policy,
+      ctx,
+      options,
+      agentCtx,
+      metadata,
+    );
     if (resolved.status === "failed") {
       return resolved.result;
     }

--- a/arcjet-guard/src/vercel-eve/v0/guard-inbound.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-inbound.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { recorded } from "../../../test/_shared/source-scan.ts";
 import {
   decisionAllow,
   decisionDenyPromptInjection,
@@ -10,6 +11,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { deniedReason } from "../../agents/denial.ts";
 import { guardInbound } from "./guard-inbound.ts";
 
@@ -546,4 +548,31 @@ test("reason mirrors outcome for both verdict shapes", async () => {
   assert.equal(unavailable.reason, unavailable.outcome);
   // oxlint-disable-next-line typescript/no-deprecated -- asserting the alias still mirrors `outcome`
   assert.equal(unavailable.reason, "UNAVAILABLE");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  await guardInbound(client, "hello", {
+    rules: [fakeRule],
+    actor: (text) => `actor-${text.length}`,
+    inputs: (text) => ({ text: policyInput.local.string(text) }),
+  });
+  assert.equal(recorded(guardCalls[0]).actor, "actor-5");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    text: policyInput.local.string("hello"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const verdict = await guardInbound(client, "hello", {
+    rules: [fakeRule],
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.allowed === false ? verdict.outcome : undefined, "UNAVAILABLE");
+  assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-inbound.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-inbound.test.ts
@@ -11,8 +11,8 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
 import { deniedReason } from "../../agents/denial.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardInbound } from "./guard-inbound.ts";
 
 test("AC5.6: ALLOW → exactly { allowed: true } with no extra fields", async () => {
@@ -550,7 +550,6 @@ test("reason mirrors outcome for both verdict shapes", async () => {
   assert.equal(unavailable.reason, "UNAVAILABLE");
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   await guardInbound(client, "hello", {
@@ -572,7 +571,7 @@ test("an input resolver failure follows the fail-closed unavailable path", async
       throw new Error("mapping failed");
     },
   });
-  assert.equal(verdict.allowed, false);
-  assert.equal(verdict.allowed === false ? verdict.outcome : undefined, "UNAVAILABLE");
+  assert.strictEqual(verdict.allowed, false);
+  assert.equal((verdict as any).reason, "UNAVAILABLE");
   assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-inbound.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-inbound.test.ts
@@ -572,6 +572,8 @@ test("an input resolver failure follows the fail-closed unavailable path", async
     },
   });
   assert.strictEqual(verdict.allowed, false);
-  assert.equal((verdict as any).reason, "UNAVAILABLE");
+  if (!verdict.allowed) {
+    assert.equal(verdict.outcome, "UNAVAILABLE");
+  }
   assert.equal(guardCalls.length, 0);
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-inbound.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-inbound.ts
@@ -1,9 +1,9 @@
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, Decision, DecisionDeny, RuleWithInput } from "../../types.ts";
-import { deniedReason, unavailableReason } from "../../agents/denial.ts";
 import { runGate } from "./gate.ts";
 
 /**

--- a/arcjet-guard/src/vercel-eve/v0/guard-inbound.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-inbound.ts
@@ -1,3 +1,5 @@
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import type { ArcjetMetadata, Decision, DecisionDeny, RuleWithInput } from "../../types.ts";
@@ -19,6 +21,17 @@ import { runGate } from "./gate.ts";
 export interface GuardInboundOptions {
   /** Rules to evaluate against the inbound text. */
   rules: RuleWithInput[];
+  /**
+   * Trusted actor identity, or a resolver over the inbound text. Derive it from
+   * authenticated server-side context; never trust the inbound text as the
+   * actor identity.
+   */
+  actor?: ActorResolver<string>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the inbound text. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<string>;
   /**
    * Guard label and capture action. Defaults to `"message.received"`.
    */
@@ -158,6 +171,7 @@ export async function guardInbound(
       rules: options.rules,
       correlationId: options.correlationId,
       metadata,
+      ...(await resolveActorInputs(options, text)),
       onAllow: (): InboundVerdict => ({ allowed: true }),
       onDeny: (decision: DecisionDeny): InboundVerdict => ({
         allowed: false,

--- a/arcjet-guard/src/vercel-eve/v0/guard-inbound.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-inbound.ts
@@ -22,16 +22,16 @@ export interface GuardInboundOptions {
   /** Rules to evaluate against the inbound text. */
   rules: RuleWithInput[];
   /**
-   * Trusted actor identity, or a resolver over the inbound text. Derive it from
-   * authenticated server-side context; never trust the inbound text as the
-   * actor identity.
+   * Trusted actor identity, or a resolver `(text) => …` over the inbound
+   * channel text. Derive it from authenticated session context closed over
+   * the call; never trust the inbound text as the actor identity.
    */
-  actor?: ActorResolver<string>;
+  actor?: ActorResolver<[string]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the inbound text. Build each
-   * value with {@link policyInput}.
+   * Typed remote-policy inputs, or a resolver over the inbound text. Build
+   * each value with {@link policyInput}.
    */
-  inputs?: InputsResolver<string>;
+  inputs?: InputsResolver<[string]>;
   /**
    * Guard label and capture action. Defaults to `"message.received"`.
    */

--- a/arcjet-guard/src/vercel-eve/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-tool.test.ts
@@ -13,8 +13,8 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
-import { policyInput } from "../../policy-input.ts";
 import { ArcjetDeniedError, ArcjetGuardUnavailableError } from "../../agents/guard-action.ts";
+import { policyInput } from "../../policy-input.ts";
 import { guardTool } from "./guard-tool.ts";
 
 /**
@@ -747,7 +747,6 @@ test("a guarded tool invoked with no context still denies", async () => {
   assert.equal(called, false, "execute never runs on DENY");
 });
 
-
 test("resolves actor and typed inputs onto the guard call", async () => {
   const { client, guardCalls } = stubClient(decisionAllow());
   const tool = createToolWithSymbols<{ id: string }, { success: boolean }>({
@@ -780,10 +779,9 @@ test("an input resolver failure follows the fail-closed unavailable path", async
       throw new Error("mapping failed");
     },
   });
-  await assert.rejects(
-    () => wrapped.execute!({ id: "one" }, { toolName: "test", callId: "c1" } as never),
-    ArcjetGuardUnavailableError,
-  );
+  await assert.rejects(async () => {
+    await wrapped.execute!({ id: "one" }, { toolName: "test", callId: "c1" } as never);
+  }, ArcjetGuardUnavailableError);
   assert.equal(guardCalls.length, 0);
   assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-tool.test.ts
@@ -754,11 +754,11 @@ test("resolves actor and typed inputs onto the guard call", async () => {
   });
   const wrapped = guardTool(client, tool, {
     action: "test.action",
-    actor: (input) => `actor-${input.id}`,
+    actor: (_input, ctx) => String(ctx?.toolName),
     inputs: (input) => ({ id: policyInput.server.string(input.id) }),
   });
   await wrapped.execute!({ id: "one" }, { toolName: "test", callId: "c1" } as never);
-  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.equal(recorded(guardCalls[0]).actor, "test");
   assert.deepEqual(recorded(guardCalls[0]).inputs, {
     id: policyInput.server.string("one"),
   });

--- a/arcjet-guard/src/vercel-eve/v0/guard-tool.test.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-tool.test.ts
@@ -13,6 +13,7 @@ import {
   fakeRule,
   stubClient,
 } from "../../../test/_shared/stub-client.ts";
+import { policyInput } from "../../policy-input.ts";
 import { ArcjetDeniedError, ArcjetGuardUnavailableError } from "../../agents/guard-action.ts";
 import { guardTool } from "./guard-tool.ts";
 
@@ -744,4 +745,45 @@ test("a guarded tool invoked with no context still denies", async () => {
     await wrapped.execute({ id: "a" }, undefined as never);
   }, /denied/i);
   assert.equal(called, false, "execute never runs on DENY");
+});
+
+
+test("resolves actor and typed inputs onto the guard call", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const tool = createToolWithSymbols<{ id: string }, { success: boolean }>({
+    execute: async () => ({ success: true }),
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    actor: (input) => `actor-${input.id}`,
+    inputs: (input) => ({ id: policyInput.server.string(input.id) }),
+  });
+  await wrapped.execute!({ id: "one" }, { toolName: "test", callId: "c1" } as never);
+  assert.equal(recorded(guardCalls[0]).actor, "actor-one");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    id: policyInput.server.string("one"),
+  });
+});
+
+test("an input resolver failure follows the fail-closed unavailable path", async () => {
+  const { client, guardCalls } = stubClient(decisionAllow());
+  let calls = 0;
+  const tool = createToolWithSymbols<{ id: string }, { success: boolean }>({
+    execute: async () => {
+      calls += 1;
+      return { success: true };
+    },
+  });
+  const wrapped = guardTool(client, tool, {
+    action: "test.action",
+    inputs: () => {
+      throw new Error("mapping failed");
+    },
+  });
+  await assert.rejects(
+    () => wrapped.execute!({ id: "one" }, { toolName: "test", callId: "c1" } as never),
+    ArcjetGuardUnavailableError,
+  );
+  assert.equal(guardCalls.length, 0);
+  assert.equal(calls, 0);
 });

--- a/arcjet-guard/src/vercel-eve/v0/guard-tool.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-tool.ts
@@ -3,12 +3,12 @@ import type { ToolDefinition, ToolContext } from "eve/tools";
 import { resolveActorInputs } from "../../agents/actor-inputs.ts";
 import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
+import { denialResult } from "../../agents/denial.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { ArcjetDeniedError, ArcjetGuardUnavailableError } from "../../agents/guard-action.ts";
 import { runGuarded } from "../../agents/guarded.ts";
 import type { ArcjetMetadata, DecisionDeny, RuleWithInput } from "../../types.ts";
 import { eveAgentContext } from "./context.ts";
-import { denialResult } from "../../agents/denial.ts";
 
 /**
  * Policy for `guardTool()` — how to guard an authored tool's execution.

--- a/arcjet-guard/src/vercel-eve/v0/guard-tool.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-tool.ts
@@ -23,17 +23,16 @@ export interface GuardToolPolicy<TInput> {
   /** Rules to evaluate, static or computed from the tool's input. */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
   /**
-   * Trusted actor identity, or a resolver over the tool input. Derive it from
-   * authenticated server-side context; never trust a model-produced tool input
-   * as the actor identity — a policy can be conditioned on the actor, so a
-   * model-controlled value could escape scope.
+   * Trusted actor identity, or a resolver `(input, ctx) => …` matching Eve
+   * `execute(input, ctx)`. Derive it from Eve `ToolContext` / session; never
+   * trust a model-produced tool input as the actor identity.
    */
-  actor?: ActorResolver<TInput>;
+  actor?: ActorResolver<[TInput, ToolContext | undefined]>;
   /**
-   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * Typed remote-policy inputs, or a resolver `(input, ctx) => …`. Build each
    * value with {@link policyInput}.
    */
-  inputs?: InputsResolver<TInput>;
+  inputs?: InputsResolver<[TInput, ToolContext | undefined]>;
   /** Metadata merged over the context's. */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -192,7 +191,7 @@ export function guardTool<TInput, TOutput>(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
-      resolvePolicy: () => resolveActorInputs(policy, input),
+      resolvePolicy: () => resolveActorInputs(policy, input, ctx),
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- onDeny may throw or return custom types; both paths are valid (throw never returns, custom type is returned)
       onDeny: ((decision) => {
         if (policy.onDeny === undefined) {

--- a/arcjet-guard/src/vercel-eve/v0/guard-tool.ts
+++ b/arcjet-guard/src/vercel-eve/v0/guard-tool.ts
@@ -1,5 +1,7 @@
 import type { ToolDefinition, ToolContext } from "eve/tools";
 
+import { resolveActorInputs } from "../../agents/actor-inputs.ts";
+import type { ActorResolver, InputsResolver } from "../../agents/actor-inputs.ts";
 import type { ArcjetAgentClient } from "../../agents/capture.ts";
 import type { OnGuardError } from "../../agents/guard-action.ts";
 import { ArcjetDeniedError, ArcjetGuardUnavailableError } from "../../agents/guard-action.ts";
@@ -20,6 +22,18 @@ export interface GuardToolPolicy<TInput> {
   action: string;
   /** Rules to evaluate, static or computed from the tool's input. */
   rules?: RuleWithInput[] | ((input: TInput) => RuleWithInput[]);
+  /**
+   * Trusted actor identity, or a resolver over the tool input. Derive it from
+   * authenticated server-side context; never trust a model-produced tool input
+   * as the actor identity — a policy can be conditioned on the actor, so a
+   * model-controlled value could escape scope.
+   */
+  actor?: ActorResolver<TInput>;
+  /**
+   * Typed remote-policy inputs, or a resolver over the tool input. Build each
+   * value with {@link policyInput}.
+   */
+  inputs?: InputsResolver<TInput>;
   /** Metadata merged over the context's. */
   metadata?: ArcjetMetadata | ((input: TInput) => ArcjetMetadata);
   /** How to respond when guard evaluation is unavailable. Default `"deny"`. */
@@ -178,6 +192,7 @@ export function guardTool<TInput, TOutput>(
       rules,
       correlationId: agentCtx.correlationId,
       metadata: mergedMetadata,
+      resolvePolicy: () => resolveActorInputs(policy, input),
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- onDeny may throw or return custom types; both paths are valid (throw never returns, custom type is returned)
       onDeny: ((decision) => {
         if (policy.onDeny === undefined) {

--- a/arcjet-guard/test/genkit/real-generate.test.ts
+++ b/arcjet-guard/test/genkit/real-generate.test.ts
@@ -26,17 +26,15 @@ import { genkit, z } from "genkit";
 import type { ArcjetDenialResult } from "../../src/agents/denial.ts";
 import { guardMiddleware } from "../../src/genkit/v1/guard-middleware.ts";
 import { guardTool } from "../../src/genkit/v1/guard-tool.ts";
+import { policyInput } from "../../src/policy-input.ts";
+import { recorded } from "../_shared/source-scan.ts";
 import { decisionAllow, decisionDenyPromptInjection, stubClient } from "../_shared/stub-client.ts";
 
 function createAi() {
   return genkit({});
 }
 
-function scriptedToolModel(
-  ai: ReturnType<typeof genkit>,
-  toolName: string,
-  input: unknown,
-) {
+function scriptedToolModel(ai: ReturnType<typeof genkit>, toolName: string, input: unknown) {
   let turns = 0;
   return ai.defineModel({ name: `scripted-${toolName}-${Math.random()}` }, async () => {
     turns += 1;
@@ -65,7 +63,9 @@ function scriptedToolModel(
   });
 }
 
-function denialFromMessages(messages: ReadonlyArray<{ role?: string; content?: ReadonlyArray<unknown> }>) {
+function denialFromMessages(
+  messages: ReadonlyArray<{ role?: string; content?: ReadonlyArray<unknown> }>,
+) {
   const toolMessage = messages.find((m) => m.role === "tool");
   assert.ok(toolMessage, "generate() must append a tool message after a tool call");
   const content = toolMessage.content ?? [];
@@ -283,4 +283,75 @@ test("outputSchema on a guarded tool does not turn DENY into an interrupt", asyn
   assert.notEqual(result.finishReason, "interrupted");
   const denial = denialFromMessages(result.messages);
   assert.equal(denial.arcjetDenied, true);
+});
+
+test("generate() context is available to guardTool actor/inputs resolvers", async () => {
+  const ai = createAi();
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const guarded = guardTool(
+    client,
+    ai.defineTool(
+      {
+        name: "lookup_order_actor",
+        description: "resolves actor from generate() ALS context",
+        inputSchema: z.object({ note: z.string() }),
+      },
+      async (input) => `ran:${input.note}`,
+    ),
+    {
+      action: "order.looked-up",
+      actor: (_input, options) =>
+        (options as { context?: { userId?: string } } | undefined)?.context?.userId ?? "anonymous",
+      inputs: (input: { note: string }) => ({ note: policyInput.server.string(input.note) }),
+    },
+  );
+
+  const model = scriptedToolModel(ai, "lookup_order_actor", { note: "hello" });
+  await ai.generate({
+    model,
+    prompt: "look up my order",
+    tools: [guarded],
+    context: { userId: "authenticated-user", sessionId: "sess-e2e" },
+  });
+
+  assert.equal(recorded(guardCalls[0]).actor, "authenticated-user");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    note: policyInput.server.string("hello"),
+  });
+});
+
+test("generate() context is available to guardMiddleware actor/inputs resolvers", async () => {
+  const ai = createAi();
+  const { client, guardCalls } = stubClient(decisionAllow());
+  const unwrapped = ai.defineTool(
+    {
+      name: "mcp_search_actor",
+      description: "unwrapped tool gated by middleware",
+      inputSchema: z.object({ q: z.string() }),
+    },
+    async (input) => `ran:${input.q}`,
+  );
+
+  const model = scriptedToolModel(ai, "mcp_search_actor", { q: "hello" });
+  await ai.generate({
+    model,
+    prompt: "search",
+    tools: [unwrapped],
+    use: [
+      guardMiddleware(client, {
+        action: "tool.invoked",
+        actor: (_call, ctx) =>
+          (ctx as { context?: { userId?: string } } | undefined)?.context?.userId ?? "anonymous",
+        inputs: (call) => ({
+          q: policyInput.server.string(String((call.input as { q?: string }).q)),
+        }),
+      }),
+    ],
+    context: { userId: "authenticated-user", sessionId: "sess-mw" },
+  });
+
+  assert.equal(recorded(guardCalls[0]).actor, "authenticated-user");
+  assert.deepEqual(recorded(guardCalls[0]).inputs, {
+    q: policyInput.server.string("hello"),
+  });
 });

--- a/arcjet-skills/docs/guard.md
+++ b/arcjet-skills/docs/guard.md
@@ -118,7 +118,8 @@ throw is swallowed). JS Strands Agents is official `@strands-agents/sdk`,
 not Python `strands`.
 
 Every JS wrapper policy accepts optional `actor` and `inputs` (static values
-or a resolver over the adapter's call argument), matching Python. Build each
+or a resolver over that adapter's native call — parsed input plus trusted
+runtime/context, like Vercel AI's `(input, ctx)`). Build each
 input with `policyInput` so a remote policy that declares those names can
 evaluate. Omit them and the remote policy has nothing to read — its rules do
 not fire.

--- a/arcjet-skills/docs/guard.md
+++ b/arcjet-skills/docs/guard.md
@@ -117,6 +117,12 @@ TanStack AI is `guardMiddleware` — do not use `guardTool` (an `execute`
 throw is swallowed). JS Strands Agents is official `@strands-agents/sdk`,
 not Python `strands`.
 
+Every JS wrapper policy accepts optional `actor` and `inputs` (static values
+or a resolver over the adapter's call argument), matching Python. Build each
+input with `policyInput` so a remote policy that declares those names can
+evaluate. Omit them and the remote policy has nothing to read — its rules do
+not fire.
+
 Every adapter uses one `ArcjetDenialResult` payload
 (`{ arcjetDenied: true, reason, message, retryable }`). Delivery is
 per-framework: return the object (AI SDK, Mastra, OpenAI Agents, Genkit

--- a/arcjet-skills/skills/guard/SKILL.md
+++ b/arcjet-skills/skills/guard/SKILL.md
@@ -77,6 +77,11 @@ Wrappers fail closed by default. HITL (`needsApproval`, `interrupt()`,
 `requireConfirmation`, `canUseTool`) is not a policy gate; Guard still runs
 after a human yes.
 
+Every wrapper policy accepts optional `actor` and `inputs` (static or a
+resolver) so a remote policy that declares those names can evaluate. Build
+each input with `policyInput`. Omit them and the remote policy has nothing
+to read — its rules do not fire.
+
 Google ADK is `guardPlugin` (no `guardTool`). TanStack AI is
 `guardMiddleware` (do not wrap `execute`). LangChain `createAgent` is
 `/langchain/v1`, not LangGraph.

--- a/arcjet-skills/skills/guard/SKILL.md
+++ b/arcjet-skills/skills/guard/SKILL.md
@@ -78,7 +78,8 @@ Wrappers fail closed by default. HITL (`needsApproval`, `interrupt()`,
 after a human yes.
 
 Every wrapper policy accepts optional `actor` and `inputs` (static or a
-resolver) so a remote policy that declares those names can evaluate. Build
+resolver over that adapter's native call — parsed input plus trusted
+runtime/context) so a remote policy that declares those names can evaluate. Build
 each input with `policyInput`. Omit them and the remote policy has nothing
 to read — its rules do not fire.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Every JS vendor wrapper now accepts optional `actor` and `inputs` so a remote Guard policy that declares those names can evaluate.

Values can be static or resolved from that adapter’s native call (parsed input plus the framework’s trusted runtime or context, the same idea as Vercel AI’s `(input, ctx)`). Build each input with `policyInput`.

Applies to Vercel AI, Eve, Mastra, LangChain, LangGraph, Genkit, OpenAI Agents, Strands, TanStack AI, Google ADK, Claude Agent SDK, and Claude Managed Agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fab4e779-692a-4b58-a53e-957f7cd52ad2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fab4e779-692a-4b58-a53e-957f7cd52ad2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

